### PR TITLE
tests/cancun/eip4788: Update to use pre-deployed contract

### DIFF
--- a/src/ethereum_test_forks/base_decorators.py
+++ b/src/ethereum_test_forks/base_decorators.py
@@ -1,0 +1,12 @@
+"""
+Decorators for the fork methods.
+"""
+
+
+def prefer_transition_to_method(method):
+    """
+    Decorator to mark a base method that must always call the `fork_to` implementation when
+    transitioning.
+    """
+    method.__prefer_transition_to_method__ = True
+    return method

--- a/src/ethereum_test_forks/base_fork.py
+++ b/src/ethereum_test_forks/base_fork.py
@@ -2,7 +2,9 @@
 Abstract base class for Ethereum forks
 """
 from abc import ABC, ABCMeta, abstractmethod
-from typing import Optional, Type
+from typing import Mapping, Optional, Type
+
+from .base_decorators import prefer_transition_to_method
 
 
 class BaseForkMeta(ABCMeta):
@@ -100,6 +102,18 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
     def get_reward(cls, block_number: int = 0, timestamp: int = 0) -> int:
         """
         Returns the expected reward amount in wei of a given fork
+        """
+        pass
+
+    @classmethod
+    @prefer_transition_to_method
+    @abstractmethod
+    def pre_allocation(cls, block_number: int = 0, timestamp: int = 0) -> Mapping:
+        """
+        Returns required pre-allocation of accounts.
+
+        This method must always call the `fork_to` method when transitioning, because the
+        allocation can only be set at genesis, and thus cannot be changed at transition time.
         """
         pass
 

--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -1,7 +1,7 @@
 """
 All Ethereum fork class definitions.
 """
-from typing import Optional
+from typing import Mapping, Optional
 
 from ..base_fork import BaseFork
 
@@ -98,6 +98,15 @@ class Frontier(BaseFork):
         5_000_000_000_000_000_000
         """
         return 5_000_000_000_000_000_000
+
+    @classmethod
+    def pre_allocation(cls, block_number: int = 0, timestamp: int = 0) -> Mapping:
+        """
+        Returns whether the fork expects pre-allocation of accounts
+
+        Frontier does not require pre-allocated accounts
+        """
+        return {}
 
 
 class Homestead(Frontier):
@@ -290,6 +299,21 @@ class Cancun(Shanghai):
         Parent beacon block root is required starting from Cancun.
         """
         return True
+
+    @classmethod
+    def pre_allocation(cls, block_number: int = 0, timestamp: int = 0) -> Mapping:
+        """
+        Cancun requires pre-allocation of the beacon root contract for EIP-4788
+        """
+        new_allocation = {
+            0x0B: {
+                "nonce": 1,
+                "code": "0x3373fffffffffffffffffffffffffffffffffffffffe14604457602036146024575f5f"
+                "fd5b620180005f350680545f35146037575f5ffd5b6201800001545f5260205ff35b426201800042"
+                "06555f3562018000420662018000015500",
+            }
+        }
+        return new_allocation | super(Cancun, cls).pre_allocation(block_number, timestamp)
 
     @classmethod
     def engine_new_payload_version(

--- a/src/ethereum_test_tools/spec/blockchain_test.py
+++ b/src/ethereum_test_tools/spec/blockchain_test.py
@@ -60,8 +60,9 @@ class BlockchainTest(BaseTest):
         """
         env = self.genesis_environment.set_fork_requirements(fork)
 
+        pre_alloc = Alloc(fork.pre_allocation(block_number=0, timestamp=Number(env.timestamp)))
         new_alloc, state_root = t8n.calc_state_root(
-            alloc=to_json(Alloc(self.pre)),
+            alloc=to_json(Alloc.merge(pre_alloc, Alloc(self.pre))),
             fork=fork,
             debug_output_path=self.get_next_transition_tool_output_path(),
         )

--- a/src/ethereum_test_tools/spec/state_test.py
+++ b/src/ethereum_test_tools/spec/state_test.py
@@ -66,8 +66,10 @@ class StateTest(BaseTest):
 
         env = env.set_fork_requirements(fork)
 
+        pre_alloc = Alloc(fork.pre_allocation(block_number=0, timestamp=Number(env.timestamp)))
+
         new_alloc, state_root = t8n.calc_state_root(
-            alloc=to_json(Alloc(self.pre)),
+            alloc=to_json(Alloc.merge(pre_alloc, Alloc(self.pre))),
             fork=fork,
             debug_output_path=self.get_next_transition_tool_output_path(),
         )

--- a/src/evm_transition_tool/transition_tool.py
+++ b/src/evm_transition_tool/transition_tool.py
@@ -207,7 +207,7 @@ class TransitionTool:
 
     def calc_state_root(
         self, *, alloc: Any, fork: Fork, debug_output_path: str = ""
-    ) -> Tuple[Dict[str, Any], bytes]:
+    ) -> Tuple[Dict, bytes]:
         """
         Calculate the state root for the given `alloc`.
         """

--- a/tests/cancun/eip4788_beacon_root/conftest.py
+++ b/tests/cancun/eip4788_beacon_root/conftest.py
@@ -1,26 +1,33 @@
 """
 Shared pytest definitions local to EIP-4788 tests.
 """
-from typing import Dict
+from typing import Dict, List
 
 import pytest
 
 from ethereum_test_tools import (
+    AccessList,
     Account,
     Environment,
+    Storage,
     TestAddress,
     Transaction,
+    add_kzg_version,
     to_address,
     to_hash_bytes,
 )
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 from .common import (
-    BEACON_ROOT_PRECOMPILE_ADDRESS,
-    BEACON_ROOT_PRECOMPILE_GAS,
+    BEACON_ROOT_CONTRACT_ADDRESS,
+    BEACON_ROOT_CONTRACT_CALL_GAS,
     DEFAULT_BEACON_ROOT_HASH,
+    HISTORICAL_ROOTS_MODULUS,
+    SYSTEM_ADDRESS,
     expected_storage,
 )
+
+BLOB_COMMITMENT_VERSION_KZG = 1
 
 
 @pytest.fixture
@@ -42,13 +49,26 @@ def env(timestamp: int, beacon_root: bytes) -> Environment:  # noqa: D103
 
 
 @pytest.fixture
+def call_beacon_root_contract() -> bool:
+    """
+    By default, do not directly call the beacon root contract.
+    """
+    return False
+
+
+@pytest.fixture
 def call_type() -> Op:  # noqa: D103
     return Op.CALL
 
 
 @pytest.fixture
+def call_value() -> int:  # noqa: D103
+    return 0
+
+
+@pytest.fixture
 def call_gas() -> int:  # noqa: D103
-    return BEACON_ROOT_PRECOMPILE_GAS
+    return BEACON_ROOT_CONTRACT_CALL_GAS
 
 
 @pytest.fixture
@@ -57,42 +77,56 @@ def caller_address() -> str:  # noqa: D103
 
 
 @pytest.fixture
-def precompile_call_account(call_type: Op, call_gas: int) -> Account:
+def precompile_call_account(call_type: Op, call_value: int, call_gas: int) -> Account:
     """
     Code to call the beacon root precompile.
     """
-    precompile_call_code = Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE)
+    args_start, args_length, return_start, return_length = 0x20, Op.CALLDATASIZE, 0x00, 0x20
+    precompile_call_code = Op.CALLDATACOPY(args_start, 0x00, args_length)
     if call_type == Op.CALL or call_type == Op.CALLCODE:
         precompile_call_code += Op.SSTORE(
-            0,  # store the result of the precompile call in storage[0]
+            0x00,  # store the result of the precompile call in storage[0]
             call_type(
                 call_gas,
-                BEACON_ROOT_PRECOMPILE_ADDRESS,
-                0x00,
-                0x00,
-                Op.CALLDATASIZE,
-                0x00,
-                0x20,
+                BEACON_ROOT_CONTRACT_ADDRESS,
+                call_value,
+                args_start,
+                args_length,
+                return_start,
+                return_length,
             ),
         )
     elif call_type == Op.DELEGATECALL or call_type == Op.STATICCALL:
         # delegatecall and staticcall use one less argument
         precompile_call_code += Op.SSTORE(
-            0,
+            0x00,
             call_type(
                 call_gas,
-                BEACON_ROOT_PRECOMPILE_ADDRESS,
-                0x00,
-                Op.CALLDATASIZE,
-                0x00,
-                0x20,
+                BEACON_ROOT_CONTRACT_ADDRESS,
+                args_start,
+                args_length,
+                return_start,
+                return_length,
             ),
         )
     precompile_call_code += (
-        Op.SSTORE(1, Op.MLOAD(0x00))
-        + Op.SSTORE(2, Op.RETURNDATASIZE)
-        + Op.RETURNDATACOPY(0, 0x0, Op.RETURNDATASIZE)
-        + Op.SSTORE(3, Op.MLOAD(0x00))
+        Op.SSTORE(  # Save the return value of the precompile call
+            0x01,
+            Op.MLOAD(return_start),
+        )
+        + Op.SSTORE(  # Save the length of the return value of the precompile call
+            0x02,
+            Op.RETURNDATASIZE,
+        )
+        + Op.RETURNDATACOPY(
+            return_start,
+            0x00,
+            Op.RETURNDATASIZE,
+        )
+        + Op.SSTORE(
+            0x03,
+            Op.MLOAD(return_start),
+        )
     )
     return Account(
         nonce=0,
@@ -118,8 +152,17 @@ def valid_input() -> bool:
 
 
 @pytest.fixture
+def system_address_balance() -> int:
+    """
+    Balance of the system address.
+    """
+    return 0
+
+
+@pytest.fixture
 def pre(
     precompile_call_account: Account,
+    system_address_balance: int,
     caller_address: str,
 ) -> Dict:
     """
@@ -132,6 +175,10 @@ def pre(
             balance=0x10**10,
         ),
         caller_address: precompile_call_account,
+        SYSTEM_ADDRESS: Account(
+            nonce=0,
+            balance=system_address_balance,
+        ),
     }
 
 
@@ -141,44 +188,108 @@ def tx_to_address(request, caller_address: Account) -> bytes:  # noqa: D103
 
 
 @pytest.fixture
+def auto_access_list() -> bool:
+    """
+    Whether to append the accessed storage keys to the transaction.
+    """
+    return False
+
+
+@pytest.fixture
+def access_list(auto_access_list: bool, timestamp: int) -> List[AccessList]:
+    """
+    Access list included in the transaction to call the beacon root precompile.
+    """
+    if auto_access_list:
+        return [
+            AccessList(
+                address=BEACON_ROOT_CONTRACT_ADDRESS,
+                storage_keys=[
+                    timestamp,
+                    timestamp + HISTORICAL_ROOTS_MODULUS,
+                ],
+            ),
+        ]
+    return []
+
+
+@pytest.fixture
+def tx_data(timestamp: int) -> bytes:
+    """
+    Data included in the transaction to call the beacon root precompile.
+    """
+    return to_hash_bytes(timestamp)
+
+
+@pytest.fixture
+def tx_type() -> int:
+    """
+    Transaction type to call the caller contract or the beacon root contract directly.
+
+    By default use a type 2 transaction.
+    """
+    return 2
+
+
+@pytest.fixture
 def tx(
     tx_to_address: str,
-    timestamp: int,
+    tx_data: bytes,
+    tx_type: int,
+    access_list: List[AccessList],
+    call_beacon_root_contract: bool,
 ) -> Transaction:
     """
     Prepares transaction to call the beacon root precompile caller account.
     """
-    return Transaction(
-        ty=2,
-        nonce=0,
-        data=to_hash_bytes(timestamp),
-        to=tx_to_address,
-        value=0,
-        gas_limit=1000000,
-        max_fee_per_gas=7,
-        max_priority_fee_per_gas=0,
-    )
+    to = BEACON_ROOT_CONTRACT_ADDRESS if call_beacon_root_contract else tx_to_address
+    kwargs: Dict = {
+        "ty": tx_type,
+        "nonce": 0,
+        "data": tx_data,
+        "to": to,
+        "value": 0,
+        "gas_limit": 1000000,
+    }
+
+    if tx_type > 0:
+        kwargs["access_list"] = access_list
+
+    if tx_type < 2:
+        kwargs["gas_price"] = 7
+
+    if tx_type > 1:
+        kwargs["max_fee_per_gas"] = 7
+        kwargs["max_priority_fee_per_gas"] = 0
+
+    if tx_type > 2:
+        kwargs["max_fee_per_blob_gas"] = 1
+        kwargs["blob_versioned_hashes"] = add_kzg_version([0], BLOB_COMMITMENT_VERSION_KZG)
+
+    return Transaction(**kwargs)
 
 
 @pytest.fixture
 def post(
     caller_address: str,
     beacon_root: bytes,
-    timestamp: int,
     valid_call: bool,
     valid_input: bool,
+    call_beacon_root_contract: bool,
 ) -> Dict:
     """
     Prepares the expected post state for a single precompile call based upon the success or
     failure of the call, and the validity of the timestamp input.
     """
+    storage = Storage()
+    if not call_beacon_root_contract:
+        storage = expected_storage(
+            beacon_root=beacon_root,
+            valid_call=valid_call,
+            valid_input=valid_input,
+        )
     return {
         caller_address: Account(
-            storage=expected_storage(
-                beacon_root,
-                timestamp,
-                valid_call,
-                valid_input,
-            ),
+            storage=storage,
         ),
     }

--- a/tests/cancun/eip4788_beacon_root/test_blocks_beacon_root_contract.py
+++ b/tests/cancun/eip4788_beacon_root/test_blocks_beacon_root_contract.py
@@ -1,0 +1,371 @@
+"""
+abstract: Tests beacon block root for [EIP-4788: Beacon block root in the EVM](https://eips.ethereum.org/EIPS/eip-4788)
+
+    Test the exposed beacon chain root in the EVM for [EIP-4788: Beacon block root in the EVM](https://eips.ethereum.org/EIPS/eip-4788) using multi-block tests
+
+note: Adding a new test
+
+    Add a function that is named `test_<test_name>` and takes at least the following arguments:
+
+    - blockchain_test
+    - env
+    - pre
+    - blocks
+    - post
+    - valid_call
+
+    The following arguments *need* to be parametrized or the test will not be generated:
+
+    -
+
+    All other `pytest.fixtures` can be parametrized to generate new combinations and test
+    cases.
+
+"""  # noqa: E501
+
+from itertools import count
+from typing import Dict, Iterable, List
+
+import pytest
+from ethereum.crypto.hash import keccak256
+
+from ethereum_test_forks import Fork
+from ethereum_test_tools import (
+    Account,
+    Block,
+    BlockchainTestFiller,
+    Storage,
+    TestAddress,
+    Transaction,
+    Withdrawal,
+    to_address,
+    to_hash_bytes,
+)
+from ethereum_test_tools.vm.opcode import Opcodes as Op
+
+from .common import (
+    BEACON_ROOT_CONTRACT_ADDRESS,
+    HISTORICAL_ROOTS_MODULUS,
+    REF_SPEC_4788_GIT_PATH,
+    REF_SPEC_4788_VERSION,
+    SYSTEM_ADDRESS,
+)
+
+REFERENCE_SPEC_GIT_PATH = REF_SPEC_4788_GIT_PATH
+REFERENCE_SPEC_VERSION = REF_SPEC_4788_VERSION
+
+
+@pytest.fixture
+def beacon_roots() -> Iterable[bytes]:
+    """
+    By default, return an iterator that returns the keccak of an internal counter.
+    """
+
+    class BeaconRoots:
+        def __init__(self) -> None:
+            self._counter = count(1)
+
+        def __iter__(self) -> "BeaconRoots":
+            return self
+
+        def __next__(self) -> bytes:
+            return keccak256(int.to_bytes(next(self._counter), length=8, byteorder="big"))
+
+    return BeaconRoots()
+
+
+@pytest.mark.parametrize(
+    "timestamps",
+    [
+        pytest.param(
+            count(
+                start=HISTORICAL_ROOTS_MODULUS - 5,
+                step=1,
+            ),
+            id="buffer_wraparound",
+        ),
+        pytest.param(
+            count(
+                start=12,
+                step=HISTORICAL_ROOTS_MODULUS,
+            ),
+            id="buffer_wraparound_overwrite",
+        ),
+        pytest.param(
+            count(
+                start=2**32,
+                step=HISTORICAL_ROOTS_MODULUS,
+            ),
+            id="buffer_wraparound_overwrite_high_timestamp",
+        ),
+        pytest.param(
+            count(
+                start=5,
+                step=HISTORICAL_ROOTS_MODULUS - 1,
+            ),
+            id="buffer_wraparound_no_overwrite",
+        ),
+        pytest.param(
+            count(
+                start=HISTORICAL_ROOTS_MODULUS - 3,
+                step=HISTORICAL_ROOTS_MODULUS + 1,
+            ),
+            id="buffer_wraparound_no_overwrite_2",
+        ),
+    ],
+)
+@pytest.mark.parametrize("block_count", [10])  # All tests use 10 blocks
+@pytest.mark.valid_from("Cancun")
+def test_multi_block_beacon_root_timestamp_calls(
+    blockchain_test: BlockchainTestFiller,
+    timestamps: Iterable[int],
+    beacon_roots: Iterable[bytes],
+    block_count: int,
+    tx: Transaction,
+    call_gas: int,
+    call_value: int,
+    system_address_balance: int,
+):
+    """
+    Tests multiple blocks where each block writes a timestamp to storage and contains one
+    transaction that calls the beacon root precompile multiple times.
+
+    The blocks might overwrite the historical roots buffer, or not, depending on the `timestamps`,
+    and whether they increment in multiples of `HISTORICAL_ROOTS_MODULUS` or not.
+
+    By default, the beacon roots are the keccak of the block number.
+
+    Each transaction checks the current timestamp and also all previous timestamps, and verifies
+    that the beacon root is correct for all of them if the timestamp is supposed to be in the
+    buffer, which might have been overwritten by a later block.
+    """
+    blocks: List[Block] = []
+    pre = {
+        TestAddress: Account(
+            nonce=0,
+            balance=0x10**10,
+        ),
+        SYSTEM_ADDRESS: Account(
+            nonce=0,
+            balance=system_address_balance,
+        ),
+    }
+    post = {}
+
+    timestamps_storage: Dict[int, int] = {}
+    roots_storage: Dict[int, bytes] = {}
+
+    all_timestamps: List[int] = []
+
+    for timestamp, beacon_root, i in zip(timestamps, beacon_roots, range(block_count)):
+        timestamp_index = timestamp % HISTORICAL_ROOTS_MODULUS
+        timestamps_storage[timestamp_index] = timestamp
+        roots_storage[timestamp_index] = beacon_root
+
+        all_timestamps.append(timestamp)
+
+        withdraw_index = count(0)
+
+        current_call_account_code = bytes()
+        current_call_account_expected_storage = Storage()
+        current_call_account_address = to_address(0x100 + i)
+
+        # We are going to call the beacon roots contract once for every timestamp of the current
+        # and all previous blocks, and check that the returned beacon root is still correct only
+        # if it was not overwritten.
+        for t in all_timestamps:
+            current_call_account_code += Op.MSTORE(0, t)
+            call_valid = (
+                timestamp_index in timestamps_storage
+                and timestamps_storage[t % HISTORICAL_ROOTS_MODULUS] == t
+            )
+            current_call_account_code += Op.SSTORE(
+                current_call_account_expected_storage.store_next(0x01 if call_valid else 0x00),
+                Op.CALL(
+                    call_gas,
+                    BEACON_ROOT_CONTRACT_ADDRESS,
+                    call_value,
+                    0x00,
+                    0x20,
+                    0x20,
+                    0x20,
+                ),
+            )
+
+            current_call_account_code += Op.SSTORE(
+                current_call_account_expected_storage.store_next(
+                    roots_storage[t % HISTORICAL_ROOTS_MODULUS] if call_valid else 0x00
+                ),
+                Op.MLOAD(0x20),
+            )
+
+        pre[current_call_account_address] = Account(
+            code=current_call_account_code,
+        )
+        post[current_call_account_address] = Account(
+            storage=current_call_account_expected_storage,
+        )
+        blocks.append(
+            Block(
+                txs=[
+                    tx.with_fields(
+                        nonce=i,
+                        to=to_address(0x100 + i),
+                        data=to_hash_bytes(timestamp),
+                    )
+                ],
+                beacon_root=beacon_root,
+                timestamp=timestamp,
+                withdrawals=[
+                    # Also withdraw to the beacon root contract and the system address
+                    Withdrawal(
+                        address=BEACON_ROOT_CONTRACT_ADDRESS,
+                        amount=1,
+                        index=next(withdraw_index),
+                        validator=0,
+                    ),
+                    Withdrawal(
+                        address=SYSTEM_ADDRESS,
+                        amount=1,
+                        index=next(withdraw_index),
+                        validator=1,
+                    ),
+                ],
+            )
+        )
+
+    blockchain_test(
+        pre=pre,
+        blocks=blocks,
+        post=post,
+    )
+
+
+@pytest.mark.parametrize(
+    "timestamps",
+    [pytest.param(count(start=1000, step=1000), id="fork_transition")],
+)
+@pytest.mark.parametrize("block_count", [20])
+@pytest.mark.valid_at_transition_to("Cancun")
+def test_beacon_root_transition_test(
+    blockchain_test: BlockchainTestFiller,
+    timestamps: Iterable[int],
+    beacon_roots: Iterable[bytes],
+    block_count: int,
+    tx: Transaction,
+    call_gas: int,
+    call_value: int,
+    system_address_balance: int,
+    fork: Fork,
+):
+    """
+    Tests the fork transition to cancun and verifies that blocks with timestamp lower than the
+    transition timestamp do not contain beacon roots in the pre-deployed contract.
+    """
+    blocks: List[Block] = []
+    pre = {
+        TestAddress: Account(
+            nonce=0,
+            balance=0x10**10,
+        ),
+        SYSTEM_ADDRESS: Account(
+            nonce=0,
+            balance=system_address_balance,
+        ),
+    }
+    post = {}
+
+    timestamps_storage: Dict[int, int] = {}
+    roots_storage: Dict[int, bytes] = {}
+
+    all_timestamps: List[int] = []
+    timestamps_in_beacon_root_contract: List[int] = []
+
+    for timestamp, beacon_root, i in zip(timestamps, beacon_roots, range(block_count)):
+        timestamp_index = timestamp % HISTORICAL_ROOTS_MODULUS
+
+        transitioned = fork.header_beacon_root_required(i, timestamp)
+        if transitioned:
+            # We've transitioned, the current timestamp must contain a value in the contract
+            timestamps_in_beacon_root_contract.append(timestamp)
+            timestamps_storage[timestamp_index] = timestamp
+            roots_storage[timestamp_index] = beacon_root
+
+        all_timestamps.append(timestamp)
+
+        withdraw_index = count(0)
+
+        current_call_account_code = bytes()
+        current_call_account_expected_storage = Storage()
+        current_call_account_address = to_address(0x100 + i)
+
+        # We are going to call the beacon roots contract once for every timestamp of the current
+        # and all previous blocks, and check that the returned beacon root is correct only
+        # if it was after the transition timestamp.
+        for t in all_timestamps:
+            current_call_account_code += Op.MSTORE(0, t)
+            call_valid = (
+                t in timestamps_in_beacon_root_contract
+                and timestamp_index in timestamps_storage
+                and timestamps_storage[t % HISTORICAL_ROOTS_MODULUS] == t
+            )
+            current_call_account_code += Op.SSTORE(
+                current_call_account_expected_storage.store_next(0x01 if call_valid else 0x00),
+                Op.CALL(
+                    call_gas,
+                    BEACON_ROOT_CONTRACT_ADDRESS,
+                    call_value,
+                    0x00,
+                    0x20,
+                    0x20,
+                    0x20,
+                ),
+            )
+
+            current_call_account_code += Op.SSTORE(
+                current_call_account_expected_storage.store_next(
+                    roots_storage[t % HISTORICAL_ROOTS_MODULUS] if call_valid else 0x00
+                ),
+                Op.MLOAD(0x20),
+            )
+
+        pre[current_call_account_address] = Account(
+            code=current_call_account_code,
+        )
+        post[current_call_account_address] = Account(
+            storage=current_call_account_expected_storage,
+        )
+        blocks.append(
+            Block(
+                txs=[
+                    tx.with_fields(
+                        nonce=i,
+                        to=to_address(0x100 + i),
+                        data=to_hash_bytes(timestamp),
+                    )
+                ],
+                beacon_root=beacon_root if transitioned else None,
+                timestamp=timestamp,
+                withdrawals=[
+                    # Also withdraw to the beacon root contract and the system address
+                    Withdrawal(
+                        address=BEACON_ROOT_CONTRACT_ADDRESS,
+                        amount=1,
+                        index=next(withdraw_index),
+                        validator=0,
+                    ),
+                    Withdrawal(
+                        address=SYSTEM_ADDRESS,
+                        amount=1,
+                        index=next(withdraw_index),
+                        validator=1,
+                    ),
+                ],
+            )
+        )
+
+    blockchain_test(
+        pre=pre,
+        blocks=blocks,
+        post=post,
+    )


### PR DESCRIPTION
Updates EIP-4788 tests to use a pre-deployed bytecode instead of the regular pre-compile.

## Framework Considerations
A new `pre_allocation` method is added to the base fork abstract class, which specifies a pre-allocation that must be performed for a given fork.

This method also has a new decorator `prefer_transition_to_method`, which marks the method so the `to-fork` implementation of the method takes priority when the method is evaluated.

This is necessary because the pre-allocation cannot be modified at fork transition, so it needs to be present in the genesis if we are transitioning to the given fork that requires this allocation. E.g. Shanghai->Cancun transition fork needs the Cancun pre-allocation of the beacon root bytecode pre-deploy.

## EVM Considerations
- `DELEGATECALL` and `CODECALL` no longer work as previously because the target address is not a precompile
- Using address `0x000000000000000000000000000000000000000b` until the mainnet address reaches consensus
- Gas tests no longer work in current implementation due to gas not being a constant

Fill using: https://github.com/marioevz/go-ethereum/tree/4844-devnet-6-t8n