### PR TITLE
types: Rename JSON output to `parentBeaconBlockRoot`

### DIFF
--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -2093,7 +2093,7 @@ class FixtureHeader:
             fork_requirement_check="header_beacon_root_required",
             source_environment="beacon_root",
         ),
-        json_encoder=JSONEncoder.Field(name="beaconRoot"),
+        json_encoder=JSONEncoder.Field(name="parentBeaconBlockRoot"),
     )
 
     hash: Optional[Hash] = header_field(


### PR DESCRIPTION
Renames the JSON output field name of the beacon root to match https://github.com/ethereum/execution-apis/pull/450