### PR TITLE
Chore: Add coverage to framework tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ console_scripts =
 [options.extras_require]
 test =
     pytest>=7.2
-    pytest-cov>=2.12,<3
+    pytest-cov>=4.0.0,<5
     pytest-xdist>=2.3.0,<3
 
 lint =

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,10 @@
 [tox]
-envlist = py3
+envlist = py3, report, clean
 
 [testenv]
+deps = 
+    pytest
+    pytest-cov
 extras =
     test
     lint
@@ -10,4 +13,18 @@ commands =
     black src fillers setup.py --check --diff
     flake8 src fillers setup.py
     mypy src fillers setup.py
-    pytest ./src/ -n auto
+    pytest ./src/ -n auto --cov --cov-append --cov-report=term-missing
+
+[testenv:report]
+deps = coverage
+skip_install = true
+commands =
+    coverage report
+    coverage html
+
+[testenv:clean]
+deps = coverage
+skip_install = true
+commands = 
+    coverage erase
+# TODO: consider adding `rm -rf htmlcov`


### PR DESCRIPTION
This PR uses `pytest-cov`/`coverage` to add test coverage reporting to the tox pytest test run of the framework tests.

Just a suggestion, perhaps there's a reason why coverage hasn't been added.

tox commands:
- `tox -e py3` runs as before but also generates a coverage report and outputs it in the console. The console output is rather verbose, it could be toned down a little.
- `tox -e report` (new) generates an html coverage report in `./htmlcov`.
- `tox -e clean` (new) runs `coverage erase` to delete the local coverage report `.coverage`. Currently, it doesn't delete the html report in the `./htmlcov` directory; this could still be added.