### PR TITLE
chore: add helpful vscode launch configs

### DIFF
--- a/.vscode/launch.recommended.json
+++ b/.vscode/launch.recommended.json
@@ -1,19 +1,142 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+
+  // If the VS Code "Run and Debug" button, respecively launch selector are not visible, see this answer:
+  // https://stackoverflow.com/a/74245823
+  // 
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch fill --until choose fork",
+      "type": "python",
+      "request": "launch",
+      "module": "pytest",
+      "args": [
+        "-c",
+        "pytest.ini",
+        "--until",
+        "${input:fork}",
+        "--evm-bin",
+        "${input:evmBinary}",
+        "-v"
+      ],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "name": "Launch fill -k choose test path",
+      "type": "python",
+      "request": "launch",
+      "module": "pytest",
+      "args": [
+        "-c",
+        "pytest.ini",
+        "--until",
+        "Cancun",
+        "--evm-bin",
+        "${input:evmBinary}",
+        "-v",
+        "-k",
+        "${input:testPathOrId}"
+      ],
+      "cwd": "${workspaceFolder}"
+    },   
+    {
+      "name": "Launch fill --until Shanghai",
+      "type": "python",
+      "request": "launch",
+      "module": "pytest",
+      "args": [
+        "-c",
+        "pytest.ini",
+        "--until",
+        "Shanghai",
+        "--evm-bin",
+        "${input:evmBinary}",
+        "-v"
+      ],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "name": "Launch fill --until Cancun",
+      "type": "python",
+      "request": "launch",
+      "module": "pytest",
+      "args": [
+        "-c",
+        "pytest.ini",
+        "--until",
+        "Cancun",
+        "--evm-bin",
+        "${input:evmBinary}",
+        "-v"
+      ],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      // To help debugging the --test-help command.
+      "name": "Launch fill --test-help",
+      "type": "python",
+      "request": "launch",
+      "module": "pytest",
+      "args": ["-c", "pytest.ini", "--test-help"],
+      "cwd": "/home/dtopz/code/github/danceratopz/execution-spec-tests"
+    },
+  ],
+  "inputs": [
+    {
+      "type": "pickString",
+      "id": "evmBinary",
+      "description": "Which evm binary to you want to run?",
+      "options": [
         {
-            "name": "Generate fixtures for evm features under development",
-            "type": "python",
-            "request": "launch",
-            "module": "pytest",
-            "args": [
-              "--until",
-              "Cancun"
-            ],
-            "cwd": "${workspaceFolder}"
-          }
-    ]
+          "label": "First evm binary in PATH",
+          "value": "evm",
+        },
+        {
+          "label": "Geth, mario's repo",
+          "value": "~/code/github/marioevz/go-ethereum/build/bin/evm",
+        },
+        {
+          "label": "Geth, danceratopz's repo",
+          "value": "~/code/github/danceratopz/go-ethereum/build/bin/evm",
+        },
+        {
+          "label": "evmone",
+          "value": "~/code/github/ethereum/evmone/build/bin/evmone-t8n",
+        },
+        {
+          "label": "besu",
+          "value": "~/code/github/danceratopz/besu/ethereum/evmtool/build/install/evmtool/bin/evm",
+        }
+      ],
+      "default": "evm"
+    },
+    {
+      "type": "pickString",
+      "id": "fork",
+      "description": "Which fork do you want to use?",
+      "options": [
+        "Frontier", 
+        "Homestead", 
+        "Byzantium",
+        "Constantinople",
+        "ConstantinopleFix",
+        "Istanbul",
+        "Berlin",
+        "London",
+        "Merge",
+        "Shanghai",
+        "Cancun",
+      ],
+      "default": "Shanghai"
+    },
+    {
+      "type": "promptString",
+      "id": "testPathOrId",
+      "description": "Enter a test path string or id to provide to pytest -k",
+      "default": "test_"
+    }
+  ]
 }


### PR DESCRIPTION
Add configs to `.vscode/launch.recommended.json` that assist debugging test cases with an interactive choice of an evm binary and test path.
 