### PR TITLE
feature: specify the target evm version to solc for yul compilation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         python: ['3.10']
         golang: [1.19]
-        solc: ['0.8.17']
+        solc: ['0.8.20']
     steps:
       - uses: actions/checkout@v2
         with:

--- a/README.md
+++ b/README.md
@@ -63,21 +63,23 @@ The following requires a Python 3.10 installation.
 
 This guide installs stable versions of the required external `evm` and `solc` executables and will only enable generation of test fixtures for features deployed to mainnet. In order to generate fixtures for features under active development, you can follow the steps below and then follow the [additional steps in the online doc](https://danceratopz.github.io/execution-spec-tests/getting_started/executing_tests_dev_fork/).
 
-1. Ensure go-ethereum's `evm` tool is in your path. Either build the required version, or alternatively:
+1. Ensure go-ethereum's `evm` tool and `solc` are in your path. Either build the required versions, or alternatively:
 
     ```console
     sudo add-apt-repository -y ppa:ethereum/ethereum
     sudo apt-get update
-    sudo apt-get install ethereum
+    sudo apt-get install ethereum solc
     ```
 
     More help:
 
     - [geth installation doc](https://geth.ethereum.org/docs/getting-started/installing-geth#ubuntu-via-ppas).
+    - [solc installation doc](https://docs.soliditylang.org/en/latest/installing-solidity.html#linux-packages).
 
-2. Ensure `solc` v0.8.17 is in your path, it can be downloaded [here](https://github.com/ethereum/solidity/releases/tag/v0.8.17). Support for more recent `solc` versions is pending, cf [execution-spec-tests#135](https://github.com/ethereum/execution-spec-tests/issues/135).
+    Help for other platforms is available in the [online doc](https://danceratopz.github.io/execution-spec-tests/getting_started/quick_start/).
 
-3. Clone the [execution-spec-tests](https://github.com/ethereum/execution-spec-tests) repo and install its and dependencies (it's recommended to use a virtual environment for the installation):
+2. Clone the [execution-spec-tests](https://github.com/ethereum/execution-spec-tests) repo and install its and dependencies (it's recommended to use a virtual environment for the installation):
+
    ```console
    git clone https://github.com/ethereum/execution-spec-tests
    cd execution-spec-tests
@@ -85,22 +87,27 @@ This guide installs stable versions of the required external `evm` and `solc` ex
    source ./venv/bin/activate
    pip install -e .[docs,lint,test]
    ```
-4. Verify the installation:
+
+3. Verify the installation:
     1. Explore test cases:
+
        ```console
        fill --collect-only
        ```
+
        Expected console output:
          ![Screenshot of pytest test collection console output](docs/getting_started/img/pytest_collect_only.png)
-       
+
     2. Execute the test cases (verbosely) in the `./tests/example/test_acl_example.py` module:
+
         ```console
         fill -v tests/example/test_acl_example.py
         ```
+
         Expected console output:
           ![Screenshot of pytest test collection console output](docs/getting_started/img/pytest_run_example.png)
         Check:
-       
+
         1. The versions of the `evm` and `solc` tools are as expected (your versions may differ from those in the highlighted box).
         2. The corresponding fixture file has been generated:
 

--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ The generated test fixtures can be used:
 1. Directly by client teams' test frameworks, and,
 2. In the integration tests executed in the [ethereum/hive](https://github.com/ethereum/hive) framework.
 
-# Getting Started
+## Getting Started
 
-## Prerequisites
+### Prerequisites
 
 The following requires a Python 3.10 installation.
 
-## Quick Start
+### Quick Start
 
 This guide installs stable versions of the required external `evm` and `solc` executables and will only enable generation of test fixtures for features deployed to mainnet. In order to generate fixtures for features under active development, you can follow the steps below and then follow the [additional steps in the online doc](https://danceratopz.github.io/execution-spec-tests/getting_started/executing_tests_dev_fork/).
 
@@ -122,6 +122,7 @@ The available test cases can be browsed in the [Test Case Reference doc](https:/
 ## Usage
 
 See the [online documentation](https://danceratopz.github.io/execution-spec-tests/) for further help with working with this codebase:
+
 1. Learn [useful command-line flags](https://danceratopz.github.io/execution-spec-tests/getting_started/executing_tests_command_line/).
 2. [Execute tests for features under development](https://danceratopz.github.io/execution-spec-tests/getting_started/executing_tests_dev_fork/) via the `--from=FORK1` and `--until=FORK2` flags.
 3. _Optional:_ [Configure VS Code](https://danceratopz.github.io/execution-spec-tests/getting_started/setup_vs_code/) to auto-format Python code and [execute tests within VS Code](https://danceratopz.github.io/execution-spec-tests/getting_started/executing_tests_vs_code/#executing-and-debugging-test-cases).

--- a/src/ethereum_test_tools/__init__.py
+++ b/src/ethereum_test_tools/__init__.py
@@ -3,7 +3,7 @@ Module containing tools for generating cross-client Ethereum execution layer
 tests.
 """
 
-from .code import Code, CodeGasMeasure, Initcode, Yul
+from .code import Code, CodeGasMeasure, Initcode, Yul, YulCompiler
 from .common import (
     AccessList,
     Account,
@@ -59,6 +59,7 @@ __all__ = (
     "Transaction",
     "Withdrawal",
     "Yul",
+    "YulCompiler",
     "add_kzg_version",
     "ceiling_division",
     "compute_create_address",

--- a/src/ethereum_test_tools/code/__init__.py
+++ b/src/ethereum_test_tools/code/__init__.py
@@ -3,13 +3,14 @@ Code related utilities and classes.
 """
 from .code import Code, code_to_bytes, code_to_hex
 from .generators import CodeGasMeasure, Initcode
-from .yul import Yul
+from .yul import Yul, YulCompiler
 
 __all__ = (
     "Code",
     "CodeGasMeasure",
     "Initcode",
     "Yul",
+    "YulCompiler",
     "code_to_bytes",
     "code_to_hex",
 )

--- a/src/ethereum_test_tools/code/yul.py
+++ b/src/ethereum_test_tools/code/yul.py
@@ -3,6 +3,7 @@ Yul frontend
 """
 
 import re
+import warnings
 from pathlib import Path
 from shutil import which
 from subprocess import PIPE, run
@@ -115,6 +116,9 @@ class Yul(Code):
             if match:
                 solc_version_string = match.group(0)
                 break
+        if not solc_version_string:
+            warnings.warn("Unable to determine solc version.")
+            solc_version_string = "unknown"
         return solc_version_string
 
 

--- a/src/ethereum_test_tools/code/yul.py
+++ b/src/ethereum_test_tools/code/yul.py
@@ -3,14 +3,14 @@ Yul frontend
 """
 
 from pathlib import Path
+from shutil import which
 from subprocess import PIPE, run
-from typing import Mapping, Optional, Tuple, Type
+from typing import Mapping, Optional, Tuple, Type, Union
 
 from ethereum_test_forks import Fork
 
 from .code import Code
 
-SOLC: Path = Path("solc")
 DEFAULT_SOLC_ARGS = ("--assemble", "-")
 
 
@@ -43,25 +43,41 @@ class Yul(Code):
     source: str
     compiled: Optional[bytes] = None
 
-    def __init__(self, source: str, fork: Fork = None):
+    def __init__(
+        self,
+        source: str,
+        fork: Optional[Fork] = None,
+        binary: Optional[Path | str] = None,
+    ):
         self.source = source
         self.evm_version = get_evm_version_from_fork(fork)
+        if binary is None:
+            which_path = which("solc")
+            if which_path is not None:
+                binary = Path(which_path)
+        if binary is None or not Path(binary).exists():
+            raise Exception(
+                """`solc` binary executable not found, please refer to
+                https://docs.soliditylang.org/en/latest/installing-solidity.html
+                for help downloading and installing `solc`"""
+            )
+        self.binary = Path(binary)
 
     def assemble(self) -> bytes:
         """
         Assembles using `solc --assemble`.
         """
         if not self.compiled:
-            solc_args: Tuple[str, ...] = ()
+            solc_args: Tuple[Union[Path, str], ...] = ()
             if self.evm_version:
                 solc_args = (
-                    str(SOLC),
+                    self.binary,
                     "--evm-version",
                     self.evm_version,
                     *DEFAULT_SOLC_ARGS,
                 )
             else:
-                solc_args = (str(SOLC), *DEFAULT_SOLC_ARGS)
+                solc_args = (self.binary, *DEFAULT_SOLC_ARGS)
             result = run(
                 solc_args,
                 input=str.encode(self.source),

--- a/src/ethereum_test_tools/code/yul.py
+++ b/src/ethereum_test_tools/code/yul.py
@@ -2,6 +2,7 @@
 Yul frontend
 """
 
+import re
 from pathlib import Path
 from shutil import which
 from subprocess import PIPE, run
@@ -96,6 +97,25 @@ class Yul(Code):
 
             self.compiled = bytes.fromhex(hex_str)
         return self.compiled
+
+    def version(self) -> str:
+        """
+        Return solc's version string
+        """
+        result = run(
+            [self.binary, "--version"],
+            stdout=PIPE,
+            stderr=PIPE,
+        )
+        solc_output = result.stdout.decode().split("\n")
+        version_pattern = r"0\.\d+\.\d+\+\S+"
+        solc_version_string = None
+        for line in solc_output:
+            match = re.search(version_pattern, line)
+            if match:
+                solc_version_string = match.group(0)
+                break
+        return solc_version_string
 
 
 YulCompiler = Type[Yul]

--- a/src/ethereum_test_tools/tests/test_code.py
+++ b/src/ethereum_test_tools/tests/test_code.py
@@ -4,6 +4,8 @@ Test suite for `ethereum_test.code` module.
 
 import pytest
 
+from ethereum_test_forks import Merge
+
 from ..code import Code, Initcode, Yul, code_to_bytes
 
 
@@ -96,7 +98,8 @@ def test_yul():
         expected_bytecode += bytes.fromhex("80")
         expected_bytecode += bytes.fromhex("55")
 
-    assert Yul(long_code).assemble() == expected_bytecode
+    # TODO(dan): workaround until it's understood why Shanghai takes so long to compile
+    assert Yul(long_code, fork=Merge).assemble() == expected_bytecode
 
 
 @pytest.mark.parametrize(

--- a/src/ethereum_test_tools/tests/test_filler.py
+++ b/src/ethereum_test_tools/tests/test_filler.py
@@ -41,7 +41,8 @@ def test_make_genesis(fork: Fork, hash: str):
                 sstore(0, f(1, 2))
                 return(0, 32)
             }
-            """
+            """,
+                fork=fork,
             ),
         ),
         TestAddress: Account(balance=0x0BA1A9CE0BA1A9CE),
@@ -127,7 +128,8 @@ def test_fill_state_test(fork: Fork, expected_json_file: str):
     assert fixture_json == expected
 
 
-def test_fill_london_blockchain_test_valid_txs():
+@pytest.mark.parametrize("fork", [London])
+def test_fill_london_blockchain_test_valid_txs(fork: Fork):
     """
     Test `ethereum_test.filler.fill_fixtures` with `BlockchainTest`.
     """
@@ -147,7 +149,8 @@ def test_fill_london_blockchain_test_valid_txs():
                     sstore(add(number(), 0x2000), selfbalance())
                     stop()
                 }
-            """
+                """,
+                fork=fork,
             ),
         ),
         "0xcccccccccccccccccccccccccccccccccccccccd": Account(
@@ -160,7 +163,8 @@ def test_fill_london_blockchain_test_valid_txs():
                       0xcccccccccccccccccccccccccccccccccccccccc,
                       0, 0, 0, 0)
                 }
-            """
+                """,
+                fork=fork,
             ),
         ),
         "0x000000000000000000000000000000000000c0de": Account(
@@ -173,7 +177,8 @@ def test_fill_london_blockchain_test_valid_txs():
                             0xcccccccccccccccccccccccccccccccccccccccc,
                             0, 0, 0, 0)
                 }
-            """
+                """,
+                fork=fork,
             ),
         ),
         "0xccccccccccccccccccccccccccccccccccccccce": Account(
@@ -188,7 +193,8 @@ def test_fill_london_blockchain_test_valid_txs():
                             0xcccccccccccccccccccccccccccccccccccccccc,
                             0, 0, 0, 0)
                 }
-            """
+                """,
+                fork=fork,
             ),
         ),
     }
@@ -387,11 +393,11 @@ def test_fill_london_blockchain_test_valid_txs():
     t8n = EvmTransitionTool()
 
     fixture = {
-        f"000/my_blockchain_test/{London}": fill_test(
+        f"000/my_blockchain_test/{fork.name()}": fill_test(
             t8n=t8n,
             b11r=b11r,
             test_spec=blockchain_test,
-            fork=London,
+            fork=fork,
             engine="NoProof",
             spec=None,
         )
@@ -413,7 +419,8 @@ def test_fill_london_blockchain_test_valid_txs():
     assert fixture_json == expected
 
 
-def test_fill_london_blockchain_test_invalid_txs():
+@pytest.mark.parametrize("fork", [London])
+def test_fill_london_blockchain_test_invalid_txs(fork):
     """
     Test `ethereum_test.filler.fill_fixtures` with `BlockchainTest`.
     """
@@ -433,7 +440,8 @@ def test_fill_london_blockchain_test_invalid_txs():
                     sstore(add(number(), 0x2000), selfbalance())
                     stop()
                 }
-            """
+                """,
+                fork=fork,
             ),
         ),
         "0xcccccccccccccccccccccccccccccccccccccccd": Account(
@@ -446,7 +454,8 @@ def test_fill_london_blockchain_test_invalid_txs():
                       0xcccccccccccccccccccccccccccccccccccccccc,
                       0, 0, 0, 0)
                 }
-            """
+                """,
+                fork=fork,
             ),
         ),
         "0x000000000000000000000000000000000000c0de": Account(
@@ -459,7 +468,8 @@ def test_fill_london_blockchain_test_invalid_txs():
                             0xcccccccccccccccccccccccccccccccccccccccc,
                             0, 0, 0, 0)
                 }
-            """
+                """,
+                fork=fork,
             ),
         ),
         "0xccccccccccccccccccccccccccccccccccccccce": Account(
@@ -474,7 +484,8 @@ def test_fill_london_blockchain_test_invalid_txs():
                             0xcccccccccccccccccccccccccccccccccccccccc,
                             0, 0, 0, 0)
                 }
-            """
+                """,
+                fork=fork,
             ),
         ),
     }
@@ -719,11 +730,11 @@ def test_fill_london_blockchain_test_invalid_txs():
     t8n = EvmTransitionTool()
 
     fixture = {
-        f"000/my_blockchain_test/{London}": fill_test(
+        f"000/my_blockchain_test/{fork.name()}": fill_test(
             t8n=t8n,
             b11r=b11r,
             test_spec=blockchain_test,
-            fork=London,
+            fork=fork,
             engine="NoProof",
             spec=None,
         )

--- a/src/pytest_plugins/test_filler/test_filler.py
+++ b/src/pytest_plugins/test_filler/test_filler.py
@@ -115,26 +115,7 @@ def pytest_report_header(config, start_path):
         binary=config.getoption("evm_bin"),
         trace=config.getoption("evm_collect_traces"),
     )
-    if config.getoption("solc_bin"):
-        solc_bin = config.getoption("solc_bin")
-    else:
-        solc_bin = which("solc")
-
-    result = subprocess.run(
-        [solc_bin, "--version"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    solc_output = result.stdout.decode().split("\n")
-
-    version_pattern = r"0\.\d+\.\d+\+\S+"
-    solc_version_string = None
-
-    for line in solc_output:
-        match = re.search(version_pattern, line)
-        if match:
-            solc_version_string = match.group(0)
-            break
+    solc_version_string = Yul("", binary=config.getoption("solc_bin")).version()
     return [f"{t8n.version()}, solc version {solc_version_string}"]
 
 

--- a/src/pytest_plugins/test_filler/test_filler.py
+++ b/src/pytest_plugins/test_filler/test_filler.py
@@ -8,8 +8,6 @@ writes the generated fixtures to file.
 import json
 import os
 import re
-import subprocess
-from shutil import which
 from typing import Any, Dict, List, Tuple, Type
 
 import pytest

--- a/tests/eips/eip4844/test_blobhash_opcode_contexts.py
+++ b/tests/eips/eip4844/test_blobhash_opcode_contexts.py
@@ -12,6 +12,7 @@ from ethereum_test_tools import (
     BlockchainTestFiller,
     TestAddress,
     Transaction,
+    YulCompiler,
     to_hash_bytes,
 )
 
@@ -48,13 +49,33 @@ def create_opcode_context(pre, tx, post):
     }
 
 
-# Dictionary of BLOBHASH opcode use cases. Each context is given a
-# pre state, tx & post state respectively, and utilized
-# directly within the context pytest fixture.
-opcode_contexts = [
-    (
+@pytest.fixture(
+    params=[
         "on_top_level_call_stack",
-        create_opcode_context(
+        "on_max_value",
+        "on_CALL",
+        "on_DELEGATECALL",
+        "on_STATICCALL",
+        "on_CALLCODE",
+        "on_INITCODE",
+        "on_CREATE",
+        "on_CREATE2",
+        "on_type_2_tx",
+        "on_type_1_tx",
+        "on_type_0_tx",
+    ]
+)
+def opcode_context(yul: YulCompiler, request):
+    """
+    Fixture that is parameterized by each BLOBHASH opcode test case
+    in order to return the corresponding constructed opcode context.
+
+    Each context is given a pre state, tx & post state respectively
+    """
+    BlobhashContext.yul_compiler = yul
+    test_case = request.param
+    if test_case == "on_top_level_call_stack":
+        return create_opcode_context(
             {
                 BlobhashContext.address("blobhash_sstore"): Account(
                     code=BlobhashContext.code("blobhash_sstore")
@@ -69,11 +90,9 @@ opcode_contexts = [
                     storage={0: simple_blob_hashes[0]}
                 ),
             },
-        ),
-    ),
-    (
-        "on_max_value",
-        create_opcode_context(
+        )
+    elif test_case == "on_max_value":
+        return create_opcode_context(
             {
                 BlobhashContext.address("blobhash_sstore"): Account(
                     code=BlobhashContext.code("blobhash_sstore")
@@ -86,11 +105,9 @@ opcode_contexts = [
             {
                 BlobhashContext.address("blobhash_sstore"): Account(storage={}),
             },
-        ),
-    ),
-    (
-        "on_CALL",
-        create_opcode_context(
+        )
+    elif test_case == "on_CALL":
+        return create_opcode_context(
             {
                 BlobhashContext.address("call"): Account(code=BlobhashContext.code("call")),
                 BlobhashContext.address("blobhash_sstore"): Account(
@@ -107,11 +124,9 @@ opcode_contexts = [
                     storage={1: simple_blob_hashes[1]}
                 ),
             },
-        ),
-    ),
-    (
-        "on_DELEGATECALL",
-        create_opcode_context(
+        )
+    elif test_case == "on_DELEGATECALL":
+        return create_opcode_context(
             {
                 BlobhashContext.address("delegatecall"): Account(
                     code=BlobhashContext.code("delegatecall")
@@ -131,11 +146,9 @@ opcode_contexts = [
                     }
                 ),
             },
-        ),
-    ),
-    (
-        "on_STATICCALL",
-        create_opcode_context(
+        )
+    elif test_case == "on_STATICCALL":
+        return create_opcode_context(
             {
                 BlobhashContext.address("staticcall"): Account(
                     code=BlobhashContext.code("staticcall")
@@ -155,11 +168,9 @@ opcode_contexts = [
                     }
                 ),
             },
-        ),
-    ),
-    (
-        "on_CALLCODE",
-        create_opcode_context(
+        )
+    elif test_case == "on_CALLCODE":
+        return create_opcode_context(
             {
                 BlobhashContext.address("callcode"): Account(
                     code=BlobhashContext.code("callcode")
@@ -179,11 +190,9 @@ opcode_contexts = [
                     }
                 ),
             },
-        ),
-    ),
-    (
-        "on_INITCODE",
-        create_opcode_context(
+        )
+    elif test_case == "on_INITCODE":
+        return create_opcode_context(
             {},
             tx_type_3.with_fields(
                 data=BlobhashContext.code("initcode"),
@@ -196,11 +205,9 @@ opcode_contexts = [
                     }
                 ),
             },
-        ),
-    ),
-    (
-        "on_CREATE",
-        create_opcode_context(
+        )
+    elif test_case == "on_CREATE":
+        return create_opcode_context(
             {
                 BlobhashContext.address("create"): Account(code=BlobhashContext.code("create")),
             },
@@ -215,11 +222,9 @@ opcode_contexts = [
                     }
                 ),
             },
-        ),
-    ),
-    (
-        "on_CREATE2",
-        create_opcode_context(
+        )
+    elif test_case == "on_CREATE2":
+        return create_opcode_context(
             {
                 BlobhashContext.address("create2"): Account(code=BlobhashContext.code("create2")),
             },
@@ -234,11 +239,9 @@ opcode_contexts = [
                     }
                 ),
             },
-        ),
-    ),
-    (
-        "on_type_2_tx",
-        create_opcode_context(
+        )
+    elif test_case == "on_type_2_tx":
+        return create_opcode_context(
             {
                 BlobhashContext.address("blobhash_sstore"): Account(
                     code=BlobhashContext.code("blobhash_sstore")
@@ -256,11 +259,9 @@ opcode_contexts = [
             {
                 BlobhashContext.address("blobhash_sstore"): Account(storage={0: 0}),
             },
-        ),
-    ),
-    (
-        "on_type_1_tx",
-        create_opcode_context(
+        )
+    elif test_case == "on_type_1_tx":
+        return create_opcode_context(
             {
                 BlobhashContext.address("blobhash_sstore"): Account(
                     code=BlobhashContext.code("blobhash_sstore")
@@ -277,11 +278,9 @@ opcode_contexts = [
             {
                 BlobhashContext.address("blobhash_sstore"): Account(storage={0: 0}),
             },
-        ),
-    ),
-    (
-        "on_type_0_tx",
-        create_opcode_context(
+        )
+    elif test_case == "on_type_0_tx":
+        return create_opcode_context(
             {
                 BlobhashContext.address("blobhash_sstore"): Account(
                     code=BlobhashContext.code("blobhash_sstore")
@@ -298,21 +297,13 @@ opcode_contexts = [
             {
                 BlobhashContext.address("blobhash_sstore"): Account(storage={0: 0}),
             },
-        ),
-    ),
-]
+        )
+    else:
+        raise Exception(f"Unknown test case {test_case}")
 
 
-@pytest.fixture(params=opcode_contexts, ids=[op[0] for op in opcode_contexts])
-def context(request):
-    """
-    Fixture that is parameterized to each value of the opcode_contexts
-    list of tuples, with the first item in each tuple set as the test ID.
-    """
-    return request.param[1]
-
-
-def test_blobhash_opcode_contexts(context, blockchain_test: BlockchainTestFiller):
+@pytest.mark.compile_yul_with("Shanghai")
+def test_blobhash_opcode_contexts(opcode_context, blockchain_test: BlockchainTestFiller):
     """
     Tests that the BLOBHASH opcode functions correctly when called in different
     contexts including:
@@ -325,7 +316,7 @@ def test_blobhash_opcode_contexts(context, blockchain_test: BlockchainTestFiller
     - BLOBHASH opcode on transaction types 0, 1 and 2.
     """
     blockchain_test(
-        pre=context.get("pre"),
-        blocks=[Block(txs=[context.get("tx")])],
-        post=context.get("post"),
+        pre=opcode_context.get("pre"),
+        blocks=[Block(txs=[opcode_context.get("tx")])],
+        post=opcode_context.get("post"),
     )

--- a/tests/eips/eip4844/util_blobhash.py
+++ b/tests/eips/eip4844/util_blobhash.py
@@ -4,9 +4,11 @@ Tests: tests/eips/eip4844/
     > test_blobhash_opcode_contexts.py
     > test_blobhash_opcode.py
 """
+from typing import Union
+
 from ethereum_test_tools import (
     TestAddress,
-    Yul,
+    YulCompiler,
     add_kzg_version,
     compute_create2_address,
     compute_create_address,
@@ -61,6 +63,7 @@ class BlobhashContext:
     to specific bytecode (with BLOBHASH), addresses and contracts.
     """
 
+    yul_compiler: Union[YulCompiler, None] = None
     addresses = {
         "blobhash_sstore": to_address(0x100),
         "blobhash_return": to_address(0x600),
@@ -100,7 +103,7 @@ class BlobhashContext:
         blobhash_verbatim = cls._get_blobhash_verbatim()
 
         code = {
-            "blobhash_sstore": Yul(
+            "blobhash_sstore": cls.yul_compiler(
                 f"""
                 {{
                    let pos := calldataload(0)
@@ -118,7 +121,7 @@ class BlobhashContext:
                 }}
                 """
             ),
-            "blobhash_return": Yul(
+            "blobhash_return": cls.yul_compiler(
                 f"""
                 {{
                    let pos := calldataload(0)
@@ -129,7 +132,7 @@ class BlobhashContext:
                 }}
                 """
             ),
-            "call": Yul(
+            "call": cls.yul_compiler(
                 """
                 {
                     calldatacopy(0, 0, calldatasize())
@@ -137,7 +140,7 @@ class BlobhashContext:
                 }
                 """
             ),
-            "delegatecall": Yul(
+            "delegatecall": cls.yul_compiler(
                 """
                 {
                     calldatacopy(0, 0, calldatasize())
@@ -145,7 +148,7 @@ class BlobhashContext:
                 }
                 """
             ),
-            "callcode": Yul(
+            "callcode": cls.yul_compiler(
                 f"""
                 {{
                     let pos := calldataload(0)
@@ -168,7 +171,7 @@ class BlobhashContext:
                 }}
                 """
             ),
-            "staticcall": Yul(
+            "staticcall": cls.yul_compiler(
                 f"""
                 {{
                     let pos := calldataload(0)
@@ -191,7 +194,7 @@ class BlobhashContext:
                 }}
                 """
             ),
-            "create": Yul(
+            "create": cls.yul_compiler(
                 """
                 {
                     calldatacopy(0, 0, calldatasize())
@@ -199,7 +202,7 @@ class BlobhashContext:
                 }
                 """
             ),
-            "create2": Yul(
+            "create2": cls.yul_compiler(
                 """
                 {
                     calldatacopy(0, 0, calldatasize())
@@ -207,7 +210,7 @@ class BlobhashContext:
                 }
                 """
             ),
-            "initcode": Yul(
+            "initcode": cls.yul_compiler(
                 f"""
                 {{
                    for {{ let pos := 0 }} lt(pos, 10) {{ pos := add(pos, 1) }}

--- a/tests/eips/test_eip3855.py
+++ b/tests/eips/test_eip3855.py
@@ -13,7 +13,7 @@ from ethereum_test_tools import (
     StateTestFiller,
     TestAddress,
     Transaction,
-    Yul,
+    YulCompiler,
     to_address,
 )
 from ethereum_test_tools.vm.opcode import Opcodes as Op
@@ -138,13 +138,14 @@ def test_push0_during_staticcall(
     post: dict,
     tx: Transaction,
     addr_1: str,
+    yul: YulCompiler,
 ):
     """
     Test PUSH0 during staticcall.
     """
     addr_2 = to_address(0x200)
 
-    code_1 = Yul(
+    code_1 = yul(
         """
         {
             sstore(0, staticcall(100000, 0x200, 0, 0, 0, 0))

--- a/tests/example/test_yul_example.py
+++ b/tests/example/test_yul_example.py
@@ -10,12 +10,12 @@ from ethereum_test_tools import (
     StateTestFiller,
     TestAddress,
     Transaction,
-    Yul,
+    YulCompiler,
 )
 
 
 @pytest.mark.valid_from("Berlin")
-def test_yul(state_test: StateTestFiller):
+def test_yul(state_test: StateTestFiller, yul: YulCompiler):
     """
     Test YUL compiled bytecode.
     """
@@ -24,7 +24,7 @@ def test_yul(state_test: StateTestFiller):
     pre = {
         "0x1000000000000000000000000000000000000000": Account(
             balance=0x0BA1A9CE0BA1A9CE,
-            code=Yul(
+            code=yul(
                 """
             {
                 function f(a, b) -> c {

--- a/tests/security/test_selfdestruct_balance_bug.py
+++ b/tests/security/test_selfdestruct_balance_bug.py
@@ -16,14 +16,15 @@ from ethereum_test_tools import (
     BlockchainTestFiller,
     TestAddress,
     Transaction,
-    Yul,
+    YulCompiler,
     to_address,
 )
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 
+@pytest.mark.compile_yul_with("Merge")  # Shanghai refuses to compile SELFDESTRUCT
 @pytest.mark.valid_from("Constantinople")
-def test_tx_selfdestruct_balance_bug(blockchain_test: BlockchainTestFiller):
+def test_tx_selfdestruct_balance_bug(blockchain_test: BlockchainTestFiller, yul: YulCompiler):
     """
     Checks balance of 0xaa after executing specific txs:
 
@@ -47,7 +48,7 @@ def test_tx_selfdestruct_balance_bug(blockchain_test: BlockchainTestFiller):
             - during tx 2, code in 0xaa does not execute,
               hence self-destruct mechanism does not trigger.
     """
-    aa_code = Yul(
+    aa_code = yul(
         """
         {
             /* 1st entrance is self-destruct */

--- a/tests/withdrawals/test_withdrawals.py
+++ b/tests/withdrawals/test_withdrawals.py
@@ -14,7 +14,7 @@ from ethereum_test_tools import (
     TestAddress,
     Transaction,
     Withdrawal,
-    Yul,
+    YulCompiler,
     compute_create_address,
     to_address,
     to_hash,
@@ -431,6 +431,7 @@ def test_self_destructing_account(blockchain_test: BlockchainTestFiller):
 def test_newly_created_contract(
     blockchain_test: BlockchainTestFiller,
     include_value_in_tx: bool,
+    yul: YulCompiler,
     request,
 ):
     """
@@ -442,7 +443,7 @@ def test_newly_created_contract(
         TestAddress: Account(balance=1000000000000000000000, nonce=0),
     }
 
-    initcode = Yul(
+    initcode = yul(
         """
         {
             return(0, 1)


### PR DESCRIPTION
This PR:
- [x] Adds an optional keyword argument to the Yul constructor that allows the user to specify the fork for which the code should be compiled for. This fixes #135.
- [x] Adds a `--solc-bin` command-line flag analogous to `--evm-bin`.
- [x] ~~Checks whether any forks (configured the command-line) don't supported by the configured solc binary.~~ This may be done in the forks plugin, but perhaps undesirable as it would potentially force users to use a development version of `solc` to run `fill` with dev forks.

Note, after changing the behavior so that Yul gets compiled with the test's current fork parameter value: `tests/security/test_selfdestruct_balance_bug.py` fails if compiled with Constantinople or Shanghai. Shanghai can be explained: This is just because `solc` refuses to compile contracts with SELFDESTRUCT. I didn't understand why the code doesn't compile for Constantinople yet. We don't need to fix this in the scope of this PR, imo, but we should make a ticket to not forget. This is currently avoided by applying `@pytest.mark.compile_yul_with("Merge")`.