### PR TITLE
Bump golang to 1.18

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         python: ['3.10']
-        golang: [1.17]
+        golang: [1.18]
         solc: ['0.8.17']
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Geth bumped the minimum golang version to 1.18 [a few days ago](https://github.com/ethereum/go-ethereum/pull/26160). Since we're building directly from master we need to do the same.