### PR TITLE
tools: Types fixes

### DIFF
--- a/src/ethereum_test_forks/base_fork.py
+++ b/src/ethereum_test_forks/base_fork.py
@@ -1,11 +1,29 @@
 """
 Abstract base class for Ethereum forks
 """
-from abc import ABC, abstractmethod
+from abc import ABC, ABCMeta, abstractmethod
 from typing import Type
 
 
-class BaseFork(ABC):
+class BaseForkMeta(ABCMeta):
+    """
+    Metaclass for BaseFork
+    """
+
+    def name(cls) -> str:
+        """
+        To be implemented by the fork base class.
+        """
+        pass
+
+    def __repr__(cls) -> str:
+        """
+        Used to properly print the name of the fork, instead of the class.
+        """
+        return cls.name()
+
+
+class BaseFork(ABC, metaclass=BaseForkMeta):
     """
     An abstract class representing an Ethereum fork.
 

--- a/src/ethereum_test_forks/tests/test_forks.py
+++ b/src/ethereum_test_forks/tests/test_forks.py
@@ -38,6 +38,9 @@ def test_forks():
     assert London.name() == "London"
     assert TestOnlyUpcomingFork.name() == "TestOnlyUpcomingFork"
     assert MergeToShanghaiAtTime15k.name() == "MergeToShanghaiAtTime15k"
+    assert f"{London}" == "London"
+    assert f"{TestOnlyUpcomingFork}" == "TestOnlyUpcomingFork"
+    assert f"{MergeToShanghaiAtTime15k}" == "MergeToShanghaiAtTime15k"
 
     # Test some fork properties
     assert Berlin.header_base_fee_required(0, 0) is False

--- a/src/ethereum_test_tools/__init__.py
+++ b/src/ethereum_test_tools/__init__.py
@@ -11,6 +11,7 @@ from .common import (
     Environment,
     Header,
     JSONEncoder,
+    Storage,
     TestAddress,
     Transaction,
     Withdrawal,

--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -14,6 +14,7 @@ from typing import (
     Sequence,
     Tuple,
     Type,
+    TypeAlias,
 )
 
 from ethereum_test_forks import Fork
@@ -99,6 +100,13 @@ class Storage:
     """
 
     data: Dict[int, int]
+
+    StorageDictType: ClassVar[TypeAlias] = Dict[
+        str | int | bytes, str | int | bytes
+    ]
+    """
+    Dictionary type to be used when defining an input to initialize a storage.
+    """
 
     class InvalidType(Exception):
         """
@@ -234,7 +242,7 @@ class Storage:
         """
         return "0x" + value.to_bytes(32, "big", signed=(value < 0)).hex()
 
-    def __init__(self, input: Dict[str | int | bytes, str | int | bytes]):
+    def __init__(self, input: StorageDictType):
         """
         Initializes the storage using a given mapping which can have
         keys and values either as string or int.

--- a/src/ethereum_test_tools/tests/test_vm.py
+++ b/src/ethereum_test_tools/tests/test_vm.py
@@ -96,4 +96,16 @@ from ..vm.opcode import Opcodes as Op
     ],
 )
 def test_opcodes(opcodes: bytes, expected: bytes):
+    """
+    Test that the `opcodes` are transformed into bytecode as expected.
+    """
     assert bytes(opcodes) == expected
+
+
+def test_opcodes_repr():
+    """
+    Test that the `repr` of an `Op` is the same as its name.
+    """
+    assert f"{Op.CALL}" == "CALL"
+    assert f"{Op.DELEGATECALL}" == "DELEGATECALL"
+    assert str(Op.ADD) == "ADD"

--- a/src/ethereum_test_tools/vm/opcode.py
+++ b/src/ethereum_test_tools/vm/opcode.py
@@ -41,6 +41,7 @@ class Opcode(bytes):
     pushed_stack_items: int
     min_stack_height: int
     data_portion_length: int
+    _name_: str
 
     def __new__(
         cls,
@@ -165,6 +166,12 @@ class Opcode(bytes):
         Returns the integer representation of the opcode.
         """
         return int.from_bytes(bytes=self, byteorder="big")
+
+    def __str__(self) -> str:
+        """
+        Return the name of the opcode, assigned at Enum creation.
+        """
+        return self._name_
 
 
 class Opcodes(Opcode, Enum):

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -55,6 +55,7 @@ delitem
 dirname
 fromhex
 getitem
+metaclass
 radd
 setitem
 zfill


### PR DESCRIPTION
## Changes Included
- The dict type needed as input to instantiate a the Storage class is now properly defined and can be used in tests
- Forks and opcodes display proper names when printed, which will be useful when using pytest parametrize