### PR TITLE
tools: fix solc compilation for the ConstantinopleFix fork

### DIFF
--- a/src/ethereum_test_tools/code/yul.py
+++ b/src/ethereum_test_tools/code/yul.py
@@ -30,7 +30,10 @@ def get_evm_version_from_fork(fork: Fork | None):
     """
     if not fork:
         return None
-    fork_to_evm_version_map: Mapping[str, str] = {"Merge": "paris"}
+    fork_to_evm_version_map: Mapping[str, str] = {
+        "Merge": "paris",
+        "ConstantinopleFix": "constantinople",
+    }
     if fork.name() in fork_to_evm_version_map:
         return fork_to_evm_version_map[fork.name()]
     return fork.name().lower()

--- a/tests/example/test_yul_example.py
+++ b/tests/example/test_yul_example.py
@@ -14,7 +14,7 @@ from ethereum_test_tools import (
 )
 
 
-@pytest.mark.valid_from("Berlin")
+@pytest.mark.valid_from("Homestead")
 def test_yul(state_test: StateTestFiller, yul: YulCompiler):
     """
     Test YUL compiled bytecode.


### PR DESCRIPTION
We have to additionally map the `ConstantinopleFix` fork to "constantinople" when setting the target evm version for solc (`solc --evm-version FORK`.

Additionally, update the yul example to run from Homestead. Frontier is not supported by solc.