### PR TITLE
tools/types: Correctly handle negative numbers in storage

### DIFF
--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -112,6 +112,31 @@ class Storage:
             """Print exception string"""
             return f"invalid value for key/value: {self.key_or_value}"
 
+    class AmbiguousKeyValue(Exception):
+        """
+        Key is represented twice in the storage.
+        """
+
+        key1: Any
+        val1: Any
+        key2: Any
+        val2: Any
+
+        def __init__(self, key1: int, val1: int, key2: int, val2: int, *args):
+            super().__init__(args)
+            self.key1 = key1
+            self.val1 = val1
+            self.key2 = key2
+            self.val2 = val2
+
+        def __str__(self):
+            """Print exception string"""
+            return f"""
+            Key is represented twice (due to negative numbers) with different
+            values in storage:
+            s[{self.key1}] = {self.val1} and s[{self.key2}] = {self.val2}
+            """
+
     class MissingKey(Exception):
         """
         Test expected to find a storage key set but key was missing.
@@ -227,9 +252,13 @@ class Storage:
         """
         res = {}
         for key in self.data:
-            res[
-                Storage.key_value_to_string(key)
-            ] = Storage.key_value_to_string(self.data[key])
+            key_repr = Storage.key_value_to_string(key)
+            val_repr = Storage.key_value_to_string(self.data[key])
+            if key_repr in res and val_repr != res[key_repr]:
+                raise Storage.AmbiguousKeyValue(
+                    key_repr, res[key_repr], key, val_repr
+                    )
+            res[key_repr] = val_repr
         return res
 
     def contains(self, other: "Storage") -> bool:

--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -117,24 +117,31 @@ class Storage:
         Key is represented twice in the storage.
         """
 
-        key1: Any
-        val1: Any
-        key2: Any
-        val2: Any
+        key_1: str | int
+        val_1: str | int
+        key_2: str | int
+        val_2: str | int
 
-        def __init__(self, key1: int, val1: int, key2: int, val2: int, *args):
+        def __init__(
+            self,
+            key_1: str | int,
+            val_1: str | int,
+            key_2: str | int,
+            val_2: str | int,
+            *args,
+        ):
             super().__init__(args)
-            self.key1 = key1
-            self.val1 = val1
-            self.key2 = key2
-            self.val2 = val2
+            self.key_1 = key_1
+            self.val_1 = val_1
+            self.key_2 = key_2
+            self.val_2 = val_2
 
         def __str__(self):
             """Print exception string"""
             return f"""
             Key is represented twice (due to negative numbers) with different
             values in storage:
-            s[{self.key1}] = {self.val1} and s[{self.key2}] = {self.val2}
+            s[{self.key_1}] = {self.val_1} and s[{self.key_2}] = {self.val_2}
             """
 
     class MissingKey(Exception):
@@ -250,14 +257,14 @@ class Storage:
         Converts the storage into a string dict with appropriate 32-byte
         hex string formatting.
         """
-        res = {}
+        res: Dict[str, str] = {}
         for key in self.data:
             key_repr = Storage.key_value_to_string(key)
             val_repr = Storage.key_value_to_string(self.data[key])
             if key_repr in res and val_repr != res[key_repr]:
                 raise Storage.AmbiguousKeyValue(
                     key_repr, res[key_repr], key, val_repr
-                    )
+                )
             res[key_repr] = val_repr
         return res
 

--- a/src/ethereum_test_tools/tests/test_types.py
+++ b/src/ethereum_test_tools/tests/test_types.py
@@ -48,6 +48,19 @@ def test_storage():
     assert "0xa" not in s
     assert 10 not in s
 
+    s = Storage({-1: -1, -2: -2})
+    assert s.data[-1] == -1
+    assert s.data[-2] == -2
+    d = s.to_dict()
+    assert (
+        d["0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"]
+        == "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+    )
+    assert (
+        d["0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe"]
+        == "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe"
+    )
+
 
 @pytest.mark.parametrize(
     ["account", "alloc", "should_pass"],

--- a/src/ethereum_test_tools/tests/test_types.py
+++ b/src/ethereum_test_tools/tests/test_types.py
@@ -60,6 +60,15 @@ def test_storage():
         d["0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe"]
         == "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe"
     )
+    # Try to add a duplicate key (negative and positive number at the same
+    # time)
+    # same value, ok
+    s[2**256 - 1] = 2**256 - 1
+    s.to_dict()
+    # different value, not ok
+    s[2**256 - 1] = 0
+    with pytest.raises(Storage.AmbiguousKeyValue):
+        s.to_dict()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Allow negative values in the storage, which are automatically converted to the EVM's two's complement of 32-byte.

Also add a check for an ambiguous storage check, i.e., the tester defined the equivalent EVM value as negative and positive numbers, and throw an exception.