### PR TITLE
github: update golang version

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         python: ['3.10']
-        golang: [1.19]
+        golang: ['1.20.5']
         solc: ['0.8.20']
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Updates the golang version required in the github actions file, so the `evm` tool compilation succeeds.