### PR TITLE
chore: add a pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: local
+    hooks:
+      - id: tox
+        name: tox
+        entry: tox
+        language: system
+        types: [python]
+        pass_filenames: false
+      - id: tox-docs
+        name: tox-docs
+        entry: tox -e docs
+        language: system
+        files: \.md$
+        pass_filenames: false

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -4,3 +4,4 @@ This documentation is aimed at maintainers of `execution-spec-tests` but may be 
 
 - [generating documentation](./docs.md).
 - [coding style](./coding_style.md).
+- [enabling pre-commit checks](./precommit.md).

--- a/docs/dev/precommit.md
+++ b/docs/dev/precommit.md
@@ -1,0 +1,17 @@
+# Enabling Pre-Commit Checks
+
+There's a [pre-commit](https://pre-commit.com/) config file available in the repository root (`.pre-commit-config.yaml`) that can be used to enable automatic checks upon commit - the commit will not go through if the checks don't pass.
+
+To enable pre-commit, the following must be ran once:
+
+```console
+pip install pre-commit
+pre-commit install
+```
+
+!!! note "Bypassing pre-commit checks"
+    Enabling of pre-commit checks is not mandatory (it cannot be enforced) and even if it is enabled, it can always be bypassed with:
+
+    ```console
+    git commit --no-verify
+    ```


### PR DESCRIPTION
Adds a [pre-commit](https://pre-commit.com/) config file in the repository root (`.pre-commit-config.yaml`) that can be used to enable automatic checks upon commit - the commit will not go through if the checks don't pass.

To enable pre-commit, the following must be ran once:

```console
pip install pre-commit
pre-commit install
```
Enabling of pre-commit checks is not mandatory (it cannot be enforced) and even if it is enabled, it can always be bypassed with:

```console
git commit --no-verify
```

I'm sure we can tweak the hooks quite a bit as we get more experience and ideas, but we can leave it as this for now.
