### PR TITLE
tests/4844: `excessDataGas` and `dataGasUsed` spec update

### DIFF
--- a/src/ethereum_test_forks/base_fork.py
+++ b/src/ethereum_test_forks/base_fork.py
@@ -14,7 +14,7 @@ class BaseForkMeta(ABCMeta):
         """
         To be implemented by the fork base class.
         """
-        pass
+        return ""
 
     def __repr__(cls) -> str:
         """
@@ -67,6 +67,14 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
     def header_excess_data_gas_required(cls, block_number: int, timestamp: int) -> bool:
         """
         Returns true if the header must contain excess data gas
+        """
+        pass
+
+    @classmethod
+    @abstractmethod
+    def header_data_gas_used_required(cls, block_number: int, timestamp: int) -> bool:
+        """
+        Returns true if the header must contain data gas used
         """
         pass
 

--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -46,6 +46,13 @@ class Frontier(BaseFork):
         return False
 
     @classmethod
+    def header_data_gas_used_required(cls, block_number: int, timestamp: int) -> bool:
+        """
+        At genesis, header must not contain data gas used
+        """
+        return False
+
+    @classmethod
     def get_reward(cls, block_number: int, timestamp: int) -> int:
         """
         At Genesis the expected reward amount in wei is
@@ -210,5 +217,12 @@ class Cancun(Shanghai):
     def header_excess_data_gas_required(cls, block_number: int, timestamp: int) -> bool:
         """
         Excess data gas is required starting from Cancun.
+        """
+        return True
+
+    @classmethod
+    def header_data_gas_used_required(cls, block_number: int, timestamp: int) -> bool:
+        """
+        Data gas used is required starting from Cancun.
         """
         return True

--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -642,6 +642,20 @@ class Environment:
         if fork.header_zero_difficulty_required(self.number, self.timestamp):
             res.difficulty = 0
 
+        if (
+            fork.header_excess_data_gas_required(self.number, self.timestamp)
+            and res.excess_data_gas is None
+            and res.parent_excess_data_gas is None
+        ):
+            res.excess_data_gas = 0
+
+        if (
+            fork.header_data_gas_used_required(self.number, self.timestamp)
+            and res.data_gas_used is None
+            and res.parent_data_gas_used is None
+        ):
+            res.data_gas_used = 0
+
         return res
 
 

--- a/src/ethereum_test_tools/spec/blockchain_test.py
+++ b/src/ethereum_test_tools/spec/blockchain_test.py
@@ -75,6 +75,7 @@ class BlockchainTest(BaseTest):
             mix_digest="0x0000000000000000000000000000000000000000000000000000000000000000",
             nonce="0x0000000000000000",
             base_fee=env.base_fee,
+            data_gas_used=env.data_gas_used,
             excess_data_gas=env.excess_data_gas,
             withdrawals_root=t8n.calc_withdrawals_root(env.withdrawals, fork)
             if env.withdrawals is not None

--- a/src/ethereum_test_tools/spec/state_test.py
+++ b/src/ethereum_test_tools/spec/state_test.py
@@ -73,6 +73,7 @@ class StateTest(BaseTest):
             mix_digest="0x0000000000000000000000000000000000000000000000000000000000000000",
             nonce="0x0000000000000000",
             base_fee=env.base_fee,
+            data_gas_used=env.data_gas_used,
             excess_data_gas=env.excess_data_gas,
             withdrawals_root=t8n.calc_withdrawals_root(env.withdrawals, fork)
             if env.withdrawals is not None

--- a/tests/eips/eip4844/README.md
+++ b/tests/eips/eip4844/README.md
@@ -46,12 +46,17 @@ Predominantly verifies that `excess_data_gas` & `data_gasprice` are calculated c
 Tests that the `excess_data_gas` is calculated correctly within a single block for various contexts, where the `parent.excess_data_gas` and the proposed block `excess_data_gas` have a variety of values. The excess data gas is calculated using the following formula:
 
 ```python
-def calc_excess_data_gas(parent: Header, new_blobs: int) -> int:
-    consumed_data_gas = new_blobs * DATA_GAS_PER_BLOB
-    if parent.excess_data_gas + consumed_data_gas < TARGET_DATA_GAS_PER_BLOCK:
+def calc_excess_data_gas(parent_excess_data_gas: int, parent_blobs: int) -> int:
+    """
+    Calculate the excess data gas for a block given the parent excess data gas
+    and the number of blobs in the block.
+    """
+    parent_consumed_data_gas = parent_blobs * DATA_GAS_PER_BLOB
+    if parent_excess_data_gas + parent_consumed_data_gas < TARGET_DATA_GAS_PER_BLOCK:
         return 0
     else:
-        return parent.excess_data_gas + consumed_data_gas - TARGET_DATA_GAS_PER_BLOCK
+        return parent_excess_data_gas + parent_consumed_data_gas - TARGET_DATA_GAS_PER_BLOCK
+
 ```
 
 For blocks to be valid in these contexts they must meet the following conditions of the EIP:

--- a/tests/eips/eip4844/test_blob_txs.py
+++ b/tests/eips/eip4844/test_blob_txs.py
@@ -889,7 +889,6 @@ def test_blob_tx_attribute_gasprice_opcode(
 def test_blob_type_tx_pre_fork(
     blockchain_test: BlockchainTestFiller,
     pre: Dict,
-    env: Environment,
     blocks: List[Block],
 ):
     """
@@ -899,5 +898,5 @@ def test_blob_type_tx_pre_fork(
         pre=pre,
         post={},
         blocks=blocks,
-        genesis_environment=env,
+        genesis_environment=Environment(),  # `env` fixture has blob fields
     )

--- a/tests/eips/eip4844/test_blob_txs.py
+++ b/tests/eips/eip4844/test_blob_txs.py
@@ -26,6 +26,7 @@ from .utils import (
     TARGET_BLOBS_PER_BLOCK,
     calc_excess_data_gas,
     get_data_gasprice,
+    get_min_excess_data_blobs_for_data_gas_price,
 )
 
 # * Adding a new test *
@@ -419,7 +420,7 @@ def test_valid_blob_tx_combinations(
     [
         # tx max_data_gas_cost of the transaction is not enough
         (
-            11,  # data gas price is 2
+            get_min_excess_data_blobs_for_data_gas_price(2) - 1,  # data gas price is 1
             TARGET_BLOBS_PER_BLOCK + 1,  # data gas cost increases to 2
             1,  # tx max_data_gas_cost is 1
             "insufficient max fee per data gas",

--- a/tests/eips/eip4844/test_blob_txs.py
+++ b/tests/eips/eip4844/test_blob_txs.py
@@ -19,6 +19,13 @@ from ethereum_test_tools import (
     to_hash_bytes,
 )
 
+from .utils import (
+    BLOB_COMMITMENT_VERSION_KZG,
+    DATA_GAS_PER_BLOB,
+    MAX_BLOBS_PER_BLOCK,
+    get_data_gasprice,
+)
+
 # * Adding a new test *
 # Add a function that is named `test_<test_name>` and takes the following
 # arguments:
@@ -37,41 +44,6 @@ from ethereum_test_tools import (
 
 REFERENCE_SPEC_GIT_PATH = "EIPS/eip-4844.md"
 REFERENCE_SPEC_VERSION = "b33e063530f0a114635dd4f89d3cca90f8cac28f"
-
-BLOB_COMMITMENT_VERSION_KZG = 1
-BLOBHASH_GAS_COST = 3
-MIN_DATA_GASPRICE = 1
-DATA_GAS_PER_BLOB = 2**17
-MAX_DATA_GAS_PER_BLOCK = 2**19
-TARGET_DATA_GAS_PER_BLOCK = 2**18
-MAX_BLOBS_PER_BLOCK = MAX_DATA_GAS_PER_BLOCK // DATA_GAS_PER_BLOB
-TARGET_BLOBS_PER_BLOCK = TARGET_DATA_GAS_PER_BLOCK // DATA_GAS_PER_BLOB
-DATA_GASPRICE_UPDATE_FRACTION = 2225652
-
-
-def fake_exponential(factor: int, numerator: int, denominator: int) -> int:
-    """
-    Used to calculate the data gas cost.
-    """
-    i = 1
-    output = 0
-    numerator_accumulator = factor * denominator
-    while numerator_accumulator > 0:
-        output += numerator_accumulator
-        numerator_accumulator = (numerator_accumulator * numerator) // (denominator * i)
-        i += 1
-    return output // denominator
-
-
-def get_data_gasprice(excess_data_gas: int) -> int:
-    """
-    Calculate the data gas price from the excess.
-    """
-    return fake_exponential(
-        MIN_DATA_GASPRICE,
-        excess_data_gas,
-        DATA_GASPRICE_UPDATE_FRACTION,
-    )
 
 
 @pytest.fixture

--- a/tests/eips/eip4844/test_blob_txs.py
+++ b/tests/eips/eip4844/test_blob_txs.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Optional, Tuple
 
 import pytest
 
-from ethereum_test_tools import Account, Block, BlockchainTestFiller, Environment
+from ethereum_test_tools import Account, Block, BlockchainTestFiller, Environment, Header
 from ethereum_test_tools import Opcodes as Op
 from ethereum_test_tools import (
     Storage,
@@ -330,11 +330,20 @@ def blocks(
     """
     Prepare the list of blocks for all test cases.
     """
-    return [
-        Block(
-            txs=txs,
-            exception=tx_error,
+    header_data_gas_used = 0
+    if len(txs) > 0:
+        header_data_gas_used = (
+            sum(
+                [
+                    len(tx.blob_versioned_hashes)
+                    for tx in txs
+                    if tx.blob_versioned_hashes is not None
+                ]
+            )
+            * DATA_GAS_PER_BLOB
         )
+    return [
+        Block(txs=txs, exception=tx_error, rlp_modifier=Header(data_gas_used=header_data_gas_used))
     ]
 
 

--- a/tests/eips/eip4844/test_blobhash_opcode.py
+++ b/tests/eips/eip4844/test_blobhash_opcode.py
@@ -19,8 +19,8 @@ from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 from .utils import (
     BLOBHASH_GAS_COST,
-    MAX_BLOB_PER_BLOCK,
-    TARGET_BLOB_PER_BLOCK,
+    MAX_BLOBS_PER_BLOCK,
+    TARGET_BLOBS_PER_BLOCK,
     BlobhashScenario,
     blobhash_index_values,
     random_blob_hashes,
@@ -71,7 +71,7 @@ def blob_tx(template_tx):
             to=address,
             access_list=[],
             max_priority_fee_per_gas=10,
-            blob_versioned_hashes=random_blob_hashes[0:MAX_BLOB_PER_BLOCK],
+            blob_versioned_hashes=random_blob_hashes[0:MAX_BLOBS_PER_BLOCK],
         )
 
     return _blob_tx
@@ -114,7 +114,7 @@ def test_blobhash_gas_cost(
                         gas_price=10 if tx_type < 2 else None,
                         access_list=[] if tx_type >= 2 else None,
                         max_priority_fee_per_gas=10 if tx_type >= 2 else None,
-                        blob_versioned_hashes=random_blob_hashes[0:TARGET_BLOB_PER_BLOCK]
+                        blob_versioned_hashes=random_blob_hashes[0:TARGET_BLOBS_PER_BLOCK]
                         if tx_type >= 3
                         else None,
                     )
@@ -174,7 +174,7 @@ def test_blobhash_scenarios(
             )
         )
         post[address] = Account(
-            storage={index: b_hashes_list[i][index] for index in range(MAX_BLOB_PER_BLOCK)}
+            storage={index: b_hashes_list[i][index] for index in range(MAX_BLOBS_PER_BLOCK)}
         )
     blockchain_test(
         pre=pre,
@@ -212,7 +212,7 @@ def test_blobhash_invalid_blob_index(
     for i in range(TOTAL_BLOCKS):
         address = to_address(0x100 + i * 0x100)
         pre[address] = Account(code=blobhash_calls)
-        blob_per_block = (i % MAX_BLOB_PER_BLOCK) + 1
+        blob_per_block = (i % MAX_BLOBS_PER_BLOCK) + 1
         blobs = [random_blob_hashes[blob] for blob in range(blob_per_block)]
         blocks.append(
             Block(
@@ -233,7 +233,7 @@ def test_blobhash_invalid_blob_index(
                 index: (0 if index < 0 or index >= blob_per_block else blobs[index])
                 for index in range(
                     -TOTAL_BLOCKS,
-                    blob_per_block + (TOTAL_BLOCKS - (i % MAX_BLOB_PER_BLOCK)),
+                    blob_per_block + (TOTAL_BLOCKS - (i % MAX_BLOBS_PER_BLOCK)),
                 )
             }
         )
@@ -287,10 +287,10 @@ def test_blobhash_multiple_txs_in_block(
     ]
     post = {
         to_address(address): Account(
-            storage={i: random_blob_hashes[i] for i in range(MAX_BLOB_PER_BLOCK)}
+            storage={i: random_blob_hashes[i] for i in range(MAX_BLOBS_PER_BLOCK)}
         )
         if address in (0x200, 0x400)
-        else Account(storage={i: 0 for i in range(MAX_BLOB_PER_BLOCK)})
+        else Account(storage={i: 0 for i in range(MAX_BLOBS_PER_BLOCK)})
         for address in range(0x100, 0x500, 0x100)
     }
     blockchain_test(

--- a/tests/eips/eip4844/test_blobhash_opcode.py
+++ b/tests/eips/eip4844/test_blobhash_opcode.py
@@ -17,7 +17,7 @@ from ethereum_test_tools import (
 )
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
-from .util_blobhash import (
+from .utils import (
     BLOBHASH_GAS_COST,
     MAX_BLOB_PER_BLOCK,
     TARGET_BLOB_PER_BLOCK,

--- a/tests/eips/eip4844/test_blobhash_opcode_contexts.py
+++ b/tests/eips/eip4844/test_blobhash_opcode_contexts.py
@@ -16,7 +16,7 @@ from ethereum_test_tools import (
     to_hash_bytes,
 )
 
-from .utils import BlobhashContext, simple_blob_hashes
+from .utils import BlobhashContext, MAX_BLOBS_PER_BLOCK, simple_blob_hashes
 
 pytestmark = pytest.mark.valid_from("Cancun")
 
@@ -136,7 +136,7 @@ def opcode_context(yul: YulCompiler, request):
                 ),
             },
             tx_type_3.with_fields(
-                data=to_hash_bytes(0) + to_hash_bytes(3),
+                data=to_hash_bytes(0) + to_hash_bytes(MAX_BLOBS_PER_BLOCK - 1),
                 to=BlobhashContext.address("delegatecall"),
             ),
             {
@@ -158,7 +158,7 @@ def opcode_context(yul: YulCompiler, request):
                 ),
             },
             tx_type_3.with_fields(
-                data=to_hash_bytes(0) + to_hash_bytes(3),
+                data=to_hash_bytes(0) + to_hash_bytes(MAX_BLOBS_PER_BLOCK - 1),
                 to=BlobhashContext.address("staticcall"),
             ),
             {
@@ -180,7 +180,7 @@ def opcode_context(yul: YulCompiler, request):
                 ),
             },
             tx_type_3.with_fields(
-                data=to_hash_bytes(0) + to_hash_bytes(3),
+                data=to_hash_bytes(0) + to_hash_bytes(MAX_BLOBS_PER_BLOCK - 1),
                 to=BlobhashContext.address("callcode"),
             ),
             {

--- a/tests/eips/eip4844/test_blobhash_opcode_contexts.py
+++ b/tests/eips/eip4844/test_blobhash_opcode_contexts.py
@@ -191,21 +191,6 @@ def opcode_context(yul: YulCompiler, request):
                 ),
             },
         )
-    elif test_case == "on_INITCODE":
-        return create_opcode_context(
-            {},
-            tx_type_3.with_fields(
-                data=BlobhashContext.code("initcode"),
-                to=None,
-            ),
-            {
-                BlobhashContext.created_contract("tx_created_contract"): Account(
-                    storage={
-                        k: v for (k, v) in zip(range(len(simple_blob_hashes)), simple_blob_hashes)
-                    }
-                ),
-            },
-        )
     elif test_case == "on_CREATE":
         return create_opcode_context(
             {

--- a/tests/eips/eip4844/test_blobhash_opcode_contexts.py
+++ b/tests/eips/eip4844/test_blobhash_opcode_contexts.py
@@ -16,7 +16,7 @@ from ethereum_test_tools import (
     to_hash_bytes,
 )
 
-from .util_blobhash import BlobhashContext, simple_blob_hashes
+from .utils import BlobhashContext, simple_blob_hashes
 
 pytestmark = pytest.mark.valid_from("Cancun")
 

--- a/tests/eips/eip4844/test_blobhash_opcode_contexts.py
+++ b/tests/eips/eip4844/test_blobhash_opcode_contexts.py
@@ -16,7 +16,7 @@ from ethereum_test_tools import (
     to_hash_bytes,
 )
 
-from .utils import BlobhashContext, MAX_BLOBS_PER_BLOCK, simple_blob_hashes
+from .utils import MAX_BLOBS_PER_BLOCK, BlobhashContext, simple_blob_hashes
 
 pytestmark = pytest.mark.valid_from("Cancun")
 

--- a/tests/eips/eip4844/test_excess_data_gas.py
+++ b/tests/eips/eip4844/test_excess_data_gas.py
@@ -395,6 +395,7 @@ def all_invalid_data_gas_used_combinations() -> Iterator[Tuple[int, int]]:
         for header_data_gas_used in range(0, MAX_BLOBS_PER_BLOCK + 1):
             if new_blobs != header_data_gas_used:
                 yield (new_blobs, header_data_gas_used * DATA_GAS_PER_BLOB)
+        yield (new_blobs, 2**64 - 1)
 
 
 @pytest.mark.parametrize(

--- a/tests/eips/eip4844/test_excess_data_gas.py
+++ b/tests/eips/eip4844/test_excess_data_gas.py
@@ -147,11 +147,18 @@ def tx_max_fee(  # noqa: D103
 
 
 @pytest.fixture
-def tx_data_cost(  # noqa: D103
+def tx_max_fee_per_data(  # noqa: D103
     fee_per_data_gas: int,
+) -> int:
+    return fee_per_data_gas
+
+
+@pytest.fixture
+def tx_data_cost(  # noqa: D103
+    tx_max_fee_per_data: int,
     new_blobs: int,
 ) -> int:
-    return fee_per_data_gas * DATA_GAS_PER_BLOB * new_blobs
+    return tx_max_fee_per_data * DATA_GAS_PER_BLOB * new_blobs
 
 
 @pytest.fixture
@@ -188,7 +195,7 @@ def post(destination_account: str, tx_value: int) -> Mapping[str, Account]:  # n
 def tx(  # noqa: D103
     new_blobs: int,
     tx_max_fee: int,
-    tx_data_cost: int,
+    tx_max_fee_per_data: int,
     destination_account: str,
 ):
     if new_blobs == 0:
@@ -212,7 +219,7 @@ def tx(  # noqa: D103
             gas_limit=21000,
             max_fee_per_gas=tx_max_fee,
             max_priority_fee_per_gas=0,
-            max_fee_per_data_gas=tx_data_cost,
+            max_fee_per_data_gas=tx_max_fee_per_data,
             access_list=[],
             blob_versioned_hashes=add_kzg_version(
                 [to_hash_bytes(x) for x in range(new_blobs)],

--- a/tests/eips/eip4844/test_excess_data_gas.py
+++ b/tests/eips/eip4844/test_excess_data_gas.py
@@ -485,6 +485,7 @@ def test_invalid_static_excess_data_gas(
     but the parent blobs included are not TARGET_BLOBS_PER_BLOCK.
     """
     blocks[0].rlp_modifier = Header(excess_data_gas=parent_excess_data_gas)
+    blocks[0].exception = "invalid excessDataGas"
     blockchain_test(
         pre=pre,
         post={},

--- a/tests/eips/eip4844/test_excess_data_gas.py
+++ b/tests/eips/eip4844/test_excess_data_gas.py
@@ -108,17 +108,10 @@ def header_excess_data_gas(  # noqa: D103
 
 
 @pytest.fixture
-def fee_per_data_gas(  # noqa: D103
+def block_fee_per_data_gas(  # noqa: D103
     correct_excess_data_gas: int,
 ) -> int:
     return get_data_gasprice(excess_data_gas=correct_excess_data_gas)
-
-
-@pytest.fixture
-def tx_max_fee_per_data_gas(  # noqa: D103
-    fee_per_data_gas: int,
-) -> int:
-    return fee_per_data_gas
 
 
 @pytest.fixture
@@ -140,25 +133,25 @@ def env(  # noqa: D103
 
 
 @pytest.fixture
-def tx_max_fee(  # noqa: D103
+def tx_max_fee_per_gas(  # noqa: D103
     block_base_fee: int,
 ) -> int:
     return block_base_fee
 
 
 @pytest.fixture
-def tx_max_fee_per_data(  # noqa: D103
-    fee_per_data_gas: int,
+def tx_max_fee_per_data_gas(  # noqa: D103
+    block_fee_per_data_gas: int,
 ) -> int:
-    return fee_per_data_gas
+    return block_fee_per_data_gas
 
 
 @pytest.fixture
 def tx_data_cost(  # noqa: D103
-    tx_max_fee_per_data: int,
+    tx_max_fee_per_data_gas: int,
     new_blobs: int,
 ) -> int:
-    return tx_max_fee_per_data * DATA_GAS_PER_BLOB * new_blobs
+    return tx_max_fee_per_data_gas * DATA_GAS_PER_BLOB * new_blobs
 
 
 @pytest.fixture
@@ -167,9 +160,9 @@ def tx_value() -> int:  # noqa: D103
 
 
 @pytest.fixture
-def tx_exact_cost(tx_value: int, tx_max_fee: int, tx_data_cost: int) -> int:  # noqa: D103
+def tx_exact_cost(tx_value: int, tx_max_fee_per_gas: int, tx_data_cost: int) -> int:  # noqa: D103
     tx_gas = 21000
-    return (tx_gas * tx_max_fee) + tx_value + tx_data_cost
+    return (tx_gas * tx_max_fee_per_gas) + tx_value + tx_data_cost
 
 
 @pytest.fixture
@@ -194,8 +187,8 @@ def post(destination_account: str, tx_value: int) -> Mapping[str, Account]:  # n
 @pytest.fixture
 def tx(  # noqa: D103
     new_blobs: int,
-    tx_max_fee: int,
-    tx_max_fee_per_data: int,
+    tx_max_fee_per_gas: int,
+    tx_max_fee_per_data_gas: int,
     destination_account: str,
 ):
     if new_blobs == 0:
@@ -206,7 +199,7 @@ def tx(  # noqa: D103
             to=destination_account,
             value=1,
             gas_limit=21000,
-            max_fee_per_gas=tx_max_fee,
+            max_fee_per_gas=tx_max_fee_per_gas,
             max_priority_fee_per_gas=0,
             access_list=[],
         )
@@ -217,9 +210,9 @@ def tx(  # noqa: D103
             to=destination_account,
             value=1,
             gas_limit=21000,
-            max_fee_per_gas=tx_max_fee,
+            max_fee_per_gas=tx_max_fee_per_gas,
             max_priority_fee_per_gas=0,
-            max_fee_per_data_gas=tx_max_fee_per_data,
+            max_fee_per_data_gas=tx_max_fee_per_data_gas,
             access_list=[],
             blob_versioned_hashes=add_kzg_version(
                 [to_hash_bytes(x) for x in range(new_blobs)],

--- a/tests/eips/eip4844/test_excess_data_gas_fork_transition.py
+++ b/tests/eips/eip4844/test_excess_data_gas_fork_transition.py
@@ -19,7 +19,12 @@ from ethereum_test_tools import (
     to_hash_bytes,
 )
 
-from .utils import BLOB_COMMITMENT_VERSION_KZG, MAX_BLOBS_PER_BLOCK, TARGET_BLOBS_PER_BLOCK
+from .utils import (
+    BLOB_COMMITMENT_VERSION_KZG,
+    MAX_BLOBS_PER_BLOCK,
+    TARGET_BLOBS_PER_BLOCK,
+    get_min_excess_data_blobs_for_data_gas_price,
+)
 
 REFERENCE_SPEC_GIT_PATH = "EIPS/eip-4844.md"
 REFERENCE_SPEC_VERSION = "ac003985b9be74ff48bd897770e6d5f2e4318715"
@@ -30,8 +35,6 @@ pytestmark = pytest.mark.valid_at_transition_to("Cancun")
 
 # Timestamp of the fork
 FORK_TIMESTAMP = 15_000
-# Data gas cost increases from 1 to 2 at this amount of excess blobs
-BLOBS_TO_DATA_GAS_COST_INCREASE = 12
 
 
 @pytest.fixture
@@ -59,7 +62,9 @@ def post_fork_block_count() -> int:
     """
     Amount of blocks to produce with the post-fork rules.
     """
-    return 12
+    return get_min_excess_data_blobs_for_data_gas_price(2) // (
+        MAX_BLOBS_PER_BLOCK - TARGET_BLOBS_PER_BLOCK
+    )
 
 
 @pytest.fixture
@@ -187,7 +192,9 @@ def test_invalid_post_fork_block_without_excess_data_gas(
     "post_fork_block_count,blob_count_per_block",
     [
         (
-            BLOBS_TO_DATA_GAS_COST_INCREASE // (MAX_BLOBS_PER_BLOCK - TARGET_BLOBS_PER_BLOCK) + 2,
+            get_min_excess_data_blobs_for_data_gas_price(2)
+            // (MAX_BLOBS_PER_BLOCK - TARGET_BLOBS_PER_BLOCK)
+            + 2,
             MAX_BLOBS_PER_BLOCK,
         ),
         (10, 0),

--- a/tests/eips/eip4844/test_point_evaluation_precompile.py
+++ b/tests/eips/eip4844/test_point_evaluation_precompile.py
@@ -5,8 +5,7 @@ EIP: https://eips.ethereum.org/EIPS/eip-4844
 import glob
 import json
 import os
-from hashlib import sha256
-from typing import Dict, Iterator, List, Literal
+from typing import Dict, Iterator, List
 
 import pytest
 
@@ -23,43 +22,20 @@ from ethereum_test_tools import (
 )
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
+from .utils import (
+    BLS_MODULUS,
+    FIELD_ELEMENTS_PER_BLOB,
+    INF_POINT,
+    POINT_EVALUATION_PRECOMPILE_ADDRESS,
+    POINT_EVALUATION_PRECOMPILE_GAS,
+    Z_Y_VALID_ENDIANNESS,
+    Z,
+    auto,
+    kzg_to_versioned_hash,
+)
+
 REFERENCE_SPEC_GIT_PATH = "EIPS/eip-4844.md"
 REFERENCE_SPEC_VERSION = "ac003985b9be74ff48bd897770e6d5f2e4318715"
-
-POINT_EVALUATION_PRECOMPILE_ADDRESS = 20
-POINT_EVALUATION_PRECOMPILE_GAS = 50_000
-BLOB_COMMITMENT_VERSION_KZG = b"\x01"
-
-BLS_MODULUS = 0x73EDA753299D7D483339D80809A1D80553BDA402FFFE5BFEFFFFFFFF00000001
-BLS_MODULUS_BYTES = BLS_MODULUS.to_bytes(32, "big")
-FIELD_ELEMENTS_PER_BLOB = 4096
-FIELD_ELEMENTS_PER_BLOB_BYTES = FIELD_ELEMENTS_PER_BLOB.to_bytes(32, "big")
-
-Z_Y_VALID_ENDIANNESS: Literal["little", "big"] = "big"
-Z_Y_INVALID_ENDIANNESS: Literal["little", "big"] = "little"
-
-Z = 0x623CE31CF9759A5C8DAF3A357992F9F3DD7F9339D8998BC8E68373E54F00B75E
-INF_POINT = (0xC0 << 376).to_bytes(48, byteorder="big")
-
-
-auto = Auto()
-
-
-def kzg_to_versioned_hash(
-    kzg_commitment: bytes | int,  # 48 bytes
-    blob_commitment_version_kzg: bytes | int = BLOB_COMMITMENT_VERSION_KZG,
-) -> bytes:
-    """
-    Calculates the versioned hash for a given KZG commitment.
-    """
-    if isinstance(kzg_commitment, int):
-        kzg_commitment = kzg_commitment.to_bytes(48, "big")
-    if isinstance(blob_commitment_version_kzg, int):
-        blob_commitment_version_kzg = blob_commitment_version_kzg.to_bytes(1, "big")
-    return blob_commitment_version_kzg + sha256(kzg_commitment).digest()[1:]
-
-
-StorageDictType = Dict[str | int | bytes, str | int | bytes]
 
 
 @pytest.fixture

--- a/tests/eips/eip4844/test_point_evaluation_precompile_gas.py
+++ b/tests/eips/eip4844/test_point_evaluation_precompile_gas.py
@@ -2,7 +2,6 @@
 Test EIP-4844: Shard Blob Transactions (Point Evaluation Precompile)
 EIP: https://eips.ethereum.org/EIPS/eip-4844
 """
-from hashlib import sha256
 from typing import Dict, Literal
 
 import pytest
@@ -19,29 +18,16 @@ from ethereum_test_tools import (
 )
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
+from .utils import (
+    INF_POINT,
+    POINT_EVALUATION_PRECOMPILE_ADDRESS,
+    POINT_EVALUATION_PRECOMPILE_GAS,
+    Z,
+    kzg_to_versioned_hash,
+)
+
 REFERENCE_SPEC_GIT_PATH = "EIPS/eip-4844.md"
 REFERENCE_SPEC_VERSION = "ac003985b9be74ff48bd897770e6d5f2e4318715"
-
-POINT_EVALUATION_PRECOMPILE_ADDRESS = 20
-POINT_EVALUATION_PRECOMPILE_GAS = 50_000
-BLOB_COMMITMENT_VERSION_KZG = b"\x01"
-
-Z = 0x623CE31CF9759A5C8DAF3A357992F9F3DD7F9339D8998BC8E68373E54F00B75E
-INF_POINT = (0xC0 << 376).to_bytes(48, byteorder="big")
-
-
-def kzg_to_versioned_hash(
-    kzg_commitment: bytes | int,  # 48 bytes
-    blob_commitment_version_kzg: bytes | int = BLOB_COMMITMENT_VERSION_KZG,
-) -> bytes:
-    """
-    Calculates the versioned hash for a given KZG commitment.
-    """
-    if isinstance(kzg_commitment, int):
-        kzg_commitment = kzg_commitment.to_bytes(48, "big")
-    if isinstance(blob_commitment_version_kzg, int):
-        blob_commitment_version_kzg = blob_commitment_version_kzg.to_bytes(1, "big")
-    return blob_commitment_version_kzg + sha256(kzg_commitment).digest()[1:]
 
 
 @pytest.fixture

--- a/tests/eips/eip4844/utils.py
+++ b/tests/eips/eip4844/utils.py
@@ -28,16 +28,16 @@ BLOBHASH_GAS_COST = 3
 BLS_MODULUS = 0x73EDA753299D7D483339D80809A1D80553BDA402FFFE5BFEFFFFFFFF00000001
 BLS_MODULUS_BYTES = BLS_MODULUS.to_bytes(32, "big")
 DATA_GAS_PER_BLOB = 2**17
-DATA_GASPRICE_UPDATE_FRACTION = 2225652
+DATA_GASPRICE_UPDATE_FRACTION = 3338477
 FIELD_ELEMENTS_PER_BLOB = 4096
 FIELD_ELEMENTS_PER_BLOB_BYTES = FIELD_ELEMENTS_PER_BLOB.to_bytes(32, "big")
 INF_POINT = (0xC0 << 376).to_bytes(48, byteorder="big")
-MAX_DATA_GAS_PER_BLOCK = 2**19
+MAX_DATA_GAS_PER_BLOCK = 786432
 MAX_BLOBS_PER_BLOCK = MAX_DATA_GAS_PER_BLOCK // DATA_GAS_PER_BLOB
 MIN_DATA_GASPRICE = 1
 POINT_EVALUATION_PRECOMPILE_ADDRESS = 20
 POINT_EVALUATION_PRECOMPILE_GAS = 50_000
-TARGET_DATA_GAS_PER_BLOCK = 2**18
+TARGET_DATA_GAS_PER_BLOCK = 393216
 TARGET_BLOBS_PER_BLOCK = TARGET_DATA_GAS_PER_BLOCK // DATA_GAS_PER_BLOB
 Z = 0x623CE31CF9759A5C8DAF3A357992F9F3DD7F9339D8998BC8E68373E54F00B75E
 Z_Y_INVALID_ENDIANNESS: Literal["little", "big"] = "little"
@@ -76,6 +76,25 @@ def get_data_gasprice(*, excess_data_gas: int) -> int:
         excess_data_gas,
         DATA_GASPRICE_UPDATE_FRACTION,
     )
+
+
+def get_min_excess_data_gas_for_data_gas_price(data_gas_price: int) -> int:
+    """
+    Gets the minimum required excess data gas value to get a given data gas cost in a block
+    """
+    current_excess_data_gas = 0
+    current_data_gas_price = 1
+    while current_data_gas_price < data_gas_price:
+        current_excess_data_gas += DATA_GAS_PER_BLOB
+        current_data_gas_price = get_data_gasprice(excess_data_gas=current_excess_data_gas)
+    return current_excess_data_gas
+
+
+def get_min_excess_data_blobs_for_data_gas_price(data_gas_price: int) -> int:
+    """
+    Gets the minimum required excess data blobs to get a given data gas cost in a block
+    """
+    return get_min_excess_data_gas_for_data_gas_price(data_gas_price) // DATA_GAS_PER_BLOB
 
 
 def calc_excess_data_gas(*, parent_excess_data_gas: int, parent_blobs: int) -> int:

--- a/tests/eips/eip4844/utils.py
+++ b/tests/eips/eip4844/utils.py
@@ -10,8 +10,8 @@ from typing import Literal, Union
 from ethereum_test_tools import (
     Auto,
     TestAddress,
-    YulCompiler,
     Transaction,
+    YulCompiler,
     add_kzg_version,
     compute_create2_address,
     compute_create_address,

--- a/tests/eips/eip4844/utils.py
+++ b/tests/eips/eip4844/utils.py
@@ -4,11 +4,14 @@ Tests: tests/eips/eip4844/
     > test_blobhash_opcode_contexts.py
     > test_blobhash_opcode.py
 """
-from typing import Union
+from hashlib import sha256
+from typing import Literal, Union
 
 from ethereum_test_tools import (
+    Auto,
     TestAddress,
     YulCompiler,
+    Transaction,
     add_kzg_version,
     compute_create2_address,
     compute_create_address,
@@ -16,10 +19,109 @@ from ethereum_test_tools import (
 )
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
-BLOBHASH_GAS_COST = 3
-TARGET_BLOB_PER_BLOCK = 2
-MAX_BLOB_PER_BLOCK = 4
+auto = Auto()
+
+
+# Constants
 BLOB_COMMITMENT_VERSION_KZG = 1
+BLOBHASH_GAS_COST = 3
+BLS_MODULUS = 0x73EDA753299D7D483339D80809A1D80553BDA402FFFE5BFEFFFFFFFF00000001
+BLS_MODULUS_BYTES = BLS_MODULUS.to_bytes(32, "big")
+DATA_GAS_PER_BLOB = 2**17
+DATA_GASPRICE_UPDATE_FRACTION = 2225652
+FIELD_ELEMENTS_PER_BLOB = 4096
+FIELD_ELEMENTS_PER_BLOB_BYTES = FIELD_ELEMENTS_PER_BLOB.to_bytes(32, "big")
+INF_POINT = (0xC0 << 376).to_bytes(48, byteorder="big")
+MAX_BLOB_PER_BLOCK = 4
+MAX_DATA_GAS_PER_BLOCK = 2**19
+MAX_BLOBS_PER_BLOCK = MAX_DATA_GAS_PER_BLOCK // DATA_GAS_PER_BLOB
+MIN_DATA_GASPRICE = 1
+POINT_EVALUATION_PRECOMPILE_ADDRESS = 20
+POINT_EVALUATION_PRECOMPILE_GAS = 50_000
+TARGET_BLOB_PER_BLOCK = 2
+TARGET_DATA_GAS_PER_BLOCK = 2**18
+TARGET_BLOBS_PER_BLOCK = TARGET_DATA_GAS_PER_BLOCK // DATA_GAS_PER_BLOB
+Z = 0x623CE31CF9759A5C8DAF3A357992F9F3DD7F9339D8998BC8E68373E54F00B75E
+Z_Y_INVALID_ENDIANNESS: Literal["little", "big"] = "little"
+Z_Y_VALID_ENDIANNESS: Literal["little", "big"] = "big"
+
+
+def fake_exponential(factor: int, numerator: int, denominator: int) -> int:
+    """
+    Used to calculate the data gas cost.
+    """
+    i = 1
+    output = 0
+    numerator_accumulator = factor * denominator
+    while numerator_accumulator > 0:
+        output += numerator_accumulator
+        numerator_accumulator = (numerator_accumulator * numerator) // (denominator * i)
+        i += 1
+    return output // denominator
+
+
+def calc_data_fee(tx: Transaction, excess_data_gas: int) -> int:
+    """
+    Calculate the data fee for a transaction.
+    """
+    return get_total_data_gas(tx) * get_data_gasprice(excess_data_gas)
+
+
+def get_total_data_gas(tx: Transaction) -> int:
+    """
+    Calculate the total data gas for a transaction.
+    """
+    if tx.blob_versioned_hashes is None:
+        return 0
+    return DATA_GAS_PER_BLOB * len(tx.blob_versioned_hashes)
+
+
+def get_data_gasprice_from_blobs(excess_blobs: int) -> int:
+    """
+    Calculate the data gas price from the excess blob count.
+    """
+    return fake_exponential(
+        MIN_DATA_GASPRICE,
+        excess_blobs * DATA_GAS_PER_BLOB,
+        DATA_GASPRICE_UPDATE_FRACTION,
+    )
+
+
+def get_data_gasprice(excess_data_gas: int) -> int:
+    """
+    Calculate the data gas price from the excess.
+    """
+    return fake_exponential(
+        MIN_DATA_GASPRICE,
+        excess_data_gas,
+        DATA_GASPRICE_UPDATE_FRACTION,
+    )
+
+
+def calc_excess_data_gas(parent_excess_data_gas: int, parent_blobs: int) -> int:
+    """
+    Calculate the excess data gas for a block given the parent excess data gas
+    and the number of blobs in the block.
+    """
+    parent_consumed_data_gas = parent_blobs * DATA_GAS_PER_BLOB
+    if parent_excess_data_gas + parent_consumed_data_gas < TARGET_DATA_GAS_PER_BLOCK:
+        return 0
+    else:
+        return parent_excess_data_gas + parent_consumed_data_gas - TARGET_DATA_GAS_PER_BLOCK
+
+
+def kzg_to_versioned_hash(
+    kzg_commitment: bytes | int,  # 48 bytes
+    blob_commitment_version_kzg: bytes | int = BLOB_COMMITMENT_VERSION_KZG,
+) -> bytes:
+    """
+    Calculates the versioned hash for a given KZG commitment.
+    """
+    if isinstance(kzg_commitment, int):
+        kzg_commitment = kzg_commitment.to_bytes(48, "big")
+    if isinstance(blob_commitment_version_kzg, int):
+        blob_commitment_version_kzg = blob_commitment_version_kzg.to_bytes(1, "big")
+    return blob_commitment_version_kzg + sha256(kzg_commitment).digest()[1:]
 
 
 # Simple list of blob versioned hashes ranging from bytes32(1 to 4)

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -103,6 +103,7 @@ shl
 shr
 sar
 rjust
+ljust
 
 keccak256
 


### PR DESCRIPTION
Addresses the following spec changes:
- [x] https://github.com/ethereum/EIPs/pull/6985
- [x] https://github.com/ethereum/EIPs/pull/7062
- [x] https://github.com/ethereum/EIPs/pull/7095
- [x] https://github.com/ethereum/EIPs/pull/7100
- [x] https://github.com/ethereum/EIPs/pull/7154
- [x] Fix minimum balance required calculation on blob transactions where the `max_fee_per_data_gas > get_data_gasprice(header.excess_data_gas)`