### PR TITLE
evm_transition_tool: Add execution-specs, `ethereum-spec-evm`

### DIFF
--- a/src/evm_transition_tool/__init__.py
+++ b/src/evm_transition_tool/__init__.py
@@ -3,6 +3,7 @@ Library of Python wrappers for the different implementations of transition tools
 """
 
 from .evmone import EvmOneTransitionTool
+from .execution_specs import ExecSpecsTransitionTool
 from .geth import GethTransitionTool
 from .transition_tool import TransitionTool, TransitionToolNotFoundInPath, UnknownTransitionTool
 
@@ -10,6 +11,7 @@ TransitionTool.set_default_tool(GethTransitionTool)
 
 __all__ = (
     "EvmOneTransitionTool",
+    "ExecSpecsTransitionTool",
     "GethTransitionTool",
     "TransitionTool",
     "TransitionToolNotFoundInPath",

--- a/src/evm_transition_tool/__init__.py
+++ b/src/evm_transition_tool/__init__.py
@@ -3,7 +3,7 @@ Library of Python wrappers for the different implementations of transition tools
 """
 
 from .evmone import EvmOneTransitionTool
-from .execution_specs import ExecSpecsTransitionTool
+from .execution_specs import ExecutionSpecsTransitionTool
 from .geth import GethTransitionTool
 from .transition_tool import TransitionTool, TransitionToolNotFoundInPath, UnknownTransitionTool
 
@@ -11,7 +11,7 @@ TransitionTool.set_default_tool(GethTransitionTool)
 
 __all__ = (
     "EvmOneTransitionTool",
-    "ExecSpecsTransitionTool",
+    "ExecutionSpecsTransitionTool",
     "GethTransitionTool",
     "TransitionTool",
     "TransitionToolNotFoundInPath",

--- a/src/evm_transition_tool/evmone.py
+++ b/src/evm_transition_tool/evmone.py
@@ -1,5 +1,5 @@
 """
-Evmone Transition tool frontend.
+Evmone Transition tool interface.
 """
 import json
 import os
@@ -24,7 +24,7 @@ def write_json_file(data: Dict[str, Any], file_path: str) -> None:
 
 class EvmOneTransitionTool(TransitionTool):
     """
-    Evmone `evmone-t8n` Transition tool frontend wrapper class.
+    Evmone `evmone-t8n` Transition tool interface wrapper class.
     """
 
     default_binary = Path("evmone-t8n")

--- a/src/evm_transition_tool/execution_specs.py
+++ b/src/evm_transition_tool/execution_specs.py
@@ -7,9 +7,11 @@ https://github.com/ethereum/execution-specs
 from pathlib import Path
 from re import compile
 
-from ethereum_test_forks import Fork
+from ethereum_test_forks import ConstantinopleFix, Fork
 
 from .geth import GethTransitionTool
+
+UNSUPPORTED_FORKS = (ConstantinopleFix,)
 
 
 class ExecSpecsTransitionTool(GethTransitionTool):
@@ -27,4 +29,4 @@ class ExecSpecsTransitionTool(GethTransitionTool):
         Returns True if the fork is supported by the tool.
         Currently, ethereum-spec-evm provides no way to determine supported forks.
         """
-        return True
+        return fork not in UNSUPPORTED_FORKS

--- a/src/evm_transition_tool/execution_specs.py
+++ b/src/evm_transition_tool/execution_specs.py
@@ -19,6 +19,41 @@ class ExecSpecsTransitionTool(GethTransitionTool):
     Ethereum Specs `ethereum-spec-evm` Transition tool frontend wrapper class.
 
     The behavior of this tool is almost identical to go-ethereum's `evm t8n` command.
+
+    note: How to use the `ethereum-spec-evm tool`
+
+        1. Create a virtual environment and activate it:
+            ```
+            python -m venv venv
+            source venv/bin/activate
+            ```
+        2. Clone the ethereum/execution-specs repository and change working directory to it:
+            ```
+            git clone git@github.com:ethereum/execution-specs.git
+            cd execution-specs
+            ```
+        3. Install the packages provided by the repository:
+            ```
+            pip install -e .
+            ```
+            Check that the `ethereum-spec-evm` command is available:
+            ```
+            ethereum-spec-evm --help
+            ```
+        4. Clone the ethereum/execution-specs-tests repository and change working directory to it:
+            ```
+            cd ..
+            git clone git@github.com:ethereum/execution-spec-tests.git
+            cd execution-spec-tests
+            ```
+        5. Install the packages provided by the ethereum/execution-spec-tests repository:
+            ```
+            pip install -e .
+            ```
+        6. Run the tests, specifying the `ethereum-spec-evm` command as the transition tool:
+            ```
+            fill --evm-bin=ethereum-spec-evm
+            ```
     """
 
     default_binary = Path("ethereum-spec-evm")

--- a/src/evm_transition_tool/execution_specs.py
+++ b/src/evm_transition_tool/execution_specs.py
@@ -20,7 +20,7 @@ class ExecSpecsTransitionTool(GethTransitionTool):
 
     The behavior of this tool is almost identical to go-ethereum's `evm t8n` command.
 
-    note: How to use the `ethereum-spec-evm tool`
+    note: How to use the `ethereum-spec-evm` tool:
 
         1. Create a virtual environment and activate it:
             ```

--- a/src/evm_transition_tool/execution_specs.py
+++ b/src/evm_transition_tool/execution_specs.py
@@ -14,7 +14,7 @@ from .geth import GethTransitionTool
 UNSUPPORTED_FORKS = (ConstantinopleFix,)
 
 
-class ExecSpecsTransitionTool(GethTransitionTool):
+class ExecutionSpecsTransitionTool(GethTransitionTool):
     """
     Ethereum Specs `ethereum-spec-evm` Transition tool frontend wrapper class.
 

--- a/src/evm_transition_tool/execution_specs.py
+++ b/src/evm_transition_tool/execution_specs.py
@@ -1,0 +1,30 @@
+"""
+Ethereum Specs EVM Transition tool frontend.
+
+https://github.com/ethereum/execution-specs
+"""
+
+from pathlib import Path
+from re import compile
+
+from ethereum_test_forks import Fork
+
+from .geth import GethTransitionTool
+
+
+class ExecSpecsTransitionTool(GethTransitionTool):
+    """
+    Ethereum Specs `ethereum-spec-evm` Transition tool frontend wrapper class.
+
+    The behavior of this tool is almost identical to go-ethereum's `evm t8n` command.
+    """
+
+    default_binary = Path("ethereum-spec-evm")
+    detect_binary_pattern = compile(r"^ethereum-spec-evm\b")
+
+    def is_fork_supported(self, fork: Fork) -> bool:
+        """
+        Returns True if the fork is supported by the tool.
+        Currently, ethereum-spec-evm provides no way to determine supported forks.
+        """
+        return True

--- a/src/evm_transition_tool/execution_specs.py
+++ b/src/evm_transition_tool/execution_specs.py
@@ -1,5 +1,5 @@
 """
-Ethereum Specs EVM Transition tool frontend.
+Ethereum Specs EVM Transition tool interface.
 
 https://github.com/ethereum/execution-specs
 """
@@ -16,7 +16,7 @@ UNSUPPORTED_FORKS = (ConstantinopleFix,)
 
 class ExecutionSpecsTransitionTool(GethTransitionTool):
     """
-    Ethereum Specs `ethereum-spec-evm` Transition tool frontend wrapper class.
+    Ethereum Specs `ethereum-spec-evm` Transition tool interface wrapper class.
 
     The behavior of this tool is almost identical to go-ethereum's `evm t8n` command.
 

--- a/src/evm_transition_tool/geth.py
+++ b/src/evm_transition_tool/geth.py
@@ -1,5 +1,5 @@
 """
-Go-ethereum Transition tool frontend.
+Go-ethereum Transition tool interface.
 """
 
 import json
@@ -17,7 +17,7 @@ from .transition_tool import TransitionTool
 
 class GethTransitionTool(TransitionTool):
     """
-    Go-ethereum `evm` Transition tool frontend wrapper class.
+    Go-ethereum `evm` Transition tool interface wrapper class.
     """
 
     default_binary = Path("evm")


### PR DESCRIPTION
Brings back support of using `ethereum-spec-evm` transition tool to fill tests.