### PR TITLE
Chore: Fix `fill --test-help` formatting for store true/false arguments

### DIFF
--- a/docs/getting_started/executing_tests_command_line.md
+++ b/docs/getting_started/executing_tests_command_line.md
@@ -107,42 +107,41 @@ fill --test-help
 Output:
 
 ```console
-usage: fill [-h] [--evm-bin EVM_BIN] [--traces TRACES] [--solc-bin SOLC_BIN]
-            [--filler-path FILLER_PATH] [--output OUTPUT]
-            [--flat-output FLAT_OUTPUT] [--forks FORKS] [--fork FORK]
-            [--from FROM] [--until UNTIL] [--test-help TEST_HELP]
+usage: fill [-h] [--evm-bin EVM_BIN] [--traces] [--solc-bin SOLC_BIN]
+            [--filler-path FILLER_PATH] [--output OUTPUT] [--flat-output]
+            [--disable-hive] [--forks] [--fork FORK] [--from FROM]
+            [--until UNTIL] [--test-help]
 
 options:
   -h, --help            show this help message and exit
 
 Arguments defining evm executable behavior:
-  --evm-bin EVM_BIN     Path to an evm executable that provides `t8n` and
-                        `b11r.` Default: First 'evm' entry in PATH
-  --traces TRACES       Collect traces of the execution information from the
-                        transition tool
+  --evm-bin EVM_BIN     Path to an evm executable that provides `t8n`. Default:
+                        First 'evm' entry in PATH.
+  --traces              Collect traces of the execution information from the
+                        transition tool.
 
 Arguments defining the solc executable:
   --solc-bin SOLC_BIN   Path to a solc executable (for Yul source compilation).
-                        Default: First 'solc' entry in PATH
+                        Default: First 'solc' entry in PATH.
 
 Arguments defining filler location and output:
   --filler-path FILLER_PATH
                         Path to filler directives
   --output OUTPUT       Directory to store the generated test fixtures. Can be
                         deleted.
-  --flat-output FLAT_OUTPUT
-                        Output each test case in the directory without the
+  --flat-output         Output each test case in the directory without the
                         folder structure.
+  --disable-hive        Output tests skipping hive-related properties.
 
 Specify the fork range to generate fixtures for:
-  --forks FORKS         Display forks supported by the test framework and exit.
+  --forks               Display forks supported by the test framework and exit.
   --fork FORK           Only fill tests for the specified fork.
   --from FROM           Fill tests from and including the specified fork.
   --until UNTIL         Fill tests until and including the specified fork.
 
 Arguments related to running execution-spec-tests:
-  --test-help TEST_HELP
-                        Only show help options specific to execution-spec-tests
+  --test-help           Only show help options specific to execution-spec-tests
                         and exit.
 
 Exit: After displaying help.

--- a/src/pytest_plugins/test_filler/test_filler.py
+++ b/src/pytest_plugins/test_filler/test_filler.py
@@ -41,7 +41,7 @@ def pytest_addoption(parser):
         type=Path,
         default=None,
         help=(
-            "Path to an evm executable that provides `t8n`. " "Default: First 'evm' entry in PATH"
+            "Path to an evm executable that provides `t8n`. Default: First 'evm' entry in PATH."
         ),
     )
     evm_group.addoption(
@@ -49,7 +49,7 @@ def pytest_addoption(parser):
         action="store_true",
         dest="evm_collect_traces",
         default=None,
-        help="Collect traces of the execution information from the " + "transition tool",
+        help="Collect traces of the execution information from the transition tool.",
     )
 
     solc_group = parser.getgroup("solc", "Arguments defining the solc executable")
@@ -60,7 +60,7 @@ def pytest_addoption(parser):
         default=None,
         help=(
             "Path to a solc executable (for Yul source compilation). "
-            "Default: First 'solc' entry in PATH"
+            "Default: First 'solc' entry in PATH."
         ),
     )
 

--- a/src/pytest_plugins/test_help/test_help.py
+++ b/src/pytest_plugins/test_help/test_help.py
@@ -54,9 +54,13 @@ def show_test_help(config):
                 # Works for 'store', 'store_true', and 'store_false'.
                 kwargs = {
                     "default": action.default,
-                    "type": action.type,
                     "help": action.help,
+                    "required": action.required,
                 }
+                if isinstance(action, argparse._StoreTrueAction):
+                    kwargs["action"] = "store_true"
+                else:
+                    kwargs["type"] = action.type
                 if action.nargs is not None and action.nargs != 0:
                     kwargs["nargs"] = action.nargs
                 new_group.add_argument(*action.option_strings, **kwargs)


### PR DESCRIPTION
Whilst reviewing #210 I noticed that the output of `fill --test-help` was misleading for `--disable-hive` (and all other `store_true`/`store_false` arguments) as it suggested that it took an argument:
![grafik](https://github.com/ethereum/execution-spec-tests/assets/91727015/029a59d8-1afc-4baa-83f6-208834afa900)

This PR fixes that:
![grafik](https://github.com/ethereum/execution-spec-tests/assets/91727015/689f593a-b5e3-40dc-b1a0-9588df7d3f6e)
