### PR TITLE
Feature: Update `tf` to fill tests within subdirectories with depth > 1, change path defaults, add --no-structure option.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         python: ['3.10']
-        golang: [1.18]
+        golang: [1.19]
         solc: ['0.8.17']
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Ethereum tests. [Further documentation](https://execution-spec-tests.readthedocs
 
 The following are required to either generate or develop tests:
 
-1. Python `3.10.0`.
+1. Python >=`3.10.0`.
+   - For dists. with the `apt` package manager ensure you have python `-dev` & `-venv` packages installed.
 2. [`go-ethereum`](https://github.com/ethereum/go-ethereum) `geth`'s `evm` utility must be accessible in the `PATH`, typically at the latest version. To get it:
    1. Install [the Go programming language](https://go.dev/doc/install) on your computer.
    2. Clone [the Geth repository](https://github.com/ethereum/go-ethereum).
@@ -51,9 +52,14 @@ tf --output="fixtures"
 
 Note that the test `post` conditions are tested against the output of the `geth` `evm` utility during test generation.
 
-To generate all the tests in the `./fillers/vm` sub-directory (category), for example, run:
+To generate all the tests within the `./fillers/vm` directory (category), for example, run:
 ```console
 tf --output="fixtures" --test-categories vm
+```
+
+This extends to sub-directories. To generate all specific tests within the `./fillers/vm/vm_arith/vm_add` sub-directory, run:
+```console
+tf --output="fixtures" --test-categories vm/vm_arith/vm_add
 ```
 
 To generate all the tests in the `./fillers/*/dup.py` modules, for example, run:
@@ -156,6 +162,9 @@ A new test can be added by either:
   the new test function(s).
 - Creating an entirely new category by adding a subdirectory in
   `fillers` with the appropriate source files and test functions.
+    - Tests within multiple sub-directories must have a `__init__.py` file
+      within each directory above it (and it own), to ensure the test is found by the test filler `tf`.
+
 
 ### Test Spec Generator Functions
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ After the installation, run this sanity check to ensure tests are generated.
 If everything is OK, you will see the beginning of the JSON format filled test.
 
 ```console
-tf --output="fixtures" --test-case yul
+tf --test-case yul
 head fixtures/example/example/yul.json
 ```
 
@@ -47,14 +47,16 @@ head fixtures/example/example/yul.json
 To generate all the tests defined in the `./fillers` sub-directory, run the `tf` command:
 
 ```console
-tf --output="fixtures"
+tf --filler-path="fillers" --output="fixtures" 
 ```
+
+This is equivalent to running `tf` with no arguments. The paths`fillers/` and `fixtures/` are both defaults for the respective command.
 
 Note that the test `post` conditions are tested against the output of the `geth` `evm` utility during test generation.
 
 To generate all the tests within the `./fillers/vm` directory (category), for example, run:
 ```console
-tf --output="fixtures" --test-categories vm
+tf --test-categories vm
 ```
 
 This extends to sub-directories. To generate all specific tests within the `./fillers/vm/vm_arith/vm_add` sub-directory, run:
@@ -64,12 +66,12 @@ tf --output="fixtures" --test-categories vm/vm_arith/vm_add
 
 To generate all the tests in the `./fillers/*/dup.py` modules, for example, run:
 ```console
-tf --output="fixtures" --test-module dup
+tf --test-module dup
 ```
 
 To generate specific tests, such as `./fillers/*/*.py::test_dup`, for example, run (remove the `test_` prefix from the test case's function name):
 ```console
-tf --output="fixtures" --test-case dup
+tf --test-case dup
 ```
 
 ### Testing the Execution Spec Tests Framework

--- a/docs/getting_started/01_quick_start.md
+++ b/docs/getting_started/01_quick_start.md
@@ -5,6 +5,7 @@
 The following are required to either generate or develop tests:
 
 1. Python `3.10.0`.
+   - For dists. with the `apt` package manager ensure you have python `-dev` & `-venv` packages installed.
 2. [`go-ethereum`](https://github.com/ethereum/go-ethereum) `geth`'s `evm` utility must be accessible in the `PATH`, typically at the latest version. To get it:
      1. Install [the Go programming language](https://go.dev/doc/install) on your computer.
      2. Clone [the Geth repository](https://github.com/ethereum/go-ethereum).
@@ -49,6 +50,11 @@ Note that the test `post` conditions are tested against the output of the `geth`
 To generate all the tests in the `./fillers/vm` sub-directory (category), for example, run:
 ```console
 tf --output="fixtures" --test-categories vm
+```
+
+This extends to sub-directories. To generate all specific tests within the `./fillers/vm/vm_arith/vm_add` sub-directory, run:
+```console
+tf --output="fixtures" --test-categories vm/vm_arith/vm_add
 ```
 
 To generate all the tests in the `./fillers/*/dup.py` modules, for example, run:

--- a/docs/getting_started/01_quick_start.md
+++ b/docs/getting_started/01_quick_start.md
@@ -32,7 +32,7 @@ After the installation, run this sanity check to ensure tests are generated.
 If everything is OK, you will see the beginning of the JSON format filled test.
 
 ```console
-tf --output="fixtures" --test-case yul
+tf --test-case yul
 head fixtures/example/example/yul.json
 ```
 
@@ -42,14 +42,17 @@ head fixtures/example/example/yul.json
 To generate all the tests defined in the `./fillers` sub-directory, run the `tf` command:
 
 ```console
-tf --output="fixtures"
+tf --filler-path="fillers" --output="fixtures" 
 ```
 
-Note that the test `post` conditions are tested against the output of the `geth` `evm` utility during test generation.
+This is equivalent to running `tf` with no arguments. The paths`fillers/` and `fixtures/` are both defaults for the respective command.
+
+!!! note
+    The test `post` conditions are tested against the output of the `geth` `evm` utility during test generation.
 
 To generate all the tests in the `./fillers/vm` sub-directory (category), for example, run:
 ```console
-tf --output="fixtures" --test-categories vm
+tf --test-categories vm
 ```
 
 This extends to sub-directories. To generate all specific tests within the `./fillers/vm/vm_arith/vm_add` sub-directory, run:
@@ -59,12 +62,12 @@ tf --output="fixtures" --test-categories vm/vm_arith/vm_add
 
 To generate all the tests in the `./fillers/*/dup.py` modules, for example, run:
 ```console
-tf --output="fixtures" --test-module dup
+tf --test-module dup
 ```
 
 To generate specific tests, such as `./fillers/*/*.py::test_dup`, for example, run (remove the `test_` prefix from the test case's function name):
 ```console
-tf --output="fixtures" --test-case dup
+tf --test-case dup
 ```
 
 ## Testing the Execution Spec Tests Framework

--- a/docs/getting_started/03_writing_tests.md
+++ b/docs/getting_started/03_writing_tests.md
@@ -49,6 +49,8 @@ A new test can be added by either:
   the new test function(s).
 - Creating an entirely new category by adding a subdirectory in
   `fillers` with the appropriate source files and test functions.
+    - Tests within multiple sub-directories must have a `__init__.py` file
+      within each directory above it (and it own), to ensure the test is found by the test filler `tf`.
 
 ## Test Spec Generator Functions
 

--- a/src/ethereum_test_filling_tool/main.py
+++ b/src/ethereum_test_filling_tool/main.py
@@ -42,14 +42,14 @@ class Filler:
 
         parser.add_argument(
             "--filler-path",
-            help="path to filler directives",
+            help="path to filler directives, default: ./fillers",
             default="fillers",
             type=Path,
         )
 
         parser.add_argument(
             "--output",
-            help="directory to store filled test fixtures",
+            help="directory to store filled test fixtures, default: ./fixtures",
             default="fixtures",
             type=Path,
         )

--- a/src/ethereum_test_filling_tool/main.py
+++ b/src/ethereum_test_filling_tool/main.py
@@ -80,7 +80,7 @@ class Filler:
         )
 
         parser.add_argument(
-            "--no-structure",
+            "--no-output-structure",
             action="store_true",
             help="removes the folder structure from test fixture output",
         )
@@ -139,7 +139,7 @@ class Filler:
             output_dir = os.path.join(
                 self.options.output,
                 *(filler.__filler_metadata__["module_path"])
-                if self.options.no_structure is None
+                if self.options.no_output_structure is None
                 else "",
             )
             os.makedirs(output_dir, exist_ok=True)

--- a/src/ethereum_test_filling_tool/main.py
+++ b/src/ethereum_test_filling_tool/main.py
@@ -189,10 +189,9 @@ def recursive_iter_modules(root, package):
     """
     for info in iter_modules([os.path.join(root, package)]):
         if info.ispkg:
-            for sub_info in recursive_iter_modules(
+            yield from recursive_iter_modules(
                 root, os.path.join(package, info.name)
-            ):
-                yield sub_info
+            )
         else:
             package_path = package.replace("/", ".")
             yield info, package_path

--- a/src/ethereum_test_filling_tool/main.py
+++ b/src/ethereum_test_filling_tool/main.py
@@ -79,6 +79,12 @@ class Filler:
             + "transition tool",
         )
 
+        parser.add_argument(
+            "--no-structure",
+            action="store_true",
+            help="removes the folder structure from test fixture output",
+        )
+
         return parser.parse_args()
 
     options: argparse.Namespace
@@ -132,7 +138,9 @@ class Filler:
             name = filler.__filler_metadata__["name"]
             output_dir = os.path.join(
                 self.options.output,
-                *(filler.__filler_metadata__["module_path"]),
+                *(filler.__filler_metadata__["module_path"])
+                if self.options.no_structure is None
+                else "",
             )
             os.makedirs(output_dir, exist_ok=True)
             path = os.path.join(output_dir, f"{name}.json")

--- a/src/ethereum_test_filling_tool/main.py
+++ b/src/ethereum_test_filling_tool/main.py
@@ -49,7 +49,8 @@ class Filler:
 
         parser.add_argument(
             "--output",
-            help="directory to store filled test fixtures, default: ./fixtures",
+            help="directory to store filled test fixtures, \
+                  default: ./fixtures",
             default="fixtures",
             type=Path,
         )

--- a/src/ethereum_test_filling_tool/main.py
+++ b/src/ethereum_test_filling_tool/main.py
@@ -91,10 +91,7 @@ class Filler:
         """
         Fill test fixtures.
         """
-        pkg_path = "fillers"
-
-        if self.options.filler_path is not None:
-            pkg_path = self.options.filler_path
+        pkg_path = self.options.filler_path
 
         fillers = []
 

--- a/src/ethereum_test_filling_tool/main.py
+++ b/src/ethereum_test_filling_tool/main.py
@@ -43,12 +43,15 @@ class Filler:
         parser.add_argument(
             "--filler-path",
             help="path to filler directives",
+            default="fillers",
+            type=Path,
         )
 
         parser.add_argument(
             "--output",
             help="directory to store filled test fixtures",
-            default="out",
+            default="fixtures",
+            type=Path,
         )
 
         parser.add_argument(


### PR DESCRIPTION
Currently when adding a new test file, we are limited to having the tests within one sub-directory from `fillers` e.g `fillers/vm`. Tests within sub-directories deeper than that will not be found by the test filler `tf`.

This PR updates `tf` to search recursively when running from a top level directory i.e:
```console
tf --output="fixtures" --test-categories vm
```
hence tests within sub-directories of `vm` will be found, e.g `vm/vm_tests`.

Similarly it adds the extra option to only fill tests from a specific sub-directory i.e:
```console
tf --output="fixtures" --test-categories vm/vm_tests/vm_chain
```
