### PR TITLE
evm_transition_tool, types: rename `beaconRoot`

### DIFF
--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -1004,7 +1004,7 @@ class Environment:
     beacon_root: Optional[FixedSizeBytesConvertible] = field(
         default=None,
         json_encoder=JSONEncoder.Field(
-            name="beaconRoot",
+            name="parentBeaconBlockRoot",
             cast_type=Hash,
         ),
     )

--- a/src/evm_transition_tool/transition_tool.py
+++ b/src/evm_transition_tool/transition_tool.py
@@ -236,7 +236,7 @@ class TransitionTool:
 
         if fork.header_beacon_root_required(0, 0):
             env[
-                "beaconRoot"
+                "parentBeaconBlockRoot"
             ] = "0x0000000000000000000000000000000000000000000000000000000000000000"
 
         new_alloc, result = self.evaluate(
@@ -283,7 +283,7 @@ class TransitionTool:
 
         if fork.header_beacon_root_required(0, 0):
             env[
-                "beaconRoot"
+                "parentBeaconBlockRoot"
             ] = "0x0000000000000000000000000000000000000000000000000000000000000000"
 
         _, result = self.evaluate(


### PR DESCRIPTION
Renames `beaconRoot` to `parentBeaconBlockRoot` when calling the t8n tool for consistency with the rest of the specs.

Fixed on t8n in the following commit: https://github.com/marioevz/go-ethereum/commit/bf3f8c2f444045c29c87abc1b7105dd712bf6bf4