### PR TITLE
tools/vm: Enhance Callable Opcodes

### DIFF
--- a/src/ethereum_test_tools/tests/test_vm.py
+++ b/src/ethereum_test_tools/tests/test_vm.py
@@ -58,6 +58,41 @@ from ..vm.opcode import Opcodes as Op
             Op.PUSH32(-1),
             bytes([0x7F] + [0xFF] * 32),
         ),
+        (
+            Op.SSTORE(
+                -1,
+                Op.CALL(
+                    Op.GAS,
+                    Op.ADDRESS,
+                    Op.PUSH1(0x20),
+                    0,
+                    0,
+                    0x20,
+                    0x1234,
+                ),
+            ),
+            bytes(
+                [
+                    0x61,
+                    0x12,
+                    0x34,
+                    0x60,
+                    0x20,
+                    0x60,
+                    0x00,
+                    0x60,
+                    0x00,
+                    0x60,
+                    0x20,
+                    0x30,
+                    0x5A,
+                    0xF1,
+                    0x7F,
+                ]
+                + [0xFF] * 32
+                + [0x55]
+            ),
+        ),
     ],
 )
 def test_opcodes(opcodes: bytes, expected: bytes):


### PR DESCRIPTION
Makes `Op` opcodes callable and the resulting bytecode automatically sets the stack up.

If the opcode has data portion, the first argument is required and it becomes the data that is appended after the opcode.

The rest of the arguments are considered the stack, and they are appended before opcode byte, in LIFO order (the last argument is pushed first to the stack, and the first argument is pushed last).

E.g.
```python
Op.SSTORE(
             -1,
             Op.CALL(
                 Op.GAS,
                 Op.ADDRESS,
                 Op.PUSH1(0x20),
                 0,
                 0,
                 0x20,
                 0x1234,
             ),
         ),
```

In this example, the `Op.SSTORE` saves the result of the `Op.CALL` into the `0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff` key of the storage, and the parameters of `Op.CALL` are pushed into the stack before its execution (`0x1234` is pushed first to the stack using an implicit `Op.PUSH2`, then `0x20` using `Op.PUSH1`, and so on until `Op.GAS`).