### PR TITLE
types: fix `FixtureEngineNewPayload` json field names

### DIFF
--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -2407,19 +2407,20 @@ class FixtureEngineNewPayload:
 
     payload: FixtureExecutionPayload = field(
         json_encoder=JSONEncoder.Field(
+            name="executionPayload",
             to_json=True,
         )
-    )
-    version: int = field(
-        json_encoder=JSONEncoder.Field(),
     )
     blob_versioned_hashes: Optional[List[FixedSizeBytesConvertible]] = field(
         default=None,
         json_encoder=JSONEncoder.Field(
-            name="blobVersionedHashes",
+            name="expectedBlobVersionedHashes",
             cast_type=lambda hashes: [Hash(hash) for hash in hashes],
             to_json=True,
         ),
+    )
+    version: int = field(
+        json_encoder=JSONEncoder.Field(),
     )
     error_code: Optional[EngineAPIError] = field(
         default=None,

--- a/src/ethereum_test_tools/tests/test_types.py
+++ b/src/ethereum_test_tools/tests/test_types.py
@@ -874,7 +874,7 @@ CHECKSUM_ADDRESS = "0x8a0A19589531694250d570040a0c4B74576919B8"
                 version=1,
             ),
             {
-                "payload": {
+                "executionPayload": {
                     "parentHash": Hash(0).hex(),
                     "feeRecipient": Address(2).hex(),
                     "stateRoot": Hash(3).hex(),
@@ -966,7 +966,7 @@ CHECKSUM_ADDRESS = "0x8a0A19589531694250d570040a0c4B74576919B8"
                 error_code=EngineAPIError.InvalidRequest,
             ),
             {
-                "payload": {
+                "executionPayload": {
                     "parentHash": Hash(0).hex(),
                     "feeRecipient": Address(2).hex(),
                     "stateRoot": Hash(3).hex(),
@@ -1007,7 +1007,7 @@ CHECKSUM_ADDRESS = "0x8a0A19589531694250d570040a0c4B74576919B8"
                     ],
                 },
                 "version": "1",
-                "blobVersionedHashes": [
+                "expectedBlobVersionedHashes": [
                     "0x0000000000000000000000000000000000000000000000000000000000000000",
                     "0x0000000000000000000000000000000000000000000000000000000000000001",
                 ],


### PR DESCRIPTION
Updates `class FixtureEngineNewPayload` to match names in https://github.com/ethereum/execution-apis/blob/main/src/engine/cancun.md, ~so we can basically:~
1) ~Read the fixture json~
2) ~Remove `version` and `error_code` (while keeping its values to use it ourselves)~
3) ~Forward it to the Engine API using the appropriate `engine_newPayload` version~

~@spencer-tb this should simplify pyspec hive simulator further.~

We can't do any of that because `engine_newPayloadVN` contains positional parameters, it doesn't receive the parameters as a big dictionary as I was imagining.