### PR TITLE
fillers/eips/eip3860: Update EIP-3860 Due to Small Spec Change

### DIFF
--- a/fillers/eips/eip3860.py
+++ b/fillers/eips/eip3860.py
@@ -460,8 +460,7 @@ def generate_create_opcode_initcode_test_cases(
     call_code = Yul(
         """
         {
-            let initdata := calldataload(0)
-            mstore(0, initdata)
+            calldatacopy(0, 0, calldatasize())
             let call_result := call(10000000, \
                 0x0000000000000000000000000000000000000100, \
                 0, 0, calldatasize(), 0, 0)

--- a/fillers/eips/eip3860.py
+++ b/fillers/eips/eip3860.py
@@ -495,11 +495,7 @@ def generate_create_opcode_initcode_test_cases(
                 let contract_length := calldatasize()
                 calldatacopy(0, 0, contract_length)
                 let gas1 := gas()
-<<<<<<< HEAD
                 let res := create2(0, 0, contract_length, 0xDEADBEEF)
-=======
-                let res := create2(0, 0, contract_length, 0xdeadbeef)
->>>>>>> 5d350d8 (fillers/eips: add salt to create2 contract creation (#20))
                 let gas2 := gas()
                 sstore(0, res)
                 sstore(1, sub(gas1, gas2))

--- a/fillers/eips/eip3860.py
+++ b/fillers/eips/eip3860.py
@@ -483,7 +483,7 @@ def generate_create_opcode_initcode_test_cases(
                 let contract_length := calldatasize()
                 calldatacopy(0, 0, contract_length)
                 let gas1 := gas()
-                let res := create2(0, 0, contract_length, 0)
+                let res := create2(0, 0, contract_length, 0xDEADBEEF)
                 let gas2 := gas()
                 sstore(0, res)
                 sstore(1, sub(gas1, gas2))
@@ -492,7 +492,7 @@ def generate_create_opcode_initcode_test_cases(
         )
         created_contract_address = compute_create2_address(
             address=0x100,
-            salt=0xdeadbeef,
+            salt=0xDEADBEEF,
             initcode=initcode.assemble(),
         )
     else:

--- a/fillers/eips/eip3860.py
+++ b/fillers/eips/eip3860.py
@@ -492,7 +492,7 @@ def generate_create_opcode_initcode_test_cases(
         )
         created_contract_address = compute_create2_address(
             address=0x100,
-            salt=0,
+            salt=0xdeadbeef,
             initcode=initcode.assemble(),
         )
     else:
@@ -525,13 +525,14 @@ def generate_create_opcode_initcode_test_cases(
         expected_gas_usage += PUSH_DUP_OPCODE_GAS
 
     if len(initcode.assemble()) > MAX_INITCODE_SIZE and eip_3860_active:
-        # Exceptionally aborts: gas usage set to 0
+        # Gas "runs out" due to exceptionally abort
+        expected_gas_usage = 0
         post[created_contract_address] = Account.NONEXISTENT
         post[to_address(0x100)] = Account(
             nonce=1,
             storage={
                 0: 0,
-                1: 0,
+                1: expected_gas_usage,
             },
         )
     else:

--- a/fillers/eips/eip3860.py
+++ b/fillers/eips/eip3860.py
@@ -495,7 +495,11 @@ def generate_create_opcode_initcode_test_cases(
                 let contract_length := calldatasize()
                 calldatacopy(0, 0, contract_length)
                 let gas1 := gas()
+<<<<<<< HEAD
                 let res := create2(0, 0, contract_length, 0xDEADBEEF)
+=======
+                let res := create2(0, 0, contract_length, 0xdeadbeef)
+>>>>>>> 5d350d8 (fillers/eips: add salt to create2 contract creation (#20))
                 let gas2 := gas()
                 sstore(0, res)
                 sstore(1, sub(gas1, gas2))

--- a/fillers/eips/eip3860.py
+++ b/fillers/eips/eip3860.py
@@ -457,6 +457,19 @@ def generate_create_opcode_initcode_test_cases(
     """
     env = Environment()
 
+    call_code = Yul(
+        """
+        {
+            let initdata := calldataload(0)
+            mstore(0, initdata)
+            let call_result := call(10000000, \
+                0x0000000000000000000000000000000000000100, \
+                0, 0, calldatasize(), 0, 0)
+            sstore(0, call_result)
+        }
+        """
+    )
+
     if opcode == "create":
         code = Yul(
             """
@@ -495,6 +508,7 @@ def generate_create_opcode_initcode_test_cases(
             salt=0xDEADBEEF,
             initcode=initcode.assemble(),
         )
+
     else:
         raise Exception("invalid opcode for generator")
 
@@ -504,13 +518,17 @@ def generate_create_opcode_initcode_test_cases(
             code=code,
             nonce=1,
         ),
+        to_address(0x200): Account(
+            code=call_code,
+            nonce=1,
+        ),
     }
 
     post: Dict[Any, Any] = {}
 
     tx = Transaction(
         nonce=0,
-        to=to_address(0x100),
+        to=to_address(0x200),
         data=initcode,
         gas_limit=10000000,
         gas_price=10,
@@ -525,16 +543,23 @@ def generate_create_opcode_initcode_test_cases(
         expected_gas_usage += PUSH_DUP_OPCODE_GAS
 
     if len(initcode.assemble()) > MAX_INITCODE_SIZE and eip_3860_active:
-        # Gas "runs out" due to exceptionally abort
-        expected_gas_usage = 0
-        post[created_contract_address] = Account.NONEXISTENT
-        post[to_address(0x100)] = Account(
+        # Call returns 0 as out of gas
+        post[to_address(0x200)] = Account(
             nonce=1,
             storage={
                 0: 0,
-                1: expected_gas_usage,
             },
         )
+
+        post[created_contract_address] = Account.NONEXISTENT
+        post[to_address(0x200)] = Account(
+            nonce=1,
+            storage={
+                0: 0,
+                1: 0,
+            },
+        )
+
     else:
         # The initcode is only executed if the length check succeeds
         expected_gas_usage += initcode.execution_gas
@@ -553,6 +578,14 @@ def generate_create_opcode_initcode_test_cases(
             expected_gas_usage += calculate_initcode_word_cost(
                 len(initcode.assemble())
             )
+
+        # Call returns 1 as valid initcode length
+        post[to_address(0x200)] = Account(
+            nonce=1,
+            storage={
+                0: 1,
+            },
+        )
 
         post[created_contract_address] = Account(code=initcode.deploy_code)
         post[to_address(0x100)] = Account(

--- a/fillers/eips/eip3860.py
+++ b/fillers/eips/eip3860.py
@@ -525,12 +525,13 @@ def generate_create_opcode_initcode_test_cases(
         expected_gas_usage += PUSH_DUP_OPCODE_GAS
 
     if len(initcode.assemble()) > MAX_INITCODE_SIZE and eip_3860_active:
+        # Exceptionally aborts: gas usage set to 0
         post[created_contract_address] = Account.NONEXISTENT
         post[to_address(0x100)] = Account(
             nonce=1,
             storage={
                 0: 0,
-                1: expected_gas_usage,
+                1: 0,
             },
         )
     else:

--- a/src/ethereum_test_tools/tests/test_helpers.py
+++ b/src/ethereum_test_tools/tests/test_helpers.py
@@ -2,7 +2,13 @@
 Test suite for `ethereum_test.helpers` module.
 """
 
-from ..common import to_address
+import pytest
+
+from ..common import (
+    compute_create2_address,
+    compute_create_address,
+    to_address,
+)
 
 
 def test_to_address():
@@ -17,4 +23,128 @@ def test_to_address():
     assert (
         to_address(2 ** (20 * 8) - 1)
         == "0xffffffffffffffffffffffffffffffffffffffff"
+    )
+
+
+@pytest.mark.parametrize(
+    "address,nonce,expected_contract_address",
+    [
+        pytest.param(
+            "0x00caa64684700d2825da7cac6ba0c6ed9fd2a1bb",
+            0,
+            "0x863df6bfa4469f3ead0be8f9f2aae51c91a907b4",
+            id="zero-nonce-0x-str-address",
+        ),
+        pytest.param(
+            "00caa64684700d2825da7cac6ba0c6ed9fd2a1bb",
+            0,
+            "0x863df6bfa4469f3ead0be8f9f2aae51c91a907b4",
+            id="zero-nonce-str-address",
+        ),
+        pytest.param(
+            int("0x00caa64684700d2825da7cac6ba0c6ed9fd2a1bb", 16),
+            0,
+            "0x863df6bfa4469f3ead0be8f9f2aae51c91a907b4",
+            id="zero-nonce-int-address",
+        ),
+        pytest.param(
+            "0x9c33eacc2f50e39940d3afaf2c7b8246b681a374",
+            3,
+            "0x7a250d5630b4cf539739df2c5dacb4c659f2488d",
+            id="non-zero-nonce-0x-str-address",
+        ),
+        pytest.param(
+            "0xba52c75764d6f594735dc735be7f1830cdf58ddf",
+            3515,
+            "0x06012c8cf97bead5deae237070f9587f8e7a266d",
+            id="large-nonce-0x-str-address",
+            marks=pytest.mark.xfail(
+                reason="Nonce too large to convert with hard-coded to_bytes "
+                "length of 1"
+            ),
+        ),
+    ],
+)
+def test_compute_create_address(
+    address: str | int, nonce: int, expected_contract_address: str
+):
+    """
+    Test `ethereum_test.helpers.compute_create_address` with some famous
+    contracts:
+    - https://etherscan.io/address/0x863df6bfa4469f3ead0be8f9f2aae51c91a907b4
+    - https://etherscan.io/address/0x7a250d5630b4cf539739df2c5dacb4c659f2488d
+    - https://etherscan.io/address/0x06012c8cf97bead5deae237070f9587f8e7a266d
+
+    """
+    assert compute_create_address(address, nonce) == expected_contract_address
+
+
+@pytest.mark.parametrize(
+    "address,salt,initcode,expected_contract_address",
+    [
+        pytest.param(
+            "0x0000000000000000000000000000000000000000",
+            "0x0000000000000000000000000000000000000000",
+            "0x00",
+            "0x4d1a2e2bb4f88f0250f26ffff098b0b30b26bf38",
+        ),
+        pytest.param(
+            "0xdeadbeef00000000000000000000000000000000",
+            "0x0000000000000000000000000000000000000000",
+            "0x00",
+            "0xB928f69Bb1D91Cd65274e3c79d8986362984fDA3",
+        ),
+        pytest.param(
+            "0xdeadbeef00000000000000000000000000000000",
+            "0xfeed000000000000000000000000000000000000",
+            "0x00",
+            "0xD04116cDd17beBE565EB2422F2497E06cC1C9833",
+        ),
+        pytest.param(
+            "0x0000000000000000000000000000000000000000",
+            "0x0000000000000000000000000000000000000000",
+            "0xdeadbeef",
+            "0x70f2b2914A2a4b783FaEFb75f459A580616Fcb5e",
+        ),
+        pytest.param(
+            "0x00000000000000000000000000000000deadbeef",
+            "0xcafebabe",
+            "0xdeadbeef",
+            "0x60f3f640a8508fC6a86d45DF051962668E1e8AC7",
+        ),
+        pytest.param(
+            "0x00000000000000000000000000000000deadbeef",
+            "0xcafebabe",
+            (
+                "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+                "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+            ),
+            "0x1d8bfDC5D46DC4f61D6b6115972536eBE6A8854C",
+        ),
+        pytest.param(
+            "0x0000000000000000000000000000000000000000",
+            "0x0000000000000000000000000000000000000000",
+            "0x",
+            "0xE33C0C7F7df4809055C3ebA6c09CFe4BaF1BD9e0",
+        ),
+    ],
+)
+def test_compute_create2_address(
+    address: str | int,
+    salt: str,
+    initcode: str,
+    expected_contract_address: str,
+):
+    """
+    Test `ethereum_test.helpers.compute_create2_address` using the CREATE2 geth
+    test cases from:
+    https://github.com/ethereum/go-ethereum/blob/2189773093b2fe6d161b6477589f964470ff5bce/core/vm/instructions_test.go
+
+    Note: `compute_create2_address` does not generate checksum addresses; s
+    """
+    salt_as_int = int(salt, 16)
+    initcode_as_bytes = bytes.fromhex(initcode[2:])
+    assert (
+        compute_create2_address(address, salt_as_int, initcode_as_bytes)
+        == expected_contract_address.lower()
     )


### PR DESCRIPTION
Currently if there is an initcode length violation for 'CREATE'/'CREATE2' the gas for the initcode execution is not deducted but stored. In the new spec change here -> [link](https://github.com/ethereum/EIPs/pull/6249) the evm exceptionally aborts as if it runs out of gas. A small fix is added to achieve the latter.

Another small change is added to match the salt addition here -> ([link](https://github.com/ethereum/execution-spec-tests/pull/20/commits/8cd2b0356a6959881c1a433b8fc0fb86152c1efa))

