### PR TITLE
feat(evm): enable tracing support for ethereum-spec-evm

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The following transition tools are supported by the framework:
 | Client | "t8n" Tool | Tracing Support |
 | -------| ---------- | --------------- |
 | [ethereum/evmone](https://github.com/ethereum/evmone) | `evmone-t8n` | Yes |
-| [ethereum/execution-specs](https://github.com/ethereum/execution-specs) | `ethereum-spec-evm` | No |
+| [ethereum/execution-specs](https://github.com/ethereum/execution-specs) | `ethereum-spec-evm` | Yes |
 | [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum) | [`evm t8n`](https://github.com/ethereum/go-ethereum/tree/master/cmd/evm) | Yes |
 | [hyperledger/besu](https://github.com/hyperledger/besu/tree/main/ethereum/evmtool) | [`evm t8n-server`](https://github.com/hyperledger/besu/tree/main/ethereum/evmtool) | No |
 | [status-im/nimbus-eth1](https://github.com/status-im/nimbus-eth1) | [`t8n`](https://github.com/status-im/nimbus-eth1/blob/master/tools/t8n/readme.md) | Yes |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,8 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 ### 🔧 Tools
 
+- ✨ Enable tracing support for `ethereum-spec-evm` ([#289](https://github.com/ethereum/execution-spec-tests/pull/289)).
+
 ### 📋 Misc
 
 - ✨ Docs: Changelog updated post release ([#321](https://github.com/ethereum/execution-spec-tests/pull/321)).

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,7 +63,7 @@ The following transition tools are supported by the framework:
 | Client | `t8n` Tool | Tracing Support |
 | -------| ---------- | --------------- |
 | [ethereum/evmone](https://github.com/ethereum/evmone) | `evmone-t8n` | Yes |
-| [ethereum/execution-specs](https://github.com/ethereum/execution-specs) | `ethereum-spec-evm` | No |
+| [ethereum/execution-specs](https://github.com/ethereum/execution-specs) | `ethereum-spec-evm` | Yes |
 | [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum) | [`evm t8n`](https://github.com/ethereum/go-ethereum/tree/master/cmd/evm) | Yes |
 | [hyperledger/besu](https://github.com/hyperledger/besu/tree/main/ethereum/evmtool) | [`evm t8n-server`](https://github.com/hyperledger/besu/tree/main/ethereum/evmtool) | No |
 | [status-im/nimbus-eth1](https://github.com/status-im/nimbus-eth1) | [`t8n`](https://github.com/status-im/nimbus-eth1/blob/master/tools/t8n/readme.md) | Yes |

--- a/src/evm_transition_tool/transition_tool.py
+++ b/src/evm_transition_tool/transition_tool.py
@@ -241,8 +241,7 @@ class TransitionTool:
         """
         traces: List[List[Dict]] = []
         for i, r in enumerate(receipts):
-            h = r["transactionHash"]
-            trace_file_name = f"trace-{i}-{h}.jsonl"
+            trace_file_name = f"trace-{i}-{r['transactionHash']}.jsonl"
             if debug_output_path:
                 shutil.copy(
                     os.path.join(temp_dir.name, trace_file_name),
@@ -296,12 +295,6 @@ class TransitionTool:
         ]
 
         if self.trace:
-            if str(self.default_binary) == "ethereum-spec-evm":
-                raise Exception(
-                    "`ethereum-spec-evm` tracing is not currently implemented in "
-                    "execution-spec-tests, see "
-                    "https://github.com/ethereum/execution-spec-tests/issues/267."
-                )
             temp_dir = tempfile.TemporaryDirectory()
             args.append("--trace")
             args.append(f"--output.basedir={temp_dir.name}")


### PR DESCRIPTION
https://github.com/ethereum/execution-specs/pull/828 implements full tracing for `ethereum-spec-evm`. This PR simply removes the exception so that tracing with the execution-specs t8n tool can be enabled within execution-spec-tests.

We should hold off merging this PR until https://github.com/ethereum/execution-specs/pull/828 is merged.
