### PR TITLE
Update Shanghai tests to use solely fork name instead of EIP numbers.

### DIFF
--- a/fillers/eips/eip3651.py
+++ b/fillers/eips/eip3651.py
@@ -155,7 +155,7 @@ def test_warm_coinbase_call_out_of_gas(fork):
         yield StateTest(env=env, pre=pre, post=post, txs=[tx])
 
 
-@test_from(fork="merged")
+@test_from(fork="shanghai")
 def test_warm_coinbase_gas_usage(fork):
     """
     Test gas usage of different opcodes assuming warm coinbase.

--- a/fillers/eips/eip3651.py
+++ b/fillers/eips/eip3651.py
@@ -21,7 +21,7 @@ from ethereum_test_tools import (
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 
-@test_from(fork="merged")
+@test_from(fork="shanghai")
 def test_warm_coinbase_call_out_of_gas(fork):
     """
     Test warm coinbase.

--- a/fillers/eips/eip3855.py
+++ b/fillers/eips/eip3855.py
@@ -18,7 +18,7 @@ from ethereum_test_tools import (
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 
-@test_from(fork="shanghai", eips=[3855])
+@test_from(fork="shanghai")
 def test_push0(fork):
     """
     Test push0 opcode.

--- a/fillers/eips/eip3860.py
+++ b/fillers/eips/eip3860.py
@@ -229,7 +229,7 @@ def generate_tx_initcode_limit_test_cases(
     )
 
 
-@test_from(fork="shanghai", eips=[3860])
+@test_from(fork="shanghai")
 def test_initcode_limit_contract_creating_tx(fork):
     """
     Test creating a contract using a transaction using an initcode that is
@@ -392,7 +392,7 @@ def generate_gas_cost_test_cases(
     )
 
 
-@test_from(fork="shanghai", eips=[3860])
+@test_from(fork="shanghai")
 def test_initcode_limit_contract_creating_tx_gas_usage(fork):
     """
     Test EIP-3860 Limit Initcode Gas Usage for a contract
@@ -570,7 +570,7 @@ def generate_create_opcode_initcode_test_cases(
     )
 
 
-@test_from(fork="shanghai", eips=[3860])
+@test_from(fork="shanghai")
 def test_initcode_limit_create_opcode(fork):
     """
     Test creating a contract using the CREATE opcode with an initcode that is
@@ -637,7 +637,7 @@ def test_initcode_limit_create_opcode(fork):
     )
 
 
-@test_from(fork="shanghai", eips=[3860])
+@test_from(fork="shanghai")
 def test_initcode_limit_create2_opcode(fork):
     """
     Test creating a contract using the CREATE2 opcode with an initcode that is


### PR DESCRIPTION
Small change: update '(eip3651, eip3855, eip3860).py' to use the Shanghai fork name solely as opposed to using EIP numbers. 'withdrawals.py' already adheres to the latter.

eip3651 - is updated from 'merged' to 'shanghai' fork? @marioevz 

