### PR TITLE
Additional Tox Checks: pep8-naming and fname8 for correct python naming conventions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ package_dir =
 python_requires = >=3.10
 
 install_requires =
-    ethereum@git+https://github.com/ethereum/execution-specs.git
+    ethereum@git+https://github.com/spencer-tb/execution-specs.git@exec-spec-tests-tox
     setuptools==58.3.0
     types-setuptools==57.4.4
 
@@ -51,27 +51,30 @@ lint =
     black==22.3.0; implementation_name == "cpython"
     flake8-spellcheck>=0.24,<0.25
     flake8-docstrings>=1.6,<2
-    flake8>=3.9,<4
+    flake8>=5,<=6
+    pep8-naming==0.13.3
 
 [flake8]
 dictionaries=en_US,python,technical
 docstring-convention = all
-extend-ignore =
-    E203    # Ignore: Whitespace before ':'
-    D107    # Ignore: Missing docstring in __init__
-    D200    # Ignore: One-line docstring should fit on one line with quotes
-    D203    # Ignore: 1 blank line required before class docstring
-    D205    # Ignore: blank line required between summary line and description
-    D212    # Ignore: Multi-line docstring summary should start at the first line
-    D400    # Ignore: First line should end with a period
-    D401    # Ignore: First line should be in imperative mood
-    D410    # Ignore: Missing blank line after section
-    D411    # Ignore: Missing blank line before section
-    D412    # Ignore: No blank lines allowed between a section header and its content
-    D413    # Ignore: Missing blank line after last section
-    D414    # Ignore: Section has no content
-    D415    # Ignore: First line should end with a period, question mark, or exclamation point
-    D416    # Ignore: Section name should end with a colon
+extend-ignore = E203, D107, D200, D203, D205,
+    D212, D400, D401, D410, D411, D412, D413,
+    D414, D415, D416, N806 
+    # Ignore E203: Whitespace before ':'
+    # Ignore D107: Missing docstring in __init__
+    # Ignore D200: One-line docstring should fit on one line with quotes
+    # Ignore D203: 1 blank line required before class docstring
+    # Ignore D205: blank line required between summary line and description
+    # Ignore D212: Multi-line docstring summary should start at the first line
+    # Ignore D400: First line should end with a period
+    # Ignore D401: First line should be in imperative mood
+    # Ignore D410: Missing blank line after section
+    # Ignore D411: Missing blank line before section
+    # Ignore D412: No blank lines allowed between a section header and its content
+    # Ignore D413: Missing blank line after last section
+    # Ignore D414: Section has no content
+    # Ignore D415: First line should end with a period, question mark, or exclamation point
+    # Ignore D416: Section name should end with a colon
 per-file-ignore =
     tests/evm_transition_tool/test_evaluate.py:E501
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ package_dir =
 python_requires = >=3.10
 
 install_requires =
-    ethereum@git+https://github.com/spencer-tb/execution-specs.git@exec-spec-tests-tox
+    ethereum@git+https://github.com/ethereum/execution-specs.git
     setuptools==58.3.0
     types-setuptools==57.4.4
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,6 +76,7 @@ extend-ignore = E203, D107, D200, D203, D205,
     # Ignore D414: Section has no content
     # Ignore D415: First line should end with a period, question mark, or exclamation point
     # Ignore D416: Section name should end with a colon
+    # Ignore N806: Variable names with all caps (ALL_CAPS)
 per-file-ignore =
     tests/evm_transition_tool/test_evaluate.py:E501
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ lint =
     flake8-docstrings>=1.6,<2
     flake8>=5,<=6
     pep8-naming==0.13.3
+    fname8>=0.0.3
 
 [flake8]
 dictionaries=en_US,python,technical

--- a/src/evm_block_builder/__init__.py
+++ b/src/evm_block_builder/__init__.py
@@ -24,7 +24,7 @@ class BlockBuilder:
         withdrawals: Optional[Any] = None,
         clique: Optional[Any] = None,
         ethash: bool = False,
-        ethashMode: str = "normal",
+        ethash_mode: str = "normal",
     ) -> Tuple[str, str]:
         """
         Build a block with specified parameters and return RLP and hash
@@ -68,7 +68,7 @@ class EvmBlockBuilder(BlockBuilder):
         withdrawals: Optional[Any] = None,
         clique: Optional[Any] = None,
         ethash: bool = False,
-        ethashMode: str = "normal",
+        ethash_mode: str = "normal",
     ) -> Tuple[str, str]:
         """
         Executes `evm b11r` with the specified arguments.
@@ -85,7 +85,7 @@ class EvmBlockBuilder(BlockBuilder):
 
         if ethash:
             args.append("--seal.ethash")
-            args.append("--seal.ethash.mode=" + ethashMode)
+            args.append("--seal.ethash.mode=" + ethash_mode)
 
         stdin = {
             "header": header,
@@ -118,7 +118,6 @@ class EvmBlockBuilder(BlockBuilder):
         Gets `evm` binary version.
         """
         if self.cached_version is None:
-
             result = subprocess.run(
                 [str(self.binary), "-v"],
                 stdout=subprocess.PIPE,

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ extras =
     test
     lint
 commands =
+    fname8 src fillers
     isort src fillers setup.py --check --diff
     black src fillers setup.py --check --diff
     flake8 src fillers setup.py


### PR DESCRIPTION
Some small additions to the tox pipeline to check that files are in accordance with [PEP8](https://peps.python.org/pep-0008/).

1) To make sure file names are correctly named I have added a custom name checking package `fname8`: this checks that python file names are of the type `[a-z0-9_]`, for example `test_python.py` or `eip1897.py` would pass but `testPython.py` or `eip-1897.py` would fail.

      ![image](https://user-images.githubusercontent.com/60348173/216458026-3617b6ed-2a04-46da-a395-4699326a698b.png)


2) As `flake8` doesn't report mixed-case function names, I have added `pep8-naming` which integrates directly with `flake8` as an extension. This also asserts that class/variable names are in accordance with PEP8. 

      ![image](https://user-images.githubusercontent.com/60348173/216457823-95264024-27f6-4ff5-8c6d-1355af394e20.png)




