### PR TITLE
src/eth_test_tools/common/types: Remove even padding on tx data field

### DIFF
--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -1256,7 +1256,7 @@ class JSONEncoder(json.JSONEncoder):
                 json_tx["to"] = ""
             return even_padding(
                 json_tx,
-                excluded=["to", "accessList"],
+                excluded=["data", "to", "accessList"],
             )
         elif isinstance(obj, FixtureBlock):
             b = {"rlp": obj.rlp}


### PR DESCRIPTION
Adds a tiny change that addresses the inconsistency between the block RLP and tx field data field.

Flagged by retesteth: http://retesteth.ethdevops.io/results/log//2023-04-27-1682591043-dretesteth.txt