### PR TITLE
fix: evm bin command line option

### DIFF
--- a/src/evm_block_builder/__init__.py
+++ b/src/evm_block_builder/__init__.py
@@ -47,18 +47,18 @@ class EvmBlockBuilder(BlockBuilder):
     binary: Path
     cached_version: Optional[str] = None
 
-    def __init__(self, binary: Optional[Path] = None):
+    def __init__(self, binary: Optional[Path | str] = None):
         if binary is None:
             which_path = which("evm")
             if which_path is not None:
                 binary = Path(which_path)
-        if binary is None or not binary.exists():
+        if binary is None or not Path(binary).exists():
             raise Exception(
                 """`evm` binary executable is not accessible, please refer to
                 https://github.com/ethereum/go-ethereum on how to compile and
                 install the full suite of utilities including the `evm` tool"""
             )
-        self.binary = binary
+        self.binary = Path(binary)
 
     def build(
         self,

--- a/src/evm_transition_tool/__init__.py
+++ b/src/evm_transition_tool/__init__.py
@@ -150,20 +150,20 @@ class EvmTransitionTool(TransitionTool):
 
     def __init__(
         self,
-        binary: Optional[Path] = None,
+        binary: Optional[Path | str] = None,
         trace: bool = False,
     ):
         if binary is None:
             which_path = which("evm")
             if which_path is not None:
                 binary = Path(which_path)
-        if binary is None or not binary.exists():
+        if binary is None or not Path(binary).exists():
             raise Exception(
                 """`evm` binary executable is not accessible, please refer to
                 https://github.com/ethereum/go-ethereum on how to compile and
                 install the full suite of utilities including the `evm` tool"""
             )
-        self.binary = binary
+        self.binary = Path(binary)
         self.trace = trace
         args = [str(self.binary), "t8n", "--help"]
         try:


### PR DESCRIPTION
As of 82533148769e566af0a58b1b66be2ccccc4e28a9, if the `--evm-bin` flag is used (`fill --evm-bin=/usr/bin/evm`), the `fill` command gave the following error:
```python
self = <evm_block_builder.EvmBlockBuilder object at 0x7fcaa9f9b3a0>, binary = '/usr/bin/evm'

    def __init__(self, binary: Optional[Path] = None):
        if binary is None:
            which_path = which("evm")
            if which_path is not None:
                binary = Path(which_path)
>       if binary is None or not binary.exists():
E       AttributeError: 'str' object has no attribute 'exists'
```
As the command-line option is saved as type str.

This PR addresses the issue by allowing the constructor argument to be one of [None, str, Path] and adds a test for it.