### PR TITLE
docs: add extra installation step for macOS when using Python >=3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ This guide installs stable versions of the required external (go-ethereum) `evm`
    ```
 
    :warning: When using Python 3.11 on macOS the following must be installed first:
+
    ```console
    brew install autoconf automake libtool
    ```

--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ This guide installs stable versions of the required external (go-ethereum) `evm`
    pip install -e '.[docs,lint,test]'
    ```
 
+   :warning: When using Python 3.11 on macOS the following must be installed first:
+   ```console
+   brew install autoconf automake libtool
+   ```
+
 3. Verify the installation:
     1. Explore test cases:
 

--- a/docs/getting_started/quick_start.md
+++ b/docs/getting_started/quick_start.md
@@ -58,6 +58,7 @@ The following requires a Python 3.10 or Python 3.11 installation.
 
     !!! note "Python 3.11 on macOS"
         When using Python 3.11 on macOS the following must be installed first:
+
         ```console
         brew install autoconf automake libtool
         ```

--- a/docs/getting_started/quick_start.md
+++ b/docs/getting_started/quick_start.md
@@ -21,7 +21,7 @@ The following requires a Python 3.10 or Python 3.11 installation.
           - [geth installation doc](https://geth.ethereum.org/docs/getting-started/installing-geth#ubuntu-via-ppas).
           - [solc installation doc](https://docs.soliditylang.org/en/latest/installing-solidity.html#linux-packages).
 
-    === "macos"
+    === "macOS"
 
           ```console
           brew update
@@ -55,6 +55,12 @@ The following requires a Python 3.10 or Python 3.11 installation.
     source ./venv/bin/activate
     pip install -e '.[docs,lint,test]'
     ```
+
+    !!! note "Python 3.11 on macOS"
+        When using Python 3.11 on macOS the following must be installed first:
+        ```console
+        brew install autoconf automake libtool
+        ```
 
 3. Verify installation:
     1. Explore test cases:

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -135,7 +135,7 @@ listdir
 lll
 lllc
 london
-macos
+macOS
 mainnet
 marioevz
 markdownlint


### PR DESCRIPTION
Current work around for the following issue: #274 related to installing coincurve v17 on macOS with Python 3.11.

<img width="838" alt="image" src="https://github.com/ethereum/execution-spec-tests/assets/60348173/da98628c-e879-4a63-aa90-c1e4ee6523bc">
