### PR TITLE
chore: use a deploy key for gh actions to push to protected branch & don't run on forks

### DIFF
--- a/.github/workflows/docs_main.yaml
+++ b/.github/workflows/docs_main.yaml
@@ -11,10 +11,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
+    - name: Checkout
+      uses: actions/checkout@v3.5.2
       with:
         fetch-depth: 0
+        ssh-key: ${{secrets.GH_ACTIONS_DEPLOY_KEY}}
 
     - name: Set up Python
       uses: actions/setup-python@v2

--- a/.github/workflows/docs_main.yaml
+++ b/.github/workflows/docs_main.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   deploy:
+    if: github.repository_owner == 'ethereum'  # don't run on forks
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/docs_tags.yaml
+++ b/.github/workflows/docs_tags.yaml
@@ -11,10 +11,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
+    - name: Checkout
+      uses: actions/checkout@v3.5.2
       with:
         fetch-depth: 0
+        ssh-key: ${{secrets.GH_ACTIONS_DEPLOY_KEY}}
 
     - name: Set up Python
       uses: actions/setup-python@v2

--- a/.github/workflows/docs_tags.yaml
+++ b/.github/workflows/docs_tags.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   deploy:
+    if: github.repository_owner == 'ethereum'  # don't run on forks
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This PR makes 2 changes to our docs continuous deployment:
1. Use a github secret to get the a "deploy key" for repo checkout, so that we can later push to the protected `gh-pages` branch **See "additional required repo config" below**.
2. Don't run these actions on forks of execution-spec-tests.

**Additional required repo config** (taken from [stackoverflow](https://stackoverflow.com/a/76135647)):
1. Generate SSH key pair: No need for passphrases etc:
    ```
    ssh-keygen -t ed25519 -C github-actions-deploy-key@ethereum-$(date -I) -f id_ed25519_github_actions_deploy_key
    ```
3. Add public key (.pub one) as a deploy key at Your repo -> Settings -> Security -> Deploy keys, check "Allow write access".
4. Add private key as a secret (name: `GH_ACTIONS_DEPLOY_KEY`) at Your repo -> Settings -> Security -> Secrets and variables -> Actions.
