### PR TITLE
feature: Add block header field metadata

### DIFF
--- a/src/ethereum_test_tools/common/json.py
+++ b/src/ethereum_test_tools/common/json.py
@@ -142,6 +142,7 @@ def field(*args, json_encoder: Optional[JSONEncoder.Field] = None, **kwargs) -> 
         metadata = kwargs["metadata"]
     else:
         metadata = {}
+    assert isinstance(metadata, dict)
 
     if json_encoder is not None:
         metadata["json_encoder"] = json_encoder

--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -30,7 +30,7 @@ from ethereum_test_forks import Fork
 from evm_transition_tool import TransitionTool
 
 from ..reference_spec.reference_spec import ReferenceSpec
-from .constants import AddrAA, EmptyOmmersRoot, EmptyTrieRoot, EngineAPIError, TestPrivateKey
+from .constants import AddrAA, EmptyOmmersRoot, EngineAPIError, TestPrivateKey
 from .conversions import (
     BytesConvertible,
     FixedSizeBytesConvertible,
@@ -2031,7 +2031,6 @@ class FixtureHeader:
             transition_tool_source="currentBaseFee",
             environment_source="base_fee",
             cast_type=Number,
-            default=7,
         ),
         json_encoder=JSONEncoder.Field(name="baseFeePerGas", cast_type=ZeroPaddedHexNumber),
     )
@@ -2042,7 +2041,6 @@ class FixtureHeader:
             fork_requirement_check="header_withdrawals_required",
             transition_tool_source="withdrawalsRoot",
             cast_type=Hash,
-            default=EmptyTrieRoot,
         ),
         json_encoder=JSONEncoder.Field(name="withdrawalsRoot"),
     )
@@ -2053,7 +2051,6 @@ class FixtureHeader:
             fork_requirement_check="header_data_gas_used_required",
             transition_tool_source="dataGasUsed",
             cast_type=Number,
-            default=0,
         ),
         json_encoder=JSONEncoder.Field(name="dataGasUsed", cast_type=ZeroPaddedHexNumber),
     )
@@ -2064,7 +2061,6 @@ class FixtureHeader:
             fork_requirement_check="header_excess_data_gas_required",
             transition_tool_source="currentExcessDataGas",
             cast_type=Number,
-            default=0,
         ),
         json_encoder=JSONEncoder.Field(name="excessDataGas", cast_type=ZeroPaddedHexNumber),
     )

--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -1851,12 +1851,16 @@ class HeaderField:
 
         if self.transition_tool_source is not None:
             if self.transition_tool_source in transition_tool_result:
-                value = transition_tool_result.get(self.transition_tool_source)
+                got_value = transition_tool_result.get(self.transition_tool_source)
+                if got_value is not None:
+                    value = got_value
 
         if self.environment_source is not None:
-            value = getattr(environment, self.environment_source, None)
-            if callable(value):
-                value = value()
+            got_value = getattr(environment, self.environment_source, None)
+            if callable(got_value):
+                got_value = got_value()
+            if got_value is not None:
+                value = got_value
 
         if required:
             if value is None:

--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -2083,7 +2083,7 @@ class FixtureHeader:
         environment: Environment,
     ) -> "FixtureHeader":
         """
-        Collects a FixedHeader object from multiple sources:
+        Collects a FixtureHeader object from multiple sources:
         - The transition tool result
         - The test's current environment
         """

--- a/src/ethereum_test_tools/spec/blockchain_test.py
+++ b/src/ethereum_test_tools/spec/blockchain_test.py
@@ -24,7 +24,6 @@ from ..common import (
     HeaderNonce,
     Number,
     ZeroPaddedHexNumber,
-    str_or_none,
     to_json,
 )
 from ..common.constants import EmptyOmmersRoot
@@ -177,29 +176,12 @@ class BlockchainTest(BaseTest):
                     + "was indeed expected to fail and add the proper "
                     + "`block.exception`"
                 )
-
-            header = FixtureHeader.from_dict(
-                result
-                | {
-                    "parentHash": env.parent_hash(),
-                    "miner": env.coinbase,
-                    "transactionsRoot": result.get("txRoot"),
-                    "difficulty": str_or_none(result.get("currentDifficulty"), "0"),
-                    "number": str(env.number),
-                    "gasLimit": str(env.gas_limit),
-                    "timestamp": str(env.timestamp),
-                    "extraData": block.extra_data
-                    if block.extra_data is not None and len(Bytes(block.extra_data)) != 0
-                    else "0x",
-                    "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",  # noqa: E501
-                    "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",  # noqa: E501
-                    "nonce": "0x0000000000000000",
-                    "baseFeePerGas": result.get("currentBaseFee"),
-                    "excessDataGas": result.get("currentExcessDataGas"),
-                }
+            env.extra_data = block.extra_data
+            header = FixtureHeader.collect(
+                fork=fork,
+                transition_tool_result=result,
+                environment=env,
             )
-
-            assert len(header.state_root) == 32
 
             if block.rlp_modifier is not None:
                 # Modify any parameter specified in the `rlp_modifier` after

--- a/src/ethereum_test_tools/spec/state_test.py
+++ b/src/ethereum_test_tools/spec/state_test.py
@@ -22,7 +22,6 @@ from ..common import (
     Number,
     Transaction,
     ZeroPaddedHexNumber,
-    str_or_none,
     to_json,
 )
 from ..common.constants import EmptyOmmersRoot, EngineAPIError
@@ -142,23 +141,11 @@ class StateTest(BaseTest):
             print_traces(traces=t8n.get_traces())
             raise e
 
-        header = FixtureHeader.from_dict(
-            result
-            | {
-                "parentHash": genesis.hash,
-                "miner": env.coinbase,
-                "transactionsRoot": result.get("txRoot"),
-                "difficulty": str_or_none(env.difficulty, result.get("currentDifficulty")),
-                "number": str(env.number),
-                "gasLimit": str(env.gas_limit),
-                "timestamp": str(env.timestamp),
-                "extraData": "0x00",
-                "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
-                "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-                "nonce": "0x0000000000000000",
-                "baseFeePerGas": result.get("currentBaseFee"),
-                "excessDataGas": result.get("currentExcessDataGas"),
-            }
+        env.extra_data = b"\x00"
+        header = FixtureHeader.collect(
+            fork=fork,
+            transition_tool_result=result,
+            environment=env,
         )
 
         block, header.hash = header.build(


### PR DESCRIPTION
## Changes Included
- Replaces the fragile dictionary mixing method to collect the header fields with a method based on field metadata, and now each header field contains metadata with the following information:
  - Method used to determine requirement based on block number, timestamp and fork configuration
  - Field source from: Current test environment, or transition tool (t8n) result dictionary
  - Default value if field is required but no value was provided by either the test environment or the transition tool result

Open questions:
Should we throw an exception if the t8n tool did not provide us the sufficient information to create the block?
At the moment we provide defaults for the 4844 fields, but for 4788 the beacon block root contained in the header will actually modify the state root, and therefore we should throw an exception in this case if the field was not provided or was ignored when calculating the state root.

Fixes #215

@winsvega 