### PR TITLE
chore: upgrade coincurve to v18 #274

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     colorlog>=6.7.0
     pytest==7.3.2
     pytest-xdist>=3.3.1,<4
-    coincurve==17.0.0
+    coincurve>=18.0.0,<19
     trie==2.1.1
 
 [options.package_data]


### PR DESCRIPTION
Requires TBD

Fixes #274.

No differences in fixtures `--until Cancun` with coincurve v17 and v18 against https://github.com/marioevz/go-ethereum/commit/632f57b81acefd951a48cb3c0f2dfd8b1af7f344.
