### PR TITLE
fillers: Replace simple Yul with Callable Opcodes

### DIFF
--- a/fillers/eips/eip3651.py
+++ b/fillers/eips/eip3651.py
@@ -74,41 +74,13 @@ def test_warm_coinbase_call_out_of_gas(fork):
         """
     )
 
-    call_code = Yul(
-        """
-        {
-           let cb := coinbase()
-           pop(call(0, cb, 0, 0, 0, 0, 0))
-        }
-        """
-    )
+    call_code = Op.POP(Op.CALL(0, Op.COINBASE, 0, 0, 0, 0, 0))
 
-    callcode_code = Yul(
-        """
-        {
-           let cb := coinbase()
-           pop(callcode(0, cb, 0, 0, 0, 0, 0))
-        }
-        """
-    )
+    callcode_code = Op.POP(Op.CALLCODE(0, Op.COINBASE, 0, 0, 0, 0, 0))
 
-    delegatecall_code = Yul(
-        """
-        {
-           let cb := coinbase()
-           pop(delegatecall(0, cb, 0, 0, 0, 0))
-        }
-        """
-    )
+    delegatecall_code = Op.POP(Op.DELEGATECALL(0, Op.COINBASE, 0, 0, 0, 0))
 
-    staticcall_code = Yul(
-        """
-        {
-           let cb := coinbase()
-           pop(staticcall(0, cb, 0, 0, 0, 0))
-        }
-        """
-    )
+    staticcall_code = Op.POP(Op.STATICCALL(0, Op.COINBASE, 0, 0, 0, 0))
 
     pre = {
         TestAddress: Account(balance=1000000000000000000000),
@@ -183,82 +155,41 @@ def test_warm_coinbase_gas_usage(fork):
     # List of opcodes that are affected by
     gas_measured_opcodes: Dict[str, CodeGasMeasure] = {
         "EXTCODESIZE": CodeGasMeasure(
-            code=Op.EXTCODESIZE(
-                Op.COINBASE,
-            ),
+            code=Op.EXTCODESIZE(Op.COINBASE),
             overhead_cost=2,
             extra_stack_items=1,
         ),
         "EXTCODECOPY": CodeGasMeasure(
-            code=Op.EXTCODECOPY(
-                Op.COINBASE,
-                0,
-                0,
-                0,
-            ),
+            code=Op.EXTCODECOPY(Op.COINBASE, 0, 0, 0),
             overhead_cost=2 + 3 + 3 + 3,
         ),
         "EXTCODEHASH": CodeGasMeasure(
-            code=Op.EXTCODEHASH(
-                Op.COINBASE,
-            ),
+            code=Op.EXTCODEHASH(Op.COINBASE),
             overhead_cost=2,
             extra_stack_items=1,
         ),
         "BALANCE": CodeGasMeasure(
-            code=Op.BALANCE(
-                Op.COINBASE,
-            ),
+            code=Op.BALANCE(Op.COINBASE),
             overhead_cost=2,
             extra_stack_items=1,
         ),
         "CALL": CodeGasMeasure(
-            code=Op.CALL(
-                0xFF,
-                Op.COINBASE,
-                0,
-                0,
-                0,
-                0,
-                0,
-            ),
+            code=Op.CALL(0xFF, Op.COINBASE, 0, 0, 0, 0, 0),
             overhead_cost=3 + 2 + 3 + 3 + 3 + 3 + 3,
             extra_stack_items=1,
         ),
         "CALLCODE": CodeGasMeasure(
-            code=Op.CALLCODE(
-                0xFF,
-                Op.COINBASE,
-                0,
-                0,
-                0,
-                0,
-                0,
-            ),
+            code=Op.CALLCODE(0xFF, Op.COINBASE, 0, 0, 0, 0, 0),
             overhead_cost=3 + 2 + 3 + 3 + 3 + 3 + 3,
             extra_stack_items=1,
         ),
         "DELEGATECALL": CodeGasMeasure(
-            code=Op.DELEGATECALL(
-                0xFF,
-                Op.COINBASE,
-                0,
-                0,
-                0,
-                0,
-            ),
+            code=Op.DELEGATECALL(0xFF, Op.COINBASE, 0, 0, 0, 0),
             overhead_cost=3 + 2 + 3 + 3 + 3 + 3,
             extra_stack_items=1,
         ),
         "STATICCALL": CodeGasMeasure(
-            code=Op.STATICCALL(
-                0xFF,
-                Op.COINBASE,
-                0,
-                0,
-                0,
-                0,
-            ),
+            code=Op.STATICCALL(0xFF, Op.COINBASE, 0, 0, 0, 0),
             overhead_cost=3 + 2 + 3 + 3 + 3 + 3,
             extra_stack_items=1,
         ),

--- a/fillers/eips/eip3651.py
+++ b/fillers/eips/eip3651.py
@@ -183,50 +183,82 @@ def test_warm_coinbase_gas_usage(fork):
     # List of opcodes that are affected by
     gas_measured_opcodes: Dict[str, CodeGasMeasure] = {
         "EXTCODESIZE": CodeGasMeasure(
-            code=Op.COINBASE + Op.EXTCODESIZE,
+            code=Op.EXTCODESIZE(
+                Op.COINBASE,
+            ),
             overhead_cost=2,
             extra_stack_items=1,
         ),
         "EXTCODECOPY": CodeGasMeasure(
-            code=Op.PUSH1(0x00) * 3 + Op.COINBASE + Op.EXTCODECOPY,
+            code=Op.EXTCODECOPY(
+                Op.COINBASE,
+                0,
+                0,
+                0,
+            ),
             overhead_cost=2 + 3 + 3 + 3,
         ),
         "EXTCODEHASH": CodeGasMeasure(
-            code=Op.COINBASE + Op.EXTCODEHASH,
+            code=Op.EXTCODEHASH(
+                Op.COINBASE,
+            ),
             overhead_cost=2,
             extra_stack_items=1,
         ),
         "BALANCE": CodeGasMeasure(
-            code=Op.COINBASE + Op.BALANCE,
+            code=Op.BALANCE(
+                Op.COINBASE,
+            ),
             overhead_cost=2,
             extra_stack_items=1,
         ),
         "CALL": CodeGasMeasure(
-            code=Op.PUSH1(0x00) * 5 + Op.COINBASE + Op.PUSH1(0xFF) + Op.CALL,
+            code=Op.CALL(
+                0xFF,
+                Op.COINBASE,
+                0,
+                0,
+                0,
+                0,
+                0,
+            ),
             overhead_cost=3 + 2 + 3 + 3 + 3 + 3 + 3,
             extra_stack_items=1,
         ),
         "CALLCODE": CodeGasMeasure(
-            code=Op.PUSH1(0x00) * 5
-            + Op.COINBASE
-            + Op.PUSH1(0xFF)
-            + Op.CALLCODE,
+            code=Op.CALLCODE(
+                0xFF,
+                Op.COINBASE,
+                0,
+                0,
+                0,
+                0,
+                0,
+            ),
             overhead_cost=3 + 2 + 3 + 3 + 3 + 3 + 3,
             extra_stack_items=1,
         ),
         "DELEGATECALL": CodeGasMeasure(
-            code=Op.PUSH1(0x00) * 4
-            + Op.COINBASE
-            + Op.PUSH1(0xFF)
-            + Op.DELEGATECALL,
+            code=Op.DELEGATECALL(
+                0xFF,
+                Op.COINBASE,
+                0,
+                0,
+                0,
+                0,
+            ),
             overhead_cost=3 + 2 + 3 + 3 + 3 + 3,
             extra_stack_items=1,
         ),
         "STATICCALL": CodeGasMeasure(
-            code=Op.PUSH1(0x00) * 4
-            + Op.COINBASE
-            + Op.PUSH1(0xFF)
-            + Op.STATICCALL,
+            code=Op.STATICCALL(
+                0xFF,
+                Op.COINBASE,
+                0,
+                0,
+                0,
+                0,
+            ),
             overhead_cost=3 + 2 + 3 + 3 + 3 + 3,
             extra_stack_items=1,
         ),

--- a/fillers/eips/eip3855.py
+++ b/fillers/eips/eip3855.py
@@ -66,7 +66,6 @@ def test_push0(fork):
     """
     Test case 3: Stack overflow by using PUSH0 1025 times
     """
-    code = Op.PUSH1(1) + Op.PUSH0 + Op.SSTORE
     code = Op.SSTORE(Op.PUSH0, 1)
     code += Op.PUSH0 * 1025
 

--- a/fillers/eips/eip3855.py
+++ b/fillers/eips/eip3855.py
@@ -43,7 +43,7 @@ def test_push0(fork):
     """
     Test case 1: Simple PUSH0 as key to SSTORE
     """
-    code = Op.PUSH1(1) + Op.PUSH0 + Op.SSTORE
+    code = Op.SSTORE(Op.PUSH0, 1)
 
     pre[addr_1] = Account(code=code)
     post[addr_1] = Account(storage={0x00: 0x01})
@@ -56,7 +56,7 @@ def test_push0(fork):
     """
     code = Op.PUSH0 * 1024
     code += Op.OR * 1023
-    code += Op.PUSH1(1) + Op.SWAP1 + Op.SSTORE
+    code += Op.SSTORE(Op.SWAP1, 1)
 
     pre[addr_1] = Account(code=code)
     post[addr_1] = Account(storage={0x00: 0x01})
@@ -67,6 +67,7 @@ def test_push0(fork):
     Test case 3: Stack overflow by using PUSH0 1025 times
     """
     code = Op.PUSH1(1) + Op.PUSH0 + Op.SSTORE
+    code = Op.SSTORE(Op.PUSH0, 1)
     code += Op.PUSH0 * 1025
 
     pre[addr_1] = Account(code=code)
@@ -79,9 +80,7 @@ def test_push0(fork):
     """
     Test case 4: Update already existing storage value
     """
-    code = (
-        Op.PUSH1(2) + Op.PUSH0 + Op.SSTORE + Op.PUSH0 + Op.PUSH1(1) + Op.SSTORE
-    )
+    code = Op.SSTORE(Op.PUSH0, 2) + Op.SSTORE(1, Op.PUSH0)
 
     pre[addr_1] = Account(code=code, storage={0x00: 0x0A, 0x01: 0x0A})
     post[addr_1] = Account(storage={0x00: 0x02, 0x01: 0x00})
@@ -103,14 +102,7 @@ def test_push0(fork):
         }
         """
     )
-    code_2 = (
-        Op.PUSH1(0xFF)
-        + Op.PUSH0
-        + Op.MSTORE8
-        + Op.PUSH1(1)
-        + Op.PUSH1(0)
-        + Op.RETURN
-    )
+    code_2 = Op.MSTORE8(Op.PUSH0, 0xFF) + Op.RETURN(Op.PUSH0, 1)
 
     pre[addr_1] = Account(code=code_1)
     pre[addr_2] = Account(code=code_2)
@@ -130,9 +122,7 @@ def test_push0(fork):
         + Op.JUMP
         + Op.PUSH0
         + Op.JUMPDEST
-        + Op.PUSH1(1)
-        + Op.PUSH0
-        + Op.SSTORE
+        + Op.SSTORE(Op.PUSH0, 1)
         + Op.STOP
     )
 

--- a/fillers/vm/chain_id.py
+++ b/fillers/vm/chain_id.py
@@ -7,9 +7,12 @@ from ethereum_test_tools import (
     Account,
     Environment,
     StateTest,
+    TestAddress,
     Transaction,
     test_from,
+    to_address,
 )
+from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 
 @test_from(Istanbul)
@@ -26,26 +29,22 @@ def test_chain_id(fork):
     )
 
     pre = {
-        "0x1000000000000000000000000000000000000000": Account(
-            code="0x4660015500"
-        ),
-        "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": Account(
-            balance=1000000000000000000000
-        ),
+        to_address(0x100): Account(code=Op.SSTORE(1, Op.CHAINID) + Op.STOP),
+        TestAddress: Account(balance=1000000000000000000000),
     }
 
     tx = Transaction(
         ty=0x0,
         chain_id=0x0,
         nonce=0,
-        to="0x1000000000000000000000000000000000000000",
+        to=to_address(0x100),
         gas_limit=100000000,
         gas_price=10,
         protected=False,
     )
 
     post = {
-        "0x1000000000000000000000000000000000000000": Account(
+        to_address(0x100): Account(
             code="0x4660015500", storage={"0x01": "0x01"}
         ),
     }


### PR DESCRIPTION
A small refactor of some filler modules, using the new callable opcodes provided in https://github.com/ethereum/execution-spec-tests/pull/102.