### PR TITLE
tests/cancun/eip4844_blobs: Update Engine API error codes for invalid tests.

### DIFF
--- a/tests/cancun/eip4844_blobs/test_blob_txs.py
+++ b/tests/cancun/eip4844_blobs/test_blob_txs.py
@@ -320,7 +320,7 @@ def env(
 
 
 @pytest.fixture
-def engine_api_error_code() -> Optional[int]:
+def engine_api_error_code() -> Optional[EngineAPIError]:
     """
     Expected Engine API error code to be returned by the client on consumption
     of the erroneous block in hive.
@@ -332,7 +332,7 @@ def engine_api_error_code() -> Optional[int]:
 def blocks(
     txs: List[Transaction],
     tx_error: Optional[str],
-    engine_api_error_code: Optional[int],
+    engine_api_error_code: Optional[EngineAPIError],
 ) -> List[Block]:
     """
     Prepare the list of blocks for all test cases.

--- a/tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py
+++ b/tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py
@@ -151,6 +151,9 @@ def test_invalid_pre_fork_block_with_blob_fields(
     """
     Test block rejection when `excessBlobGas` and/or `blobGasUsed` fields are present on a pre-fork
     block.
+
+    Blocks sent by NewPayloadV2 (Shanghai) that contain `excessBlobGas` and `blobGasUsed` fields
+    must be rejected with the `-32602: Invalid params` error.
     """
     header_modifier = Header()
     if excess_blob_gas_present:
@@ -193,6 +196,9 @@ def test_invalid_post_fork_block_without_blob_fields(
     """
     Test block rejection when `excessBlobGas` and/or `blobGasUsed` fields are missing on a
     post-fork block.
+
+    Blocks sent by NewPayloadV3 (Cancun) without `excessBlobGas` and `blobGasUsed` fields must be
+    rejected with the `-32602: Invalid params` error.
     """
     header_modifier = Header()
     if excess_blob_gas_missing:


### PR DESCRIPTION
Further addition to the previous PR here -> https://github.com/ethereum/execution-spec-tests/pull/248

Fixes `test_blob_type_tx_pre_fork` test in hive.