### PR TITLE
forks: Change from ShardingFork to Cancun

### DIFF
--- a/fillers/eips/eip4844/README.md
+++ b/fillers/eips/eip4844/README.md
@@ -76,7 +76,7 @@ Asserts that blocks with invalid `excess_data_gas` values in the header are igno
 
 **3) 🔴 test_fork_transition_excess_data_gas_in_header():**
 
-Tests that the `excess_data_gas` calculation is correct when transitioning from the Shanghai fork to the Sharding fork, where appended blocks are valid and state changes occur. Each block has a single transaction with `MAX_BLOBS_PER_BLOCK` blobs. The first block during the transition period has a parent of zero `excess_data_gas` in the header. Each block afterwards calculates `excess_data_gas` using the following `calc_excess_data_gas` function such that it continuously increases.
+Tests that the `excess_data_gas` calculation is correct when transitioning from the Shanghai fork to the Cancun fork, where appended blocks are valid and state changes occur. Each block has a single transaction with `MAX_BLOBS_PER_BLOCK` blobs. The first block during the transition period has a parent of zero `excess_data_gas` in the header. Each block afterwards calculates `excess_data_gas` using the following `calc_excess_data_gas` function such that it continuously increases.
 
 **4) 🔴 test_invalid_blob_txs():**
 
@@ -97,6 +97,6 @@ Asserts that blocks with invalid blob transactions are rejected and no state cha
 - `len(blobs)` is zero within a transaction. Valid blob txs (type 3) must have at least one blob within it, obeying the following condition:
   - `len(tx.message.blob_versioned_hashes) > 0`
 
-- Blob transaction type 3 is used in a pre-Sharding fork. This transcation type can only be used in a post-Sharding fork.
+- Blob transaction type 3 is used in a pre-Cancun fork. This transcation type can only be used in a post-Cancun fork.
 
   

--- a/fillers/eips/eip4844/datahash_opcode.py
+++ b/fillers/eips/eip4844/datahash_opcode.py
@@ -6,7 +6,7 @@ import itertools
 from copy import copy
 from typing import Dict, List, Sequence
 
-from ethereum_test_forks import Fork, ShardingFork
+from ethereum_test_forks import Cancun, Fork
 from ethereum_test_tools import (
     Account,
     Block,
@@ -52,7 +52,7 @@ env = Environment(  # Global state test environment
 )
 
 
-@test_from(fork=ShardingFork)
+@test_from(fork=Cancun)
 def test_datahash_opcode_contexts(_: Fork):
     """
     Test DATAHASH opcode called on different contexts.
@@ -430,7 +430,7 @@ def test_datahash_opcode_contexts(_: Fork):
         )
 
 
-@test_from(fork=ShardingFork)
+@test_from(fork=Cancun)
 def test_datahash_gas_cost(_: Fork):
     """
     Test DATAHASH opcode gas cost using a variety of indexes.
@@ -521,7 +521,7 @@ def test_datahash_gas_cost(_: Fork):
     yield BlockchainTest(pre=pre, post=post, blocks=blocks, tag="tx_type_3")
 
 
-@test_from(fork=ShardingFork)
+@test_from(fork=Cancun)
 def test_datahash_blob_versioned_hash(_: Fork):
     """
     Tests that the `DATAHASH` opcode returns the correct versioned hash for
@@ -651,7 +651,7 @@ def test_datahash_blob_versioned_hash(_: Fork):
     )
 
 
-@test_from(fork=ShardingFork)
+@test_from(fork=Cancun)
 def test_datahash_invalid_blob_index(_: Fork):
     """
     Tests that the `DATAHASH` opcode returns a zeroed bytes32 value
@@ -719,7 +719,7 @@ def test_datahash_invalid_blob_index(_: Fork):
     )
 
 
-@test_from(fork=ShardingFork)
+@test_from(fork=Cancun)
 def test_datahash_multiple_txs_in_block(_: Fork):
     """
     Tests that the `DATAHASH` opcode returns the appropriate values

--- a/fillers/eips/eip4844/excess_data_gas.py
+++ b/fillers/eips/eip4844/excess_data_gas.py
@@ -6,10 +6,10 @@ from dataclasses import dataclass
 from typing import List, Mapping, Optional
 
 from ethereum_test_forks import (
+    Cancun,
     Fork,
     Shanghai,
-    ShanghaiToShardingAtTime15k,
-    ShardingFork,
+    ShanghaiToCancunAtTime15k,
     is_fork,
 )
 from ethereum_test_tools import (
@@ -182,7 +182,7 @@ class ExcessDataGasCalcTestCase:
         )
 
 
-@test_from(fork=ShardingFork)
+@test_from(fork=Cancun)
 def test_excess_data_gas_calc(_: Fork):
     """
     Test calculation of the excess_data_gas increase/decrease across multiple
@@ -397,7 +397,7 @@ class InvalidExcessDataGasInHeaderTestCase:
         )
 
 
-@test_from(fork=ShardingFork)
+@test_from(fork=Cancun)
 def test_invalid_excess_data_gas_in_header(_: Fork):
     """
     Test rejection of a block with invalid excess_data_gas in the header.
@@ -526,7 +526,7 @@ def test_invalid_excess_data_gas_in_header(_: Fork):
         yield tc.generate()
 
 
-@test_only(fork=ShanghaiToShardingAtTime15k)
+@test_only(fork=ShanghaiToCancunAtTime15k)
 def test_fork_transition_excess_data_gas_in_header(_: Fork):
     """
     Test excess_data_gas calculation in the header when the fork is activated.
@@ -537,7 +537,7 @@ def test_fork_transition_excess_data_gas_in_header(_: Fork):
     }
     destination_account = to_address(0x100)
 
-    # Generate some blocks to reach Sharding fork
+    # Generate some blocks to reach Cancun fork
     FORK_TIMESTAMP = 15_000
     blocks: List[Block] = []
     for t in range(999, FORK_TIMESTAMP, 1_000):
@@ -735,7 +735,7 @@ def test_invalid_blob_txs(fork: Fork):
         - block blob count > MAX_BLOBS_PER_BLOCK
     """
     test_cases: List[InvalidBlobTransactionTestCase] = []
-    if is_fork(fork, ShardingFork):
+    if is_fork(fork, Cancun):
         test_cases = [
             InvalidBlobTransactionTestCase(
                 tag="insufficient_max_fee_per_data_gas",
@@ -783,7 +783,7 @@ def test_invalid_blob_txs(fork: Fork):
             # ),
         ]
     else:
-        # Pre-Sharding, blocks with type 3 txs must be rejected
+        # Pre-Cancun, blocks with type 3 txs must be rejected
         test_cases = [
             InvalidBlobTransactionTestCase(
                 tag="type_3_tx_pre_fork",

--- a/src/ethereum_test_forks/__init__.py
+++ b/src/ethereum_test_forks/__init__.py
@@ -21,9 +21,9 @@ from .forks.forks import (
 from .forks.transition import (
     BerlinToLondonAt5,
     MergeToShanghaiAtTime15k,
-    ShanghaiToShardingAtTime15k,
+    ShanghaiToCancunAtTime15k,
 )
-from .forks.upcoming import ShardingFork
+from .forks.upcoming import Cancun
 from .helpers import (
     fork_only,
     forks_from,
@@ -50,8 +50,8 @@ __all__ = [
     "MergeToShanghaiAtTime15k",
     "MuirGlacier",
     "Shanghai",
-    "ShanghaiToShardingAtTime15k",
-    "ShardingFork",
+    "ShanghaiToCancunAtTime15k",
+    "Cancun",
     "fork_only",
     "forks_from",
     "forks_from_until",

--- a/src/ethereum_test_forks/forks/transition.py
+++ b/src/ethereum_test_forks/forks/transition.py
@@ -3,7 +3,7 @@ List of all transition fork definitions.
 """
 from ..transition_base_fork import transition_fork
 from .forks import Berlin, London, Merge, Shanghai
-from .upcoming import ShardingFork, TestOnlyUpcomingFork
+from .upcoming import Cancun, TestOnlyUpcomingFork
 
 
 # Transition Forks
@@ -35,16 +35,16 @@ class MergeToShanghaiAtTime15k(Merge):
         return timestamp >= 15_000
 
 
-@transition_fork(to_fork=ShardingFork)
-class ShanghaiToShardingAtTime15k(Shanghai):
+@transition_fork(to_fork=Cancun)
+class ShanghaiToCancunAtTime15k(Shanghai):
     """
-    Shanghai to Sharding transition at Timestamp 15k
+    Shanghai to Cancun transition at Timestamp 15k
     """
 
     @classmethod
     def header_excess_data_gas_required(cls, _: int, timestamp: int) -> bool:
         """
-        Excess data gas is required if transitioning to Sharding.
+        Excess data gas is required if transitioning to Cancun.
         """
         return timestamp >= 15_000
 

--- a/src/ethereum_test_forks/forks/upcoming.py
+++ b/src/ethereum_test_forks/forks/upcoming.py
@@ -6,9 +6,9 @@ supported by most clients.
 from .forks import Shanghai
 
 
-class ShardingFork(Shanghai):
+class Cancun(Shanghai):
     """
-    Sharding fork
+    Cancun fork
     """
 
     @classmethod
@@ -16,7 +16,7 @@ class ShardingFork(Shanghai):
         cls, block_number: int, timestamp: int
     ) -> bool:
         """
-        Excess data gas is required starting from Sharding.
+        Excess data gas is required starting from Cancun.
         """
         return True
 

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -34,6 +34,7 @@ petersburg
 randao
 rlp
 sharding
+cancun
 t8n
 trie
 txs


### PR DESCRIPTION
Changes any occurance of Sharding or ShardingFork to Cancun. 

In accordance with this PR: https://github.com/mdehoog/go-ethereum/pull/126

All tests file successfully with the above.