### PR TITLE
 Add Functions to copy Transaction/Block Objects

### DIFF
--- a/fillers/withdrawals/withdrawals.py
+++ b/fillers/withdrawals/withdrawals.py
@@ -88,7 +88,11 @@ def test_use_value_in_tx(_):
 
     blocks = [
         Block(
-            txs=[tx.with_error("intrinsic gas too low: have 0, want 21000")],
+            txs=[
+                tx.with_fields(
+                    error="intrinsic gas too low: have 0, want 21000"
+                )
+            ],
             withdrawals=[
                 withdrawal,
             ],
@@ -161,11 +165,13 @@ def test_use_value_in_contract(_):
 
     blocks = [
         Block(
-            txs=[tx.with_nonce(0)],
+            txs=[tx.with_fields(nonce=0)],
             withdrawals=[withdrawal],
         ),
         Block(
-            txs=[tx.with_nonce(1)],  # Same tx again, just increase nonce
+            txs=[
+                tx.with_fields(nonce=1)
+            ],  # Same tx again, just increase nonce
         ),
     ]
     post = {
@@ -492,7 +498,7 @@ def test_newly_created_contract(_):
 
     # Same test but include value in the contract creating transaction
 
-    tx.value = ONE_GWEI
+    block = block.with_fields(txs=[tx.with_fields(value=ONE_GWEI)])
     post[created_contract].balance = 2 * ONE_GWEI
 
     yield BlockchainTest(

--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -710,6 +710,18 @@ class Transaction:
         tx.nonce = nonce
         return tx
 
+    def with_fields(self, **kwargs) -> "Transaction":
+        """
+        Create a copy of the transaction with modified fields.
+        """
+        tx = copy(self)
+        for key, value in kwargs.items():
+            if hasattr(tx, key):
+                setattr(tx, key, value)
+            else:
+                raise ValueError(f"Invalid field '{key}' for Transaction")
+        return tx
+
 
 @dataclass
 class FixtureTransaction:

--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -691,22 +691,6 @@ class Transaction:
             else:
                 self.ty = 0
 
-    def with_error(self, error: str) -> "Transaction":
-        """
-        Create a copy of the transaction with an added error.
-        """
-        tx = copy(self)
-        tx.error = error
-        return tx
-
-    def with_nonce(self, nonce: int) -> "Transaction":
-        """
-        Create a copy of the transaction with a modified nonce.
-        """
-        tx = copy(self)
-        tx.nonce = nonce
-        return tx
-
     def with_fields(self, **kwargs) -> "Transaction":
         """
         Create a copy of the transaction with modified fields.
@@ -1211,7 +1195,7 @@ class JSONEncoder(json.JSONEncoder):
             return super().default(obj)
 
 
-def even_padding(input: Dict, excluded: List[Any | None]) -> Dict:
+def even_padding(input: Dict, excluded: List[Any]) -> Dict:
     """
     Adds even padding to each field in the input (nested) dictionary.
     """
@@ -1219,7 +1203,7 @@ def even_padding(input: Dict, excluded: List[Any | None]) -> Dict:
         if key not in excluded:
             if isinstance(value, dict):
                 even_padding(value, excluded)
-            elif isinstance(value, str):
+            elif isinstance(value, str | None):
                 if value != "0x" and value is not None:
                     input[key] = key_value_padding(value)
                 else:

--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -950,6 +950,18 @@ class Block(Header):
         new_block.rlp = rlp
         return new_block
 
+    def with_fields(self, **kwargs) -> "Block":
+        """
+        Create a copy of the block with modified fields.
+        """
+        new_block = copy(self)
+        for key, value in kwargs.items():
+            if hasattr(new_block, key):
+                setattr(new_block, key, value)
+            else:
+                raise ValueError(f"Invalid field '{key}' for Block")
+        return new_block
+
 
 @dataclass(kw_only=True)
 class FixtureBlock:

--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -588,9 +588,6 @@ class Environment:
         if fork.header_zero_difficulty_required(self.number, self.timestamp):
             res.difficulty = 0
 
-        if fork.header_excess_data_gas_required(self.number, self.timestamp):
-            res.excess_data_gas = 0
-
         return res
 
 


### PR DESCRIPTION
Currently we modify only some yielded Transaction objects correctly. This PR adds generic functions to allow us to modify all yielded Transaction/Block object correctly: using `tx.with_fields()` or `block.with_fields()`. 

These create a copy of the object such that when you have a Transaction/Block object yielded within a test case, you can create a simply copy/modification of that object for another test case to yielded later within the test.