### PR TITLE
readme: fix pip install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ This guide installs stable versions of the required external `evm` and `solc` ex
    cd execution-spec-tests
    python3 -m venv ./venv/
    source ./venv/bin/activate
-   pip install -e .[docs,lint,test]
+   pip install -e '.[docs,lint,test]'
    ```
 
 3. Verify the installation:

--- a/docs/getting_started/quick_start.md
+++ b/docs/getting_started/quick_start.md
@@ -59,32 +59,33 @@ The following requires a Python 3.10 or Python 3.11 installation.
 3. Verify installation:
     1. Explore test cases:
 
-    2. ```console
+        ```console
         fill --collect-only
         ```
 
-       Expected console output:
-       <figure markdown>  <!-- markdownlint-disable MD033 (MD033=no-inline-html) -->
-         ![Screenshot of pytest test collection console output](./img/pytest_collect_only.png){align=center}
-       </figure>
-    3. Execute the test cases (verbosely) in the `./tests/berlin/eip2930_access_list/test_acl.py` module:
+        Expected console output:
+        <figure markdown>  <!-- markdownlint-disable MD033 (MD033=no-inline-html) -->
+            ![Screenshot of pytest test collection console output](./img/pytest_collect_only.png){align=center}
+        </figure>
 
-       ```console
-       fill -v tests/berlin/eip2930_access_list/test_acl.py
-       ```
+    2. Execute the test cases (verbosely) in the `./tests/berlin/eip2930_access_list/test_acl.py` module:
 
-       Expected console output:
-       <figure markdown>  <!-- markdownlint-disable MD033 (MD033=no-inline-html) -->
-        ![Screenshot of pytest test collection console output](./img/pytest_run_example.png){align=center}
-       </figure>
-       Check:
+        ```console
+        fill -v tests/berlin/eip2930_access_list/test_acl.py
+        ```
 
-       1. The versions of the `evm` and `solc` tools are as expected (your versions may differ from those in the highlighted box).
-       2. The corresponding fixture file has been generated:
+        Expected console output:
+        <figure markdown>  <!-- markdownlint-disable MD033 (MD033=no-inline-html) -->
+            ![Screenshot of pytest test collection console output](./img/pytest_run_example.png){align=center}
+        </figure>
+        Check:
 
-          ```console
-          head fixtures/berlin/eip2930_access_list/acl/access_list.json
-          ```
+        1. The versions of the `evm` and `solc` tools are as expected (your versions may differ from those in the highlighted box).
+        2. The corresponding fixture file has been generated:
+
+            ```console
+            head fixtures/berlin/eip2930_access_list/acl/access_list.json
+            ```
 
 ## Next Steps
 

--- a/docs/getting_started/quick_start.md
+++ b/docs/getting_started/quick_start.md
@@ -48,13 +48,13 @@ The following requires a Python 3.10 or Python 3.11 installation.
 
 2. Clone the [execution-spec-tests](https://github.com/ethereum/execution-spec-tests) repo and install its and dependencies (it's recommended to use a virtual environment for the installation):
 
-   ```console
-   git clone https://github.com/ethereum/execution-spec-tests
-   cd execution-spec-tests
-   python3 -m venv ./venv/
-   source ./venv/bin/activate
-   pip install -e .[docs,lint,test]
-   ```
+    ```console
+    git clone https://github.com/ethereum/execution-spec-tests
+    cd execution-spec-tests
+    python3 -m venv ./venv/
+    source ./venv/bin/activate
+    pip install -e '.[docs,lint,test]'
+    ```
 
 3. Verify installation:
     1. Explore test cases:


### PR DESCRIPTION
zsh does not like the `[` character so wrap it with `''`.