### PR TITLE
Fixture Format: Append withdrawals list to the end of genesisRLP for >= Shanghai

### DIFF
--- a/src/ethereum_test_tools/spec/blockchain_test.py
+++ b/src/ethereum_test_tools/spec/blockchain_test.py
@@ -81,7 +81,7 @@ class BlockchainTest(BaseTest):
             else None,
         )
 
-        (genesis_rlp, h) = b11r.build(genesis.to_geth_dict(), "", [])
+        (genesis_rlp, h) = b11r.build(genesis.to_geth_dict(), "", [], env.withdrawals)
         genesis.hash = h
 
         return genesis_rlp, genesis

--- a/src/ethereum_test_tools/spec/blockchain_test.py
+++ b/src/ethereum_test_tools/spec/blockchain_test.py
@@ -85,7 +85,7 @@ class BlockchainTest(BaseTest):
             header=genesis.to_geth_dict(),
             txs="",
             ommers=[],
-            withdrawals=env.withdrawals
+            withdrawals=env.withdrawals,
         )
         return genesis_rlp, genesis
 

--- a/src/ethereum_test_tools/spec/blockchain_test.py
+++ b/src/ethereum_test_tools/spec/blockchain_test.py
@@ -81,9 +81,12 @@ class BlockchainTest(BaseTest):
             else None,
         )
 
-        (genesis_rlp, h) = b11r.build(genesis.to_geth_dict(), "", [], env.withdrawals)
-        genesis.hash = h
-
+        (genesis_rlp, genesis.hash) = b11r.build(
+            header=genesis.to_geth_dict(),
+            txs="",
+            ommers=[],
+            withdrawals=env.withdrawals
+        )
         return genesis_rlp, genesis
 
     def make_block(
@@ -133,10 +136,10 @@ class BlockchainTest(BaseTest):
             env = set_fork_requirements(env, fork)
 
             (next_alloc, result, txs_rlp) = t8n.evaluate(
-                previous_alloc,
-                to_json_or_none(block.txs),
-                to_json(env),
-                fork,
+                alloc=previous_alloc,
+                txs=to_json_or_none(block.txs),
+                env=to_json(env),
+                fork=fork,
                 chain_id=chain_id,
                 reward=reward,
                 eips=eips,

--- a/src/ethereum_test_tools/spec/state_test.py
+++ b/src/ethereum_test_tools/spec/state_test.py
@@ -84,7 +84,7 @@ class StateTest(BaseTest):
             header=genesis.to_geth_dict(),
             txs="",
             ommers=[],
-            withdrawals=env.withdrawals
+            withdrawals=env.withdrawals,
         )
         return genesis_rlp, genesis
 

--- a/src/ethereum_test_tools/spec/state_test.py
+++ b/src/ethereum_test_tools/spec/state_test.py
@@ -80,9 +80,12 @@ class StateTest(BaseTest):
             else None,
         )
 
-        (genesis_rlp, h) = b11r.build(genesis.to_geth_dict(), "", [], env.withdrawals)
-        genesis.hash = h
-
+        (genesis_rlp, genesis.hash) = b11r.build(
+            header=genesis.to_geth_dict(),
+            txs="",
+            ommers=[],
+            withdrawals=env.withdrawals
+        )
         return genesis_rlp, genesis
 
     def make_blocks(
@@ -104,10 +107,10 @@ class StateTest(BaseTest):
         env = set_fork_requirements(env, fork)
 
         (alloc, result, txs_rlp) = t8n.evaluate(
-            to_json(self.pre),
-            to_json(self.txs),
-            to_json(env),
-            fork,
+            alloc=to_json(self.pre),
+            txs=to_json(self.txs),
+            env=to_json(env),
+            fork=fork,
             chain_id=chain_id,
             reward=reward,
             eips=eips,

--- a/src/ethereum_test_tools/spec/state_test.py
+++ b/src/ethereum_test_tools/spec/state_test.py
@@ -80,7 +80,7 @@ class StateTest(BaseTest):
             else None,
         )
 
-        (genesis_rlp, h) = b11r.build(genesis.to_geth_dict(), "", [])
+        (genesis_rlp, h) = b11r.build(genesis.to_geth_dict(), "", [], env.withdrawals)
         genesis.hash = h
 
         return genesis_rlp, genesis

--- a/src/evm_block_builder/__init__.py
+++ b/src/evm_block_builder/__init__.py
@@ -43,7 +43,6 @@ class EvmBlockBuilder(BlockBuilder):
     """
     Go-ethereum `evm` Block builder frontend.
     """
-
     binary: Path
     cached_version: Optional[str] = None
 
@@ -73,6 +72,7 @@ class EvmBlockBuilder(BlockBuilder):
         """
         Executes `evm b11r` with the specified arguments.
         """
+
         args = [
             str(self.binary),
             "b11r",
@@ -81,6 +81,8 @@ class EvmBlockBuilder(BlockBuilder):
             "--input.ommers=stdin",
             "--seal.clique=stdin",
             "--output.block=stdout",
+            "--input.withdrawals=stdin"
+            if withdrawals is not None else "",
         ]
 
         if ethash:

--- a/src/evm_block_builder/__init__.py
+++ b/src/evm_block_builder/__init__.py
@@ -43,6 +43,7 @@ class EvmBlockBuilder(BlockBuilder):
     """
     Go-ethereum `evm` Block builder frontend.
     """
+
     binary: Path
     cached_version: Optional[str] = None
 
@@ -72,7 +73,6 @@ class EvmBlockBuilder(BlockBuilder):
         """
         Executes `evm b11r` with the specified arguments.
         """
-
         args = [
             str(self.binary),
             "b11r",
@@ -81,8 +81,7 @@ class EvmBlockBuilder(BlockBuilder):
             "--input.ommers=stdin",
             "--seal.clique=stdin",
             "--output.block=stdout",
-            "--input.withdrawals=stdin"
-            if withdrawals is not None else "",
+            "--input.withdrawals=stdin" if withdrawals is not None else "",
         ]
 
         if ethash:


### PR DESCRIPTION
This PR addresses the following issues: https://github.com/ethereum/execution-spec-tests/issues/76 and https://github.com/ethereum/execution-spec-tests/issues/64, where it certain fixture test cases were found to be missing withdrawals in their `genesisRLP`. The withdrawals list will now be appended to the end of the `genesisRLP` for all test cases `>= Shanghai`. 
```python
#Before: `many_withdrawals.json`
"genesisRLP": "0xf9021...363b421c0c0",
#Now:
"genesisRLP": "0xf9021...363b421c0c0c0",
```

A small refactor of specific functions within `state_test` and `blockchain_test` are added to help spot similar issues more quickly in the future.