### PR TITLE
pytest: remove excessively restrictive unsupported fork check

### DIFF
--- a/src/pytest_plugins/forks/forks.py
+++ b/src/pytest_plugins/forks/forks.py
@@ -305,9 +305,27 @@ def pytest_generate_tests(metafunc):
 
     if "fork" in metafunc.fixturenames:
         if not intersection_range:
-            pytest.skip(  # this reason is not reported on the command-line
-                f"{test_name} is not valid for any any of forks specified on the command-line."
-            )
+            if metafunc.config.getoption("verbose") >= 2:
+                pytest_params = [
+                    pytest.param(
+                        None,
+                        marks=[
+                            pytest.mark.skip(
+                                reason=(
+                                    f"{test_name} is not valid for any any of forks specified on "
+                                    "the command-line."
+                                )
+                            )
+                        ],
+                    )
+                ]
+                metafunc.parametrize("fork", pytest_params, scope="function")
+            else:
+                # This will not be reported in the test execution output; it will be listed
+                # in the pytest collection summary at the start of the test run.
+                pytest.skip(
+                    f"{test_name} is not valid for any any of forks specified on the command-line."
+                )
         else:
             pytest_params = [
                 pytest.param(


### PR DESCRIPTION
1. Fixes #201.
2. Improves reporting for the case when the intersection between a test's validity range and the specified fork range (on the command-line or default) is empty:
    1. If `-vv` is specified (`config.getoption("verbose") >= 2`) then report each test with the reason why it was skipped in the pytest execution output.
    2. If `config.getoption("verbose") >= 2`, use the previous behaviour, report that tests were skipped in the collection summary at the beginning of the test run, but don't report each test explicitly in the execution output.