### PR TITLE
Fixture Format: Remove zero padding for data field in txs fixture format.

### DIFF
--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -1089,7 +1089,7 @@ class JSONEncoder(json.JSONEncoder):
                         },
                         remove_none=True,
                     ),
-                    excluded=["to", "accessList"],
+                    excluded=["to", "data", "accessList"],
                 )
                 for tx in obj.txs or []
             ]

--- a/src/evm_transition_tool/__init__.py
+++ b/src/evm_transition_tool/__init__.py
@@ -250,7 +250,6 @@ class EvmTransitionTool(TransitionTool):
         Gets `evm` binary version.
         """
         if self.cached_version is None:
-
             result = subprocess.run(
                 [str(self.binary), "-v"],
                 stdout=subprocess.PIPE,


### PR DESCRIPTION
Zero padding shouldn't be in data field for fixture format -> https://github.com/ethereum/execution-spec-tests/issues/86