### PR TITLE
pytest: compile Yul with --target-version shanghai when fork is cancun

### DIFF
--- a/docs/gen_test_case_reference.py
+++ b/docs/gen_test_case_reference.py
@@ -190,7 +190,9 @@ def run_collect_only(test_path: Path = source_directory) -> Tuple[str, str]:
     collect_only_command = f"fill --collect-only -q --until {DEV_FORKS[-1]} {test_path}"
     # strip out the test module
     output_lines = [
-        line.split("::")[1] for line in output.split("\n") if line.startswith("tests/")
+        line.split("::")[1]
+        for line in output.split("\n")
+        if line.startswith("tests/") and "::" in line
     ]
     # prefix with required indent for admonition in MARKDOWN_TEST_CASES_TEMPLATE
     collect_only_output = "\n".join("    " + line for line in output_lines)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+"""
+Pytest (plugin) definitions local to Cancun tests.
+"""
+import warnings
+
+import pytest
+
+
+def pytest_collection_modifyitems(items):
+    """
+    Modify tests post collection.
+
+    Here we override the default behavior of the `yul` fixture so that
+    solc compiles with shanghai instead of cancun (which is unavailable
+    in solc 0.8.20).
+    """
+    for item in items:
+        if "Cancun" in item.name and "yul" in item.fixturenames:
+            warnings.warn("Compiling Yul source with Shanghai, not Cancun.")
+            item.add_marker(pytest.mark.compile_yul_with("Shanghai"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,12 @@
 """
-Pytest (plugin) definitions local to Cancun tests.
+Pytest definitions applied to all tests.
 """
 import warnings
 
 import pytest
 
 
-def pytest_collection_modifyitems(items):
+def pytest_collection_modifyitems(items, config):
     """
     Modify tests post collection.
 
@@ -16,5 +16,8 @@ def pytest_collection_modifyitems(items):
     """
     for item in items:
         if "Cancun" in item.name and "yul" in item.fixturenames:
-            warnings.warn("Compiling Yul source with Shanghai, not Cancun.")
+            if config.getoption("verbose") >= 2:
+                warnings.warn(f"Compiling Yul source for f{item.name} with Shanghai, not Cancun.")
+            else:
+                warnings.warn("Compiling Yul source with Shanghai, not Cancun.")
             item.add_marker(pytest.mark.compile_yul_with("Shanghai"))


### PR DESCRIPTION
This fixes test fixture generation when the fork fixture's parameter value is Cancun. The root cause is that we pass the fork parameter value to solc's `--target-version` option and, clearly, the last stable version of solc doesn't offer Cancun support :-)

Additionally, warnings are issued in the pytest summary:
-  If verbosity <= 1 (no verbosity flag or `-v` ): "UserWarning: Compiling Yul source with Shanghai, not Cancun.".
-  If verbosity is >=2, then each warning also mentions the test node id.

All Yul tests can be executed using:
```
fill --until Cancun -m yul_test
```