### PR TITLE
Fix cancun filling error "ValueError: missing required field 'blob_gas_used'"

### DIFF
--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -1956,7 +1956,6 @@ class HeaderFieldSource:
                 if self.default is not None:
                     value = self.default
                 else:
-                    import pdb; pdb.set_trace()
                     raise ValueError(f"missing required field '{field_name}'")
 
         if value is not None and self.parse_type is not None:

--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -1956,6 +1956,7 @@ class HeaderFieldSource:
                 if self.default is not None:
                     value = self.default
                 else:
+                    import pdb; pdb.set_trace()
                     raise ValueError(f"missing required field '{field_name}'")
 
         if value is not None and self.parse_type is not None:
@@ -2140,6 +2141,7 @@ class FixtureHeader:
             parse_type=Number,
             fork_requirement_check="header_blob_gas_used_required",
             source_transition_tool="blobGasUsed",
+            source_environment="blob_gas_used",
         ),
         json_encoder=JSONEncoder.Field(name="blobGasUsed", cast_type=ZeroPaddedHexNumber),
     )

--- a/tests/cancun/eip6780_selfdestruct/test_selfdestruct.py
+++ b/tests/cancun/eip6780_selfdestruct/test_selfdestruct.py
@@ -58,6 +58,7 @@ def env() -> Environment:
     """Default environment for all tests."""
     return Environment(
         coinbase="0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+        blob_gas_used=0,
     )
 
 


### PR DESCRIPTION
Currently attempting to fill tests with Cancun configuration:

```
fill tests/cancun/eip6780_selfdestruct/ --fork=Cancun --evm-bin=$(which evm)
```

Causes test filling to fail with error from the issue title.  The patch here fixes filling for state tests from selfdestruct.  However, filling of blockchain tests still fails.