### PR TITLE
tools: Fixes, Improvements to Opcodes/Code/Types

### DIFF
--- a/src/ethereum_test_tools/code/code.py
+++ b/src/ethereum_test_tools/code/code.py
@@ -45,6 +45,12 @@ class Code:
         """
         return Code(bytecode=(code_to_bytes(other) + code_to_bytes(self)))
 
+    def __len__(self) -> int:
+        """
+        Returns the length of the bytecode.
+        """
+        return len(self.assemble())
+
 
 def code_to_bytes(code: str | bytes | Code) -> bytes:
     """

--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -4,7 +4,20 @@ Useful types for generating Ethereum tests.
 import json
 from copy import copy, deepcopy
 from dataclasses import dataclass, field
-from typing import Any, ClassVar, Dict, List, Mapping, Optional, Sequence, Tuple, Type, TypeAlias
+from itertools import count
+from typing import (
+    Any,
+    ClassVar,
+    Dict,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    TypeAlias,
+)
 
 from coincurve.keys import PrivateKey, PublicKey
 from ethereum import rlp as eth_rlp
@@ -83,6 +96,8 @@ class Storage:
     """
 
     data: Dict[int, int]
+
+    current_slot: Iterator[int]
 
     StorageDictType: ClassVar[TypeAlias] = Dict[str | int | bytes, str | int | bytes]
     """
@@ -225,7 +240,7 @@ class Storage:
             hex_str = "0" + hex_str
         return "0x" + hex_str
 
-    def __init__(self, input: StorageDictType):
+    def __init__(self, input: StorageDictType, start_slot: int = 0):
         """
         Initializes the storage using a given mapping which can have
         keys and values either as string or int.
@@ -237,7 +252,7 @@ class Storage:
             value = Storage.parse_key_value(input[key])
             key = Storage.parse_key_value(key)
             self.data[key] = value
-        pass
+        self.current_slot = count(start_slot)
 
     def __len__(self) -> int:
         """Returns number of elements in the storage"""
@@ -262,6 +277,16 @@ class Storage:
     def __delitem__(self, key: str | int):
         """Deletes an item from the storage"""
         del self.data[Storage.parse_key_value(key)]
+
+    def store_next(self, value: str | int) -> int:
+        """
+        Stores a value in the storage and returns the key where the value is stored.
+
+        Increments the key counter so the next time this function is called,
+        the next key is used.
+        """
+        self[slot := next(self.current_slot)] = value
+        return slot
 
     def to_dict(self) -> Mapping[str, str]:
         """

--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -219,7 +219,7 @@ class Storage:
             input = int(input, 0)
         elif type(input) is int:
             pass
-        elif type(input) is bytes:
+        elif isinstance(input, bytes):
             input = int.from_bytes(input, "big")
         else:
             raise Storage.InvalidType(input)

--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -258,27 +258,27 @@ class Storage:
         """Returns number of elements in the storage"""
         return len(self.data)
 
-    def __contains__(self, key: str | int) -> bool:
+    def __contains__(self, key: str | int | bytes) -> bool:
         """Checks for an item in the storage"""
         key = Storage.parse_key_value(key)
         return key in self.data
 
-    def __getitem__(self, key: str | int) -> int:
+    def __getitem__(self, key: str | int | bytes) -> int:
         """Returns an item from the storage"""
         key = Storage.parse_key_value(key)
         if key not in self.data:
             raise KeyError()
         return self.data[key]
 
-    def __setitem__(self, key: str | int, value: str | int):  # noqa: SC200
+    def __setitem__(self, key: str | int | bytes, value: str | int | bytes):  # noqa: SC200
         """Sets an item in the storage"""
         self.data[Storage.parse_key_value(key)] = Storage.parse_key_value(value)
 
-    def __delitem__(self, key: str | int):
+    def __delitem__(self, key: str | int | bytes):
         """Deletes an item from the storage"""
         del self.data[Storage.parse_key_value(key)]
 
-    def store_next(self, value: str | int) -> int:
+    def store_next(self, value: str | int | bytes) -> int:
         """
         Stores a value in the storage and returns the key where the value is stored.
 

--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -240,7 +240,7 @@ class Storage:
             hex_str = "0" + hex_str
         return "0x" + hex_str
 
-    def __init__(self, input: StorageDictType, start_slot: int = 0):
+    def __init__(self, input: StorageDictType = {}, start_slot: int = 0):
         """
         Initializes the storage using a given mapping which can have
         keys and values either as string or int.

--- a/src/ethereum_test_tools/tests/test_types.py
+++ b/src/ethereum_test_tools/tests/test_types.py
@@ -65,6 +65,18 @@ def test_storage():
     with pytest.raises(Storage.AmbiguousKeyValue):
         s.to_dict()
 
+    # Check store counter
+    s = Storage({})
+    s.store_next(0x100)
+    s.store_next(0x200)
+    s.store_next(0x300)
+    d = s.to_dict()
+    assert d == {
+        "0x00": ("0x0100"),
+        "0x01": ("0x0200"),
+        "0x02": ("0x0300"),
+    }
+
 
 @pytest.mark.parametrize(
     ["account", "alloc", "should_pass"],

--- a/src/ethereum_test_tools/tests/test_types.py
+++ b/src/ethereum_test_tools/tests/test_types.py
@@ -68,8 +68,8 @@ def test_storage():
     # Check store counter
     s = Storage({})
     s.store_next(0x100)
-    s.store_next(0x200)
-    s.store_next(0x300)
+    s.store_next("0x200")
+    s.store_next(b"\x03\x00".rjust(32, b"\x00"))
     d = s.to_dict()
     assert d == {
         "0x00": ("0x0100"),

--- a/src/ethereum_test_tools/tests/test_vm.py
+++ b/src/ethereum_test_tools/tests/test_vm.py
@@ -20,6 +20,15 @@ from ..vm.opcode import Opcodes as Op
             ),
         ),
         (
+            Op.PUSH1("0x01"),
+            bytes(
+                [
+                    0x60,
+                    0x01,
+                ]
+            ),
+        ),
+        (
             Op.PUSH1(0xFF),
             bytes(
                 [
@@ -48,6 +57,10 @@ from ..vm.opcode import Opcodes as Op
         ),
         (
             Op.PUSH20(0x01),
+            bytes([0x73] + [0x00] * 19 + [0x01]),
+        ),
+        (
+            Op.PUSH20("0x01"),
             bytes([0x73] + [0x00] * 19 + [0x01]),
         ),
         (

--- a/src/ethereum_test_tools/vm/opcode.py
+++ b/src/ethereum_test_tools/vm/opcode.py
@@ -122,7 +122,7 @@ class Opcode(bytes):
                     signed=signed,
                 )
             else:
-                raise TypeError("Opcode data portion must be either an int or a bytes")
+                raise TypeError("Opcode data portion must be either an int or bytes/hex string")
 
         # The rest of the arguments conform the stack.
         while len(args) > 0:

--- a/src/ethereum_test_tools/vm/opcode.py
+++ b/src/ethereum_test_tools/vm/opcode.py
@@ -107,7 +107,8 @@ class Opcode(bytes):
                 raise ValueError("Opcode with data portion requires at least one argument")
             data = args.pop(0)
             if isinstance(data, bytes):
-                data_portion = data
+                assert len(data) <= self.data_portion_length
+                data_portion = data.rjust(self.data_portion_length, b"\x00")
             elif isinstance(data, int):
                 signed = data < 0
                 data_portion = data.to_bytes(

--- a/src/ethereum_test_tools/vm/opcode.py
+++ b/src/ethereum_test_tools/vm/opcode.py
@@ -94,6 +94,7 @@ class Opcode(bytes):
         automatically converted to PUSH operations, and negative numbers always
         use a PUSH32 operation.
 
+        Hex-strings will automatically be converted to bytes.
 
         """
         args: List[Union[int, bytes, str, "Opcode"]] = list(args_t)


### PR DESCRIPTION
## Changes Included
- Add `len` to the `Code` class
- Allow `Opcode`'s data portion or stack elements to be hex strings
- Adds a counter to the storage type, which allows to automatically store a value to the next slot in an internal counter, and return the slot number.

### Storage counter
Tests can now use the following pattern:
```
bytecode = Op.SSTORE(storage.store_next(expected_value), Op.CALLDATALOAD(0))
bytecode += Op.SSTORE(storage.store_next(expected_value_2), Op.CALLDATALOAD(1))
```
And `storage` will keep track of the next storage slot to use, keeping code clean, and preventing overwriting a verification value in a loop for example.