### PR TITLE
fillers/eips/eip3860: Update EIP-3860 Due to Spec Change

### DIFF
--- a/fillers/eips/eip3860.py
+++ b/fillers/eips/eip3860.py
@@ -460,8 +460,7 @@ def generate_create_opcode_initcode_test_cases(
     call_code = Yul(
         """
         {
-            let initdata := calldataload(0)
-            mstore(0, initdata)
+            calldatacopy(0, 0, calldatasize())
             let call_result := call(10000000, \
                 0x0000000000000000000000000000000000000100, \
                 0, 0, calldatasize(), 0, 0)

--- a/fillers/eips/eip3860.py
+++ b/fillers/eips/eip3860.py
@@ -495,11 +495,7 @@ def generate_create_opcode_initcode_test_cases(
                 let contract_length := calldatasize()
                 calldatacopy(0, 0, contract_length)
                 let gas1 := gas()
-<<<<<<< HEAD
                 let res := create2(0, 0, contract_length, 0xDEADBEEF)
-=======
-                let res := create2(0, 0, contract_length, 0xdeadbeef)
->>>>>>> 5d350d8 (fillers/eips: add salt to create2 contract creation (#20))
                 let gas2 := gas()
                 sstore(0, res)
                 sstore(1, sub(gas1, gas2))

--- a/fillers/eips/eip3860.py
+++ b/fillers/eips/eip3860.py
@@ -461,10 +461,11 @@ def generate_create_opcode_initcode_test_cases(
         """
         {
             calldatacopy(0, 0, calldatasize())
-            let call_result := call(10000000, \
+            let call_result := call(5000000, \
                 0x0000000000000000000000000000000000000100, \
                 0, 0, calldatasize(), 0, 0)
             sstore(0, call_result)
+            sstore(call_result, 1)
         }
         """
     )
@@ -542,16 +543,16 @@ def generate_create_opcode_initcode_test_cases(
         expected_gas_usage += PUSH_DUP_OPCODE_GAS
 
     if len(initcode.assemble()) > MAX_INITCODE_SIZE and eip_3860_active:
-        # Call returns 0 as out of gas
+        # Call returns 0 as out of gas s[0]==1
         post[to_address(0x200)] = Account(
             nonce=1,
             storage={
-                0: 0,
+                0: 1,
             },
         )
 
         post[created_contract_address] = Account.NONEXISTENT
-        post[to_address(0x200)] = Account(
+        post[to_address(0x100)] = Account(
             nonce=1,
             storage={
                 0: 0,
@@ -578,11 +579,12 @@ def generate_create_opcode_initcode_test_cases(
                 len(initcode.assemble())
             )
 
-        # Call returns 1 as valid initcode length
+        # Call returns 1 as valid initcode length s[0]==1 && s[1]==1
         post[to_address(0x200)] = Account(
             nonce=1,
             storage={
                 0: 1,
+                1: 1,
             },
         )
 

--- a/fillers/eips/eip3860.py
+++ b/fillers/eips/eip3860.py
@@ -464,7 +464,6 @@ def generate_create_opcode_initcode_test_cases(
             let call_result := call(5000000, \
                 0x0000000000000000000000000000000000000100, \
                 0, 0, calldatasize(), 0, 0)
-            sstore(0, call_result)
             sstore(call_result, 1)
         }
         """
@@ -548,6 +547,7 @@ def generate_create_opcode_initcode_test_cases(
             nonce=1,
             storage={
                 0: 1,
+                1: 0,
             },
         )
 
@@ -583,7 +583,7 @@ def generate_create_opcode_initcode_test_cases(
         post[to_address(0x200)] = Account(
             nonce=1,
             storage={
-                0: 1,
+                0: 0,
                 1: 1,
             },
         )

--- a/fillers/eips/eip3860.py
+++ b/fillers/eips/eip3860.py
@@ -492,7 +492,7 @@ def generate_create_opcode_initcode_test_cases(
         )
         created_contract_address = compute_create2_address(
             address=0x100,
-            salt=0,
+            salt=0xdeadbeef,
             initcode=initcode.assemble(),
         )
     else:
@@ -525,13 +525,14 @@ def generate_create_opcode_initcode_test_cases(
         expected_gas_usage += PUSH_DUP_OPCODE_GAS
 
     if len(initcode.assemble()) > MAX_INITCODE_SIZE and eip_3860_active:
-        # Exceptionally aborts: gas usage set to 0
+        # Gas "runs out" due to exceptionally abort
+        expected_gas_usage = 0
         post[created_contract_address] = Account.NONEXISTENT
         post[to_address(0x100)] = Account(
             nonce=1,
             storage={
                 0: 0,
-                1: 0,
+                1: expected_gas_usage,
             },
         )
     else:

--- a/fillers/eips/eip3860.py
+++ b/fillers/eips/eip3860.py
@@ -495,7 +495,11 @@ def generate_create_opcode_initcode_test_cases(
                 let contract_length := calldatasize()
                 calldatacopy(0, 0, contract_length)
                 let gas1 := gas()
+<<<<<<< HEAD
                 let res := create2(0, 0, contract_length, 0xDEADBEEF)
+=======
+                let res := create2(0, 0, contract_length, 0xdeadbeef)
+>>>>>>> 5d350d8 (fillers/eips: add salt to create2 contract creation (#20))
                 let gas2 := gas()
                 sstore(0, res)
                 sstore(1, sub(gas1, gas2))

--- a/fillers/eips/eip3860.py
+++ b/fillers/eips/eip3860.py
@@ -495,11 +495,7 @@ def generate_create_opcode_initcode_test_cases(
                 let contract_length := calldatasize()
                 calldatacopy(0, 0, contract_length)
                 let gas1 := gas()
-<<<<<<< HEAD
-                let res := create2(0, 0, contract_length, 0xdeadbeef)
-=======
                 let res := create2(0, 0, contract_length, 0xDEADBEEF)
->>>>>>> 26a64f0 (Tox fix.)
                 let gas2 := gas()
                 sstore(0, res)
                 sstore(1, sub(gas1, gas2))

--- a/fillers/eips/eip3860.py
+++ b/fillers/eips/eip3860.py
@@ -483,7 +483,11 @@ def generate_create_opcode_initcode_test_cases(
                 let contract_length := calldatasize()
                 calldatacopy(0, 0, contract_length)
                 let gas1 := gas()
+<<<<<<< HEAD
                 let res := create2(0, 0, contract_length, 0xdeadbeef)
+=======
+                let res := create2(0, 0, contract_length, 0xDEADBEEF)
+>>>>>>> 26a64f0 (Tox fix.)
                 let gas2 := gas()
                 sstore(0, res)
                 sstore(1, sub(gas1, gas2))
@@ -492,7 +496,7 @@ def generate_create_opcode_initcode_test_cases(
         )
         created_contract_address = compute_create2_address(
             address=0x100,
-            salt=0xdeadbeef,
+            salt=0xDEADBEEF,
             initcode=initcode.assemble(),
         )
     else:

--- a/fillers/eips/eip3860.py
+++ b/fillers/eips/eip3860.py
@@ -525,12 +525,13 @@ def generate_create_opcode_initcode_test_cases(
         expected_gas_usage += PUSH_DUP_OPCODE_GAS
 
     if len(initcode.assemble()) > MAX_INITCODE_SIZE and eip_3860_active:
+        # Exceptionally aborts: gas usage set to 0
         post[created_contract_address] = Account.NONEXISTENT
         post[to_address(0x100)] = Account(
             nonce=1,
             storage={
                 0: 0,
-                1: expected_gas_usage,
+                1: 0,
             },
         )
     else:


### PR DESCRIPTION
Currently if there is an initcode length violation for 'CREATE'/'CREATE2' the gas for the initcode execution is not deducted but stored. In the new spec change here -> https://github.com/ethereum/EIPs/pull/6249 the evm exceptionally aborts as if it runs out of gas. A small fix is added to achieve the latter.