### PR TITLE
chore: run github actions on macos

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,7 +38,7 @@ jobs:
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then PLATFORM="linux-amd64"; else PLATFORM="macosx-amd64"; fi
           RELEASE_NAME=$(curl https://binaries.soliditylang.org/${PLATFORM}/list.json | jq -r --arg SOLC_VERSION "${{ matrix.solc }}" '.releases[$SOLC_VERSION]')
-          wget -O $GITHUB_WORKSPACE/bin/solc https://binaries.soliditylang.org/linux-amd64/$RELEASE_NAME
+          wget -O $GITHUB_WORKSPACE/bin/solc https://binaries.soliditylang.org/${PLATFORM}/$RELEASE_NAME
           chmod a+x $GITHUB_WORKSPACE/bin/solc
           echo $GITHUB_WORKSPACE/bin >> $GITHUB_PATH
       - name: Setup Tools/Dependencies Ubuntu

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Setup Tools/Dependencies macOS
         if: runner.os == 'macOS'
         run: |
-          brew install aspell aspell-en
+          brew install aspell
       - name: Install Tox and any other packages
         run: pip install tox
       - name: Run Tox (CPython)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,7 +36,8 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Install solc compiler
         run: |
-          RELEASE_NAME=$(curl https://binaries.soliditylang.org/linux-amd64/list.json | jq -r --arg SOLC_VERSION "${{ matrix.solc }}" '.releases[$SOLC_VERSION]')
+          if [ "$RUNNER_OS" == "Linux" ]; then PLATFORM="linux-amd64"; else PLATFORM="macosx-amd64"; fi
+          RELEASE_NAME=$(curl https://binaries.soliditylang.org/${PLATFORM}/list.json | jq -r --arg SOLC_VERSION "${{ matrix.solc }}" '.releases[$SOLC_VERSION]')
           wget -O $GITHUB_WORKSPACE/bin/solc https://binaries.soliditylang.org/linux-amd64/$RELEASE_NAME
           chmod a+x $GITHUB_WORKSPACE/bin/solc
           echo $GITHUB_WORKSPACE/bin >> $GITHUB_PATH

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,12 +4,13 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         python: ['3.10', '3.11']
         golang: ['1.20.5']
         solc: ['0.8.20', '0.8.21']
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -39,9 +40,14 @@ jobs:
           wget -O $GITHUB_WORKSPACE/bin/solc https://binaries.soliditylang.org/linux-amd64/$RELEASE_NAME
           chmod a+x $GITHUB_WORKSPACE/bin/solc
           echo $GITHUB_WORKSPACE/bin >> $GITHUB_PATH
-      - name: Install Aspell
+      - name: Setup Tools/Dependencies Ubuntu
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get install aspell aspell-en
+      - name: Setup Tools/Dependencies macOS
+        if: runner.os == 'macOS'
+        run: |
+          brew install aspell aspell-en
       - name: Install Tox and any other packages
         run: pip install tox
       - name: Run Tox (CPython)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,10 +7,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python: ['3.10', '3.11']
         golang: ['1.20.5']
-        solc: ['0.8.20', '0.8.21']
-        os: [ubuntu-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            python: '3.10'
+            solc: '0.8.20'
+          - os: ubuntu-latest
+            python: '3.11'
+            solc: '0.8.21'
+          - os: macos-latest
+            python: '3.11'
+            solc: '0.8.21'
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,16 +21,16 @@ jobs:
             golang: '1.20.5'
             solc: '0.8.21'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
       - name: Checkout go-ethereum
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ethereum/go-ethereum
           path: go-ethereum
       - name: Setup golang
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.golang }}
       - name: Build evm cmd
@@ -40,7 +40,7 @@ jobs:
           go build .
           echo $GITHUB_WORKSPACE/go-ethereum/cmd/evm >> $GITHUB_PATH
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
       - name: Install solc compiler

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,6 +49,8 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew install aspell
+          # Add additional packages on 3.11: https://github.com/ethereum/execution-spec-tests/issues/274
+          if [ ${{ matrix.python }} == '3.11' ]; then brew install autoconf automake libtool; fi
       - name: Install Tox and any other packages
         run: pip install tox
       - name: Run Tox (CPython)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,16 +7,18 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        golang: ['1.20.5']
         include:
           - os: ubuntu-latest
             python: '3.10'
+            golang: '1.20.5'
             solc: '0.8.20'
           - os: ubuntu-latest
             python: '3.11'
+            golang: '1.20.5'
             solc: '0.8.21'
           - os: macos-latest
             python: '3.11'
+            golang: '1.20.5'
             solc: '0.8.21'
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.golang }}
+          cache-dependency-path: go-ethereum/go.sum
       - name: Build evm cmd
         run: |
           mkdir -p $GITHUB_WORKSPACE/bin

--- a/src/ethereum_test_tools/reference_spec/git_reference_spec.py
+++ b/src/ethereum_test_tools/reference_spec/git_reference_spec.py
@@ -4,6 +4,7 @@ Reference Specification file located in a github repository.
 
 import base64
 import json
+import warnings
 from dataclasses import dataclass
 from typing import Any, Dict
 
@@ -66,6 +67,10 @@ class GitReferenceSpec(ReferenceSpec):
             return self._latest_spec
         response = requests.get(self.api_url())
         if response.status_code != 200:
+            warnings.warn(
+                f"Unable to get latest version, status code: {response.status_code} - "
+                f"text: {response.text}"
+            )
             return None
         content = json.loads(response.content)
         content["content"] = _decode_base64_content(content["content"])

--- a/src/ethereum_test_tools/tests/test_reference_spec.py
+++ b/src/ethereum_test_tools/tests/test_reference_spec.py
@@ -7,18 +7,84 @@ Test suite for `ethereum_test_tools.common.reference_spec` module.
 import re
 
 import pytest
+import requests
 
 from ..reference_spec.git_reference_spec import GitReferenceSpec
 from ..reference_spec.reference_spec import NoLatestKnownVersion
 
+# the content field from https://api.github.com/repos/ethereum/EIPs/contents/EIPS/eip-100.md
+# as of 2023-08-29
+response_content = "LS0tCmVpcDogMTAwCnRpdGxlOiBDaGFuZ2UgZGlmZmljdWx0eSBhZGp1c3Rt\
+ZW50IHRvIHRhcmdldCBtZWFuIGJsb2NrIHRpbWUgaW5jbHVkaW5nIHVuY2xl\
+cwphdXRob3I6IFZpdGFsaWsgQnV0ZXJpbiAoQHZidXRlcmluKQp0eXBlOiBT\
+dGFuZGFyZHMgVHJhY2sKY2F0ZWdvcnk6IENvcmUKc3RhdHVzOiBGaW5hbApj\
+cmVhdGVkOiAyMDE2LTA0LTI4Ci0tLQoKIyMjIFNwZWNpZmljYXRpb24KCkN1\
+cnJlbnRseSwgdGhlIGZvcm11bGEgdG8gY29tcHV0ZSB0aGUgZGlmZmljdWx0\
+eSBvZiBhIGJsb2NrIGluY2x1ZGVzIHRoZSBmb2xsb3dpbmcgbG9naWM6Cgpg\
+YGAgcHl0aG9uCmFkal9mYWN0b3IgPSBtYXgoMSAtICgodGltZXN0YW1wIC0g\
+cGFyZW50LnRpbWVzdGFtcCkgLy8gMTApLCAtOTkpCmNoaWxkX2RpZmYgPSBp\
+bnQobWF4KHBhcmVudC5kaWZmaWN1bHR5ICsgKHBhcmVudC5kaWZmaWN1bHR5\
+IC8vIEJMT0NLX0RJRkZfRkFDVE9SKSAqIGFkal9mYWN0b3IsIG1pbihwYXJl\
+bnQuZGlmZmljdWx0eSwgTUlOX0RJRkYpKSkKLi4uCmBgYAoKSWYgYGJsb2Nr\
+Lm51bWJlciA+PSBCWVpBTlRJVU1fRk9SS19CTEtOVU1gLCB3ZSBjaGFuZ2Ug\
+dGhlIGZpcnN0IGxpbmUgdG8gdGhlIGZvbGxvd2luZzoKCmBgYCBweXRob24K\
+YWRqX2ZhY3RvciA9IG1heCgoMiBpZiBsZW4ocGFyZW50LnVuY2xlcykgZWxz\
+ZSAxKSAtICgodGltZXN0YW1wIC0gcGFyZW50LnRpbWVzdGFtcCkgLy8gOSks\
+IC05OSkKYGBgCiMjIyBSYXRpb25hbGUKClRoaXMgbmV3IGZvcm11bGEgZW5z\
+dXJlcyB0aGF0IHRoZSBkaWZmaWN1bHR5IGFkanVzdG1lbnQgYWxnb3JpdGht\
+IHRhcmdldHMgYSBjb25zdGFudCBhdmVyYWdlIHJhdGUgb2YgYmxvY2tzIHBy\
+b2R1Y2VkIGluY2x1ZGluZyB1bmNsZXMsIGFuZCBzbyBlbnN1cmVzIGEgaGln\
+aGx5IHByZWRpY3RhYmxlIGlzc3VhbmNlIHJhdGUgdGhhdCBjYW5ub3QgYmUg\
+bWFuaXB1bGF0ZWQgdXB3YXJkIGJ5IG1hbmlwdWxhdGluZyB0aGUgdW5jbGUg\
+cmF0ZS4gQSBmb3JtdWxhIHRoYXQgYWNjb3VudHMgZm9yIHRoZSBleGFjdCBu\
+dW1iZXIgb2YgaW5jbHVkZWQgdW5jbGVzOgpgYGAgcHl0aG9uCmFkal9mYWN0\
+b3IgPSBtYXgoMSArIGxlbihwYXJlbnQudW5jbGVzKSAtICgodGltZXN0YW1w\
+IC0gcGFyZW50LnRpbWVzdGFtcCkgLy8gOSksIC05OSkKYGBgCmNhbiBiZSBm\
+YWlybHkgZWFzaWx5IHNlZW4gdG8gYmUgKHRvIHdpdGhpbiBhIHRvbGVyYW5j\
+ZSBvZiB+My80MTk0MzA0KSBtYXRoZW1hdGljYWxseSBlcXVpdmFsZW50IHRv\
+IGFzc3VtaW5nIHRoYXQgYSBibG9jayB3aXRoIGBrYCB1bmNsZXMgaXMgZXF1\
+aXZhbGVudCB0byBhIHNlcXVlbmNlIG9mIGBrKzFgIGJsb2NrcyB0aGF0IGFs\
+bCBhcHBlYXIgd2l0aCB0aGUgZXhhY3Qgc2FtZSB0aW1lc3RhbXAsIGFuZCB0\
+aGlzIGlzIGxpa2VseSB0aGUgc2ltcGxlc3QgcG9zc2libGUgd2F5IHRvIGFj\
+Y29tcGxpc2ggdGhlIGRlc2lyZWQgZWZmZWN0LiBCdXQgc2luY2UgdGhlIGV4\
+YWN0IGZvcm11bGEgZGVwZW5kcyBvbiB0aGUgZnVsbCBibG9jayBhbmQgbm90\
+IGp1c3QgdGhlIGhlYWRlciwgd2UgYXJlIGluc3RlYWQgdXNpbmcgYW4gYXBw\
+cm94aW1hdGUgZm9ybXVsYSB0aGF0IGFjY29tcGxpc2hlcyBhbG1vc3QgdGhl\
+IHNhbWUgZWZmZWN0IGJ1dCBoYXMgdGhlIGJlbmVmaXQgdGhhdCBpdCBkZXBl\
+bmRzIG9ubHkgb24gdGhlIGJsb2NrIGhlYWRlciAoYXMgeW91IGNhbiBjaGVj\
+ayB0aGUgdW5jbGUgaGFzaCBhZ2FpbnN0IHRoZSBibGFuayBoYXNoKS4KCkNo\
+YW5naW5nIHRoZSBkZW5vbWluYXRvciBmcm9tIDEwIHRvIDkgZW5zdXJlcyB0\
+aGF0IHRoZSBibG9jayB0aW1lIHJlbWFpbnMgcm91Z2hseSB0aGUgc2FtZSAo\
+aW4gZmFjdCwgaXQgc2hvdWxkIGRlY3JlYXNlIGJ5IH4zJSBnaXZlbiB0aGUg\
+Y3VycmVudCB1bmNsZSByYXRlIG9mIDclKS4KCiMjIyBSZWZlcmVuY2VzCgox\
+LiBFSVAgMTAwIGlzc3VlIGFuZCBkaXNjdXNzaW9uOiBodHRwczovL2dpdGh1\
+Yi5jb20vZXRoZXJldW0vRUlQcy9pc3N1ZXMvMTAwCjIuIGh0dHBzOi8vYml0\
+c2xvZy53b3JkcHJlc3MuY29tLzIwMTYvMDQvMjgvdW5jbGUtbWluaW5nLWFu\
+LWV0aGVyZXVtLWNvbnNlbnN1cy1wcm90b2NvbC1mbGF3Lwo="
 
-def test_git_reference_spec():
+
+def test_git_reference_spec(monkeypatch):
     """
     Test Git reference spec.
     """
+
+    def mock_get(self):
+        class Response:
+            content = (
+                '{"content": "'
+                + response_content
+                + '", "sha":"78b94002190eb71cb04b8757629397f9418e8cce"}'
+            )
+            status_code = 200
+
+        return Response()
+
+    monkeypatch.setattr(requests, "get", mock_get)
+
     ref_spec = GitReferenceSpec(
         SpecPath="EIPS/eip-100.md",
     )
+
     latest_spec = ref_spec._get_latest_spec()
     assert latest_spec is not None
     assert "sha" in latest_spec


### PR DESCRIPTION
Additionally run github actions on macos-latest. Previously, it was only ubuntu-latest.

To help detect issues such as #274.