### PR TITLE
tests: Remove start alloc balance to beacon root precompile

### DIFF
--- a/tests/cancun/eip4788_beacon_root/conftest.py
+++ b/tests/cancun/eip4788_beacon_root/conftest.py
@@ -8,7 +8,6 @@ import pytest
 from ethereum_test_tools import (
     Account,
     Environment,
-    HistoryStorageAddress,
     TestAddress,
     Transaction,
     to_address,
@@ -128,7 +127,6 @@ def pre(
     source account of all test transactions, and the precompile caller account.
     """
     return {
-        HistoryStorageAddress: Account(balance=1),
         TestAddress: Account(
             nonce=0,
             balance=0x10**10,

--- a/tests/cancun/eip4844_blobs/test_blob_txs.py
+++ b/tests/cancun/eip4844_blobs/test_blob_txs.py
@@ -21,14 +21,7 @@ from typing import Dict, List, Optional, Tuple
 
 import pytest
 
-from ethereum_test_tools import (
-    Account,
-    Block,
-    BlockchainTestFiller,
-    Environment,
-    Header,
-    HistoryStorageAddress,
-)
+from ethereum_test_tools import Account, Block, BlockchainTestFiller, Environment, Header
 from ethereum_test_tools import Opcodes as Op
 from ethereum_test_tools import (
     Storage,
@@ -302,7 +295,6 @@ def pre(  # noqa: D103
     blocks.
     """
     return {
-        HistoryStorageAddress: Account(balance=1),
         TestAddress: Account(balance=total_account_minimum_balance + account_balance_modifier),
     }
 

--- a/tests/cancun/eip4844_blobs/test_blob_txs_full.py
+++ b/tests/cancun/eip4844_blobs/test_blob_txs_full.py
@@ -14,7 +14,6 @@ from ethereum_test_tools import (
     BlockchainTestFiller,
     Environment,
     Header,
-    HistoryStorageAddress,
     TestAddress,
     Transaction,
     to_address,
@@ -227,7 +226,6 @@ def pre() -> Dict:
     source account of all test transactions.
     """
     return {
-        HistoryStorageAddress: Account(balance=1),
         TestAddress: Account(balance=10**40),
     }
 

--- a/tests/cancun/eip4844_blobs/test_blobhash_opcode.py
+++ b/tests/cancun/eip4844_blobs/test_blobhash_opcode.py
@@ -26,7 +26,6 @@ from ethereum_test_tools import (
     Block,
     BlockchainTestFiller,
     CodeGasMeasure,
-    HistoryStorageAddress,
     TestAddress,
     Transaction,
     to_address,
@@ -46,7 +45,6 @@ pytestmark = pytest.mark.valid_from("Cancun")
 @pytest.fixture
 def pre():  # noqa: D103
     return {
-        HistoryStorageAddress: Account(balance=1),
         TestAddress: Account(balance=10000000000000000000000),
     }
 

--- a/tests/cancun/eip4844_blobs/test_excess_blob_gas.py
+++ b/tests/cancun/eip4844_blobs/test_excess_blob_gas.py
@@ -33,7 +33,6 @@ from ethereum_test_tools import (
     BlockchainTestFiller,
     Environment,
     Header,
-    HistoryStorageAddress,
     TestAddress,
     TestAddress2,
     Transaction,
@@ -165,7 +164,6 @@ def tx_exact_cost(tx_value: int, tx_max_fee_per_gas: int, tx_data_cost: int) -> 
 @pytest.fixture
 def pre(tx_exact_cost: int) -> Mapping[str, Account]:  # noqa: D103
     return {
-        HistoryStorageAddress: Account(balance=1),
         TestAddress: Account(balance=tx_exact_cost),
         TestAddress2: Account(balance=10**40),
     }

--- a/tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py
+++ b/tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py
@@ -14,7 +14,6 @@ from ethereum_test_tools import (
     BlockchainTestFiller,
     Environment,
     Header,
-    HistoryStorageAddress,
     TestAddress,
     Transaction,
     add_kzg_version,
@@ -43,7 +42,6 @@ def env() -> Environment:  # noqa: D103
 @pytest.fixture
 def pre() -> Mapping[str, Account]:  # noqa: D103
     return {
-        HistoryStorageAddress: Account(balance=1),
         TestAddress: Account(balance=10**40),
     }
 

--- a/tests/cancun/eip4844_blobs/test_point_evaluation_precompile.py
+++ b/tests/cancun/eip4844_blobs/test_point_evaluation_precompile.py
@@ -40,7 +40,6 @@ from ethereum_test_tools import (
     Auto,
     Block,
     BlockchainTestFiller,
-    HistoryStorageAddress,
     Storage,
     TestAddress,
     Transaction,
@@ -174,7 +173,6 @@ def pre(
     source account of all test transactions, and the precompile caller account.
     """
     return {
-        HistoryStorageAddress: Account(balance=1),
         TestAddress: Account(
             nonce=0,
             balance=0x10**18,
@@ -518,7 +516,6 @@ def test_point_evaluation_precompile_gas_tx_to(
     """
     start_balance = 10**18
     pre = {
-        HistoryStorageAddress: Account(balance=1),
         TestAddress: Account(
             nonce=0,
             balance=start_balance,
@@ -593,7 +590,6 @@ def test_point_evaluation_precompile_before_fork(
     precompile_caller_address = to_address(0x100)
 
     pre = {
-        HistoryStorageAddress: Account(balance=1),
         TestAddress: Account(
             nonce=0,
             balance=0x10**18,

--- a/tests/cancun/eip4844_blobs/test_point_evaluation_precompile_gas.py
+++ b/tests/cancun/eip4844_blobs/test_point_evaluation_precompile_gas.py
@@ -13,7 +13,6 @@ from ethereum_test_tools import (
     Block,
     BlockchainTestFiller,
     CodeGasMeasure,
-    HistoryStorageAddress,
     TestAddress,
     Transaction,
     copy_opcode_cost,
@@ -143,7 +142,6 @@ def pre(
     source account of all test transactions, and the precompile caller account.
     """
     return {
-        HistoryStorageAddress: Account(balance=1),
         TestAddress: Account(
             nonce=0,
             balance=0x10**18,

--- a/tests/cancun/eip5656_mcopy/test_mcopy.py
+++ b/tests/cancun/eip5656_mcopy/test_mcopy.py
@@ -9,7 +9,7 @@ from typing import Mapping, Tuple
 import pytest
 from ethereum.crypto.hash import keccak256
 
-from ethereum_test_tools import Account, Environment, HistoryStorageAddress
+from ethereum_test_tools import Account, Environment
 from ethereum_test_tools import Opcodes as Op
 from ethereum_test_tools import (
     StateTestFiller,
@@ -108,7 +108,6 @@ def bytecode_storage(
 @pytest.fixture
 def pre(bytecode_storage: Tuple[bytes, Storage]) -> Mapping:  # noqa: D103
     return {
-        HistoryStorageAddress: Account(balance=1),
         TestAddress: Account(balance=10**40),
         code_address: Account(code=bytecode_storage[0]),
     }

--- a/tests/cancun/eip5656_mcopy/test_mcopy_contexts.py
+++ b/tests/cancun/eip5656_mcopy/test_mcopy_contexts.py
@@ -9,7 +9,7 @@ from typing import List, Mapping, Tuple
 
 import pytest
 
-from ethereum_test_tools import Account, Environment, HistoryStorageAddress, OpcodeCallArg
+from ethereum_test_tools import Account, Environment, OpcodeCallArg
 from ethereum_test_tools import Opcodes as Op
 from ethereum_test_tools import (
     StateTestFiller,
@@ -151,7 +151,6 @@ def pre(  # noqa: D103
     callee_bytecode: bytes,
 ) -> Mapping:
     return {
-        HistoryStorageAddress: Account(balance=1),
         TestAddress: Account(balance=10**40),
         code_address: Account(code=bytecode_storage[0]),
         callee_address: Account(code=callee_bytecode),

--- a/tests/cancun/eip5656_mcopy/test_mcopy_memory_expansion.py
+++ b/tests/cancun/eip5656_mcopy/test_mcopy_memory_expansion.py
@@ -9,7 +9,7 @@ from typing import Mapping, Tuple
 
 import pytest
 
-from ethereum_test_tools import Account, Environment, HistoryStorageAddress
+from ethereum_test_tools import Account, Environment
 from ethereum_test_tools import Opcodes as Op
 from ethereum_test_tools import (
     StateTestFiller,
@@ -134,7 +134,6 @@ def pre(  # noqa: D103
     callee_bytecode: bytes,
 ) -> Mapping:
     return {
-        HistoryStorageAddress: Account(balance=1),
         TestAddress: Account(balance=tx_max_fee_per_gas * tx_gas_limit),
         caller_address: Account(code=bytecode_storage[0]),
         memory_expansion_address: Account(code=callee_bytecode),

--- a/tests/cancun/eip6780_selfdestruct/test_selfdestruct.py
+++ b/tests/cancun/eip6780_selfdestruct/test_selfdestruct.py
@@ -17,7 +17,6 @@ from ethereum_test_tools import (
     Block,
     BlockchainTestFiller,
     Environment,
-    HistoryStorageAddress,
     Initcode,
     StateTestFiller,
     Storage,
@@ -186,7 +185,6 @@ def pre(
 ) -> Dict[str, Account]:
     """Pre-state of all tests"""
     pre = {
-        HistoryStorageAddress: Account(balance=1),
         TestAddress: Account(balance=100_000_000_000_000_000_000),
         initcode_copy_from_address: Account(code=selfdestruct_contract_initcode),
     }


### PR DESCRIPTION
Removes the necessary pre-alloc balance at the EIP-4788 pre-compile address.

Tested using https://github.com/ethereum/go-ethereum/pull/27289/commits/2ce4c013b6c28b6ee9bee36e11de38e2a7b7536b and works perfectly.

This will remain a draft until the EIP PR is decided to be included the main branch: https://github.com/ethereum/EIPs/pull/7431