### PR TITLE
tools/code: Add conditional bytecode generator

### DIFF
--- a/src/ethereum_test_tools/__init__.py
+++ b/src/ethereum_test_tools/__init__.py
@@ -3,7 +3,7 @@ Module containing tools for generating cross-client Ethereum execution layer
 tests.
 """
 
-from .code import Code, CodeGasMeasure, Initcode, Yul, YulCompiler
+from .code import Code, CodeGasMeasure, Conditional, Initcode, Yul, YulCompiler
 from .common import (
     AccessList,
     Account,
@@ -59,6 +59,7 @@ __all__ = (
     "BlockchainTestFiller",
     "Code",
     "CodeGasMeasure",
+    "Conditional",
     "EngineAPIError",
     "Environment",
     "Fixture",

--- a/src/ethereum_test_tools/code/__init__.py
+++ b/src/ethereum_test_tools/code/__init__.py
@@ -2,12 +2,13 @@
 Code related utilities and classes.
 """
 from .code import Code
-from .generators import CodeGasMeasure, Initcode
+from .generators import CodeGasMeasure, Conditional, Initcode
 from .yul import Yul, YulCompiler
 
 __all__ = (
     "Code",
     "CodeGasMeasure",
+    "Conditional",
     "Initcode",
     "Yul",
     "YulCompiler",

--- a/src/ethereum_test_tools/tests/test_code.py
+++ b/src/ethereum_test_tools/tests/test_code.py
@@ -10,7 +10,8 @@ from packaging import version
 
 from ethereum_test_forks import Fork, Homestead, Shanghai, forks_from_until, get_deployed_forks
 
-from ..code import Code, Initcode, Yul
+from ..code import Code, Conditional, Initcode, Yul
+from ..vm.opcode import Opcodes as Op
 
 
 @pytest.mark.parametrize(
@@ -239,3 +240,23 @@ def test_yul(
 )
 def test_initcode(initcode: Initcode, bytecode: bytes):
     assert bytes(initcode) == bytecode
+
+
+@pytest.mark.parametrize(
+    "conditional_bytecode,expected",
+    [
+        (
+            Conditional(
+                condition=Op.CALLDATALOAD(0),
+                if_true=Op.MSTORE(0, Op.SLOAD(0)) + Op.RETURN(0, 32),
+                if_false=Op.SSTORE(0, 69),
+            ),
+            bytes.fromhex("600035600d5801576045600055600f5801565b60005460005260206000f35b"),
+        ),
+    ],
+)
+def test_opcodes_if(conditional_bytecode: bytes, expected: bytes):
+    """
+    Test that the if opcode macro is transformed into bytecode as expected.
+    """
+    assert bytes(conditional_bytecode) == expected


### PR DESCRIPTION
Implements a conditional code generator, to skip using Yul in these cases.

It uses a combination of the `PC`, `JUMP` and `JUMPI` opcodes, but in the future these could be replaced by `RJUMP` and `RJUMPI`.