### PR TITLE
pytest: Parametrize fork covariant parameters

### DIFF
--- a/.wordlist_opcodes.txt
+++ b/.wordlist_opcodes.txt
@@ -148,3 +148,5 @@ selfdestruct
 sendall
 blobhash
 mcopy
+precompile
+precompiles

--- a/.wordlist_python_pytest.txt
+++ b/.wordlist_python_pytest.txt
@@ -28,6 +28,8 @@ parametrized
 param
 params
 parametrize
+parametrizer
+parametrizers
 popen
 pytester
 pytestmark

--- a/src/ethereum_test_forks/__init__.py
+++ b/src/ethereum_test_forks/__init__.py
@@ -2,7 +2,7 @@
 Ethereum test fork definitions.
 """
 
-from .base_fork import Fork
+from .base_fork import Fork, ForkAttribute
 from .forks.forks import (
     ArrowGlacier,
     Berlin,
@@ -39,6 +39,7 @@ from .helpers import (
 
 __all__ = [
     "Fork",
+    "ForkAttribute",
     "ArrowGlacier",
     "Berlin",
     "BerlinToLondonAt5",

--- a/src/ethereum_test_forks/base_fork.py
+++ b/src/ethereum_test_forks/base_fork.py
@@ -2,7 +2,7 @@
 Abstract base class for Ethereum forks
 """
 from abc import ABC, ABCMeta, abstractmethod
-from typing import Mapping, Optional, Type
+from typing import List, Mapping, Optional, Type
 
 from .base_decorators import prefer_transition_to_method
 
@@ -102,6 +102,22 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
     def get_reward(cls, block_number: int = 0, timestamp: int = 0) -> int:
         """
         Returns the expected reward amount in wei of a given fork
+        """
+        pass
+
+    @classmethod
+    @abstractmethod
+    def tx_types(cls, block_number: int = 0, timestamp: int = 0) -> List[int]:
+        """
+        Returns a list of the transaction types supported by the fork
+        """
+        pass
+
+    @classmethod
+    @abstractmethod
+    def precompiles(cls, block_number: int = 0, timestamp: int = 0) -> List[int]:
+        """
+        Returns a list pre-compiles supported by the fork
         """
         pass
 

--- a/src/ethereum_test_forks/base_fork.py
+++ b/src/ethereum_test_forks/base_fork.py
@@ -2,9 +2,21 @@
 Abstract base class for Ethereum forks
 """
 from abc import ABC, ABCMeta, abstractmethod
-from typing import List, Mapping, Optional, Type
+from typing import Any, List, Mapping, Optional, Protocol, Type
 
 from .base_decorators import prefer_transition_to_method
+
+
+class ForkAttribute(Protocol):
+    """
+    A protocol to get the attribute of a fork at a given block number and timestamp.
+    """
+
+    def __call__(self, block_number: int = 0, timestamp: int = 0) -> Any:
+        """
+        Returns the value of the attribute at the given block number and timestamp.
+        """
+        pass
 
 
 class BaseForkMeta(ABCMeta):

--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -1,7 +1,7 @@
 """
 All Ethereum fork class definitions.
 """
-from typing import Mapping, Optional
+from typing import List, Mapping, Optional
 
 from ..base_fork import BaseFork
 
@@ -100,6 +100,20 @@ class Frontier(BaseFork):
         return 5_000_000_000_000_000_000
 
     @classmethod
+    def tx_types(cls, block_number: int = 0, timestamp: int = 0) -> List[int]:
+        """
+        At Genesis, only legacy transactions are allowed
+        """
+        return [0]
+
+    @classmethod
+    def precompiles(cls, block_number: int = 0, timestamp: int = 0) -> List[int]:
+        """
+        At Genesis, no pre-compiles are allowed
+        """
+        return []
+
+    @classmethod
     def pre_allocation(cls, block_number: int = 0, timestamp: int = 0) -> Mapping:
         """
         Returns whether the fork expects pre-allocation of accounts
@@ -114,7 +128,12 @@ class Homestead(Frontier):
     Homestead fork
     """
 
-    pass
+    @classmethod
+    def precompiles(cls, block_number: int = 0, timestamp: int = 0) -> List[int]:
+        """
+        At Homestead, EC-recover, SHA256, RIPEMD160, and Identity pre-compiles are introduced
+        """
+        return [1, 2, 3, 4] + super(Homestead, cls).precompiles(block_number, timestamp)
 
 
 class Byzantium(Homestead):
@@ -129,6 +148,15 @@ class Byzantium(Homestead):
         3_000_000_000_000_000_000 wei
         """
         return 3_000_000_000_000_000_000
+
+    @classmethod
+    def precompiles(cls, block_number: int = 0, timestamp: int = 0) -> List[int]:
+        """
+        At Byzantium, pre-compiles for bigint modular exponentiation, addition and scalar
+        multiplication on elliptic curve alt_bn128, and optimal ate pairing check on
+        elliptic curve alt_bn128 are introduced
+        """
+        return [5, 6, 7, 8] + super(Byzantium, cls).precompiles(block_number, timestamp)
 
 
 class Constantinople(Byzantium):
@@ -158,7 +186,12 @@ class Istanbul(ConstantinopleFix):
     Istanbul fork
     """
 
-    pass
+    @classmethod
+    def precompiles(cls, block_number: int = 0, timestamp: int = 0) -> List[int]:
+        """
+        At Istanbul, pre-compile for blake2 compression is introduced
+        """
+        return [9] + super(Istanbul, cls).precompiles(block_number, timestamp)
 
 
 # Glacier forks skipped, unless explicitly specified
@@ -175,7 +208,12 @@ class Berlin(Istanbul):
     Berlin fork
     """
 
-    pass
+    @classmethod
+    def tx_types(cls, block_number: int = 0, timestamp: int = 0) -> List[int]:
+        """
+        At Berlin, access list transactions are introduced
+        """
+        return [1] + super(Berlin, cls).tx_types(block_number, timestamp)
 
 
 class London(Berlin):
@@ -189,6 +227,13 @@ class London(Berlin):
         Base Fee is required starting from London.
         """
         return True
+
+    @classmethod
+    def tx_types(cls, block_number: int = 0, timestamp: int = 0) -> List[int]:
+        """
+        At London, dynamic fee transactions are introduced
+        """
+        return [2] + super(London, cls).tx_types(block_number, timestamp)
 
 
 # Glacier forks skipped, unless explicitly specified
@@ -299,6 +344,20 @@ class Cancun(Shanghai):
         Parent beacon block root is required starting from Cancun.
         """
         return True
+
+    @classmethod
+    def tx_types(cls, block_number: int = 0, timestamp: int = 0) -> List[int]:
+        """
+        At Cancun, blob type transactions are introduced
+        """
+        return [3] + super(Cancun, cls).tx_types(block_number, timestamp)
+
+    @classmethod
+    def precompiles(cls, block_number: int = 0, timestamp: int = 0) -> List[int]:
+        """
+        At Cancun, pre-compile for kzg point evaluation is introduced
+        """
+        return [0xA] + super(Cancun, cls).precompiles(block_number, timestamp)
 
     @classmethod
     def pre_allocation(cls, block_number: int = 0, timestamp: int = 0) -> Mapping:

--- a/src/ethereum_test_forks/tests/test_forks.py
+++ b/src/ethereum_test_forks/tests/test_forks.py
@@ -163,3 +163,11 @@ def test_pre_alloc():
         "test": "test",
         "test2": "test2",
     }
+
+
+def test_precompiles():
+    Cancun.precompiles() == list(range(11))[1:]
+
+
+def test_tx_types():
+    Cancun.tx_types() == list(range(4))

--- a/src/ethereum_test_forks/transition_base_fork.py
+++ b/src/ethereum_test_forks/transition_base_fork.py
@@ -3,7 +3,7 @@ Base objects used to define transition forks.
 """
 from typing import List, Type
 
-from .base_fork import BaseFork, Fork
+from .base_fork import BaseFork, Fork, ForkAttribute
 
 ALWAYS_TRANSITIONED_BLOCK_NUMBER = 10_000
 ALWAYS_TRANSITIONED_BLOCK_TIMESTAMP = 10_000_000
@@ -51,18 +51,22 @@ def transition_fork(to_fork: Fork, at_block: int = 0, at_timestamp: int = 0):
 
         NewTransitionClass.name = lambda: transition_name  # type: ignore
 
-        def make_transition_method(base_method, from_fork_method, to_fork_method):
+        def make_transition_method(
+            base_method: ForkAttribute,
+            from_fork_method: ForkAttribute,
+            to_fork_method: ForkAttribute,
+        ):
             def transition_method(
                 cls,
                 block_number: int = ALWAYS_TRANSITIONED_BLOCK_NUMBER,
                 timestamp: int = ALWAYS_TRANSITIONED_BLOCK_TIMESTAMP,
             ):
                 if getattr(base_method, "__prefer_transition_to_method__", False):
-                    return to_fork_method(block_number, timestamp)
+                    return to_fork_method(block_number=block_number, timestamp=timestamp)
                 return (
-                    to_fork_method(block_number, timestamp)
+                    to_fork_method(block_number=block_number, timestamp=timestamp)
                     if block_number >= at_block and timestamp >= at_timestamp
-                    else from_fork_method(block_number, timestamp)
+                    else from_fork_method(block_number=block_number, timestamp=timestamp)
                 )
 
             return classmethod(transition_method)

--- a/src/pytest_plugins/forks/forks.py
+++ b/src/pytest_plugins/forks/forks.py
@@ -1,13 +1,17 @@
 """
 Pytest plugin to enable fork range configuration for the test session.
 """
+import itertools
 import sys
 import textwrap
+from dataclasses import dataclass, field
+from typing import Any, Callable, List
 
 import pytest
 from pytest import Metafunc
 
 from ethereum_test_forks import (
+    Fork,
     forks_from_until,
     get_deployed_forks,
     get_forks,
@@ -52,6 +56,98 @@ def pytest_addoption(parser):
     )
 
 
+@dataclass(kw_only=True)
+class ForkCovariantParameter:
+    """
+    Value list for a fork covariant parameter in a given fork.
+    """
+
+    name: str
+    values: List[Any]
+
+
+@dataclass(kw_only=True)
+class ForkParametrizer:
+    """
+    A parametrizer for a test case that is parametrized by the fork.
+    """
+
+    fork: Fork
+    mark: pytest.MarkDecorator | None = None
+    fork_covariant_parameters: List[ForkCovariantParameter] = field(default_factory=list)
+
+    def get_parameter_names(self) -> List[str]:
+        """
+        Return the parameter names for the test case.
+        """
+        return ["fork"] + [p.name for p in self.fork_covariant_parameters]
+
+    def get_parameter_values(self) -> List[Any]:
+        """
+        Return the parameter values for the test case.
+        """
+        return [
+            pytest.param(*params, marks=[self.mark] if self.mark else [])
+            for params in itertools.product(
+                [self.fork],
+                *[p.values for p in self.fork_covariant_parameters],
+            )
+        ]
+
+
+@dataclass(kw_only=True)
+class CovariantDescriptor:
+    """
+    A descriptor for a parameter that is covariant with the fork:
+    the parametrized values change depending on the fork.
+    """
+
+    marker_name: str
+    description: str
+    fork_attribute_name: str
+    parameter_name: str
+
+    def check_enabled(self, metafunc: Metafunc) -> bool:
+        """
+        Check if the marker is enabled for the given test function.
+        """
+        m = metafunc.definition.iter_markers(self.marker_name)
+        return m is not None and len(list(m)) > 0
+
+    def add_values(self, metafunc: Metafunc, fork_parametrizer: ForkParametrizer) -> None:
+        """
+        Add the values for the covariant parameter to the parametrizer.
+        """
+        if not self.check_enabled(metafunc=metafunc):
+            return
+        fork = fork_parametrizer.fork
+        fork_attribute: Callable[[int, int], List[Any]] = getattr(fork, self.fork_attribute_name)
+        values = fork_attribute(0, 0)
+        assert isinstance(values, list)
+        assert len(values) > 0
+        fork_parametrizer.fork_covariant_parameters.append(
+            ForkCovariantParameter(name=self.parameter_name, values=values)
+        )
+
+
+fork_covariant_descriptors = [
+    CovariantDescriptor(
+        marker_name="with_all_tx_types",
+        description="marks a test to be parametrized for all tx types at parameter named tx_type"
+        " of type int",
+        fork_attribute_name="tx_types",
+        parameter_name="tx_type",
+    ),
+    CovariantDescriptor(
+        marker_name="with_all_precompiles",
+        description="marks a test to be parametrized for all precompiles at parameter named"
+        " precompile of type int",
+        fork_attribute_name="precompiles",
+        parameter_name="precompile",
+    ),
+]
+
+
 @pytest.hookimpl(tryfirst=True)
 def pytest_configure(config):
     """
@@ -75,6 +171,9 @@ def pytest_configure(config):
         "markers",
         "valid_until(fork): specifies until which fork a test case is valid",
     )
+
+    for d in fork_covariant_descriptors:
+        config.addinivalue_line("markers", f"{d.marker_name}: {d.description}")
 
     single_fork = config.getoption("single_fork")
     forks_from = config.getoption("forks_from")
@@ -328,19 +427,45 @@ def pytest_generate_tests(metafunc):
                 )
         else:
             pytest_params = [
-                pytest.param(
-                    fork,
-                    marks=[
-                        pytest.mark.skip(
-                            reason=(
-                                f"Fork '{fork}' unsupported by "
-                                f"'{metafunc.config.getoption('evm_bin')}'."
-                            )
+                ForkParametrizer(
+                    fork=fork,
+                    mark=pytest.mark.skip(
+                        reason=(
+                            f"Fork '{fork}' unsupported by "
+                            f"'{metafunc.config.getoption('evm_bin')}'."
                         )
-                    ],
+                    ),
                 )
                 if fork.name() in metafunc.config.unsupported_forks
-                else pytest.param(fork)
+                else ForkParametrizer(fork=fork)
                 for fork in intersection_range
             ]
-            metafunc.parametrize("fork", pytest_params, scope="function")
+            add_fork_covariant_parameters(metafunc, pytest_params)
+            parametrize_fork(metafunc, pytest_params)
+
+
+def add_fork_covariant_parameters(
+    metafunc: Metafunc, fork_parametrizers: List[ForkParametrizer]
+) -> None:
+    """
+    Iterate over the fork covariant descriptors and add their values to the test function.
+    """
+    for covariant_descriptor in fork_covariant_descriptors:
+        for fork_parametrizer in fork_parametrizers:
+            covariant_descriptor.add_values(metafunc=metafunc, fork_parametrizer=fork_parametrizer)
+
+
+def parametrize_fork(metafunc: Metafunc, fork_parametrizers: List[ForkParametrizer]) -> None:
+    """
+    Add the fork parameters to the test function.
+    """
+    param_names: List[str] = []
+    param_values: List[Any] = []
+
+    for fork_parametrizer in fork_parametrizers:
+        if not param_names:
+            param_names = fork_parametrizer.get_parameter_names()
+        else:
+            assert param_names == fork_parametrizer.get_parameter_names()
+        param_values.extend(fork_parametrizer.get_parameter_values())
+    metafunc.parametrize(param_names, param_values, scope="function")

--- a/src/pytest_plugins/forks/forks.py
+++ b/src/pytest_plugins/forks/forks.py
@@ -5,13 +5,14 @@ import itertools
 import sys
 import textwrap
 from dataclasses import dataclass, field
-from typing import Any, Callable, List
+from typing import Any, List
 
 import pytest
 from pytest import Metafunc
 
 from ethereum_test_forks import (
     Fork,
+    ForkAttribute,
     forks_from_until,
     get_deployed_forks,
     get_forks,
@@ -121,8 +122,8 @@ class CovariantDescriptor:
         if not self.check_enabled(metafunc=metafunc):
             return
         fork = fork_parametrizer.fork
-        fork_attribute: Callable[[int, int], List[Any]] = getattr(fork, self.fork_attribute_name)
-        values = fork_attribute(0, 0)
+        get_fork_covariant_values: ForkAttribute = getattr(fork, self.fork_attribute_name)
+        values = get_fork_covariant_values(block_number=0, timestamp=0)
         assert isinstance(values, list)
         assert len(values) > 0
         fork_parametrizer.fork_covariant_parameters.append(

--- a/tests/cancun/eip4788_beacon_root/conftest.py
+++ b/tests/cancun/eip4788_beacon_root/conftest.py
@@ -265,6 +265,9 @@ def tx(
         kwargs["max_fee_per_blob_gas"] = 1
         kwargs["blob_versioned_hashes"] = add_kzg_version([0], BLOB_COMMITMENT_VERSION_KZG)
 
+    if tx_type > 3:
+        raise Exception(f"Unexpected transaction type: '{tx_type}'. Test requires update.")
+
     return Transaction(**kwargs)
 
 

--- a/tests/cancun/eip4788_beacon_root/conftest.py
+++ b/tests/cancun/eip4788_beacon_root/conftest.py
@@ -255,14 +255,13 @@ def tx(
     if tx_type > 0:
         kwargs["access_list"] = access_list
 
-    if tx_type < 2:
+    if tx_type <= 1:
         kwargs["gas_price"] = 7
-
-    if tx_type > 1:
+    else:
         kwargs["max_fee_per_gas"] = 7
         kwargs["max_priority_fee_per_gas"] = 0
 
-    if tx_type > 2:
+    if tx_type == 3:
         kwargs["max_fee_per_blob_gas"] = 1
         kwargs["blob_versioned_hashes"] = add_kzg_version([0], BLOB_COMMITMENT_VERSION_KZG)
 

--- a/tests/cancun/eip4788_beacon_root/test_beacon_root_contract.py
+++ b/tests/cancun/eip4788_beacon_root/test_beacon_root_contract.py
@@ -200,9 +200,9 @@ def test_beacon_root_equal_to_timestamp(
     )
 
 
-@pytest.mark.parametrize("tx_type", range(4))
 @pytest.mark.parametrize("auto_access_list", [False, True])
 @pytest.mark.parametrize("call_beacon_root_contract", [True])
+@pytest.mark.with_all_tx_types
 @pytest.mark.valid_from("Cancun")
 def test_tx_to_beacon_root_contract(
     state_test: StateTestFiller,

--- a/tests/shanghai/eip4895_withdrawals/test_withdrawals.py
+++ b/tests/shanghai/eip4895_withdrawals/test_withdrawals.py
@@ -732,7 +732,6 @@ def test_withdrawing_to_precompiles(
     """
     Test withdrawing to all precompiles for a given fork.
     """
-
     pre: Dict = {
         TestAddress: Account(balance=1000000000000000000000, nonce=0),
     }

--- a/tests/shanghai/eip4895_withdrawals/test_withdrawals.py
+++ b/tests/shanghai/eip4895_withdrawals/test_withdrawals.py
@@ -722,3 +722,43 @@ def test_large_amount(blockchain_test: BlockchainTestFiller):
         )
     ]
     blockchain_test(pre=pre, post=post, blocks=blocks)
+
+
+@pytest.mark.parametrize("amount", [0, 1])
+@pytest.mark.with_all_precompiles
+def test_withdrawing_to_precompiles(
+    blockchain_test: BlockchainTestFiller, precompile: int, amount: int
+):
+    """
+    Test withdrawing to all precompiles for a given fork.
+    """
+
+    pre: Dict = {
+        TestAddress: Account(balance=1000000000000000000000, nonce=0),
+    }
+    post: Dict = {}
+
+    blocks = [
+        # First block performs the withdrawal
+        Block(
+            withdrawals=[
+                Withdrawal(
+                    index=0,
+                    validator=0,
+                    address=to_address(precompile),
+                    amount=amount,
+                )
+            ]
+        ),
+        # Second block sends a transaction to the precompile
+        Block(
+            txs=[
+                Transaction(
+                    nonce=0,
+                    gas_limit=100000,
+                    to=to_address(precompile),
+                ),
+            ],
+        ),
+    ]
+    blockchain_test(pre=pre, post=post, blocks=blocks)


### PR DESCRIPTION
### Changes Included

#### Forks
Forks now have `tx_types` and `precompiles` methods, which must return all valid transaction types and enabled precompiles in the given fork.

#### Pytest Plugins: Forks
Introduce covariant parameter markers, which allow to parametrize a test with all valid values for a given property on a given fork.

- `@pytest.mark.with_all_tx_types`
- `@pytest.mark.with_all_precompiles`

E.g. using `@pytest.mark.with_all_tx_types` the tester can now specify that the test must be parametrized on each fork with all the valid transaction type numbers as a parameter at that specific fork, (Shanghai: `[0, 1, 2]`, Cancun: `[0, 1, 2, 3]`), and eventually, on future forks, it should be parametrized using newer transaction types.