### PR TITLE
Pytest plugins: Implement EIP reference version checking as dynamic tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -7,3 +7,4 @@ addopts =
     -p pytest_plugins.test_filler.test_filler
     -p pytest_plugins.forks.forks
     -p pytest_plugins.spec_version_checker.spec_version_checker
+    -m "not eip_version_check"

--- a/src/ethereum_test_tools/reference_spec/git_reference_spec.py
+++ b/src/ethereum_test_tools/reference_spec/git_reference_spec.py
@@ -44,11 +44,17 @@ class GitReferenceSpec(ReferenceSpec):
         """
         return self.SpecVersion
 
-    def _get_latest_known_spec(self) -> Dict | None:
-        response = requests.get(
+    def api_url(self) -> str:
+        """
+        The URL used to retrieve the version via the Github API.
+        """
+        return (
             f"https://api.github.com/repos/{self.RepositoryOwner}/"
-            + f"{self.RepositoryName}/git/blobs/{self.SpecVersion}"
+            f"{self.RepositoryName}/contents/{self.SpecPath}"
         )
+
+    def _get_latest_known_spec(self) -> Dict | None:
+        response = requests.get(self.api_url())
         if response.status_code != 200:
             return None
         content = json.loads(response.content)
@@ -58,10 +64,7 @@ class GitReferenceSpec(ReferenceSpec):
     def _get_latest_spec(self) -> Dict | None:
         if self._latest_spec is not None:
             return self._latest_spec
-        response = requests.get(
-            f"https://api.github.com/repos/{self.RepositoryOwner}/"
-            + f"{self.RepositoryName}/contents/{self.SpecPath}"
-        )
+        response = requests.get(self.api_url())
         if response.status_code != 200:
             return None
         content = json.loads(response.content)

--- a/src/ethereum_test_tools/reference_spec/reference_spec.py
+++ b/src/ethereum_test_tools/reference_spec/reference_spec.py
@@ -55,6 +55,13 @@ class ReferenceSpec:
         pass
 
     @abstractmethod
+    def api_url(self) -> str:
+        """
+        Returns the URL required to poll the version from an API, if needed.
+        """
+        pass
+
+    @abstractmethod
     def latest_version(self) -> str:
         """
         Returns a digest that points to the latest version of the spec.

--- a/src/pytest_plugins/spec_version_checker/spec_version_checker.py
+++ b/src/pytest_plugins/spec_version_checker/spec_version_checker.py
@@ -2,79 +2,141 @@
 A pytest plugin that checks that the spec version specified in test/filler
 modules matches that of https://github.com/ethereum/EIPs.
 """
-import warnings
+
+import re
+from types import ModuleType
 
 import pytest
+from _pytest.nodes import Item
+from _pytest.python import Module
 
 from ethereum_test_tools import ReferenceSpec, ReferenceSpecTypes
 
-IGNORE_PACKAGES = [
-    "tests.vm.",
-    "tests.example.",
-    "tests.security.",
-]
 
-
-class OutdatedReferenceSpec(Warning):
+def get_ref_spec_from_module(module: ModuleType) -> None | ReferenceSpec:
     """
-    Warning when the spec version found in a filler module is out of date.
+    Return the reference spec object defined in a module.
+
+    Raises:
+        Exception: If the module path contains "eip" and the module
+            does not define a reference spec.
+
+    Returns:
+        spec_obj: Return None if the module path does not contain "eip",
+            i.e., the module is not required to define a reference spec,
+            otherwise, return the ReferenceSpec object as defined by the
+            module.
     """
-
-    def __init__(self, filler_module: str, spec_obj: ReferenceSpec):
-        super().__init__(
-            "There is newer version of the spec referenced in filler "
-            f"{filler_module}, tests might be outdated: "
-            f"Spec: {spec_obj.name()}. "
-            "Referenced version: "
-            f"{spec_obj.known_version()}. "
-            "Latest version: "
-            f"{spec_obj.latest_version()}."
-        )
-
-
-class NoReferenceSpecDefined(Warning):
-    """
-    Warning when no spec version was found in a filler module.
-    """
-
-    def __init__(self, filler_module: str):
-        super().__init__(f"No reference spec defined in {filler_module}.")
-
-
-class UnableToCheckReferenceSpec(Warning):
-    """
-    Warnings when the current spec version can not be determined.
-    """
-
-    def __init__(self, filler_module: str, error: Exception):
-        super().__init__(
-            f"Reference spec could not be determined for " f"{filler_module}: {error}."
-        )
-
-
-@pytest.fixture(autouse=True, scope="module")
-def reference_spec(request):
-    """
-    Returns the reference spec used for the generated test fixtures in a
-    given module.
-    """
-    module_dict = request.module.__dict__
+    if not is_test_for_an_eip(str(module.__file__)):
+        return None
+    module_dict = module.__dict__
     parseable_ref_specs = [
         ref_spec_type
         for ref_spec_type in ReferenceSpecTypes
         if ref_spec_type.parseable_from_module(module_dict)
     ]
-    filler_module = request.module.__name__
-    if any(filler_module.startswith(package) for package in IGNORE_PACKAGES):
-        return None
     if len(parseable_ref_specs) > 0:
-        spec_obj = parseable_ref_specs[0].parse_from_module(module_dict)
+        module_dict = module.__dict__
         try:
-            if spec_obj.is_outdated():
-                warnings.warn(OutdatedReferenceSpec(filler_module, spec_obj))
-            return spec_obj
+            spec_obj = parseable_ref_specs[0].parse_from_module(module_dict)
         except Exception as e:
-            warnings.warn(UnableToCheckReferenceSpec(filler_module, e))
-            return None
-    warnings.warn(NoReferenceSpecDefined(filler_module))
-    return None
+            raise Exception(f"Error in spec_version_checker: {e} (this test is generated).")
+    else:
+        raise Exception("Test doesn't define REFERENCE_SPEC_GIT_PATH and REFERENCE_SPEC_VERSION")
+    return spec_obj
+
+
+@pytest.fixture(autouse=True, scope="module")
+def reference_spec(request) -> None | ReferenceSpec:
+    """
+    Pytest fixture that returns the reference spec defined in a module.
+
+    See `get_ref_spec_from_module`.
+    """
+    return get_ref_spec_from_module(request.module)
+
+
+def is_test_for_an_eip(input_string: str) -> bool:
+    """
+    Return True if `input_string` contains an EIP number, i.e., eipNNNN.
+    """
+    pattern = re.compile(r".*eip\d{1,4}", re.IGNORECASE)
+    if pattern.match(input_string):
+        return True
+    return False
+
+
+def test_eip_spec_version(module: ModuleType):
+    """
+    Test that the ReferenceSpec object as defined in the test module
+    is not outdated when compared to the remote hash from
+    ethereum/EIPs.
+    """
+    ref_spec = get_ref_spec_from_module(module)
+    assert ref_spec, "No reference spec object defined"
+
+    message = (
+        "The version of the spec referenced in "
+        f"{module} does not match that from ethereum/EIPs, "
+        f"tests might be outdated: Spec: {ref_spec.name()}. "
+        f"Referenced version: {ref_spec.known_version()}. "
+        f"Latest version: {ref_spec.latest_version()}. The "
+        f"version was retrieved from {ref_spec.api_url()}."
+    )
+    return
+    try:
+        is_up_to_date = not ref_spec.is_outdated()
+    except Exception as e:
+        raise Exception(
+            f"Error in spec_version_checker: {e} (this test is generated). "
+            f"Reference spec URL: {ref_spec.api_url()}."
+        )
+
+    assert is_up_to_date, message
+
+
+class EIPSpecTestItem(Item):
+    """
+    Custom pytest test item to test EIP spec versions.
+    """
+
+    def __init__(self, name, parent, module):
+        super().__init__(name, parent)
+        self.module = module
+
+    @classmethod
+    def from_parent(cls, parent, module):
+        """
+        Public constructor to define new tests.
+        https://docs.pytest.org/en/latest/reference/reference.html#pytest.nodes.Node.from_parent
+        """
+        return super().from_parent(parent=parent, name="test_eip_spec_version", module=module)
+
+    def runtest(self):
+        """
+        Define the test to execute for this item.
+        """
+        test_eip_spec_version(self.module)
+
+    def reportinfo(self):
+        """
+        Get location information for this test item to use test reports.
+        """
+        return "spec_version_checker", 0, f"{self.name}"
+
+
+def pytest_collection_modifyitems(session, config, items):
+    """
+    Insert a new test EIPSpecTestItem for every test modules that
+    contains 'eip' in its path.
+    """
+    modules = set(item.parent for item in items if isinstance(item.parent, Module))
+    new_test_eip_spec_version_items = [
+        EIPSpecTestItem.from_parent(module, module.obj)
+        for module in modules
+        if is_test_for_an_eip(str(module.path))
+    ]
+    items.extend(new_test_eip_spec_version_items)
+    # this gives a nice ordering for the new tests added here, but re-orders the entire
+    # default pytest item ordering which based on ordering of test functions in test modules
+    # items.sort(key=lambda x: x.nodeid)

--- a/src/pytest_plugins/spec_version_checker/spec_version_checker.py
+++ b/src/pytest_plugins/spec_version_checker/spec_version_checker.py
@@ -13,6 +13,20 @@ from _pytest.python import Module
 from ethereum_test_tools import ReferenceSpec, ReferenceSpecTypes
 
 
+@pytest.hookimpl(tryfirst=True)
+def pytest_configure(config):
+    """
+    Register the plugin's custom markers and process command-line options.
+
+    Custom marker registration:
+    https://docs.pytest.org/en/7.1.x/how-to/writing_plugins.html#registering-custom-markers
+    """
+    config.addinivalue_line(
+        "markers",
+        "eip_version_check: a test that tests the reference spec defined in an EIP test module.",
+    )
+
+
 def get_ref_spec_from_module(module: ModuleType) -> None | ReferenceSpec:
     """
     Return the reference spec object defined in a module.
@@ -136,6 +150,8 @@ def pytest_collection_modifyitems(session, config, items):
         for module in modules
         if is_test_for_an_eip(str(module.path))
     ]
+    for item in new_test_eip_spec_version_items:
+        item.add_marker("eip_version_check", append=True)
     items.extend(new_test_eip_spec_version_items)
     # this gives a nice ordering for the new tests added here, but re-orders the entire
     # default pytest item ordering which based on ordering of test functions in test modules

--- a/src/pytest_plugins/test_filler/test_filler.py
+++ b/src/pytest_plugins/test_filler/test_filler.py
@@ -26,6 +26,7 @@ from ethereum_test_tools import (
 )
 from evm_block_builder import EvmBlockBuilder
 from evm_transition_tool import EvmTransitionTool
+from pytest_plugins.spec_version_checker.spec_version_checker import EIPSpecTestItem
 
 
 def pytest_addoption(parser):
@@ -370,7 +371,10 @@ def pytest_collection_modifyitems(items, config):
     Here we dynamically apply "state_test" or "blockchain_test" markers
     to a test if the test function uses the corresponding fixture.
     """
+
     for item in items:
+        if isinstance(item, EIPSpecTestItem):
+            continue
         if "state_test" in item.fixturenames:
             marker = pytest.mark.state_test()
             item.add_marker(marker)
@@ -394,6 +398,9 @@ def pytest_runtest_call(item):
     """
     Pytest hook called in the context of test execution.
     """
+
+    if isinstance(item, EIPSpecTestItem):
+        return
 
     class InvalidFiller(Exception):
         def __init__(self, message):

--- a/src/pytest_plugins/test_filler/test_filler.py
+++ b/src/pytest_plugins/test_filler/test_filler.py
@@ -371,7 +371,6 @@ def pytest_collection_modifyitems(items, config):
     Here we dynamically apply "state_test" or "blockchain_test" markers
     to a test if the test function uses the corresponding fixture.
     """
-
     for item in items:
         if isinstance(item, EIPSpecTestItem):
             continue
@@ -398,7 +397,6 @@ def pytest_runtest_call(item):
     """
     Pytest hook called in the context of test execution.
     """
-
     if isinstance(item, EIPSpecTestItem):
         return
 

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -255,6 +255,7 @@ collectonly
 dedent
 dest
 fixturenames
+fspath
 funcargs
 getgroup
 getoption
@@ -264,6 +265,7 @@ IGNORECASE
 makepyfile
 metafunc
 modifyitems
+nodeid
 originalname
 parametrized
 param
@@ -272,6 +274,7 @@ parametrize
 pytester
 pytestmark
 regexes
+reportinfo
 ret
 runpytest
 runtest


### PR DESCRIPTION
This PR:
- Gets the `spec_version_checker` plugin ready for the test folder restructure.
- Implements the version checks as tests instead of issuing warnings. A new test is dynamically added by the plugin for each test module whose path matches `eip\d{1,4}` that checks that the reference spec defined in the module is up-to-date with ethereum/EIPs.

These tests as-is are currently always ran. We might have to be careful that our (especially our CI/CD) Github API access doesn't get rate limited :slightly_smiling_face: 

Only run the EIP version check tests:
```console
pytest -m eip_version_check
```
Run all tests except the version check tests:
```console
pytest -m "not eip_version_check"
```