### PR TITLE
Split withdrawals test

### DIFF
--- a/fillers/withdrawals/withdrawals.py
+++ b/fillers/withdrawals/withdrawals.py
@@ -89,7 +89,12 @@ def test_withdrawals_use_value_in_tx(_):
                 withdrawal,
             ],
             exception="Transaction without funds",
-        ),
+        )
+    ]
+
+    yield BlockchainTest(pre=pre, post={}, blocks=blocks)
+
+    blocks = [
         Block(
             txs=[],
             withdrawals=[


### PR DESCRIPTION
This splits the test `test_withdrawals_use_value_in_tx` into two. One is the invalid case when a withdrawal is used in the same block and the other is the invalid case when a withdrawal is used in the next block.

This makes the test comply with the requirement proposed in #41.