### PR TITLE
tools/types: Convert to JSON on fixture init

### DIFF
--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -1128,6 +1128,7 @@ class JSONEncoder(json.JSONEncoder):
             return b
         elif isinstance(obj, Fixture):
             if obj._json is not None:
+                obj._json["_info"] = obj.info
                 return obj._json
 
             f = {

--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -928,6 +928,14 @@ class Fixture:
     name: str = ""
     index: int = 0
 
+    _json: Dict[str, Any] | None = None
+
+    def __post_init__(self):
+        """
+        Post init hook to convert to JSON after instantiation.
+        """
+        self._json = to_json(self)
+
     def fill_info(
         self,
         t8n: TransitionTool,
@@ -1119,6 +1127,9 @@ class JSONEncoder(json.JSONEncoder):
                 b["withdrawals"] = b_wds
             return b
         elif isinstance(obj, Fixture):
+            if obj._json is not None:
+                return obj._json
+
             f = {
                 "_info": obj.info,
                 "blocks": [


### PR DESCRIPTION
Fixes some tests where there was a modification to the transactions/withdrawals after yield, by immediately converting to JSON on fixture initialization.