### PR TITLE
Transition Tool EIPs Support, Print Traces, Helper Methods

### DIFF
--- a/src/ethereum_test_filling_tool/main.py
+++ b/src/ethereum_test_filling_tool/main.py
@@ -68,6 +68,13 @@ class Filler:
             help="limit to filling only tests with matching name",
         )
 
+        parser.add_argument(
+            "--traces",
+            action="store_true",
+            help="collect traces of the execution information from the "
+            + "transition tool",
+        )
+
         return parser.parse_args()
 
     options: argparse.Namespace
@@ -115,7 +122,9 @@ class Filler:
 
         os.makedirs(self.options.output, exist_ok=True)
 
-        t8n = EvmTransitionTool(binary=self.options.evm_bin)
+        t8n = EvmTransitionTool(
+            binary=self.options.evm_bin, trace=self.options.traces
+        )
         b11r = EvmBlockBuilder(binary=self.options.evm_bin)
 
         for filler in fillers:

--- a/src/ethereum_test_tools/__init__.py
+++ b/src/ethereum_test_tools/__init__.py
@@ -7,6 +7,7 @@ from .code import Code, Yul
 from .common import (
     Account,
     Block,
+    CodeGasMeasure,
     Environment,
     JSONEncoder,
     TestAddress,
@@ -23,6 +24,7 @@ __all__ = (
     "Block",
     "BlockchainTest",
     "Code",
+    "CodeGasMeasure",
     "Environment",
     "JSONEncoder",
     "StateTest",

--- a/src/ethereum_test_tools/code/code.py
+++ b/src/ethereum_test_tools/code/code.py
@@ -6,7 +6,7 @@ from re import sub
 from typing import Union
 
 
-class Code(str):
+class Code(object):
     """
     Generic code object.
     """

--- a/src/ethereum_test_tools/common/__init__.py
+++ b/src/ethereum_test_tools/common/__init__.py
@@ -8,7 +8,7 @@ from .constants import (
     TestAddress,
     TestPrivateKey,
 )
-from .helpers import to_address, to_hash
+from .helpers import CodeGasMeasure, to_address, to_hash
 from .types import (
     Account,
     Block,
@@ -29,6 +29,7 @@ __all__ = (
     "AddrAA",
     "AddrBB",
     "Block",
+    "CodeGasMeasure",
     "EmptyTrieRoot",
     "Environment",
     "Fixture",

--- a/src/ethereum_test_tools/common/helpers.py
+++ b/src/ethereum_test_tools/common/helpers.py
@@ -1,6 +1,10 @@
 """
-Helper functions for generating Ethereum tests.
+Helper functions/classes used to generate Ethereum tests.
 """
+
+from dataclasses import dataclass
+
+from ..code import Code, code_to_bytes
 
 
 def to_address(input: int | str) -> str:
@@ -25,3 +29,71 @@ def to_hash(input: int | str) -> str:
     if type(input) is int:
         return "0x" + input.to_bytes(32, "big").hex()
     raise Exception("invalid type to convert to hash")
+
+
+@dataclass(kw_only=True)
+class CodeGasMeasure(Code):
+    """
+    Helper class used to generate bytecode that measures gas usage of a
+    bytecode, taking into account and subtracting any extra overhead gas costs
+    required to execute.
+    """
+
+    code: bytes | str | Code
+    """
+    Bytecode to be executed to measure the gas usage.
+    """
+    overhead_cost: int
+    """
+    Extra gas cost to be subtracted from extra operations.
+    """
+    extra_stack_items: int = 0
+    """
+    Extra stack items that remain at the end of the execution.
+    To be considered when subtracting the value of the previous GAS operation,
+    and to be popped at the end of the execution.
+    """
+    sstore_key: int = 0
+    """
+    Storage key to save the gas used.
+    """
+
+    def assemble(self) -> bytes:
+        res = bytes()
+        res += bytes(
+            [
+                0x5A,  # GAS
+            ]
+        )
+        res += code_to_bytes(self.code)  # Execute code to measure its gas cost
+        res += bytes(
+            [
+                0x5A,  # GAS
+            ]
+        )
+        # We need to swap and pop for each extra stack item that remained from
+        # the execution of the code
+        res += (
+            bytes(
+                [
+                    0x90,  # SWAP1
+                    0x50,  # POP
+                ]
+            )
+            * self.extra_stack_items
+        )
+        res += bytes(
+            [
+                0x90,  # SWAP1
+                0x03,  # SUB
+                0x60,  # PUSH1
+                self.overhead_cost + 2,  # Overhead cost + GAS opcode price
+                0x90,  # SWAP1
+                0x03,  # SUB
+                0x60,  # PUSH1
+                self.sstore_key,  # -> SSTORE key
+                0x55,  # SSTORE
+                0x00,  # STOP
+            ]
+        )
+        return res

--- a/src/ethereum_test_tools/common/helpers.py
+++ b/src/ethereum_test_tools/common/helpers.py
@@ -59,6 +59,9 @@ class CodeGasMeasure(Code):
     """
 
     def assemble(self) -> bytes:
+        """
+        Assemble the bytecode that measures gas usage.
+        """
         res = bytes()
         res += bytes(
             [

--- a/src/ethereum_test_tools/common/helpers.py
+++ b/src/ethereum_test_tools/common/helpers.py
@@ -37,13 +37,14 @@ class CodeGasMeasure(Code):
     Helper class used to generate bytecode that measures gas usage of a
     bytecode, taking into account and subtracting any extra overhead gas costs
     required to execute.
+    By default, the result gas calculation is saved to storage key 0.
     """
 
     code: bytes | str | Code
     """
     Bytecode to be executed to measure the gas usage.
     """
-    overhead_cost: int
+    overhead_cost: int = 0
     """
     Extra gas cost to be subtracted from extra operations.
     """

--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -84,6 +84,7 @@ class Storage:
             self.v = v
 
         def __str__(self):
+            """Print exception string"""
             return f"invalid type for key/value: {self.v}"
 
     class MissingKey(Exception):
@@ -98,6 +99,7 @@ class Storage:
             self.k = k
 
         def __str__(self):
+            """Print exception string"""
             return "key {0} not found in storage".format(
                 Storage.key_value_to_string(self.k)
             )
@@ -119,6 +121,7 @@ class Storage:
             self.got = got
 
         def __str__(self):
+            """Print exception string"""
             return "incorrect value for key {0}: want {1}, got{2}".format(
                 Storage.key_value_to_string(self.k),
                 Storage.key_value_to_string(self.want),
@@ -298,6 +301,7 @@ class Account:
             self.got = got
 
         def __str__(self):
+            """Print exception string"""
             return (
                 f"unexpected nonce for account {self.account}: "
                 + f"want {self.want}, got {self.got}"
@@ -322,6 +326,7 @@ class Account:
             self.got = got
 
         def __str__(self):
+            """Print exception string"""
             return (
                 f"unexpected balance for account {self.account}: "
                 + f"want {self.want}, got {self.got}"
@@ -346,6 +351,7 @@ class Account:
             self.got = got
 
         def __str__(self):
+            """Print exception string"""
             return (
                 f"unexpected code for account {self.account}: "
                 + f"want {self.want}, got {self.got}"
@@ -516,6 +522,7 @@ class Transaction:
         """
 
         def __str__(self):
+            """Print exception string"""
             return (
                 "only one type of fee payment field can be used in a single tx"
             )
@@ -527,6 +534,7 @@ class Transaction:
         """
 
         def __str__(self):
+            """Print exception string"""
             return "can't define both 'signature' and 'private_key'"
 
     def __post_init__(self) -> None:

--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -72,6 +72,59 @@ class Storage:
 
     data: Dict[int, int]
 
+    class InvalidType(Exception):
+        """
+        Invalid type used when describing test's expected storage.
+        """
+
+        v: Any
+
+        def __init__(self, v: Any, *args):
+            super().__init__(args)
+            self.v = v
+
+        def __str__(self):
+            return f"invalid type for key/value: {self.v}"
+
+    class MissingKey(Exception):
+        """
+        Test expected to find a storage key set but key was missing.
+        """
+
+        k: int
+
+        def __init__(self, k: int, *args):
+            super().__init__(args)
+            self.k = k
+
+        def __str__(self):
+            return "key {0} not found in storage".format(
+                Storage.key_value_to_string(self.k)
+            )
+
+    class KeyValueMismatch(Exception):
+        """
+        Test expected a certain value in a storage key but value found
+        was different.
+        """
+
+        k: int
+        want: int
+        got: int
+
+        def __init__(self, k: int, want: int, got: int, *args):
+            super().__init__(args)
+            self.k = k
+            self.want = want
+            self.got = got
+
+        def __str__(self):
+            return "incorrect value for key {0}: want {1}, got{2}".format(
+                Storage.key_value_to_string(self.k),
+                Storage.key_value_to_string(self.want),
+                Storage.key_value_to_string(self.got),
+            )
+
     @staticmethod
     def parse_key_value(input: str | int) -> int:
         """
@@ -85,7 +138,7 @@ class Storage:
         elif type(input) is int:
             return input
 
-        raise Exception("invalid type for key/value of storage")
+        raise Storage.InvalidType(input)
 
     @staticmethod
     def key_value_to_string(value: int) -> str:
@@ -172,19 +225,9 @@ class Storage:
             if k not in self.data:
                 # storage[k]==0 is equal to missing storage
                 if other[k] != 0:
-                    raise Exception(
-                        "key {0} not found in storage".format(
-                            Storage.key_value_to_string(k)
-                        )
-                    )
+                    raise Storage.MissingKey(k)
             elif self.data[k] != other.data[k]:
-                raise Exception(
-                    "incorrect value for key {0}: want {1}, got{2}".format(
-                        Storage.key_value_to_string(k),
-                        Storage.key_value_to_string(self.data[k]),
-                        Storage.key_value_to_string(other.data[k]),
-                    )
-                )
+                raise Storage.KeyValueMismatch(k, self.data[k], other.data[k])
 
     def must_be_equal(self, other: "Storage"):
         """
@@ -193,30 +236,16 @@ class Storage:
         # Test keys contained in both storage objects
         for k in self.data.keys() & other.data.keys():
             if self.data[k] != other.data[k]:
-                raise Exception(
-                    "incorrect value for key {0}: want {1}, got {2}".format(
-                        Storage.key_value_to_string(k),
-                        Storage.key_value_to_string(self.data[k]),
-                        Storage.key_value_to_string(other.data[k]),
-                    )
-                )
+                raise Storage.KeyValueMismatch(k, self.data[k], other.data[k])
+
         # Test keys contained in either one of the storage objects
         for k in self.data.keys() ^ other.data.keys():
             if k in self.data:
                 if self.data[k] != 0:
-                    raise Exception(
-                        "expected key {0}={1} not found in storage".format(
-                            Storage.key_value_to_string(k),
-                            Storage.key_value_to_string(self.data[k]),
-                        )
-                    )
+                    raise Storage.KeyValueMismatch(k, self.data[k], 0)
+
             elif other.data[k] != 0:
-                raise Exception(
-                    "unexpected key {0}={1} found in storage".format(
-                        Storage.key_value_to_string(k),
-                        Storage.key_value_to_string(other.data[k]),
-                    )
-                )
+                raise Storage.KeyValueMismatch(k, 0, other.data[k])
 
 
 @dataclass(kw_only=True)
@@ -250,6 +279,78 @@ class Account:
     state.
     """
 
+    class NonceMismatch(Exception):
+        """
+        Test expected a certain nonce value for an account but a different
+        value was found.
+        """
+
+        account: str
+        want: int | None
+        got: int | None
+
+        def __init__(
+            self, account: str, want: int | None, got: int | None, *args
+        ):
+            super().__init__(args)
+            self.account = account
+            self.want = want
+            self.got = got
+
+        def __str__(self):
+            return (
+                f"unexpected nonce for account {self.account}: "
+                + f"want {self.want}, got {self.got}"
+            )
+
+    class BalanceMismatch(Exception):
+        """
+        Test expected a certain balance for an account but a different
+        value was found.
+        """
+
+        account: str
+        want: int | None
+        got: int | None
+
+        def __init__(
+            self, account: str, want: int | None, got: int | None, *args
+        ):
+            super().__init__(args)
+            self.account = account
+            self.want = want
+            self.got = got
+
+        def __str__(self):
+            return (
+                f"unexpected balance for account {self.account}: "
+                + f"want {self.want}, got {self.got}"
+            )
+
+    class CodeMismatch(Exception):
+        """
+        Test expected a certain bytecode for an account but a different
+        one was found.
+        """
+
+        account: str
+        want: str | None
+        got: str | None
+
+        def __init__(
+            self, account: str, want: str | None, got: str | None, *args
+        ):
+            super().__init__(args)
+            self.account = account
+            self.want = want
+            self.got = got
+
+        def __str__(self):
+            return (
+                f"unexpected code for account {self.account}: "
+                + f"want {self.want}, got {self.got}"
+            )
+
     def __post_init__(self) -> None:
         """Automatically init account members"""
         if self.storage is not None and type(self.storage) is dict:
@@ -263,27 +364,29 @@ class Account:
         if self.nonce is not None:
             actual_nonce = int_or_none(alloc.get("nonce"), 0)
             if self.nonce != actual_nonce:
-                raise Exception(
-                    f"unexpected nonce for account {account}: "
-                    + f"{actual_nonce}, expected {self.nonce}"
+                raise Account.NonceMismatch(
+                    account=account,
+                    want=self.nonce,
+                    got=actual_nonce,
                 )
 
         if self.balance is not None:
             actual_balance = int_or_none(alloc.get("balance"), 0)
             if self.balance != actual_balance:
-                raise Exception(
-                    "unexpected balance for account "
-                    + f"{account}: {actual_balance}, "
-                    + f"expected {self.balance}"
+                raise Account.BalanceMismatch(
+                    account=account,
+                    want=self.balance,
+                    got=actual_balance,
                 )
 
         if self.code is not None:
             expected_code = code_to_hex(self.code)
             actual_code = str_or_none(alloc.get("code"), "0x")
             if expected_code != actual_code:
-                raise Exception(
-                    f"unexpected code for account {account}: "
-                    + f"{actual_code}, expected {expected_code}"
+                raise Account.CodeMismatch(
+                    account=account,
+                    want=expected_code,
+                    got=actual_code,
                 )
 
         if self.storage is not None:
@@ -407,6 +510,25 @@ class Transaction:
     protected: bool = True
     error: Optional[str] = None
 
+    class InvalidFeePayment(Exception):
+        """
+        Transaction described more than one fee payment type.
+        """
+
+        def __str__(self):
+            return (
+                "only one type of fee payment field can be used in a single tx"
+            )
+
+    class InvalidSignaturePrivateKey(Exception):
+        """
+        Transaction describes both the signature and private key of
+        source account.
+        """
+
+        def __str__(self):
+            return "can't define both 'signature' and 'private_key'"
+
     def __post_init__(self) -> None:
         """
         Ensures the transaction has no conflicting properties.
@@ -416,9 +538,7 @@ class Transaction:
             and self.max_fee_per_gas is not None
             and self.max_priority_fee_per_gas is not None
         ):
-            raise Exception(
-                "only one type of fee payment field can be used in a single tx"
-            )
+            raise Transaction.InvalidFeePayment()
 
         if (
             self.gas_price is None
@@ -428,7 +548,7 @@ class Transaction:
             self.gas_price = 10
 
         if self.signature is not None and self.secret_key is not None:
-            raise Exception("can't define both 'signature' and 'private_key'")
+            raise Transaction.InvalidSignaturePrivateKey()
 
         if self.signature is None and self.secret_key is None:
             self.secret_key = TestPrivateKey

--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -122,7 +122,7 @@ class Storage:
 
         def __str__(self):
             """Print exception string"""
-            return "incorrect value for key {0}: want {1}, got{2}".format(
+            return "incorrect value for key {0}: want {1}, got {2}".format(
                 Storage.key_value_to_string(self.k),
                 Storage.key_value_to_string(self.want),
                 Storage.key_value_to_string(self.got),

--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -179,7 +179,7 @@ class Storage:
                     )
             elif self.data[k] != other.data[k]:
                 raise Exception(
-                    "incorrect value for key {0}: {1}!={2}".format(
+                    "incorrect value for key {0}: want {1}, got{2}".format(
                         Storage.key_value_to_string(k),
                         Storage.key_value_to_string(self.data[k]),
                         Storage.key_value_to_string(other.data[k]),
@@ -194,7 +194,7 @@ class Storage:
         for k in self.data.keys() & other.data.keys():
             if self.data[k] != other.data[k]:
                 raise Exception(
-                    "incorrect value for key {0}: {1}!={2}".format(
+                    "incorrect value for key {0}: want {1}, got {2}".format(
                         Storage.key_value_to_string(k),
                         Storage.key_value_to_string(self.data[k]),
                         Storage.key_value_to_string(other.data[k]),

--- a/src/ethereum_test_tools/filling/decorators.py
+++ b/src/ethereum_test_tools/filling/decorators.py
@@ -1,7 +1,7 @@
 """
 Decorators for expanding filler definitions.
 """
-from typing import Any, Callable, Mapping, cast
+from typing import Any, Callable, List, Mapping, Optional, cast
 
 from ..common import Fixture
 from ..spec import TestSpec
@@ -15,6 +15,7 @@ TESTS_PREFIX_LEN = len(TESTS_PREFIX)
 def test_from_until(
     fork_from: str,
     fork_until: str,
+    eips: Optional[List[int]] = None,
 ) -> Callable[[TestSpec], Callable[[Any, Any, str], Mapping[str, Fixture]]]:
     """
     Decorator that takes a test generator and fills it for all forks after the
@@ -28,7 +29,12 @@ def test_from_until(
     ) -> Callable[[Any, Any, str], Mapping[str, Fixture]]:
         def inner(t8n, b11r, engine) -> Mapping[str, Fixture]:
             return fill_test(
-                t8n, b11r, fn, forks_from_until(fork_from, fork_until), engine
+                t8n,
+                b11r,
+                fn,
+                forks_from_until(fork_from, fork_until),
+                engine,
+                eips=eips,
             )
 
         name = fn.__name__
@@ -46,6 +52,7 @@ def test_from_until(
 
 def test_from(
     fork: str,
+    eips: Optional[List[int]] = None,
 ) -> Callable[[TestSpec], Callable[[Any, Any, str], Mapping[str, Fixture]]]:
     """
     Decorator that takes a test generator and fills it for all forks after the
@@ -57,7 +64,9 @@ def test_from(
         fn: TestSpec,
     ) -> Callable[[Any, Any, str], Mapping[str, Fixture]]:
         def inner(t8n, b11r, engine) -> Mapping[str, Fixture]:
-            return fill_test(t8n, b11r, fn, forks_from(fork), engine)
+            return fill_test(
+                t8n, b11r, fn, forks_from(fork), engine, eips=eips
+            )
 
         name = fn.__name__
         assert name.startswith(TESTS_PREFIX)
@@ -74,6 +83,7 @@ def test_from(
 
 def test_only(
     fork: str,
+    eips: Optional[List[int]] = None,
 ) -> Callable[[TestSpec], Callable[[Any, Any, str], Mapping[str, Fixture]]]:
     """
     Decorator that takes a test generator and fills it only for the specified
@@ -85,7 +95,7 @@ def test_only(
         fn: TestSpec,
     ) -> Callable[[Any, Any, str], Mapping[str, Fixture]]:
         def inner(t8n, b11r, engine) -> Mapping[str, Fixture]:
-            return fill_test(t8n, b11r, fn, [fork], engine)
+            return fill_test(t8n, b11r, fn, [fork], engine, eips=eips)
 
         name = fn.__name__
         assert name.startswith(TESTS_PREFIX)

--- a/src/ethereum_test_tools/filling/fill.py
+++ b/src/ethereum_test_tools/filling/fill.py
@@ -36,7 +36,10 @@ def fill_test(
                 # Fork not supported by hive, skip
                 continue
 
+            t8n.reset_traces()
+
             genesis = test.make_genesis(b11r, t8n, fork)
+
             (blocks, head, alloc) = test.make_blocks(
                 b11r, t8n, genesis, fork, reward=get_reward(fork), eips=eips
             )

--- a/src/ethereum_test_tools/filling/fill.py
+++ b/src/ethereum_test_tools/filling/fill.py
@@ -1,7 +1,7 @@
 """
 Filler object definitions.
 """
-from typing import List, Mapping
+from typing import List, Mapping, Optional
 
 from evm_block_builder import BlockBuilder
 from evm_transition_tool import TransitionTool, map_fork
@@ -17,6 +17,7 @@ def fill_test(
     test_spec: TestSpec,
     forks: List[str],
     engine: str,
+    eips: Optional[List[int]] = None,
 ) -> Mapping[str, Fixture]:
     """
     Fills fixtures for certain forks.
@@ -37,14 +38,16 @@ def fill_test(
 
             genesis = test.make_genesis(b11r, t8n, fork)
             (blocks, head, alloc) = test.make_blocks(
-                b11r, t8n, genesis, fork, reward=get_reward(fork)
+                b11r, t8n, genesis, fork, reward=get_reward(fork), eips=eips
             )
 
             fixture = Fixture(
                 blocks=blocks,
                 genesis=genesis,
                 head=head,
-                fork=fork,
+                fork="+".join([fork] + [str(eip) for eip in eips])
+                if eips is not None
+                else fork,
                 pre_state=test.pre,
                 post_state=alloc,
                 seal_engine=engine,

--- a/src/ethereum_test_tools/spec/base_test.py
+++ b/src/ethereum_test_tools/spec/base_test.py
@@ -1,6 +1,7 @@
 """
 Generic Ethereum test base class
 """
+import pprint
 from abc import abstractmethod
 from typing import (
     Any,
@@ -17,6 +18,14 @@ from evm_block_builder import BlockBuilder
 from evm_transition_tool import TransitionTool
 
 from ..common import Account, FixtureBlock, FixtureHeader, Transaction
+
+
+def print_traces(traces: List[List[Dict]]):
+    print("Printing traces for debugging purposes:")
+    pp = pprint.PrettyPrinter(indent=4)
+    for number, block in enumerate(traces):
+        print(f"Block {number}:")
+        pp.pprint(block)
 
 
 def normalize_address(address: str) -> str:

--- a/src/ethereum_test_tools/spec/base_test.py
+++ b/src/ethereum_test_tools/spec/base_test.py
@@ -1,7 +1,6 @@
 """
 Generic Ethereum test base class
 """
-import pprint
 from abc import abstractmethod
 from typing import (
     Any,
@@ -18,14 +17,6 @@ from evm_block_builder import BlockBuilder
 from evm_transition_tool import TransitionTool
 
 from ..common import Account, FixtureBlock, FixtureHeader, Transaction
-
-
-def print_traces(traces: List[List[Dict]]):
-    print("Printing traces for debugging purposes:")
-    pp = pprint.PrettyPrinter(indent=4)
-    for number, block in enumerate(traces):
-        print(f"Block {number}:")
-        pp.pprint(block)
 
 
 def normalize_address(address: str) -> str:

--- a/src/ethereum_test_tools/spec/base_test.py
+++ b/src/ethereum_test_tools/spec/base_test.py
@@ -2,7 +2,16 @@
 Generic Ethereum test base class
 """
 from abc import abstractmethod
-from typing import Any, Callable, Dict, Generator, List, Mapping, Tuple
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generator,
+    List,
+    Mapping,
+    Optional,
+    Tuple,
+)
 
 from evm_block_builder import BlockBuilder
 from evm_transition_tool import TransitionTool
@@ -100,6 +109,7 @@ class BaseTest:
         fork: str,
         chain_id: int = 1,
         reward: int = 0,
+        eips: Optional[List[int]] = None,
     ) -> Tuple[List[FixtureBlock], str, Dict[str, Any]]:
         """
         Generate the blockchain that must be executed sequentially during test.

--- a/src/ethereum_test_tools/spec/blockchain_test.py
+++ b/src/ethereum_test_tools/spec/blockchain_test.py
@@ -29,12 +29,8 @@ from ..common import (
     to_json_or_none,
 )
 from ..vm import set_fork_requirements
-from .base_test import (
-    BaseTest,
-    print_traces,
-    verify_post_alloc,
-    verify_transactions,
-)
+from .base_test import BaseTest, verify_post_alloc, verify_transactions
+from .debugging import print_traces
 
 
 @dataclass(kw_only=True)
@@ -99,7 +95,9 @@ class BlockchainTest(BaseTest):
         chain_id=1,
         reward=0,
         eips: Optional[List[int]] = None,
-    ) -> Tuple[FixtureBlock, Environment, Dict[str, Any], str, List[Dict]]:
+    ) -> Tuple[
+        FixtureBlock, Environment, Dict[str, Any], str, List[List[Dict]]
+    ]:
         """
         Produces a block based on the previous environment and allocation.
         If the block is an invalid block, the environment and allocation

--- a/src/ethereum_test_tools/spec/blockchain_test.py
+++ b/src/ethereum_test_tools/spec/blockchain_test.py
@@ -4,7 +4,16 @@ Blockchain test filler.
 
 import tempfile
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, Generator, List, Mapping, Tuple
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generator,
+    List,
+    Mapping,
+    Optional,
+    Tuple,
+)
 
 from evm_block_builder import BlockBuilder
 from evm_transition_tool import TransitionTool
@@ -85,6 +94,7 @@ class BlockchainTest(BaseTest):
         previous_head: str,
         chain_id=1,
         reward=0,
+        eips: Optional[List[int]] = None,
     ) -> Tuple[FixtureBlock, Environment, Dict[str, Any], str]:
         """
         Produces a block based on the previous environment and allocation.
@@ -125,9 +135,10 @@ class BlockchainTest(BaseTest):
                     to_json_or_none(block.txs),
                     to_json(env),
                     fork,
-                    txsPath=txs_rlp_file.name,
+                    txs_path=txs_rlp_file.name,
                     chain_id=chain_id,
                     reward=reward,
+                    eips=eips,
                 )
                 txs_rlp = txs_rlp_file.read().decode().strip('"')
 
@@ -215,6 +226,7 @@ class BlockchainTest(BaseTest):
         fork: str,
         chain_id=1,
         reward=0,
+        eips: Optional[List[int]] = None,
     ) -> Tuple[List[FixtureBlock], str, Dict[str, Any]]:
         """
         Create a block list from the blockchain test definition.
@@ -240,6 +252,7 @@ class BlockchainTest(BaseTest):
                 previous_head=head,
                 chain_id=chain_id,
                 reward=reward,
+                eips=eips,
             )
             blocks.append(fixture_block)
 

--- a/src/ethereum_test_tools/spec/debugging.py
+++ b/src/ethereum_test_tools/spec/debugging.py
@@ -1,0 +1,18 @@
+"""
+Test spec debugging tools.
+"""
+import pprint
+from typing import Dict, List
+
+
+def print_traces(traces: List[List[List[Dict]]]):
+    print("Printing traces for debugging purposes:")
+    pp = pprint.PrettyPrinter(indent=2)
+    for block_number, block in enumerate(traces):
+        print(f"Block {block_number}:")
+        for tx_number, tx in enumerate(block):
+            print(f"Transaction {tx_number}:")
+            for exec_step, trace in enumerate(tx):
+                print(f"Step {exec_step}:")
+                pp.pprint(trace)
+                print()

--- a/src/ethereum_test_tools/spec/debugging.py
+++ b/src/ethereum_test_tools/spec/debugging.py
@@ -6,6 +6,9 @@ from typing import Dict, List
 
 
 def print_traces(traces: List[List[List[Dict]]]):
+    """
+    Print the traces from the transition tool for debugging.
+    """
     print("Printing traces for debugging purposes:")
     pp = pprint.PrettyPrinter(indent=2)
     for block_number, block in enumerate(traces):

--- a/src/ethereum_test_tools/spec/debugging.py
+++ b/src/ethereum_test_tools/spec/debugging.py
@@ -5,10 +5,16 @@ import pprint
 from typing import Dict, List
 
 
-def print_traces(traces: List[List[List[Dict]]]):
+def print_traces(traces: List[List[List[Dict]]] | None):
     """
     Print the traces from the transition tool for debugging.
     """
+    if traces is None:
+        print(
+            "Traces not collected. Use `--traces` to see detailed"
+            + " execution information."
+        )
+        return
     print("Printing traces for debugging purposes:")
     pp = pprint.PrettyPrinter(indent=2)
     for block_number, block in enumerate(traces):

--- a/src/ethereum_test_tools/spec/state_test.py
+++ b/src/ethereum_test_tools/spec/state_test.py
@@ -3,7 +3,16 @@ State test filler.
 """
 import tempfile
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, Generator, List, Mapping, Tuple
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generator,
+    List,
+    Mapping,
+    Optional,
+    Tuple,
+)
 
 from evm_block_builder import BlockBuilder
 from evm_transition_tool import TransitionTool
@@ -84,6 +93,7 @@ class StateTest(BaseTest):
         fork: str,
         chain_id=1,
         reward=0,
+        eips: Optional[List[int]] = None,
     ) -> Tuple[List[FixtureBlock], str, Dict[str, Any]]:
         """
         Create a block from the state test definition.
@@ -100,9 +110,10 @@ class StateTest(BaseTest):
                 to_json(self.txs),
                 to_json(env),
                 fork,
-                txsPath=txs_rlp_file.name,
+                txs_path=txs_rlp_file.name,
                 chain_id=chain_id,
                 reward=reward,
+                eips=eips,
             )
             txs_rlp = txs_rlp_file.read().decode().strip('"')
 

--- a/src/ethereum_test_tools/spec/state_test.py
+++ b/src/ethereum_test_tools/spec/state_test.py
@@ -27,12 +27,8 @@ from ..common import (
     to_json,
 )
 from ..vm import set_fork_requirements
-from .base_test import (
-    BaseTest,
-    print_traces,
-    verify_post_alloc,
-    verify_transactions,
-)
+from .base_test import BaseTest, verify_post_alloc, verify_transactions
+from .debugging import print_traces
 
 
 @dataclass(kw_only=True)

--- a/src/ethereum_test_tools/spec/state_test.py
+++ b/src/ethereum_test_tools/spec/state_test.py
@@ -104,7 +104,7 @@ class StateTest(BaseTest):
 
         env = set_fork_requirements(env, fork)
 
-        (alloc, result, txs_rlp, traces) = t8n.evaluate(
+        (alloc, result, txs_rlp) = t8n.evaluate(
             to_json(self.pre),
             to_json(self.txs),
             to_json(env),
@@ -126,7 +126,7 @@ class StateTest(BaseTest):
         try:
             verify_post_alloc(self.post, alloc)
         except Exception as e:
-            print_traces(traces=[traces])
+            print_traces(traces=t8n.get_traces())
             raise e
 
         header = FixtureHeader.from_dict(

--- a/src/evm_transition_tool/__init__.py
+++ b/src/evm_transition_tool/__init__.py
@@ -27,7 +27,7 @@ class TransitionTool:
         chain_id: int = 1,
         reward: int = 0,
         eips: Optional[List[int]] = None,
-    ) -> Tuple[Dict[str, Any], Dict[str, Any], str, List[Dict]]:
+    ) -> Tuple[Dict[str, Any], Dict[str, Any], str, List[List[Dict]]]:
         """
         Simulate a state transition with specified parameters
         """
@@ -95,7 +95,7 @@ class EvmTransitionTool(TransitionTool):
         chain_id: int = 1,
         reward: int = 0,
         eips: Optional[List[int]] = None,
-    ) -> Tuple[Dict[str, Any], Dict[str, Any], str, List[Dict]]:
+    ) -> Tuple[Dict[str, Any], Dict[str, Any], str, List[List[Dict]]]:
         """
         Executes `evm t8n` with the specified arguments.
         """
@@ -146,16 +146,17 @@ class EvmTransitionTool(TransitionTool):
             txs_rlp = txs_rlp_file.read().strip('"')
 
         receipts: List[Any] = output["result"]["receipts"]
-        traces: List[Dict] = []
+        traces: List[List[Dict]] = []
         for i, r in enumerate(receipts):
             h = r["transactionHash"]
             trace_file_name = f"trace-{i}-{h}.jsonl"
             with open(
                 os.path.join(tmp_dir.name, trace_file_name), "r"
             ) as trace_jsonl_file:
-
+                tx_traces: List[Dict] = []
                 for trace_line in trace_jsonl_file.readlines():
-                    traces.append(json.loads(trace_line))
+                    tx_traces.append(json.loads(trace_line))
+                traces.append(tx_traces)
 
         tmp_dir.cleanup()
 

--- a/src/evm_transition_tool/__init__.py
+++ b/src/evm_transition_tool/__init__.py
@@ -7,7 +7,7 @@ import subprocess
 from abc import abstractmethod
 from pathlib import Path
 from shutil import which
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 
 class TransitionTool:
@@ -24,7 +24,8 @@ class TransitionTool:
         fork: str,
         chain_id: int = 1,
         reward: int = 0,
-        txsPath: Optional[str] = None,
+        txs_path: Optional[str] = None,
+        eips: Optional[List[int]] = None,
     ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
         """
         Simulate a state transition with specified parameters
@@ -92,11 +93,14 @@ class EvmTransitionTool(TransitionTool):
         fork: str,
         chain_id: int = 1,
         reward: int = 0,
-        txsPath: Optional[str] = None,
+        txs_path: Optional[str] = None,
+        eips: Optional[List[int]] = None,
     ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
         """
         Executes `evm t8n` with the specified arguments.
         """
+        if eips is not None:
+            fork = "+".join([fork] + [str(eip) for eip in eips])
         args = [
             str(self.binary),
             "t8n",
@@ -110,8 +114,8 @@ class EvmTransitionTool(TransitionTool):
             f"--state.reward={reward}",
         ]
 
-        if txsPath is not None:
-            args.append(f"--output.body={txsPath}")
+        if txs_path is not None:
+            args.append(f"--output.body={txs_path}")
 
         stdin = {
             "alloc": alloc,

--- a/src/evm_transition_tool/__init__.py
+++ b/src/evm_transition_tool/__init__.py
@@ -102,7 +102,7 @@ class EvmTransitionTool(TransitionTool):
         if eips is not None:
             fork = "+".join([fork] + [str(eip) for eip in eips])
 
-        tmp_dir = tempfile.TemporaryDirectory()
+        temp_dir = tempfile.TemporaryDirectory()
 
         args = [
             str(self.binary),
@@ -113,7 +113,7 @@ class EvmTransitionTool(TransitionTool):
             "--output.result=stdout",
             "--output.alloc=stdout",
             "--output.body=txs.rlp",
-            f"--output.basedir={tmp_dir.name}",
+            f"--output.basedir={temp_dir.name}",
             f"--state.fork={fork}",
             f"--state.chainid={chain_id}",
             f"--state.reward={reward}",
@@ -142,7 +142,7 @@ class EvmTransitionTool(TransitionTool):
         if "alloc" not in output or "result" not in output:
             raise Exception("malformed result")
 
-        with open(os.path.join(tmp_dir.name, "txs.rlp"), "r") as txs_rlp_file:
+        with open(os.path.join(temp_dir.name, "txs.rlp"), "r") as txs_rlp_file:
             txs_rlp = txs_rlp_file.read().strip('"')
 
         receipts: List[Any] = output["result"]["receipts"]
@@ -151,14 +151,14 @@ class EvmTransitionTool(TransitionTool):
             h = r["transactionHash"]
             trace_file_name = f"trace-{i}-{h}.jsonl"
             with open(
-                os.path.join(tmp_dir.name, trace_file_name), "r"
-            ) as trace_jsonl_file:
+                os.path.join(temp_dir.name, trace_file_name), "r"
+            ) as trace_file:
                 tx_traces: List[Dict] = []
-                for trace_line in trace_jsonl_file.readlines():
+                for trace_line in trace_file.readlines():
                     tx_traces.append(json.loads(trace_line))
                 traces.append(tx_traces)
 
-        tmp_dir.cleanup()
+        temp_dir.cleanup()
 
         return (output["alloc"], output["result"], txs_rlp, traces)
 

--- a/src/evm_transition_tool/tests/test_evaluate.py
+++ b/src/evm_transition_tool/tests/test_evaluate.py
@@ -97,7 +97,7 @@ def test_evm_t8n(t8n: TransitionTool, test_dir: str) -> None:
         env = json.load(env)
         expected = json.load(exp)
 
-        (result_alloc, result) = t8n.evaluate(alloc, txs, env, "Berlin")
+        (result_alloc, result, _, _) = t8n.evaluate(alloc, txs, env, "Berlin")
         print(result)
         assert result_alloc == expected.get("alloc")
         assert result == expected.get("result")

--- a/src/evm_transition_tool/tests/test_evaluate.py
+++ b/src/evm_transition_tool/tests/test_evaluate.py
@@ -97,7 +97,7 @@ def test_evm_t8n(t8n: TransitionTool, test_dir: str) -> None:
         env = json.load(env)
         expected = json.load(exp)
 
-        (result_alloc, result, _, _) = t8n.evaluate(alloc, txs, env, "Berlin")
+        (result_alloc, result, _) = t8n.evaluate(alloc, txs, env, "Berlin")
         print(result)
         assert result_alloc == expected.get("alloc")
         assert result == expected.get("result")

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -127,6 +127,7 @@ push
 dup
 log
 
+push0
 push1
 push2
 push3

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -12,6 +12,8 @@ calc
 coinbase
 crypto
 dao
+eip
+eips
 eth
 ethash
 ethereum


### PR DESCRIPTION
## Changes Included
- Adds EIPs support for a test to specify extra EIPs used to call the transition tool
- When a test fails during the filling phase, now the full traces are printed
- Include a gas measuring helper, to easily create tests that expect a certain amount of gas usage on a code excerpt
- Add custom exception types, to better catch specific types of errors