### PR TITLE
pytest: modify --help to only print option help from ./src/pytest_plugins

### DIFF
--- a/src/entry_points/__init__.py
+++ b/src/entry_points/__init__.py
@@ -1,0 +1,6 @@
+"""
+Entry points defined by execution-spec-tests.
+
+This __init__.py is required by tox to make this folder a valid package.
+tox creates entry points which contains "import entry_points".
+"""

--- a/src/entry_points/fill.py
+++ b/src/entry_points/fill.py
@@ -1,14 +1,56 @@
 """
 Define an entry point wrapper for pytest.
+
+Essentially an alias for pytest but modifies the behavior of --help:
+- 'fill --help' only prints the options defined by ./src/pytest_plugins/.
+- 'fill --help -v' prints the full help (equivalent to 'pytest --help')
+
+The approach is brittle, but pragmatic. There isn't a direct way to trace
+back a command-line option to the plugin that registered it because when
+a plugin registers a command-line option, it doesn't tag that option with
+its own name or ID.
+
+There's an open feature request for this:
+https://github.com/pytest-dev/pytest/issues/9452
 """
 
+import subprocess
 import sys
 
 import pytest
 
 
 def main():  # noqa: D103
-    pytest.main(sys.argv[1:])
+    if "--help" in sys.argv and "-v" not in sys.argv:
+        sys.argv.remove("--help")
+
+        result = subprocess.run(["pytest", "--help"], capture_output=True, text=True)
+        output = result.stdout
+
+        start_string = "Arguments defining evm executable behavior:"
+        end_string = "distributed and subprocess testing:"
+
+        start = output.find(start_string)
+        end = output.find(end_string)
+
+        if start != -1 and end != -1:
+            required_help_text = output[start : end - 2]
+            print(
+                "The 'fill' command is an alias for 'pytest'. Run 'fill --help -v' to\n"
+                "see the complete pytest cli help.\n\n"
+                "Here are the custom options provided by the plugins defined by the\n"
+                "execution-spec-tests framework.\n"
+            )
+            print(required_help_text)
+        else:
+            print(
+                "Unable to extract required help text. Run `fill --help` instead and "
+                "go and shout at the maintainers."
+            )
+        return
+    else:
+        sys.argv.remove("-v")
+        pytest.main(sys.argv[1:])
 
 
 if __name__ == "__main__":

--- a/src/entry_points/tests/test_fill.py
+++ b/src/entry_points/tests/test_fill.py
@@ -1,0 +1,58 @@
+"""
+Tests for the 'fill' entry point.
+"""
+
+import subprocess
+
+
+def run_fill_command(args):
+    """
+    Runs fill command with provided arguments and returns output.
+    """
+    command = ["fill"] + args
+    result = subprocess.run(command, capture_output=True, text=True)
+    return result.stdout
+
+
+def test_fill_help():
+    """
+    Tests the 'fill --help' command.
+    """
+    output = run_fill_command(["--help"])
+
+    # check our custom help message is present
+    assert "The 'fill' command is an alias for 'pytest'. Run 'fill --help -v' to" in output
+    assert "Here are the custom options provided by the plugins defined by the" in output
+
+    # check our custom options are present
+    assert "--until" in output
+    assert "--evm-bin" in output
+    assert "--solc-bin" in output
+
+    # check that pytest help output is not present
+    assert "general:" not in output
+    assert "PYTEST_PLUGINS" not in output
+
+    # check error message is not present
+    assert "Unable to extract required help text." not in output
+
+
+def test_fill_help_v():
+    """Tests 'fill --help -v' command."""
+    output = run_fill_command(["--help", "-v"])
+
+    # check our custom help message is present
+    assert "The 'fill' command is an alias for 'pytest'. Run 'fill --help -v' to" not in output
+    assert "Here are the custom options provided by the plugins defined by the" not in output
+
+    # check our custom options are present
+    assert "--until" in output
+    assert "--evm-bin" in output
+    assert "--solc-bin" in output
+
+    # check if full help is present
+    assert "general:" in output
+    assert "PYTEST_PLUGINS" in output
+
+    # check error message is not present
+    assert "Unable to extract required help text." not in output


### PR DESCRIPTION
"fill" is defined as an entry point in execution-spec-tests and is a wrapper for pytest.

This PR modifies the behavior of "fill --help":
- 'fill --help' only prints the options defined by ./src/pytest_plugins/.
- 'fill --help -v' prints the full help (equivalent to 'pytest --help')

The approach is brittle, but pragmatic. There isn't a direct way to trace back a command-line option to the plugin that registered it because when a plugin registers a command-line option, it doesn't tag that option with its own name or ID.

There's an open feature request for this:
https://github.com/pytest-dev/pytest/issues/9452

Now:
![grafik](https://github.com/ethereum/execution-spec-tests/assets/91727015/01da2749-934c-451e-a2b8-fa8de62f668e)
