### PR TITLE
Fix rlp for blocks with no withdrawals.

### DIFF
--- a/src/ethereum_test_tools/spec/blockchain_test.py
+++ b/src/ethereum_test_tools/spec/blockchain_test.py
@@ -184,7 +184,7 @@ class BlockchainTest(BaseTest):
                 header=header.to_geth_dict(),
                 txs=txs_rlp,
                 ommers=[],
-                withdrawals=to_json_or_none(block.withdrawals),
+                withdrawals=to_json_or_none(env.withdrawals),
             )
 
             if block.exception is None:


### PR DESCRIPTION
Regarding https://github.com/ethereum/execution-spec-tests/issues/36

It looks like before RLP serialization for blocks:

![image](https://user-images.githubusercontent.com/60348173/213814559-e9d59685-4df6-401f-88f9-cf95fcd68532.png)

the `Block` class (block) doesn't set withdrawals to the empty list `[ ]` for Shanghai, and instead this remains as a None type. This 

This PR contains one solution to the latter. As withdrawals are within the Environment class, and it is updated according to the fork type before RLP serialization:

![image](https://user-images.githubusercontent.com/60348173/213816155-926a7c62-94af-49c1-8f43-b9737274282e.png)

we can use it instead, as the withdrawals None type here is set to the empty list `[ ]` within `set_fork_requirements`.