### PR TITLE
chore: enable python 311

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.10']
+        python: ['3.10', '3.11']
         golang: ['1.20.5']
         solc: ['0.8.20']
     steps:

--- a/src/ethereum_test_tools/spec/blockchain_test.py
+++ b/src/ethereum_test_tools/spec/blockchain_test.py
@@ -2,7 +2,7 @@
 Blockchain test filler.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pprint import pprint
 from typing import Any, Callable, Dict, Generator, List, Mapping, Optional, Tuple, Type
 
@@ -34,7 +34,7 @@ class BlockchainTest(BaseTest):
     pre: Mapping[str, Account]
     post: Mapping[str, Account]
     blocks: List[Block]
-    genesis_environment: Environment = Environment()
+    genesis_environment: Environment = field(default_factory=Environment)
     tag: str = ""
 
     @classmethod


### PR DESCRIPTION
Allow usage of execution-spec-tests with Python 3.11.