### PR TITLE
Update Solc Version Check To Use SemVer

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ install_requires =
     pytest-xdist>=3.3.1,<4
     coincurve==17.0.0
     trie==2.1.1
+    semver==3.0.1
 
 [options.package_data]
 ethereum_test_tools =

--- a/src/ethereum_test_tools/code/yul.py
+++ b/src/ethereum_test_tools/code/yul.py
@@ -131,7 +131,7 @@ class Yul(SupportsBytes, Sized):
             stderr=PIPE,
         )
         solc_output = result.stdout.decode().split("\n")
-        version_pattern = r"0\.\d+\.\d+\+\S+"
+        version_pattern = r"0\.\d+\.\d+.*\+commit.*"
         solc_version_string = None
         for line in solc_output:
             match = re.search(version_pattern, line)

--- a/src/ethereum_test_tools/tests/conftest.py
+++ b/src/ethereum_test_tools/tests/conftest.py
@@ -7,13 +7,9 @@ from semver import Version
 
 from ..code import Yul
 
-SUPPORTED_SOLC_VERSIONS = [
-    Version.parse(v)
-    for v in [
-        "0.8.20",
-        "0.8.21",
-    ]
-]
+SUPPORTED_SOLC_VERSIONS = [Version.parse(v) for v in ["0.8.20", "0.8.21", "0.8.22"]]
+
+SOLC_PADDING_VERSION = Version.parse("0.8.21")
 
 
 @pytest.fixture(scope="session")

--- a/src/ethereum_test_tools/tests/conftest.py
+++ b/src/ethereum_test_tools/tests/conftest.py
@@ -3,12 +3,12 @@ Common pytest fixtures for ethereum_test_tools tests.
 """
 
 import pytest
-from packaging import version
+from semver import Version
 
 from ..code import Yul
 
 SUPPORTED_SOLC_VERSIONS = [
-    version.parse(v)
+    Version.parse(v)
     for v in [
         "0.8.20",
         "0.8.21",
@@ -17,9 +17,9 @@ SUPPORTED_SOLC_VERSIONS = [
 
 
 @pytest.fixture(scope="session")
-def solc_version() -> version.Version:
+def solc_version() -> Version:
     """Return the version of solc being used for tests."""
-    solc_version = version.parse(Yul("").version().split("+")[0])
+    solc_version = Yul("").version().finalize_version()
     if solc_version not in SUPPORTED_SOLC_VERSIONS:
         raise Exception("Unsupported solc version: {}".format(solc_version))
     return solc_version

--- a/src/ethereum_test_tools/tests/test_code.py
+++ b/src/ethereum_test_tools/tests/test_code.py
@@ -6,7 +6,7 @@ from string import Template
 from typing import SupportsBytes
 
 import pytest
-from packaging import version
+from semver import Version
 
 from ethereum_test_forks import Fork, Homestead, Shanghai, forks_from_until, get_deployed_forks
 
@@ -72,11 +72,11 @@ def yul_code(request: pytest.FixtureRequest, fork: Fork, padding_before: str, pa
     return compiled_yul_code
 
 
-SOLC_PADDING_VERSION = version.parse("0.8.21")
+SOLC_PADDING_VERSION = Version.parse("0.8.21")
 
 
 @pytest.fixture()
-def expected_bytes(request: pytest.FixtureRequest, solc_version: version.Version, fork: Fork):
+def expected_bytes(request: pytest.FixtureRequest, solc_version: Version, fork: Fork):
     """Return the expected bytes for the test."""
     expected_bytes = request.param
     if isinstance(expected_bytes, Template):

--- a/src/ethereum_test_tools/tests/test_code.py
+++ b/src/ethereum_test_tools/tests/test_code.py
@@ -12,6 +12,7 @@ from ethereum_test_forks import Fork, Homestead, Shanghai, forks_from_until, get
 
 from ..code import Code, Conditional, Initcode, Yul
 from ..vm.opcode import Opcodes as Op
+from .conftest import SOLC_PADDING_VERSION
 
 
 @pytest.mark.parametrize(
@@ -72,9 +73,6 @@ def yul_code(request: pytest.FixtureRequest, fork: Fork, padding_before: str, pa
     return compiled_yul_code
 
 
-SOLC_PADDING_VERSION = Version.parse("0.8.21")
-
-
 @pytest.fixture()
 def expected_bytes(request: pytest.FixtureRequest, solc_version: Version, fork: Fork):
     """Return the expected bytes for the test."""
@@ -82,20 +80,17 @@ def expected_bytes(request: pytest.FixtureRequest, solc_version: Version, fork: 
     if isinstance(expected_bytes, Template):
         if solc_version < SOLC_PADDING_VERSION or fork == Homestead:
             solc_padding = ""
-        elif solc_version == SOLC_PADDING_VERSION:
-            solc_padding = "00"
         else:
-            raise Exception("Unsupported solc version: {}".format(solc_version))
+            solc_padding = "00"
         return bytes.fromhex(expected_bytes.substitute(solc_padding=solc_padding))
     if isinstance(expected_bytes, bytes):
         if fork == Shanghai:
             expected_bytes = b"\x5f" + expected_bytes[2:]
         if solc_version < SOLC_PADDING_VERSION or fork == Homestead:
             return expected_bytes
-        elif solc_version == SOLC_PADDING_VERSION:
-            return expected_bytes + b"\x00"
         else:
-            raise Exception("Unsupported solc version: {}".format(solc_version))
+            return expected_bytes + b"\x00"
+
     raise Exception("Unsupported expected_bytes type: {}".format(type(expected_bytes)))
 
 

--- a/src/ethereum_test_tools/tests/test_filler.py
+++ b/src/ethereum_test_tools/tests/test_filler.py
@@ -7,7 +7,7 @@ import os
 from typing import Any, Dict, List
 
 import pytest
-from packaging import version
+from semver import Version
 
 from ethereum_test_forks import Berlin, Fork, Istanbul, London
 from evm_transition_tool import GethTransitionTool
@@ -25,16 +25,16 @@ def remove_info(fixture_json: Dict[str, Any]):
 
 
 @pytest.fixture()
-def hash(request: pytest.FixtureRequest, solc_version: version.Version):
+def hash(request: pytest.FixtureRequest, solc_version: Version):
     """
     Set the hash based on the fork and solc version.
     """
-    if solc_version == version.parse("0.8.20"):
+    if solc_version == Version.parse("0.8.20"):
         if request.node.funcargs["fork"] == Berlin:
             return bytes.fromhex("193e550de3")
         elif request.node.funcargs["fork"] == London:
             return bytes.fromhex("b053deac0e")
-    elif solc_version == version.parse("0.8.21"):
+    elif solc_version == Version.parse("0.8.21"):
         if request.node.funcargs["fork"] == Berlin:
             return bytes.fromhex("f3a35d34f6")
         elif request.node.funcargs["fork"] == London:

--- a/src/ethereum_test_tools/tests/test_filler.py
+++ b/src/ethereum_test_tools/tests/test_filler.py
@@ -16,6 +16,7 @@ from ..code import Yul
 from ..common import Account, Block, Environment, TestAddress, Transaction, to_json
 from ..filling import fill_test
 from ..spec import BlockchainTest, StateTest
+from .conftest import SOLC_PADDING_VERSION
 
 
 def remove_info(fixture_json: Dict[str, Any]):
@@ -34,13 +35,11 @@ def hash(request: pytest.FixtureRequest, solc_version: Version):
             return bytes.fromhex("193e550de3")
         elif request.node.funcargs["fork"] == London:
             return bytes.fromhex("b053deac0e")
-    elif solc_version == Version.parse("0.8.21"):
+    else:
         if request.node.funcargs["fork"] == Berlin:
             return bytes.fromhex("f3a35d34f6")
         elif request.node.funcargs["fork"] == London:
             return bytes.fromhex("c5fa75d7f6")
-    else:
-        raise Exception("Unsupported solc version: {}".format(solc_version))
 
 
 @pytest.mark.parametrize(
@@ -441,7 +440,12 @@ def test_fill_london_blockchain_test_valid_txs(fork: Fork, solc_version: str):
     fixture_json = to_json(fixture)
     remove_info(fixture_json)
 
-    assert fixture_json == expected[f"solc={solc_version}"]
+    if solc_version >= SOLC_PADDING_VERSION:
+        expected = expected["solc=padding_version"]
+    else:
+        expected = expected[f"solc={solc_version}"]
+
+    assert fixture_json == expected
 
 
 @pytest.mark.parametrize("fork", [London])
@@ -777,4 +781,9 @@ def test_fill_london_blockchain_test_invalid_txs(fork: Fork, solc_version: str):
     fixture_json = to_json(fixture)
     remove_info(fixture_json)
 
-    assert fixture_json == expected[f"solc={solc_version}"]
+    if solc_version >= SOLC_PADDING_VERSION:
+        expected = expected["solc=padding_version"]
+    else:
+        expected = expected[f"solc={solc_version}"]
+
+    assert fixture_json == expected

--- a/src/ethereum_test_tools/tests/test_fixtures/blockchain_london_invalid_filled.json
+++ b/src/ethereum_test_tools/tests/test_fixtures/blockchain_london_invalid_filled.json
@@ -427,7 +427,7 @@
             "sealEngine": "NoProof"
         }
     },
-    "solc=0.8.21": {
+    "solc=padding_version": {
         "000/my_blockchain_test/London": {
             "blocks": [
                 {

--- a/src/ethereum_test_tools/tests/test_fixtures/blockchain_london_valid_filled.json
+++ b/src/ethereum_test_tools/tests/test_fixtures/blockchain_london_valid_filled.json
@@ -417,7 +417,7 @@
             "sealEngine": "NoProof"
         }
     },
-    "solc=0.8.21": {
+    "solc=padding_version": {
         "000/my_blockchain_test/London": {
             "blocks": [
                 {


### PR DESCRIPTION
Following this discord thread -> [here](https://discord.com/channels/595666850260713488/753271902520213625/1145736190356623466).


When using a development version of solidity we hard fail like the following:
```
Version: 0.8.20-develop.2023.5.1+commit.0cb27949.Darwin.appleclang
```
This commit allows the latter. 