### PR TITLE
tests/eip4844: Skip invalid blob tx to address test case

### DIFF
--- a/tests/cancun/eip4844_blobs/test_blob_txs.py
+++ b/tests/cancun/eip4844_blobs/test_blob_txs.py
@@ -694,8 +694,8 @@ def test_invalid_blob_hash_versioning(
     "destination_account,tx_error", [(None, "no_contract_creating_blob_txs")], ids=[""]
 )
 # TODO: Uncomment after #242 -> https://github.com/ethereum/execution-spec-tests/issues/242
-# @pytest.mark.valid_from("Cancun")
 @pytest.mark.skip(reason="Unable to fill due to invalid field in transaction")
+@pytest.mark.valid_from("Cancun")
 def test_invalid_blob_tx_contract_creation(
     blockchain_test: BlockchainTestFiller,
     pre: Dict,

--- a/tests/cancun/eip4844_blobs/test_blob_txs.py
+++ b/tests/cancun/eip4844_blobs/test_blob_txs.py
@@ -693,7 +693,9 @@ def test_invalid_blob_hash_versioning(
 @pytest.mark.parametrize(
     "destination_account,tx_error", [(None, "no_contract_creating_blob_txs")], ids=[""]
 )
-@pytest.mark.valid_from("Cancun")
+# TODO: Uncomment after #242 -> https://github.com/ethereum/execution-spec-tests/issues/242
+# @pytest.mark.valid_from("Cancun")
+@pytest.mark.skip(reason="Unable to fill due to invalid field in transaction")
 def test_invalid_blob_tx_contract_creation(
     blockchain_test: BlockchainTestFiller,
     pre: Dict,


### PR DESCRIPTION
Temporarily skip the `test_invalid_blob_tx_contract_creation` due to the following issue: #242 

We can re-add the test once the issue is resolved.