### PR TITLE
Add `disable-hive` flag

### DIFF
--- a/src/ethereum_test_tools/__init__.py
+++ b/src/ethereum_test_tools/__init__.py
@@ -35,7 +35,14 @@ from .common import (
 )
 from .filling.fill import fill_test
 from .reference_spec import ReferenceSpec, ReferenceSpecTypes
-from .spec import BaseTest, BlockchainTest, BlockchainTestFiller, StateTest, StateTestFiller
+from .spec import (
+    BaseTest,
+    BaseTestConfig,
+    BlockchainTest,
+    BlockchainTestFiller,
+    StateTest,
+    StateTestFiller,
+)
 from .vm import Opcode, OpcodeCallArg, Opcodes
 
 __all__ = (
@@ -43,6 +50,7 @@ __all__ = (
     "Account",
     "Auto",
     "BaseTest",
+    "BaseTestConfig",
     "Block",
     "BlockchainTest",
     "BlockchainTestFiller",

--- a/src/ethereum_test_tools/spec/__init__.py
+++ b/src/ethereum_test_tools/spec/__init__.py
@@ -1,12 +1,13 @@
 """
 Test spec definitions and utilities.
 """
-from .base_test import BaseTest, TestSpec, verify_post_alloc
+from .base_test import BaseTest, BaseTestConfig, TestSpec, verify_post_alloc
 from .blockchain_test import BlockchainTest, BlockchainTestFiller, BlockchainTestSpec
 from .state_test import StateTest, StateTestFiller, StateTestSpec
 
 __all__ = (
     "BaseTest",
+    "BaseTestConfig",
     "BlockchainTest",
     "BlockchainTestFiller",
     "BlockchainTestSpec",

--- a/src/ethereum_test_tools/spec/base_test.py
+++ b/src/ethereum_test_tools/spec/base_test.py
@@ -2,6 +2,7 @@
 Generic Ethereum test base class
 """
 from abc import abstractmethod
+from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, Generator, List, Mapping, Optional, Tuple
 
 from ethereum_test_forks import Fork
@@ -56,6 +57,19 @@ def verify_post_alloc(expected_post: Mapping, got_alloc: Mapping):
                     raise Exception(f"expected account not found: {address}")
 
 
+@dataclass(kw_only=True)
+class BaseTestConfig:
+    """
+    General configuration that all tests must support.
+    """
+
+    disable_hive: bool = False
+    """
+    Disable any hive-related properties that the output could contain.
+    """
+
+
+@dataclass(kw_only=True)
 class BaseTest:
     """
     Represents a base Ethereum test which must return a genesis and a
@@ -64,6 +78,7 @@ class BaseTest:
 
     pre: Mapping
     tag: str = ""
+    base_test_config: BaseTestConfig = field(default_factory=BaseTestConfig)
 
     @abstractmethod
     def make_genesis(

--- a/src/ethereum_test_tools/spec/blockchain_test.py
+++ b/src/ethereum_test_tools/spec/blockchain_test.py
@@ -212,13 +212,15 @@ class BlockchainTest(BaseTest):
                 withdrawals=env.withdrawals,
             )
 
-            new_payload = FixtureEngineNewPayload.from_fixture_header(
-                fork=fork,
-                header=header,
-                transactions=txs,
-                withdrawals=env.withdrawals,
-                error_code=block.engine_api_error_code,
-            )
+            new_payload: FixtureEngineNewPayload | None = None
+            if not self.base_test_config.disable_hive:
+                new_payload = FixtureEngineNewPayload.from_fixture_header(
+                    fork=fork,
+                    header=header,
+                    transactions=txs,
+                    withdrawals=env.withdrawals,
+                    error_code=block.engine_api_error_code,
+                )
 
             if block.exception is None:
                 # Return environment and allocation of the following block

--- a/src/ethereum_test_tools/spec/state_test.py
+++ b/src/ethereum_test_tools/spec/state_test.py
@@ -167,13 +167,15 @@ class StateTest(BaseTest):
             withdrawals=env.withdrawals,
         )
 
-        new_payload = FixtureEngineNewPayload.from_fixture_header(
-            fork=fork,
-            header=header,
-            transactions=txs,
-            withdrawals=env.withdrawals,
-            error_code=self.engine_api_error_code,
-        )
+        new_payload: FixtureEngineNewPayload | None = None
+        if not self.base_test_config.disable_hive:
+            new_payload = FixtureEngineNewPayload.from_fixture_header(
+                fork=fork,
+                header=header,
+                transactions=txs,
+                withdrawals=env.withdrawals,
+                error_code=self.engine_api_error_code,
+            )
 
         return (
             [

--- a/src/pytest_plugins/test_filler/test_filler.py
+++ b/src/pytest_plugins/test_filler/test_filler.py
@@ -16,6 +16,7 @@ import pytest
 from ethereum_test_forks import Fork
 from ethereum_test_tools import (
     BaseTest,
+    BaseTestConfig,
     BlockchainTest,
     BlockchainTestFiller,
     Fixture,
@@ -84,6 +85,13 @@ def pytest_addoption(parser):
         dest="flat_output",
         default=False,
         help="Output each test case in the directory without the folder structure.",
+    )
+    test_group.addoption(
+        "--disable-hive",
+        action="store_true",
+        dest="disable_hive",
+        default=False,
+        help="Output tests skipping hive-related properties.",
     )
 
 
@@ -155,6 +163,16 @@ def t8n(request, evm_bin: Path) -> TransitionTool:
     return TransitionTool.from_binary_path(
         binary_path=evm_bin, trace=request.config.getoption("evm_collect_traces")
     )
+
+
+@pytest.fixture(autouse=True, scope="session")
+def base_test_config(request) -> BaseTestConfig:
+    """
+    Returns the base test configuration that all tests must use.
+    """
+    config = BaseTestConfig()
+    config.disable_hive = request.config.getoption("disable_hive")
+    return config
 
 
 def strip_test_prefix(name: str) -> str:
@@ -314,7 +332,7 @@ SPEC_TYPES_PARAMETERS: List[str] = [s.pytest_parameter_name() for s in SPEC_TYPE
 
 @pytest.fixture(scope="function")
 def state_test(
-    request, t8n, fork, engine, reference_spec, eips, fixture_collector
+    request, t8n, fork, engine, reference_spec, eips, fixture_collector, base_test_config
 ) -> StateTestFiller:
     """
     Fixture used to instantiate an auto-fillable StateTest object from within
@@ -330,6 +348,7 @@ def state_test(
 
     class StateTestWrapper(StateTest):
         def __init__(self, *args, **kwargs):
+            kwargs["base_test_config"] = base_test_config
             super(StateTestWrapper, self).__init__(*args, **kwargs)
             fixture_collector.add_fixture(
                 request.node,

--- a/src/pytest_plugins/test_filler/test_filler.py
+++ b/src/pytest_plugins/test_filler/test_filler.py
@@ -367,7 +367,7 @@ def state_test(
 
 @pytest.fixture(scope="function")
 def blockchain_test(
-    request, t8n, fork, engine, reference_spec, eips, fixture_collector
+    request, t8n, fork, engine, reference_spec, eips, fixture_collector, base_test_config
 ) -> BlockchainTestFiller:
     """
     Fixture used to define an auto-fillable BlockchainTest analogous to the
@@ -377,6 +377,7 @@ def blockchain_test(
 
     class BlockchainTestWrapper(BlockchainTest):
         def __init__(self, *args, **kwargs):
+            kwargs["base_test_config"] = base_test_config
             super(BlockchainTestWrapper, self).__init__(*args, **kwargs)
             fixture_collector.add_fixture(
                 request.node,


### PR DESCRIPTION
Adds a flag that removes all hive related properties from the output fixtures.

At the moment it only removes the Engine API directive instructions.

~Requires #207, hence draft.~ Rebased and removed dependency.