### PR TITLE
feature: Add flag to dump debug t8n information

### DIFF
--- a/src/ethereum_test_tools/spec/base_test.py
+++ b/src/ethereum_test_tools/spec/base_test.py
@@ -3,7 +3,9 @@ Generic Ethereum test base class
 """
 from abc import abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, Generator, List, Mapping, Optional, Tuple
+from itertools import count
+from os import path
+from typing import Any, Callable, Dict, Generator, Iterator, List, Mapping, Optional, Tuple
 
 from ethereum_test_forks import Fork
 from evm_transition_tool import TransitionTool
@@ -79,6 +81,8 @@ class BaseTest:
     pre: Mapping
     tag: str = ""
     base_test_config: BaseTestConfig = field(default_factory=BaseTestConfig)
+    debug_transition_tool_dump_path: Optional[str] = ""
+    transition_tool_call_counter: Iterator[int] = field(init=False, default_factory=count)
 
     @abstractmethod
     def make_genesis(
@@ -113,6 +117,17 @@ class BaseTest:
         spec type as filler for the test.
         """
         pass
+
+    def get_next_transition_tool_output_path(self) -> str:
+        """
+        Returns the path to the next transition tool output file.
+        """
+        if not self.debug_transition_tool_dump_path:
+            return ""
+        return path.join(
+            self.debug_transition_tool_dump_path,
+            str(next(self.transition_tool_call_counter)),
+        )
 
 
 TestSpec = Callable[[Fork], Generator[BaseTest, None, None]]

--- a/src/ethereum_test_tools/spec/base_test.py
+++ b/src/ethereum_test_tools/spec/base_test.py
@@ -81,8 +81,10 @@ class BaseTest:
     pre: Mapping
     tag: str = ""
     base_test_config: BaseTestConfig = field(default_factory=BaseTestConfig)
-    debug_transition_tool_dump_path: Optional[str] = ""
-    transition_tool_call_counter: Iterator[int] = field(init=False, default_factory=count)
+
+    # Transition tool specific fields
+    t8n_dump_dir: Optional[str] = ""
+    t8n_call_counter: Iterator[int] = field(init=False, default_factory=count)
 
     @abstractmethod
     def make_genesis(
@@ -122,11 +124,11 @@ class BaseTest:
         """
         Returns the path to the next transition tool output file.
         """
-        if not self.debug_transition_tool_dump_path:
+        if not self.t8n_dump_dir:
             return ""
         return path.join(
-            self.debug_transition_tool_dump_path,
-            str(next(self.transition_tool_call_counter)),
+            self.t8n_dump_dir,
+            str(next(self.t8n_call_counter)),
         )
 
 

--- a/src/ethereum_test_tools/spec/blockchain_test.py
+++ b/src/ethereum_test_tools/spec/blockchain_test.py
@@ -67,8 +67,9 @@ class BlockchainTest(BaseTest):
             coinbase=Address(0),
             state_root=Hash(
                 t8n.calc_state_root(
-                    to_json(Alloc(self.pre)),
-                    fork,
+                    alloc=to_json(Alloc(self.pre)),
+                    fork=fork,
+                    debug_output_path=self.get_next_transition_tool_output_path(),
                 )
             ),
             transactions_root=Hash(EmptyTrieRoot),
@@ -86,7 +87,11 @@ class BlockchainTest(BaseTest):
             data_gas_used=ZeroPaddedHexNumber.or_none(env.data_gas_used),
             excess_data_gas=ZeroPaddedHexNumber.or_none(env.excess_data_gas),
             withdrawals_root=Hash.or_none(
-                t8n.calc_withdrawals_root(env.withdrawals, fork)
+                t8n.calc_withdrawals_root(
+                    withdrawals=env.withdrawals,
+                    fork=fork,
+                    debug_output_path=self.get_next_transition_tool_output_path(),
+                )
                 if env.withdrawals is not None
                 else None
             ),
@@ -158,6 +163,7 @@ class BlockchainTest(BaseTest):
                 chain_id=chain_id,
                 reward=fork.get_reward(Number(env.number), Number(env.timestamp)),
                 eips=eips,
+                debug_output_path=self.get_next_transition_tool_output_path(),
             )
             try:
                 rejected_txs = verify_transactions(txs, result)

--- a/src/ethereum_test_tools/spec/state_test.py
+++ b/src/ethereum_test_tools/spec/state_test.py
@@ -66,8 +66,9 @@ class StateTest(BaseTest):
             coinbase=Address(0),
             state_root=Hash(
                 t8n.calc_state_root(
-                    to_json(Alloc(self.pre)),
-                    fork,
+                    alloc=to_json(Alloc(self.pre)),
+                    fork=fork,
+                    debug_output_path=self.get_next_transition_tool_output_path(),
                 )
             ),
             transactions_root=Hash(EmptyTrieRoot),
@@ -85,7 +86,11 @@ class StateTest(BaseTest):
             data_gas_used=ZeroPaddedHexNumber.or_none(env.data_gas_used),
             excess_data_gas=ZeroPaddedHexNumber.or_none(env.excess_data_gas),
             withdrawals_root=Hash.or_none(
-                t8n.calc_withdrawals_root(env.withdrawals, fork)
+                t8n.calc_withdrawals_root(
+                    withdrawals=env.withdrawals,
+                    fork=fork,
+                    debug_output_path=self.get_next_transition_tool_output_path(),
+                )
                 if env.withdrawals is not None
                 else None
             ),
@@ -125,6 +130,7 @@ class StateTest(BaseTest):
             chain_id=chain_id,
             reward=fork.get_reward(Number(env.number), Number(env.timestamp)),
             eips=eips,
+            debug_output_path=self.get_next_transition_tool_output_path(),
         )
 
         rejected_txs = verify_transactions(txs, result)

--- a/src/evm_transition_tool/tests/test_evaluate.py
+++ b/src/evm_transition_tool/tests/test_evaluate.py
@@ -76,7 +76,7 @@ def test_calc_state_root(
 
     env = TestEnv()
     env.base_fee = base_fee
-    assert t8n.calc_state_root(alloc, fork).startswith(hash)
+    assert t8n.calc_state_root(alloc=alloc, fork=fork).startswith(hash)
 
 
 @pytest.mark.parametrize("evm_tool", [GethTransitionTool])

--- a/src/evm_transition_tool/transition_tool.py
+++ b/src/evm_transition_tool/transition_tool.py
@@ -6,6 +6,7 @@ import os
 import shutil
 from abc import abstractmethod
 from itertools import groupby
+from json import dump
 from pathlib import Path
 from re import Pattern
 from typing import Any, Dict, List, Optional, Tuple, Type
@@ -26,6 +27,17 @@ class TransitionToolNotFoundInPath(Exception):
         if binary:
             message = f"{message} ({binary})"
         super().__init__(message)
+
+
+def dump_files_to_directory(output_path: str, files: Dict[str, Any]) -> None:
+    """
+    Dump the files to the given directory.
+    """
+    os.makedirs(output_path, exist_ok=True)
+    for file_name, file_contents in files.items():
+        file_path = os.path.join(output_path, file_name)
+        with open(file_path, "w") as f:
+            dump(file_contents, f, ensure_ascii=True, indent=4)
 
 
 class TransitionTool:
@@ -145,6 +157,7 @@ class TransitionTool:
         chain_id: int = 1,
         reward: int = 0,
         eips: Optional[List[int]] = None,
+        debug_output_path: str = "",
     ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
         """
         Simulate a state transition with specified parameters
@@ -185,7 +198,7 @@ class TransitionTool:
         """
         return self.traces
 
-    def calc_state_root(self, alloc: Any, fork: Fork) -> bytes:
+    def calc_state_root(self, *, alloc: Any, fork: Fork, debug_output_path: str = "") -> bytes:
         """
         Calculate the state root for the given `alloc`.
         """
@@ -206,13 +219,15 @@ class TransitionTool:
         if fork.header_withdrawals_required(0, 0):
             env["withdrawals"] = []
 
-        _, result = self.evaluate(alloc, [], env, fork)
+        _, result = self.evaluate(alloc, [], env, fork, debug_output_path=debug_output_path)
         state_root = result.get("stateRoot")
         if state_root is None or not isinstance(state_root, str):
             raise Exception("Unable to calculate state root")
         return bytes.fromhex(state_root[2:])
 
-    def calc_withdrawals_root(self, withdrawals: Any, fork: Fork) -> bytes:
+    def calc_withdrawals_root(
+        self, *, withdrawals: Any, fork: Fork, debug_output_path: str = ""
+    ) -> bytes:
         """
         Calculate the state root for the given `alloc`.
         """
@@ -240,7 +255,7 @@ class TransitionTool:
         if fork.header_excess_data_gas_required(0, 0):
             env["currentExcessDataGas"] = "0"
 
-        _, result = self.evaluate({}, [], env, fork)
+        _, result = self.evaluate({}, [], env, fork, debug_output_path=debug_output_path)
         withdrawals_root = result.get("withdrawalsRoot")
         if withdrawals_root is None:
             raise Exception(

--- a/src/pytest_plugins/test_filler/test_filler.py
+++ b/src/pytest_plugins/test_filler/test_filler.py
@@ -96,9 +96,9 @@ def pytest_addoption(parser):
 
     debug_group = parser.getgroup("debug", "Arguments defining debug behavior")
     debug_group.addoption(
-        "--transition-tool-debug-dump-path",
+        "--t8n-dump-dir",
         action="store",
-        dest="transition_tool_debug_dump_path",
+        dest="t8n_dump_dir",
         default="",
         help="Path to dump the transition tool debug output.",
     )
@@ -365,9 +365,7 @@ def state_test(
     class StateTestWrapper(StateTest):
         def __init__(self, *args, **kwargs):
             kwargs["base_test_config"] = base_test_config
-            if debug_transition_tool_dump_path := request.config.getoption(
-                "transition_tool_debug_dump_path"
-            ):
+            if debug_transition_tool_dump_path := request.config.getoption("t8n_dump_dir"):
                 kwargs["debug_transition_tool_dump_path"] = os.path.join(
                     debug_transition_tool_dump_path, convert_test_name_to_path(request.node.name)
                 )

--- a/src/pytest_plugins/test_filler/test_filler.py
+++ b/src/pytest_plugins/test_filler/test_filler.py
@@ -194,7 +194,7 @@ def strip_test_prefix(name: str) -> str:
     return name
 
 
-def test_name_to_path(name: str) -> str:
+def convert_test_name_to_path(name: str) -> str:
     """
     Converts a test name to a path.
     """
@@ -369,7 +369,7 @@ def state_test(
                 "transition_tool_debug_dump_path"
             ):
                 kwargs["debug_transition_tool_dump_path"] = os.path.join(
-                    debug_transition_tool_dump_path, test_name_to_path(request.node.name)
+                    debug_transition_tool_dump_path, convert_test_name_to_path(request.node.name)
                 )
             super(StateTestWrapper, self).__init__(*args, **kwargs)
             fixture_collector.add_fixture(

--- a/src/pytest_plugins/test_filler/test_filler.py
+++ b/src/pytest_plugins/test_filler/test_filler.py
@@ -94,6 +94,15 @@ def pytest_addoption(parser):
         help="Output tests skipping hive-related properties.",
     )
 
+    debug_group = parser.getgroup("debug", "Arguments defining debug behavior")
+    debug_group.addoption(
+        "--transition-tool-debug-dump-path",
+        action="store",
+        dest="transition_tool_debug_dump_path",
+        default="",
+        help="Path to dump the transition tool debug output.",
+    )
+
 
 @pytest.hookimpl(tryfirst=True)
 def pytest_configure(config):
@@ -183,6 +192,13 @@ def strip_test_prefix(name: str) -> str:
     if name.startswith(TEST_PREFIX):
         return name[len(TEST_PREFIX) :]
     return name
+
+
+def test_name_to_path(name: str) -> str:
+    """
+    Converts a test name to a path.
+    """
+    return re.sub(r"[\[=\-]", "_", name).replace("]", "")
 
 
 class FixtureCollector:
@@ -349,6 +365,12 @@ def state_test(
     class StateTestWrapper(StateTest):
         def __init__(self, *args, **kwargs):
             kwargs["base_test_config"] = base_test_config
+            if debug_transition_tool_dump_path := request.config.getoption(
+                "transition_tool_debug_dump_path"
+            ):
+                kwargs["debug_transition_tool_dump_path"] = os.path.join(
+                    debug_transition_tool_dump_path, test_name_to_path(request.node.name)
+                )
             super(StateTestWrapper, self).__init__(*args, **kwargs)
             fixture_collector.add_fixture(
                 request.node,

--- a/src/pytest_plugins/test_filler/test_filler.py
+++ b/src/pytest_plugins/test_filler/test_filler.py
@@ -365,9 +365,9 @@ def state_test(
     class StateTestWrapper(StateTest):
         def __init__(self, *args, **kwargs):
             kwargs["base_test_config"] = base_test_config
-            if debug_transition_tool_dump_path := request.config.getoption("t8n_dump_dir"):
-                kwargs["debug_transition_tool_dump_path"] = os.path.join(
-                    debug_transition_tool_dump_path, convert_test_name_to_path(request.node.name)
+            if t8n_dump_dir := request.config.getoption("t8n_dump_dir"):
+                kwargs["t8n_dump_dir"] = os.path.join(
+                    t8n_dump_dir, convert_test_name_to_path(request.node.name)
                 )
             super(StateTestWrapper, self).__init__(*args, **kwargs)
             fixture_collector.add_fixture(


### PR DESCRIPTION
Adds flag `--transition-tool-debug-dump-path` which can be used to specify a path where debugging information for all transition tool invocations will be dumped.

For example:
```
fill ./tests/frontier/opcodes/test_dup.py  --transition-tool-debug-dump-path=./tmp/
```
Will result in the following folders:
```
test_dup_fork_Berlin             test_dup_fork_Frontier   test_dup_fork_Merge
test_dup_fork_Byzantium          test_dup_fork_Homestead  test_dup_fork_Shanghai
...
```
inside `./tmp/`, and inside each folder there will be several numbered subfolders with all the information about each call to the transition tool.

@shemnon @chfast let me know if this is helpful and whether you have any suggestions!