### PR TITLE
chore: speed up tox execution

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -8,3 +8,4 @@ addopts =
     -p pytest_plugins.forks.forks
     -p pytest_plugins.spec_version_checker.spec_version_checker
     -m "not eip_version_check"
+    --dist loadscope

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 env_list =
-    py3
+    framework
     tests
 
-[testenv:py3]
+[testenv:framework]
 description = Run checks of the tests library
 deps =
     pytest
@@ -19,13 +19,19 @@ setenv =
 src = src setup.py docs/gen_test_case_reference.py
 
 commands =
-    fname8 {[testenv:py3]src}
-    isort {[testenv:py3]src} --check --diff
-    black {[testenv:py3]src} --check --diff
-    flake8 {[testenv:py3]src}
-    mypy {[testenv:py3]src}
+    fname8 {[testenv:framework]src}
+    isort {[testenv:framework]src} --check --diff
+    black {[testenv:framework]src} --check --diff
+    flake8 {[testenv:framework]src}
+    mypy {[testenv:framework]src}
     pytest -c ./pytest-framework.ini -n auto
     mkdocs build --strict
+
+[testenv:py3]
+description = An alias for the 'framework' tox environment
+deps = {[testenv:framework]deps}
+extras = {[testenv:framework]extras}
+commands = {[testenv:framework]commands}
 
 [testenv:tests]
 description = Run checks of the Ethereum tests

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 env_list =
     framework
     tests
+    docs
 
 [testenv:framework]
 description = Run checks of the tests library
@@ -11,12 +12,8 @@ deps =
 extras =
     test
     lint
-    docs
 
-setenv =
-    SPEC_TESTS_AUTO_GENERATE_FILES = true
-
-src = src setup.py docs/gen_test_case_reference.py
+src = src setup.py
 
 commands =
     fname8 {[testenv:framework]src}
@@ -25,7 +22,6 @@ commands =
     flake8 {[testenv:framework]src}
     mypy {[testenv:framework]src}
     pytest -c ./pytest-framework.ini -n auto
-    mkdocs build --strict
 
 [testenv:py3]
 description = An alias for the 'framework' tox environment
@@ -34,17 +30,13 @@ extras = {[testenv:framework]extras}
 commands = {[testenv:framework]commands}
 
 [testenv:tests]
-description = Run checks of the Ethereum tests
+description = Run checks of the test cases in tests/
 deps =
     pytest
 
 extras =
     test
     lint
-    docs
-
-setenv =
-    SPEC_TESTS_AUTO_GENERATE_FILES = true
 
 commands =
     fname8 tests
@@ -53,4 +45,23 @@ commands =
     flake8 tests
     mypy tests
     pytest
+
+[testenv:docs]
+description = Run documentation checks
+
+extras =
+    lint
+    docs
+
+setenv =
+    SPEC_TESTS_AUTO_GENERATE_FILES = true
+
+src = setup.py docs/gen_test_case_reference.py
+
+commands =
+    fname8 {[testenv:docs]src}
+    isort {[testenv:docs]src} --check --diff
+    black {[testenv:docs]src} --check --diff
+    flake8 {[testenv:docs]src}
+    mypy {[testenv:docs]src}
     mkdocs build --strict

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ commands =
     black tests --check --diff
     flake8 tests
     mypy tests
-    pytest
+    pytest -n auto
 
 [testenv:docs]
 description = Run documentation checks

--- a/tox.ini
+++ b/tox.ini
@@ -52,6 +52,7 @@ description = Run documentation checks
 extras =
     lint
     docs
+    test  # we run pytest --collect-only in docs
 
 setenv =
     SPEC_TESTS_AUTO_GENERATE_FILES = true


### PR DESCRIPTION
This PR:
1. Renames the tox environment "py3" to "framework".
2. Adds an environment "py3" which is an alias for "framework".
3. Adds a new environment docs. The duplicated doc checks have been moved from the framework and test environments to the docs environment.
4. Adds `--dist loadscope` to pytest.ini - this fixes #159.

Running `tox` is now essentially equivalent to running `tox -e framework; tox -e tests; tox -e docs`.

Assuming the tox venvs have already been created, these changes speed-up execution of `tox` on my 16 core laptop from 60s to 33s. More targeted checks (e.g. docs only via `tox -e docs`) can also now be manually executed. The main speed-up comes from using xdist when executing pytest on the "tests" directory.