### PR TITLE
entrypoints: Add new line at the end of each file when merging word lists

### DIFF
--- a/src/entry_points/create_whitelist_for_flake8_spelling.py
+++ b/src/entry_points/create_whitelist_for_flake8_spelling.py
@@ -26,6 +26,7 @@ def main():
         for path in paths:
             with open(path) as wordlist:
                 whitelist.write(wordlist.read())
+                whitelist.write("\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently, the resulting flake8 wordlist contains the last word and the first word of the next file merged together because some of the files do not have a new line at the end.

This fix appends a new line at the end of each file.