### PR TITLE
Tools: add a t8n script to t8n dump dir to easily reproduce executed t8n tool commands

### DIFF
--- a/.wordlist_python_pytest.txt
+++ b/.wordlist_python_pytest.txt
@@ -15,6 +15,7 @@ getoption
 groupby
 hookimpl
 hookwrapper
+IEXEC
 IGNORECASE
 iterdir
 ljust


### PR DESCRIPTION
Requires https://github.com/ethereum/execution-spec-tests/pull/229.

Adds an executable script to each subdir in the `--t8n-dump-dir` in order to reasily rerun t8n tool executions performed during the test run in isolation.

E.g.
```
fill --fork=Shanghai --traces --t8n-dump-dir=/tmp/geth-t8n
```
results in:
![grafik](https://github.com/ethereum/execution-spec-tests/assets/91727015/28207677-834c-4ce0-8473-b39b7e61d7b4)
and then:
```
/tmp/geth-t8n/test_yul_fork_Shanghai/2/t8n.sh
```
reruns the t8n command ran for the test and outputs:
```

INFO [08-18|15:52:41.232] Trie dumping started                     root=91d0a9..9fd44b
INFO [08-18|15:52:41.232] Trie dumping complete                    accounts=3 elapsed="162.897µs"
INFO [08-18|15:52:41.232] Wrote file                               file=/tmp/tmp32lqi24l/txs.rlp
{
  "alloc": {
    "0x1000000000000000000000000000000000000000": {
      "code": "0x600f565b5f828201905092915050565b6019600260016003565b5f5560205ff3",
      "storage": {
        "0x0000000000000000000000000000000000000000000000000000000000000000": "0x0000000000000000000000000000000000000000000000000000000000000003"
      },
      "balance": "0xba1a9ce0ba1a9ce"
    },
    "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba": {
...
```