### PR TITLE
keep `protected` field in transactions

### DIFF
--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -1216,8 +1216,6 @@ class JSONEncoder(json.JSONEncoder):
             if "gas" in json_tx:
                 json_tx["gasLimit"] = json_tx["gas"]
                 del json_tx["gas"]
-            if "protected" in json_tx:
-                del json_tx["protected"]
             if "to" not in json_tx:
                 json_tx["to"] = ""
             return even_padding(

--- a/src/ethereum_test_tools/tests/test_fixtures/blockchain_london_invalid_filled.json
+++ b/src/ethereum_test_tools/tests/test_fixtures/blockchain_london_invalid_filled.json
@@ -34,7 +34,8 @@
                         "gasLimit": "0x0f4240",
                         "maxFeePerGas": "0x03e8",
                         "maxPriorityFeePerGas": "0x01",
-                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"
+                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+                        "protected": true
                     }
                 ],
                 "uncleHeaders": []
@@ -72,7 +73,8 @@
                         "gasLimit": "0x0f4240",
                         "maxPriorityFeePerGas": "0x0a",
                         "maxFeePerGas": "0x03e8",
-                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"
+                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+                        "protected": true
                     },
                     {
                         "type": "0x02",
@@ -84,7 +86,8 @@
                         "gasLimit": "0x0f4240",
                         "maxPriorityFeePerGas": "0x64",
                         "maxFeePerGas": "0x03e8",
-                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"
+                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+                        "protected": true
                     },
                     {
                         "type": "0x02",
@@ -96,7 +99,8 @@
                         "gasLimit": "0x0f4240",
                         "maxPriorityFeePerGas": "0x64",
                         "maxFeePerGas": "0x03e8",
-                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"
+                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+                        "protected": true
                     }
                 ],
                 "uncleHeaders": []
@@ -139,7 +143,8 @@
                         "gasLimit": "0x0f4240",
                         "maxPriorityFeePerGas": "0x03e8",
                         "maxFeePerGas": "0x03e8",
-                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"
+                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+                        "protected": true
                     },
                     {
                         "type": "0x02",
@@ -151,7 +156,8 @@
                         "gasLimit": "0x0f4240",
                         "maxPriorityFeePerGas": "0x64",
                         "maxFeePerGas": "0x03e8",
-                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"
+                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+                        "protected": true
                     },
                     {
                         "type": "0x02",
@@ -163,7 +169,8 @@
                         "gasLimit": "0x0f4240",
                         "maxPriorityFeePerGas": "0x0186a0",
                         "maxFeePerGas": "0x0186a0",
-                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"
+                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+                        "protected": true
                     }
                 ],
                 "uncleHeaders": []
@@ -206,7 +213,8 @@
                         "gasLimit": "0x0f4240",
                         "maxPriorityFeePerGas": "0x03e8",
                         "maxFeePerGas": "0x03e8",
-                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"
+                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+                        "protected": true
                     },
                     {
                         "type": "0x02",
@@ -218,7 +226,8 @@
                         "gasLimit": "0x0f4240",
                         "maxPriorityFeePerGas": "0x64",
                         "maxFeePerGas": "0x03e8",
-                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"
+                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+                        "protected": true
                     },
                     {
                         "type": "0x02",
@@ -230,7 +239,8 @@
                         "gasLimit": "0x0f4240",
                         "maxPriorityFeePerGas": "0x0186a0",
                         "maxFeePerGas": "0x0186a0",
-                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"
+                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+                        "protected": true
                     }
                 ],
                 "uncleHeaders": []

--- a/src/ethereum_test_tools/tests/test_fixtures/blockchain_london_valid_filled.json
+++ b/src/ethereum_test_tools/tests/test_fixtures/blockchain_london_valid_filled.json
@@ -34,7 +34,8 @@
                         "gasLimit": "0x0f4240",
                         "maxPriorityFeePerGas": "0x01",
                         "maxFeePerGas": "0x03e8",
-                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"
+                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+                        "protected": true
                     }
                 ],
                 "uncleHeaders": []
@@ -72,7 +73,8 @@
                         "gasLimit": "0x0f4240",
                         "maxPriorityFeePerGas": "0x0a",
                         "maxFeePerGas": "0x03e8",
-                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"
+                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+                        "protected": true
                     },
                     {
                         "type": "0x02",
@@ -84,7 +86,8 @@
                         "gasLimit": "0x0f4240",
                         "maxPriorityFeePerGas": "0x64",
                         "maxFeePerGas": "0x03e8",
-                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"
+                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+                        "protected": true
                     },
                     {
                         "type": "0x02",
@@ -96,7 +99,8 @@
                         "gasLimit": "0x0f4240",
                         "maxPriorityFeePerGas": "0x64",
                         "maxFeePerGas": "0x03e8",
-                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"
+                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+                        "protected": true
                     }
                 ],
                 "uncleHeaders": []
@@ -134,7 +138,8 @@
                         "gasLimit": "0x0f4240",
                         "maxPriorityFeePerGas": "0x03e8",
                         "maxFeePerGas": "0x03e8",
-                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"
+                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+                        "protected": true
                     },
                     {
                         "type": "0x02",
@@ -146,7 +151,8 @@
                         "gasLimit": "0x0f4240",
                         "maxPriorityFeePerGas": "0x64",
                         "maxFeePerGas": "0x03e8",
-                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"
+                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+                        "protected": true
                     },
                     {
                         "type": "0x02",
@@ -158,7 +164,8 @@
                         "gasLimit": "0x0f4240",
                         "maxPriorityFeePerGas": "0x0186a0",
                         "maxFeePerGas": "0x0186a0",
-                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"
+                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+                        "protected": true
                     }
                 ],
                 "uncleHeaders": []
@@ -196,7 +203,8 @@
                         "gasLimit": "0x0f4240",
                         "maxPriorityFeePerGas": "0x03e8",
                         "maxFeePerGas": "0x03e8",
-                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"
+                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+                        "protected": true
                     },
                     {
                         "type": "0x02",
@@ -208,7 +216,8 @@
                         "gasLimit": "0x0f4240",
                         "maxPriorityFeePerGas": "0x64",
                         "maxFeePerGas": "0x03e8",
-                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"
+                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+                        "protected": true
                     },
                     {
                         "type": "0x02",
@@ -220,7 +229,8 @@
                         "gasLimit": "0x0f4240",
                         "maxPriorityFeePerGas": "0x0186a0",
                         "maxFeePerGas": "0x0186a0",
-                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"
+                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+                        "protected": true
                     }
                 ],
                 "uncleHeaders": []

--- a/src/ethereum_test_tools/tests/test_fixtures/chainid_istanbul_filled.json
+++ b/src/ethereum_test_tools/tests/test_fixtures/chainid_istanbul_filled.json
@@ -31,7 +31,8 @@
                         "data": "0x",
                         "gasLimit": "0x05f5e100",
                         "gasPrice": "0x0a",
-                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"
+                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+                        "protected": false
                     }
                 ],
                 "uncleHeaders": []

--- a/src/ethereum_test_tools/tests/test_fixtures/chainid_london_filled.json
+++ b/src/ethereum_test_tools/tests/test_fixtures/chainid_london_filled.json
@@ -32,7 +32,8 @@
                         "data": "0x",
                         "gasLimit": "0x05f5e100",
                         "gasPrice": "0x0a",
-                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"
+                        "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+                        "protected": false
                     }
                 ],
                 "uncleHeaders": []


### PR DESCRIPTION
Keep the `protected` field in the transactions. This field might be important for signing transactions with the right signing hash.