### PR TITLE
evm_transition_tool/geth: Save traces to dump dir

### DIFF
--- a/src/evm_transition_tool/geth.py
+++ b/src/evm_transition_tool/geth.py
@@ -4,6 +4,7 @@ Go-ethereum Transition tool interface.
 
 import json
 import os
+import shutil
 import subprocess
 import tempfile
 from pathlib import Path
@@ -123,6 +124,11 @@ class GethTransitionTool(TransitionTool):
             for i, r in enumerate(receipts):
                 h = r["transactionHash"]
                 trace_file_name = f"trace-{i}-{h}.jsonl"
+                if debug_output_path:
+                    shutil.copy(
+                        os.path.join(temp_dir.name, trace_file_name),
+                        os.path.join(debug_output_path, trace_file_name),
+                    )
                 with open(os.path.join(temp_dir.name, trace_file_name), "r") as trace_file:
                     tx_traces: List[Dict] = []
                     for trace_line in trace_file.readlines():


### PR DESCRIPTION
Small update to copy trace files to the dump t8n directory.