### PR TITLE
feature: Add engine API forkchoice updated information in fixtures

### DIFF
--- a/src/ethereum_test_forks/base_fork.py
+++ b/src/ethereum_test_forks/base_fork.py
@@ -174,6 +174,16 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
         """
         pass
 
+    @classmethod
+    @abstractmethod
+    def engine_forkchoice_updated_version(
+        cls, block_number: int = 0, timestamp: int = 0
+    ) -> Optional[int]:
+        """
+        Returns `None` if the forks canonical chain cannot be set using the forkchoice method.
+        """
+        pass
+
     # Meta information about the fork
     @classmethod
     def name(cls) -> str:

--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -92,6 +92,15 @@ class Frontier(BaseFork):
         return False
 
     @classmethod
+    def engine_forkchoice_updated_version(
+        cls, block_number: int = 0, timestamp: int = 0
+    ) -> Optional[int]:
+        """
+        At genesis, forkchoice updates cannot be sent through the engine API.
+        """
+        return cls.engine_new_payload_version(block_number, timestamp)
+
+    @classmethod
     def get_reward(cls, block_number: int = 0, timestamp: int = 0) -> int:
         """
         At Genesis the expected reward amount in wei is

--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -2707,6 +2707,11 @@ class Fixture:
             to_json=True,
         ),
     )
+    fcu_version: Optional[int] = field(
+        json_encoder=JSONEncoder.Field(
+            name="engineFcuVersion",
+        ),
+    )
     genesis: FixtureHeader = field(
         json_encoder=JSONEncoder.Field(
             name="genesisBlockHeader",

--- a/src/ethereum_test_tools/filling/fill.py
+++ b/src/ethereum_test_tools/filling/fill.py
@@ -34,6 +34,20 @@ def fill_test(
         eips=eips,
     )
 
+    fcu_version: int | None = None
+    if not test_spec.base_test_config.disable_hive:
+        last_valid_block = next(
+            (block.block_header for block in reversed(blocks) if block.expected_exception is None),
+            None,
+        )
+        fcu_version = (
+            fork.engine_forkchoice_updated_version(
+                last_valid_block.number, last_valid_block.timestamp
+            )
+            if last_valid_block
+            else None
+        )
+
     fork_name = fork.name()
     fixture = Fixture(
         blocks=blocks,
@@ -44,12 +58,8 @@ def fill_test(
         pre_state=pre,
         post_state=alloc_to_accounts(alloc),
         seal_engine=engine,
-        fcu_version=fork.engine_forkchoice_updated_version(
-            blocks[-1].block_header.number, blocks[-1].block_header.timestamp
-        )
-        if not test_spec.base_test_config.disable_hive and blocks[-1].block_header
-        else None,
         name=test_spec.tag,
+        fcu_version=fcu_version,
     )
     fixture.fill_info(t8n, spec)
 

--- a/src/ethereum_test_tools/filling/fill.py
+++ b/src/ethereum_test_tools/filling/fill.py
@@ -44,6 +44,11 @@ def fill_test(
         pre_state=pre,
         post_state=alloc_to_accounts(alloc),
         seal_engine=engine,
+        fcu_version=fork.engine_forkchoice_updated_version(
+            blocks[-1].block_header.number, blocks[-1].block_header.timestamp
+        )
+        if not test_spec.base_test_config.disable_hive and blocks[-1].block_header
+        else None,
         name=test_spec.tag,
     )
     fixture.fill_info(t8n, spec)

--- a/src/ethereum_test_tools/filling/fill.py
+++ b/src/ethereum_test_tools/filling/fill.py
@@ -26,27 +26,13 @@ def fill_test(
 
     pre, genesis_rlp, genesis = test_spec.make_genesis(t8n, fork)
 
-    (blocks, head, alloc) = test_spec.make_blocks(
+    (blocks, head, alloc, fcu_version) = test_spec.make_blocks(
         t8n,
         genesis,
         pre,
         fork,
         eips=eips,
     )
-
-    fcu_version: int | None = None
-    if not test_spec.base_test_config.disable_hive:
-        last_valid_block = next(
-            (block.block_header for block in reversed(blocks) if block.expected_exception is None),
-            None,
-        )
-        fcu_version = (
-            fork.engine_forkchoice_updated_version(
-                last_valid_block.number, last_valid_block.timestamp
-            )
-            if last_valid_block
-            else None
-        )
 
     fork_name = fork.name()
     fixture = Fixture(

--- a/src/ethereum_test_tools/spec/base_test.py
+++ b/src/ethereum_test_tools/spec/base_test.py
@@ -127,7 +127,7 @@ class BaseTest:
         fork: Fork,
         chain_id: int = 1,
         eips: Optional[List[int]] = None,
-    ) -> Tuple[List[FixtureBlock], Hash, Dict[str, Any]]:
+    ) -> Tuple[List[FixtureBlock], Hash, Dict[str, Any], Optional[int]]:
         """
         Generate the blockchain that must be executed sequentially during test.
         """

--- a/src/ethereum_test_tools/spec/state_test.py
+++ b/src/ethereum_test_tools/spec/state_test.py
@@ -127,7 +127,7 @@ class StateTest(BaseTest):
         fork: Fork,
         chain_id=1,
         eips: Optional[List[int]] = None,
-    ) -> Tuple[List[FixtureBlock], Hash, Dict[str, Any]]:
+    ) -> Tuple[List[FixtureBlock], Hash, Dict[str, Any], Optional[int]]:
         """
         Create a block from the state test definition.
         Performs checks against the expected behavior of the test.
@@ -178,15 +178,18 @@ class StateTest(BaseTest):
             withdrawals=env.withdrawals,
         )
 
+        # Hive specific fields
         new_payload: FixtureEngineNewPayload | None = None
+        fcu_version: int | None = None
         if not self.base_test_config.disable_hive:
             new_payload = FixtureEngineNewPayload.from_fixture_header(
                 fork=fork,
                 header=header,
                 transactions=txs,
                 withdrawals=env.withdrawals,
-                error_code=self.engine_api_error_code,
+                error_code=None,
             )
+            fcu_version = fork.engine_forkchoice_updated_version(header.number, header.timestamp)
 
         return (
             [
@@ -201,6 +204,7 @@ class StateTest(BaseTest):
             ],
             header.hash,
             alloc,
+            fcu_version,
         )
 
 

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -84,6 +84,7 @@ extcodesize
 fn
 fname
 forkchoice
+fcu
 formatOnSave
 formatter
 fromhex


### PR DESCRIPTION
Similar to the following PR: #183 but for engine API forkchoice updated payload attriubes & version.

This information can be extracted and utilized in hive. Tagging https://github.com/ethereum/hive/pull/830.

