### PR TITLE
tests/cancun/eip4844_blobs: fix tx max_fee_per_gas

### DIFF
--- a/tests/cancun/eip4844_blobs/test_blobhash_opcode.py
+++ b/tests/cancun/eip4844_blobs/test_blobhash_opcode.py
@@ -129,6 +129,7 @@ def test_blobhash_gas_cost(
                         to=address,
                         gas_price=10 if tx_type < 2 else None,
                         access_list=[] if tx_type >= 1 else None,
+                        max_fee_per_gas=10 if tx_type >= 2 else None,
                         max_priority_fee_per_gas=10 if tx_type >= 2 else None,
                         max_fee_per_data_gas=10 if tx_type >= 3 else None,
                         blob_versioned_hashes=random_blob_hashes[


### PR DESCRIPTION
The `test_blobhash_opcode.py::test_blobhash_gas_cost` should not set `max_fee_per_gas` for transaction type 0 and 1.

Fixes https://github.com/ethereum/execution-spec-tests/issues/220.