### PR TITLE
chore: move xdist to the main install requires

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     requests>=2.31.0
     colorlog>=6.7.0
     pytest==7.3.2
+    pytest-xdist>=3.3.1,<4
 
 [options.package_data]
 ethereum_test_tools =
@@ -50,7 +51,6 @@ console_scripts =
 test =
     # pytest already in 'install_requires'
     pytest-cov>=4.1.0,<5
-    pytest-xdist>=3.3.1,<4
 
 lint =
     isort>=5.8,<6

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,6 @@ description = Run documentation checks
 extras =
     lint
     docs
-    test  # we run pytest --collect-only in docs
 
 setenv =
     SPEC_TESTS_AUTO_GENERATE_FILES = true


### PR DESCRIPTION
This PR proposes to move `xdist` to the main requires list in the setup.

Reasoning being that the `--dist` option is now included by default in the `pystest.ini` and usually users (in my opinion) would like to do:
```bash
pip install -e .
```
and then run `fill` command, which is no longer possible.

Granted that the `README.md` correctly states that the correct install command is `pip install -e .[docs,lint,test]`, but even so, I think all the tools necessary to fill the tests should be installed with `pip install .`.