### PR TITLE
tools/types: Assert tx[to] always within fixtures.

### DIFF
--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -1252,6 +1252,8 @@ class JSONEncoder(json.JSONEncoder):
                 del json_tx["gas"]
             if "protected" in json_tx:
                 del json_tx["protected"]
+            if "to" not in json_tx:
+                json_tx["to"] = ""
             return even_padding(
                 json_tx,
                 excluded=["to", "accessList"],


### PR DESCRIPTION
Previous PR merged changes the fixture format of transactions in the `newly_created_contract` withdrawals test case. The `tx["to"]` field should be present in fixture even set to `None`. The PR makes sure that `tx["to"] = ""` if its set to 'None' in a test case.