### PR TITLE
chore: use python 3.10 in doc deploy workflows

### DIFF
--- a/.github/workflows/docs_main.yaml
+++ b/.github/workflows/docs_main.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: '3.10'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/docs_tags.yaml
+++ b/.github/workflows/docs_tags.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: '3.10'
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Previously 3.11 was specified.