### PR TITLE
chore: fix pytest warnings and specify docstring style

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ plugins:
       handlers:
         python:
           options:
+            docstring_style: google
             members_order: source
             group_by_category: false
   - search

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     types-setuptools==57.4.4
     requests==2.28.2
     colorlog>=6.7.0
-    pytest==7.3.1
+    pytest==7.3.2
 
 [options.package_data]
 ethereum_test_tools =
@@ -49,8 +49,8 @@ console_scripts =
 [options.extras_require]
 test =
     # pytest already in 'install_requires'
-    pytest-cov>=2.12,<3
-    pytest-xdist>=2.3.0,<3
+    pytest-cov>=4.1.0,<5
+    pytest-xdist>=3.3.1,<4
 
 lint =
     isort>=5.8,<6

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,7 +79,7 @@ docs =
 
 [flake8]
 dictionaries=en_US,python,technical
-docstring-convention = all
+docstring-convention = google
 extend-ignore = E203, D107, D200, D203, D205,
     D212, D400, D401, D410, D411, D412, D413,
     D414, D415, D416, N806 


### PR DESCRIPTION
This PR cherry picks 2 useful commits from #143 that I'd like to fast track. In particular, the docstring commit would be useful to start experimenting with better generated doc.

1. Updates pytest and pytest plugins in order to fix this issue with pytest-cov plugin:

```
========================================================================== warnings summary ==========================================================================
src/pytest_plugins/forks/tests/test_forks.py::test_from_london_option_no_validity_marker[London]
src/pytest_plugins/forks/tests/test_forks.py::test_no_options_no_validity_marker
src/pytest_plugins/forks/tests/test_forks.py::test_from_london_option_no_validity_marker[Merge]
src/pytest_plugins/forks/tests/test_forks.py::test_from_london_until_shanghai_option_no_validity_marker
  /home/dtopz/code/github/danceratopz/execution-spec-tests/.tox/py3/lib/python3.10/site-packages/pytest_cov/plugin.py:113: PytestDeprecationWarning: The hookimpl pytest_load_initial_conftests uses old-style configuration options (marks or attributes).
  Please use the pytest.hookimpl(tryfirst=True) decorator instead
   to configure the hooks.
   See https://docs.pytest.org/en/latest/deprecations.html#configuring-hook-specs-impls-using-markers
    @pytest.mark.tryfirst

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

2. Defines the docstring format used to be "google" in the `mkdocs` and `flake8` tools. This allows:
