### PR TITLE
filler: allow genesis state root calc to modify pre-alloc

### DIFF
--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -684,6 +684,15 @@ class Account:
             expected_storage.must_be_equal(address=address, other=actual_storage)
 
     @classmethod
+    def from_dict(cls: Type, data: "Dict | Account") -> "Account":
+        """
+        Create account from dictionary.
+        """
+        if isinstance(data, cls):
+            return data
+        return cls(**data)
+
+    @classmethod
     def with_code(cls: Type, code: BytesConvertible) -> "Account":
         """
         Create account with provided `code` and nonce of `1`.
@@ -691,7 +700,7 @@ class Account:
         return Account(nonce=1, code=code)
 
 
-class Alloc(dict, Mapping[FixedSizeBytesConvertible, Account], SupportsJSON):
+class Alloc(dict, Mapping[FixedSizeBytesConvertible, Account | Dict], SupportsJSON):
     """
     Allocation of accounts in the state, pre and post test execution.
     """
@@ -700,7 +709,9 @@ class Alloc(dict, Mapping[FixedSizeBytesConvertible, Account], SupportsJSON):
         """
         Returns the JSON representation of the allocation.
         """
-        return encoder.default({Address(address): account for address, account in self.items()})
+        return encoder.default(
+            {Address(address): Account.from_dict(account) for address, account in self.items()}
+        )
 
 
 def alloc_to_accounts(got_alloc: Dict[str, Any]) -> Mapping[str, Account]:

--- a/src/ethereum_test_tools/filling/fill.py
+++ b/src/ethereum_test_tools/filling/fill.py
@@ -1,7 +1,6 @@
 """
 Filler object definitions.
 """
-from copy import copy
 from typing import List, Optional
 
 from ethereum_test_forks import Fork
@@ -25,11 +24,12 @@ def fill_test(
     """
     t8n.reset_traces()
 
-    genesis_rlp, genesis = test_spec.make_genesis(t8n, fork)
+    pre, genesis_rlp, genesis = test_spec.make_genesis(t8n, fork)
 
     (blocks, head, alloc) = test_spec.make_blocks(
         t8n,
         genesis,
+        pre,
         fork,
         eips=eips,
     )
@@ -41,7 +41,7 @@ def fill_test(
         genesis_rlp=genesis_rlp,
         head=head,
         fork="+".join([fork_name] + [str(eip) for eip in eips]) if eips is not None else fork_name,
-        pre_state=copy(test_spec.pre),
+        pre_state=pre,
         post_state=alloc_to_accounts(alloc),
         seal_engine=engine,
         name=test_spec.tag,

--- a/src/ethereum_test_tools/spec/base_test.py
+++ b/src/ethereum_test_tools/spec/base_test.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, Dict, Generator, Iterator, List, Mapping, Opti
 from ethereum_test_forks import Fork
 from evm_transition_tool import TransitionTool
 
-from ..common import Account, Address, Bytes, FixtureBlock, FixtureHeader, Hash, Transaction
+from ..common import Account, Address, Alloc, Bytes, FixtureBlock, FixtureHeader, Hash, Transaction
 
 
 def verify_transactions(txs: List[Transaction] | None, result) -> List[int]:
@@ -91,7 +91,7 @@ class BaseTest:
         self,
         t8n: TransitionTool,
         fork: Fork,
-    ) -> Tuple[Bytes, FixtureHeader]:
+    ) -> Tuple[Alloc, Bytes, FixtureHeader]:
         """
         Create a genesis block from the test definition.
         """
@@ -102,6 +102,7 @@ class BaseTest:
         self,
         t8n: TransitionTool,
         genesis: FixtureHeader,
+        pre: Alloc,
         fork: Fork,
         chain_id: int = 1,
         eips: Optional[List[int]] = None,

--- a/src/ethereum_test_tools/tests/test_filler.py
+++ b/src/ethereum_test_tools/tests/test_filler.py
@@ -76,7 +76,9 @@ def test_make_genesis(fork: Fork, hash: bytes):
 
     t8n = GethTransitionTool()
 
-    _, genesis = StateTest(env=env, pre=pre, post={}, txs=[], tag="some_state_test").make_genesis(
+    _, _, genesis = StateTest(
+        env=env, pre=pre, post={}, txs=[], tag="some_state_test"
+    ).make_genesis(
         t8n,
         fork,
     )

--- a/src/evm_transition_tool/tests/test_evaluate.py
+++ b/src/evm_transition_tool/tests/test_evaluate.py
@@ -76,7 +76,7 @@ def test_calc_state_root(  # noqa: D103
 
     env = TestEnv()
     env.base_fee = base_fee
-    assert t8n.calc_state_root(alloc=alloc, fork=fork).startswith(hash)
+    assert t8n.calc_state_root(alloc=alloc, fork=fork)[1].startswith(hash)
 
 
 @pytest.mark.parametrize("evm_tool", [GethTransitionTool])

--- a/src/evm_transition_tool/transition_tool.py
+++ b/src/evm_transition_tool/transition_tool.py
@@ -205,7 +205,9 @@ class TransitionTool:
         """
         return self.traces
 
-    def calc_state_root(self, *, alloc: Any, fork: Fork, debug_output_path: str = "") -> bytes:
+    def calc_state_root(
+        self, *, alloc: Any, fork: Fork, debug_output_path: str = ""
+    ) -> Tuple[Dict[str, Any], bytes]:
         """
         Calculate the state root for the given `alloc`.
         """
@@ -234,7 +236,7 @@ class TransitionTool:
                 "beaconRoot"
             ] = "0x0000000000000000000000000000000000000000000000000000000000000000"
 
-        _, result = self.evaluate(
+        new_alloc, result = self.evaluate(
             alloc=alloc,
             txs=[],
             env=env,
@@ -244,7 +246,7 @@ class TransitionTool:
         state_root = result.get("stateRoot")
         if state_root is None or not isinstance(state_root, str):
             raise Exception("Unable to calculate state root")
-        return bytes.fromhex(state_root[2:])
+        return new_alloc, bytes.fromhex(state_root[2:])
 
     def calc_withdrawals_root(
         self, *, withdrawals: Any, fork: Fork, debug_output_path: str = ""


### PR DESCRIPTION
After Cancun fork, due to [EIP-4788](https://eips.ethereum.org/EIPS/eip-4788), `t8n` automatically updates the storage when calculating the genesis state root to perform the nonce increment of the beacon root stateful pre-compile:
```json
"0x000000000000000000000000000000000000000b": {
                "nonce": "0x01",
                "balance": "0x00",
                "code": "0x",
                "storage": {}
            }
```

Instead of doing this manually for every test, with this PR we fetch the updated `pre` that is the result of calling the `t8n` to calculate the genesis state root, and use that as input `pre` for each test.

This has the added benefit that it will not matter if the client reading the genesis applies or not the pre-compile nonce update because it will be contained in the `pre` of the test.