### PR TITLE
docs: update execution-specs t8n installation help

### DIFF
--- a/src/evm_transition_tool/execution_specs.py
+++ b/src/evm_transition_tool/execution_specs.py
@@ -23,17 +23,45 @@ class ExecutionSpecsTransitionTool(GethTransitionTool):
 
     The behavior of this tool is almost identical to go-ethereum's `evm t8n` command.
 
-    note: How to use the `ethereum-spec-evm` tool:
+    note: Using the latest version of the `ethereum-spec-evm` tool:
+
+        As the `ethereum` package provided by `execution-specs` is a requirement of
+        `execution-spec-tests`, the `ethereum-spec-evm` is already installed in the
+        virtual environment where `execution-spec-tests` is installed
+        (via `pip install -e .`). Therefore, the `ethereum-spec-evm` transition tool
+        can be used to fill tests via:
+
+        ```console
+            fill --evm-bin=ethereum-spec-evm
+        ```
+
+        To ensure you're using the latest version of `ethereum-spec-evm` you can run:
+
+        ```
+        pip install --force-reinstall -e .
+        ```
+
+        or
+
+        ```
+        pip install --force-reinstall -e .[docs,lint,tests]
+        ```
+
+        as appropriate.
+
+    note: Using a specific version of the `ethereum-spec-evm` tool:
 
         1. Create a virtual environment and activate it:
             ```
-            python -m venv venv
-            source venv/bin/activate
+            python -m venv venv-execution-specs
+            source venv-execution-specs/bin/activate
             ```
-        2. Clone the ethereum/execution-specs repository and change working directory to it:
+        2. Clone the ethereum/execution-specs repository, change working directory to it and
+            retrieve the desired version of the repository:
             ```
             git clone git@github.com:ethereum/execution-specs.git
             cd execution-specs
+            git checkout <version>
             ```
         3. Install the packages provided by the repository:
             ```
@@ -55,7 +83,7 @@ class ExecutionSpecsTransitionTool(GethTransitionTool):
             ```
         6. Run the tests, specifying the `ethereum-spec-evm` command as the transition tool:
             ```
-            fill --evm-bin=ethereum-spec-evm
+            fill --evm-bin=path/to/venv-execution-specs/ethereum-spec-evm
             ```
     """
 


### PR DESCRIPTION
As execution-specs is installed as one of our dependencies, using its transition tool works out of the box (after installing execution-spec-tests):
```
fill --evm-bin=ethereum-spec-evm
```

Note: Not working out of the box until https://github.com/ethereum/execution-specs/pull/823 is merged :laughing: (use that branch if you want to test).