### PR TITLE
framework: add switch-case construct for conditional bytecode evaluation

### DIFF
--- a/src/ethereum_test_tools/__init__.py
+++ b/src/ethereum_test_tools/__init__.py
@@ -3,7 +3,16 @@ Module containing tools for generating cross-client Ethereum execution layer
 tests.
 """
 
-from .code import Code, CodeGasMeasure, Conditional, Initcode, Yul, YulCompiler
+from .code import (
+    BytecodeCase,
+    Code,
+    CodeGasMeasure,
+    Conditional,
+    Initcode,
+    Switch,
+    Yul,
+    YulCompiler,
+)
 from .common import (
     AccessList,
     Account,
@@ -58,6 +67,7 @@ __all__ = (
     "Block",
     "BlockchainTest",
     "BlockchainTestFiller",
+    "BytecodeCase",
     "Code",
     "CodeGasMeasure",
     "Conditional",
@@ -78,6 +88,7 @@ __all__ = (
     "StateTest",
     "StateTestFiller",
     "Storage",
+    "Switch",
     "TestAddress",
     "TestAddress2",
     "TestPrivateKey",

--- a/src/ethereum_test_tools/__init__.py
+++ b/src/ethereum_test_tools/__init__.py
@@ -4,7 +4,8 @@ tests.
 """
 
 from .code import (
-    BytecodeCase,
+    CalldataCase,
+    Case,
     Code,
     CodeGasMeasure,
     Conditional,
@@ -67,7 +68,8 @@ __all__ = (
     "Block",
     "BlockchainTest",
     "BlockchainTestFiller",
-    "BytecodeCase",
+    "Case",
+    "CalldataCase",
     "Code",
     "CodeGasMeasure",
     "Conditional",

--- a/src/ethereum_test_tools/code/__init__.py
+++ b/src/ethereum_test_tools/code/__init__.py
@@ -2,14 +2,16 @@
 Code related utilities and classes.
 """
 from .code import Code
-from .generators import CodeGasMeasure, Conditional, Initcode
+from .generators import BytecodeCase, CodeGasMeasure, Conditional, Initcode, Switch
 from .yul import Yul, YulCompiler
 
 __all__ = (
+    "BytecodeCase",
     "Code",
     "CodeGasMeasure",
     "Conditional",
     "Initcode",
+    "Switch",
     "Yul",
     "YulCompiler",
 )

--- a/src/ethereum_test_tools/code/__init__.py
+++ b/src/ethereum_test_tools/code/__init__.py
@@ -2,11 +2,12 @@
 Code related utilities and classes.
 """
 from .code import Code
-from .generators import BytecodeCase, CodeGasMeasure, Conditional, Initcode, Switch
+from .generators import CalldataCase, Case, CodeGasMeasure, Conditional, Initcode, Switch
 from .yul import Yul, YulCompiler
 
 __all__ = (
-    "BytecodeCase",
+    "Case",
+    "CalldataCase",
     "Code",
     "CodeGasMeasure",
     "Conditional",

--- a/src/ethereum_test_tools/code/generators.py
+++ b/src/ethereum_test_tools/code/generators.py
@@ -261,7 +261,7 @@ class Switch(Code):
     """
     Helper class used to generate switch-case expressions in EVM bytecode.
 
-    Switch-cae behavior:
+    Switch-case behavior:
         - If no condition is met in the list of BytecodeCases conditions,
             the `default_action` bytecode is executed.
         - If multiple conditions are met, the action from the first valid

--- a/src/ethereum_test_tools/code/generators.py
+++ b/src/ethereum_test_tools/code/generators.py
@@ -304,27 +304,25 @@ class Switch(Code):
         # The length required to jump over the default action and its JUMP bytecode
         condition_jump_length = len(self.bytecode) + 3
 
-        # Reversed: first case in list has priority; it will become the outer-most onion layer.
-        # We build up layers around the default_action, after 1 iteration of the loop, the bytecode
-        # is laid out as:
+        # Reversed: first case in the list has priority; it will become the outer-most onion layer.
+        # We build up layers around the default_action, after 1 iteration of the loop, a simplified
+        # representation of the bytecode is:
         #
-        #  [ case[n-1].condition + JUMPI
-        #    default_action + JUMP,
-        #    JUMPDEST + case[n-1].action,
-        #    JUMPDEST]
+        #  JUMPI(case[n-1].condition)
+        #  + default_action + JUMP()
+        #  + JUMPDEST + case[n-1].action + JUMP()
         #
         # and after n=len(cases) iterations:
         #
-        #  [ case[0].condition + JUMPI
-        #    case[1].condition + JUMPI
+        #  JUMPI(case[0].condition)
+        #  + JUMPI(case[1].condition)
         #    ...
-        #    case[n-1].condition + JUMPI
-        #    default_action + JUMP,
-        #    JUMPDEST + case[n-1].action,
-        #    ...
-        #    JUMPDEST + case[1].action,
-        #    JUMPDEST + case[0].action,
-        #    JUMPDEST]
+        #  + JUMPI(case[n-1].condition)
+        #  + default_action + JUMP
+        #  + JUMPDEST + case[n-1].action + JUMP()
+        #  + ...
+        #  + JUMPDEST + case[1].action + JUMP()
+        #  + JUMPDEST + case[0].action + JUMP()
         #
         for case in reversed(self.cases):
             action_jump_length -= len(case.action) + 6

--- a/src/ethereum_test_tools/code/generators.py
+++ b/src/ethereum_test_tools/code/generators.py
@@ -301,7 +301,7 @@ class Switch(Code):
         # All conditions get pre-pended to this bytecode; if none are met, we reach the default
         self.bytecode = to_bytes(self.default_action) + Op.JUMP(Op.ADD(Op.PC, action_jump_length))
 
-        # The length required to jump over the condition and action of the next case
+        # The length required to jump over the default action and its JUMP bytecode
         condition_jump_length = len(self.bytecode) + 3
 
         # Reversed: first case in list has priority; it will become the outer-most onion layer.
@@ -326,10 +326,8 @@ class Switch(Code):
         #    JUMPDEST + case[0].action,
         #    JUMPDEST]
         #
-        for i, case in enumerate(reversed(self.cases)):
-            action_jump_length = (
-                sum(len(case.action) + 6 for case in self.cases[: len(self.cases) - i - 1]) + 3
-            )
+        for case in reversed(self.cases):
+            action_jump_length -= len(case.action) + 6
             action = Op.JUMPDEST + case.action + Op.JUMP(Op.ADD(Op.PC, action_jump_length))
             condition = Op.JUMPI(Op.ADD(Op.PC, condition_jump_length), case.condition)
             # wrap the current case around the onion as its next layer

--- a/src/ethereum_test_tools/code/generators.py
+++ b/src/ethereum_test_tools/code/generators.py
@@ -108,7 +108,7 @@ class Initcode(Code):
         if initcode_length is not None:
             assert initcode_length >= len(
                 initcode_plus_deploy_code
-            ), "specified invalid lenght for initcode"
+            ), "specified invalid length for initcode"
 
             padding_bytes = bytes(
                 [padding_byte] * (initcode_length - len(initcode_plus_deploy_code))
@@ -214,8 +214,8 @@ class Conditional(Code):
 
     def __post_init__(self):
         """
-        Assemble the conditional bytecode by generating the necessary jumps and
-        jumpdests surrounding the condition and the two possible execution
+        Assemble the conditional bytecode by generating the necessary jump and
+        jumpdest opcodes surrounding the condition and the two possible execution
         paths.
 
         In the future, PC usage should be replaced by using RJUMP and RJUMPI

--- a/src/ethereum_test_tools/tests/test_code.py
+++ b/src/ethereum_test_tools/tests/test_code.py
@@ -11,7 +11,7 @@ from semver import Version
 from ethereum_test_forks import Fork, Homestead, Shanghai, forks_from_until, get_deployed_forks
 from evm_transition_tool import GethTransitionTool
 
-from ..code import BytecodeCase, Code, Conditional, Initcode, Switch, Yul
+from ..code import CalldataCase, Case, Code, Conditional, Initcode, Switch, Yul
 from ..common import Account, Environment, TestAddress, Transaction, to_hash_bytes
 from ..filling import fill_test
 from ..spec import StateTest
@@ -321,8 +321,8 @@ def test_opcodes_if(conditional_bytecode: bytes, expected: bytes):
             to_hash_bytes(1),
             Switch(
                 cases=[
-                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 1), action=Op.SSTORE(0, 1)),
-                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 2), action=Op.SSTORE(0, 2)),
+                    Case(condition=Op.EQ(Op.CALLDATALOAD(0), 1), action=Op.SSTORE(0, 1)),
+                    Case(condition=Op.EQ(Op.CALLDATALOAD(0), 2), action=Op.SSTORE(0, 2)),
                 ],
                 default_action=b"",
             ),
@@ -330,11 +330,23 @@ def test_opcodes_if(conditional_bytecode: bytes, expected: bytes):
             id="no-default-action-condition-met",
         ),
         pytest.param(
+            to_hash_bytes(1),
+            Switch(
+                cases=[
+                    CalldataCase(value=1, action=Op.SSTORE(0, 1)),
+                    CalldataCase(value=2, action=Op.SSTORE(0, 2)),
+                ],
+                default_action=b"",
+            ),
+            {0: 1},
+            id="no-default-action-condition-met-calldata",
+        ),
+        pytest.param(
             to_hash_bytes(0),
             Switch(
                 cases=[
-                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 1), action=Op.SSTORE(0, 1)),
-                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 2), action=Op.SSTORE(0, 2)),
+                    Case(condition=Op.EQ(Op.CALLDATALOAD(0), 1), action=Op.SSTORE(0, 1)),
+                    Case(condition=Op.EQ(Op.CALLDATALOAD(0), 2), action=Op.SSTORE(0, 2)),
                 ],
                 default_action=b"",
             ),
@@ -353,9 +365,7 @@ def test_opcodes_if(conditional_bytecode: bytes, expected: bytes):
         pytest.param(
             to_hash_bytes(1),
             Switch(
-                cases=[
-                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 1), action=Op.SSTORE(0, 1))
-                ],
+                cases=[Case(condition=Op.EQ(Op.CALLDATALOAD(0), 1), action=Op.SSTORE(0, 1))],
                 default_action=Op.SSTORE(0, 3),
             ),
             {0: 1},
@@ -364,9 +374,7 @@ def test_opcodes_if(conditional_bytecode: bytes, expected: bytes):
         pytest.param(
             to_hash_bytes(0),
             Switch(
-                cases=[
-                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 1), action=Op.SSTORE(0, 1))
-                ],
+                cases=[Case(condition=Op.EQ(Op.CALLDATALOAD(0), 1), action=Op.SSTORE(0, 1))],
                 default_action=Op.SSTORE(0, 3),
             ),
             {0: 3},
@@ -376,8 +384,8 @@ def test_opcodes_if(conditional_bytecode: bytes, expected: bytes):
             to_hash_bytes(0),
             Switch(
                 cases=[
-                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 1), action=Op.SSTORE(0, 1)),
-                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 2), action=Op.SSTORE(0, 2)),
+                    Case(condition=Op.EQ(Op.CALLDATALOAD(0), 1), action=Op.SSTORE(0, 1)),
+                    Case(condition=Op.EQ(Op.CALLDATALOAD(0), 2), action=Op.SSTORE(0, 2)),
                 ],
                 default_action=Op.SSTORE(0, 3),
             ),
@@ -388,8 +396,8 @@ def test_opcodes_if(conditional_bytecode: bytes, expected: bytes):
             to_hash_bytes(1),
             Switch(
                 cases=[
-                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 1), action=Op.SSTORE(0, 1)),
-                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 2), action=Op.SSTORE(0, 2)),
+                    Case(condition=Op.EQ(Op.CALLDATALOAD(0), 1), action=Op.SSTORE(0, 1)),
+                    Case(condition=Op.EQ(Op.CALLDATALOAD(0), 2), action=Op.SSTORE(0, 2)),
                 ],
                 default_action=Op.SSTORE(0, 3),
             ),
@@ -400,8 +408,8 @@ def test_opcodes_if(conditional_bytecode: bytes, expected: bytes):
             to_hash_bytes(2),
             Switch(
                 cases=[
-                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 1), action=Op.SSTORE(0, 1)),
-                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 2), action=Op.SSTORE(0, 2)),
+                    Case(condition=Op.EQ(Op.CALLDATALOAD(0), 1), action=Op.SSTORE(0, 1)),
+                    Case(condition=Op.EQ(Op.CALLDATALOAD(0), 2), action=Op.SSTORE(0, 2)),
                 ],
                 default_action=Op.SSTORE(0, 3),
             ),
@@ -412,11 +420,11 @@ def test_opcodes_if(conditional_bytecode: bytes, expected: bytes):
             to_hash_bytes(1),
             Switch(
                 cases=[
-                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 1), action=Op.SSTORE(0, 1)),
-                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 2), action=Op.SSTORE(0, 2)),
-                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 3), action=Op.SSTORE(0, 3)),
-                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 4), action=Op.SSTORE(0, 4)),
-                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 5), action=Op.SSTORE(0, 5)),
+                    Case(condition=Op.EQ(Op.CALLDATALOAD(0), 1), action=Op.SSTORE(0, 1)),
+                    Case(condition=Op.EQ(Op.CALLDATALOAD(0), 2), action=Op.SSTORE(0, 2)),
+                    Case(condition=Op.EQ(Op.CALLDATALOAD(0), 3), action=Op.SSTORE(0, 3)),
+                    Case(condition=Op.EQ(Op.CALLDATALOAD(0), 4), action=Op.SSTORE(0, 4)),
+                    Case(condition=Op.EQ(Op.CALLDATALOAD(0), 5), action=Op.SSTORE(0, 5)),
                 ],
                 default_action=Op.SSTORE(0, 6),
             ),
@@ -424,14 +432,29 @@ def test_opcodes_if(conditional_bytecode: bytes, expected: bytes):
             id="five-cases-first-condition-met",
         ),
         pytest.param(
+            to_hash_bytes(1),
+            Switch(
+                cases=[
+                    CalldataCase(value=1, action=Op.SSTORE(0, 1)),
+                    CalldataCase(value=2, action=Op.SSTORE(0, 2)),
+                    CalldataCase(value=3, action=Op.SSTORE(0, 3)),
+                    CalldataCase(value=4, action=Op.SSTORE(0, 4)),
+                    CalldataCase(value=5, action=Op.SSTORE(0, 5)),
+                ],
+                default_action=Op.SSTORE(0, 6),
+            ),
+            {0: 1},
+            id="five-cases-first-condition-met-calldata",
+        ),
+        pytest.param(
             to_hash_bytes(3),
             Switch(
                 cases=[
-                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 1), action=Op.SSTORE(0, 1)),
-                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 2), action=Op.SSTORE(0, 2)),
-                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 3), action=Op.SSTORE(0, 3)),
-                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 4), action=Op.SSTORE(0, 4)),
-                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 5), action=Op.SSTORE(0, 5)),
+                    Case(condition=Op.EQ(Op.CALLDATALOAD(0), 1), action=Op.SSTORE(0, 1)),
+                    Case(condition=Op.EQ(Op.CALLDATALOAD(0), 2), action=Op.SSTORE(0, 2)),
+                    Case(condition=Op.EQ(Op.CALLDATALOAD(0), 3), action=Op.SSTORE(0, 3)),
+                    Case(condition=Op.EQ(Op.CALLDATALOAD(0), 4), action=Op.SSTORE(0, 4)),
+                    Case(condition=Op.EQ(Op.CALLDATALOAD(0), 5), action=Op.SSTORE(0, 5)),
                 ],
                 default_action=Op.SSTORE(0, 6),
             ),
@@ -439,14 +462,29 @@ def test_opcodes_if(conditional_bytecode: bytes, expected: bytes):
             id="five-cases-third-condition-met",
         ),
         pytest.param(
+            to_hash_bytes(3),
+            Switch(
+                cases=[
+                    CalldataCase(value=1, action=Op.SSTORE(0, 1)),
+                    CalldataCase(value=2, action=Op.SSTORE(0, 2)),
+                    CalldataCase(value=3, action=Op.SSTORE(0, 3)),
+                    CalldataCase(value=4, action=Op.SSTORE(0, 4)),
+                    CalldataCase(value=5, action=Op.SSTORE(0, 5)),
+                ],
+                default_action=Op.SSTORE(0, 6),
+            ),
+            {0: 3},
+            id="five-cases-third-condition-met-calldata",
+        ),
+        pytest.param(
             to_hash_bytes(5),
             Switch(
                 cases=[
-                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 1), action=Op.SSTORE(0, 1)),
-                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 2), action=Op.SSTORE(0, 2)),
-                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 3), action=Op.SSTORE(0, 3)),
-                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 4), action=Op.SSTORE(0, 4)),
-                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 5), action=Op.SSTORE(0, 5)),
+                    Case(condition=Op.EQ(Op.CALLDATALOAD(0), 1), action=Op.SSTORE(0, 1)),
+                    Case(condition=Op.EQ(Op.CALLDATALOAD(0), 2), action=Op.SSTORE(0, 2)),
+                    Case(condition=Op.EQ(Op.CALLDATALOAD(0), 3), action=Op.SSTORE(0, 3)),
+                    Case(condition=Op.EQ(Op.CALLDATALOAD(0), 4), action=Op.SSTORE(0, 4)),
+                    Case(condition=Op.EQ(Op.CALLDATALOAD(0), 5), action=Op.SSTORE(0, 5)),
                 ],
                 default_action=Op.SSTORE(0, 6),
             ),
@@ -457,11 +495,11 @@ def test_opcodes_if(conditional_bytecode: bytes, expected: bytes):
             to_hash_bytes(3),
             Switch(
                 cases=[
-                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 1), action=Op.SSTORE(0, 1)),
-                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 2), action=Op.SSTORE(0, 2)),
-                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 3), action=Op.SSTORE(0, 3)),
-                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 3), action=Op.SSTORE(0, 4)),
-                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 3), action=Op.SSTORE(0, 5)),
+                    Case(condition=Op.EQ(Op.CALLDATALOAD(0), 1), action=Op.SSTORE(0, 1)),
+                    Case(condition=Op.EQ(Op.CALLDATALOAD(0), 2), action=Op.SSTORE(0, 2)),
+                    Case(condition=Op.EQ(Op.CALLDATALOAD(0), 3), action=Op.SSTORE(0, 3)),
+                    Case(condition=Op.EQ(Op.CALLDATALOAD(0), 3), action=Op.SSTORE(0, 4)),
+                    Case(condition=Op.EQ(Op.CALLDATALOAD(0), 3), action=Op.SSTORE(0, 5)),
                 ],
                 default_action=Op.SSTORE(0, 6),
             ),
@@ -472,11 +510,11 @@ def test_opcodes_if(conditional_bytecode: bytes, expected: bytes):
             to_hash_bytes(9),
             Switch(
                 cases=[
-                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 1), action=Op.SSTORE(0, 1)),
-                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 2), action=Op.SSTORE(0, 2)),
-                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 3), action=Op.SSTORE(0, 3)),
-                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 4), action=Op.SSTORE(0, 4)),
-                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 5), action=Op.SSTORE(0, 5)),
+                    Case(condition=Op.EQ(Op.CALLDATALOAD(0), 1), action=Op.SSTORE(0, 1)),
+                    Case(condition=Op.EQ(Op.CALLDATALOAD(0), 2), action=Op.SSTORE(0, 2)),
+                    Case(condition=Op.EQ(Op.CALLDATALOAD(0), 3), action=Op.SSTORE(0, 3)),
+                    Case(condition=Op.EQ(Op.CALLDATALOAD(0), 4), action=Op.SSTORE(0, 4)),
+                    Case(condition=Op.EQ(Op.CALLDATALOAD(0), 5), action=Op.SSTORE(0, 5)),
                 ],
                 default_action=Op.SSTORE(0, 6),
             ),
@@ -487,11 +525,11 @@ def test_opcodes_if(conditional_bytecode: bytes, expected: bytes):
             to_hash_bytes(0),
             Switch(
                 cases=[
-                    BytecodeCase(condition=Op.EQ(1, 2), action=Op.SSTORE(0, 1)),
-                    BytecodeCase(condition=Op.EQ(1, 2), action=Op.SSTORE(0, 1)),
-                    BytecodeCase(condition=Op.EQ(1, 2), action=Op.SSTORE(0, 1)),
-                    BytecodeCase(condition=Op.EQ(1, 1), action=Op.SSTORE(0, 2)),
-                    BytecodeCase(condition=Op.EQ(1, 2), action=Op.SSTORE(0, 1)),
+                    Case(condition=Op.EQ(1, 2), action=Op.SSTORE(0, 1)),
+                    Case(condition=Op.EQ(1, 2), action=Op.SSTORE(0, 1)),
+                    Case(condition=Op.EQ(1, 2), action=Op.SSTORE(0, 1)),
+                    Case(condition=Op.EQ(1, 1), action=Op.SSTORE(0, 2)),
+                    Case(condition=Op.EQ(1, 2), action=Op.SSTORE(0, 1)),
                 ],
                 default_action=b"",
             ),
@@ -502,14 +540,14 @@ def test_opcodes_if(conditional_bytecode: bytes, expected: bytes):
             to_hash_bytes(0),
             Switch(
                 cases=[
-                    BytecodeCase(condition=Op.EQ(1, 2), action=Op.SSTORE(0, 1)),
-                    BytecodeCase(condition=Op.EQ(1, 2), action=Op.SSTORE(0, 1)),
-                    BytecodeCase(
+                    Case(condition=Op.EQ(1, 2), action=Op.SSTORE(0, 1)),
+                    Case(condition=Op.EQ(1, 2), action=Op.SSTORE(0, 1)),
+                    Case(
                         condition=Op.EQ(1, 2),
                         action=Op.SSTORE(0, 1) + Op.SSTORE(1, 1) + Op.SSTORE(2, 1),
                     ),
-                    BytecodeCase(condition=Op.EQ(1, 1), action=Op.SSTORE(0, 2) + Op.SSTORE(1, 2)),
-                    BytecodeCase(condition=Op.EQ(1, 2), action=Op.SSTORE(0, 1)),
+                    Case(condition=Op.EQ(1, 1), action=Op.SSTORE(0, 2) + Op.SSTORE(1, 2)),
+                    Case(condition=Op.EQ(1, 2), action=Op.SSTORE(0, 1)),
                 ],
                 default_action=b"",
             ),
@@ -520,23 +558,23 @@ def test_opcodes_if(conditional_bytecode: bytes, expected: bytes):
             to_hash_bytes(0),
             Switch(
                 cases=[
-                    BytecodeCase(
+                    Case(
                         condition=Op.EQ(1, 2),
                         action=Op.SSTORE(0, 1),
                     ),
-                    BytecodeCase(
+                    Case(
                         condition=Op.EQ(Op.CALLDATALOAD(0), 1),
                         action=Op.SSTORE(0, 1),
                     ),
-                    BytecodeCase(
+                    Case(
                         condition=Op.EQ(1, 2),
                         action=Op.SSTORE(0, 1) + Op.SSTORE(1, 1) + Op.SSTORE(2, 1),
                     ),
-                    BytecodeCase(
+                    Case(
                         condition=Op.EQ(1, 1),
                         action=Op.SSTORE(0, 2) + Op.SSTORE(1, 2),
                     ),
-                    BytecodeCase(
+                    Case(
                         condition=Op.EQ(Op.CALLDATALOAD(0), 1),
                         action=Op.SSTORE(0, 1),
                     ),
@@ -551,23 +589,23 @@ def test_opcodes_if(conditional_bytecode: bytes, expected: bytes):
             Op.SSTORE(0x10, 1)
             + Switch(
                 cases=[
-                    BytecodeCase(
+                    Case(
                         condition=Op.EQ(1, 2),
                         action=Op.SSTORE(0, 1),
                     ),
-                    BytecodeCase(
+                    Case(
                         condition=Op.EQ(Op.CALLDATALOAD(0), 1),
                         action=Op.SSTORE(0, 1),
                     ),
-                    BytecodeCase(
+                    Case(
                         condition=Op.EQ(1, 2),
                         action=Op.SSTORE(0, 1) + Op.SSTORE(1, 1) + Op.SSTORE(2, 1),
                     ),
-                    BytecodeCase(
+                    Case(
                         condition=Op.EQ(1, 1),
                         action=Op.SSTORE(0, 2) + Op.SSTORE(1, 2),
                     ),
-                    BytecodeCase(
+                    Case(
                         condition=Op.EQ(Op.CALLDATALOAD(0), 1),
                         action=Op.SSTORE(0, 1),
                     ),
@@ -581,9 +619,7 @@ def test_opcodes_if(conditional_bytecode: bytes, expected: bytes):
         pytest.param(
             to_hash_bytes(1),
             Switch(
-                cases=[
-                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 1), action=Op.SSTORE(0, 1))
-                ],
+                cases=[Case(condition=Op.EQ(Op.CALLDATALOAD(0), 1), action=Op.SSTORE(0, 1))],
                 default_action=Op.PUSH32(2**256 - 1) * 8,
             ),
             {0: 1},
@@ -592,9 +628,7 @@ def test_opcodes_if(conditional_bytecode: bytes, expected: bytes):
         pytest.param(
             to_hash_bytes(1),
             Switch(
-                cases=[
-                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 1), action=Op.SSTORE(0, 1))
-                ],
+                cases=[Case(condition=Op.EQ(Op.CALLDATALOAD(0), 1), action=Op.SSTORE(0, 1))],
                 default_action=Op.PUSH32(2**256 - 1) * 2048,
             ),
             {0: 1},

--- a/src/ethereum_test_tools/tests/test_code.py
+++ b/src/ethereum_test_tools/tests/test_code.py
@@ -578,6 +578,28 @@ def test_opcodes_if(conditional_bytecode: bytes, expected: bytes):
             {0: 2, 1: 2, 0x10: 1, 0x11: 1},
             id="nested-within-bytecode",
         ),
+        pytest.param(
+            to_hash_bytes(1),
+            Switch(
+                cases=[
+                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 1), action=Op.SSTORE(0, 1))
+                ],
+                default_action=Op.PUSH32(2**256 - 1) * 8,
+            ),
+            {0: 1},
+            id="jumpi-larger-than-1-byte",
+        ),
+        pytest.param(
+            to_hash_bytes(1),
+            Switch(
+                cases=[
+                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 1), action=Op.SSTORE(0, 1))
+                ],
+                default_action=Op.PUSH32(2**256 - 1) * 2048,
+            ),
+            {0: 1},
+            id="jumpi-larger-than-4-bytes",
+        ),
     ],
 )
 def test_switch(tx_data: bytes, switch_bytecode: bytes, expected_storage: Mapping):

--- a/src/ethereum_test_tools/tests/test_code.py
+++ b/src/ethereum_test_tools/tests/test_code.py
@@ -3,14 +3,18 @@ Test suite for `ethereum_test.code` module.
 """
 
 from string import Template
-from typing import SupportsBytes
+from typing import Mapping, SupportsBytes
 
 import pytest
 from semver import Version
 
 from ethereum_test_forks import Fork, Homestead, Shanghai, forks_from_until, get_deployed_forks
+from evm_transition_tool import GethTransitionTool
 
-from ..code import Code, Conditional, Initcode, Yul
+from ..code import BytecodeCase, Code, Conditional, Initcode, Switch, Yul
+from ..common import Account, Environment, TestAddress, Transaction, to_hash_bytes
+from ..filling import fill_test
+from ..spec import StateTest
 from ..vm.opcode import Opcodes as Op
 from .conftest import SOLC_PADDING_VERSION
 
@@ -308,3 +312,152 @@ def test_opcodes_if(conditional_bytecode: bytes, expected: bytes):
     Test that the if opcode macro is transformed into bytecode as expected.
     """
     assert bytes(conditional_bytecode) == expected
+
+
+@pytest.mark.parametrize(
+    "tx_data,switch_bytecode,expected_storage",
+    [
+        pytest.param(
+            to_hash_bytes(1),
+            Switch(
+                cases=[
+                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 1), action=Op.SSTORE(0, 1)),
+                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 2), action=Op.SSTORE(0, 2)),
+                ],
+                default_action=b"",
+            ),
+            {0: 1},
+            id="no-default-action-condition-met",
+        ),
+        pytest.param(
+            to_hash_bytes(0),
+            Switch(
+                cases=[
+                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 1), action=Op.SSTORE(0, 1)),
+                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 2), action=Op.SSTORE(0, 2)),
+                ],
+                default_action=b"",
+            ),
+            {0: 0},
+            id="no-default-action-no-condition-met",
+        ),
+        pytest.param(
+            to_hash_bytes(1),
+            Switch(
+                cases=[],
+                default_action=Op.SSTORE(0, 3),
+            ),
+            {0: 3},
+            id="no-cases",
+        ),
+        pytest.param(
+            to_hash_bytes(1),
+            Switch(
+                cases=[
+                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 1), action=Op.SSTORE(0, 1)),
+                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 2), action=Op.SSTORE(0, 2)),
+                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 3), action=Op.SSTORE(0, 3)),
+                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 4), action=Op.SSTORE(0, 4)),
+                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 5), action=Op.SSTORE(0, 5)),
+                ],
+                default_action=Op.SSTORE(0, 6),
+            ),
+            {0: 1},
+            id="five-cases-first-condition-met",
+        ),
+        pytest.param(
+            to_hash_bytes(3),
+            Switch(
+                cases=[
+                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 1), action=Op.SSTORE(0, 1)),
+                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 2), action=Op.SSTORE(0, 2)),
+                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 3), action=Op.SSTORE(0, 3)),
+                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 4), action=Op.SSTORE(0, 4)),
+                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 5), action=Op.SSTORE(0, 5)),
+                ],
+                default_action=Op.SSTORE(0, 6),
+            ),
+            {0: 3},
+            id="five-cases-third-condition-met",
+        ),
+        pytest.param(
+            to_hash_bytes(5),
+            Switch(
+                cases=[
+                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 1), action=Op.SSTORE(0, 1)),
+                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 2), action=Op.SSTORE(0, 2)),
+                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 3), action=Op.SSTORE(0, 3)),
+                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 4), action=Op.SSTORE(0, 4)),
+                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 5), action=Op.SSTORE(0, 5)),
+                ],
+                default_action=Op.SSTORE(0, 6),
+            ),
+            {0: 5},
+            id="five-cases-last-met",
+        ),
+        pytest.param(
+            to_hash_bytes(3),
+            Switch(
+                cases=[
+                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 1), action=Op.SSTORE(0, 1)),
+                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 2), action=Op.SSTORE(0, 2)),
+                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 3), action=Op.SSTORE(0, 3)),
+                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 3), action=Op.SSTORE(0, 4)),
+                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 3), action=Op.SSTORE(0, 5)),
+                ],
+                default_action=Op.SSTORE(0, 6),
+            ),
+            {0: 3},
+            id="five-cases-multiple-conditions-met",  # first in list should be evaluated
+        ),
+        pytest.param(
+            to_hash_bytes(9),
+            Switch(
+                cases=[
+                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 1), action=Op.SSTORE(0, 1)),
+                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 2), action=Op.SSTORE(0, 2)),
+                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 3), action=Op.SSTORE(0, 3)),
+                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 4), action=Op.SSTORE(0, 4)),
+                    BytecodeCase(condition=Op.EQ(Op.CALLDATALOAD(0), 5), action=Op.SSTORE(0, 5)),
+                ],
+                default_action=Op.SSTORE(0, 6),
+            ),
+            {0: 6},
+            id="five-cases-no-condition-met",
+        ),
+        pytest.param(
+            to_hash_bytes(0),
+            Switch(
+                cases=[
+                    BytecodeCase(condition=Op.EQ(1, 2), action=Op.SSTORE(0, 1)),
+                    BytecodeCase(condition=Op.EQ(1, 2), action=Op.SSTORE(0, 1)),
+                    BytecodeCase(condition=Op.EQ(1, 2), action=Op.SSTORE(0, 1)),
+                    BytecodeCase(condition=Op.EQ(1, 1), action=Op.SSTORE(0, 2)),
+                    BytecodeCase(condition=Op.EQ(1, 2), action=Op.SSTORE(0, 1)),
+                ],
+                default_action=b"",
+            ),
+            {0: 2},
+            id="no-calldataload-condition-met",
+        ),
+    ],
+)
+def test_switch(tx_data: bytes, switch_bytecode: bytes, expected_storage: Mapping):
+    """
+    Test that the switch opcode macro gets executed as using the t8n tool.
+    """
+    code_address = 0x100
+    pre = {
+        TestAddress: Account(balance=10_000_000, nonce=0),
+        code_address: Account(code=switch_bytecode),
+    }
+    txs = [Transaction(to=code_address, data=tx_data, gas_limit=1_000_000)]
+    post = {TestAddress: Account(nonce=1), code_address: Account(storage=expected_storage)}
+    state_test = StateTest(env=Environment(), pre=pre, txs=txs, post=post)
+    fill_test(
+        t8n=GethTransitionTool(),
+        test_spec=state_test,
+        fork=Shanghai,
+        engine="NoProof",
+        spec=None,
+    )

--- a/tests/cancun/eip1153_tstore/test_tstorage_reentrancy_contexts.py
+++ b/tests/cancun/eip1153_tstore/test_tstorage_reentrancy_contexts.py
@@ -8,7 +8,7 @@ from enum import EnumMeta, unique
 
 import pytest
 
-from ethereum_test_tools import Account, BytecodeCase, Conditional, Environment
+from ethereum_test_tools import Account, CalldataCase, Conditional, Environment
 from ethereum_test_tools import Opcodes as Op
 from ethereum_test_tools import StateTestFiller, Switch, TestAddress, Transaction, to_hash_bytes
 
@@ -139,8 +139,8 @@ class DynamicReentrancyTestCases(EnumMeta):
                     ),
                     cases=[
                         # the first, reentrant call, which reverts/receives invalid
-                        BytecodeCase(
-                            condition=Op.EQ(Op.CALLDATALOAD(0), 2),
+                        CalldataCase(
+                            value=2,
                             action=(
                                 Op.MSTORE(0, 3)
                                 + Op.MSTORE(0, Op.CALL(Op.GAS(), callee_address, 0, 0, 32, 0, 0))
@@ -148,9 +148,7 @@ class DynamicReentrancyTestCases(EnumMeta):
                             ),
                         ),
                         # the second, reentrant call, which returns successfully
-                        BytecodeCase(
-                            condition=Op.EQ(Op.CALLDATALOAD(0), 3), action=Op.TSTORE(0xFF, 0x101)
-                        ),
+                        CalldataCase(value=3, action=Op.TSTORE(0xFF, 0x101)),
                     ],
                 ),
                 "expected_storage": {0: 0x00, 1: 0x01, 2: 0x100, 3: 0x100},

--- a/tests/cancun/eip1153_tstore/test_tstorage_reentrancy_contexts.py
+++ b/tests/cancun/eip1153_tstore/test_tstorage_reentrancy_contexts.py
@@ -8,9 +8,9 @@ from enum import EnumMeta, unique
 
 import pytest
 
-from ethereum_test_tools import Account, Conditional, Environment
+from ethereum_test_tools import Account, BytecodeCase, Conditional, Environment
 from ethereum_test_tools import Opcodes as Op
-from ethereum_test_tools import StateTestFiller, TestAddress, Transaction, to_hash_bytes
+from ethereum_test_tools import StateTestFiller, Switch, TestAddress, Transaction, to_hash_bytes
 
 from . import PytestParameterEnum
 from .spec import ref_spec_1153
@@ -128,10 +128,8 @@ class DynamicReentrancyTestCases(EnumMeta):
                     "",
                     "Based on [ethereum/tests/.../10_revertUndoesStoreAfterReturnFiller.yml](https://github.com/ethereum/tests/blob/9b00b68593f5869eb51a6659e1cc983e875e616b/src/EIPTestsFiller/StateTests/stEIP1153-transientStorage/10_revertUndoesStoreAfterReturnFiller.yml).",  # noqa: E501
                 ),
-                "bytecode": Conditional(
-                    condition=SETUP_CONDITION,
-                    # setup
-                    if_true=(
+                "bytecode": Switch(
+                    default_action=(  # setup; make first reentrant sub-call
                         Op.TSTORE(0xFF, 0x100)
                         + Op.SSTORE(2, Op.TLOAD(0xFF))
                         + Op.MSTORE(0, 2)
@@ -139,17 +137,21 @@ class DynamicReentrancyTestCases(EnumMeta):
                         + Op.SSTORE(1, Op.MLOAD(0))  # should be 1 (successful call)
                         + Op.SSTORE(3, Op.TLOAD(0xFF))
                     ),
-                    # first, reentrant call, which reverts/receives invalid
-                    if_false=Conditional(
-                        condition=Op.EQ(Op.CALLDATALOAD(0), 0x02),
-                        if_true=(
-                            Op.MSTORE(0, 3)
-                            + Op.MSTORE(0, Op.CALL(Op.GAS(), callee_address, 0, 0, 32, 0, 0))
-                            + opcode_call
+                    cases=[
+                        # the first, reentrant call, which reverts/receives invalid
+                        BytecodeCase(
+                            condition=Op.EQ(Op.CALLDATALOAD(0), 2),
+                            action=(
+                                Op.MSTORE(0, 3)
+                                + Op.MSTORE(0, Op.CALL(Op.GAS(), callee_address, 0, 0, 32, 0, 0))
+                                + opcode_call
+                            ),
                         ),
-                        # second, successful reentrant call
-                        if_false=Op.TSTORE(0xFF, 0x101),
-                    ),
+                        # the second, reentrant call, which returns successfully
+                        BytecodeCase(
+                            condition=Op.EQ(Op.CALLDATALOAD(0), 3), action=Op.TSTORE(0xFF, 0x101)
+                        ),
+                    ],
                 ),
                 "expected_storage": {0: 0x00, 1: 0x01, 2: 0x100, 3: 0x100},
             }


### PR DESCRIPTION
Adds a `Switch` bytecode class that implements switch case behaviour. It should help make the transient storage reentrancy tests more readable; see the refactored test case in 0045bf80ec446ceaf14ff12f41edfbf9d91a8f56 which performs two reentrant calls. It might be clearer to use `Switch` instead of `Conditional` in the other reentrancy test cases, too.

Example from test code:
https://github.com/ethereum/execution-spec-tests/blob/253eb361ac786cadb85b0658bd880b6d6769babd/src/ethereum_test_tools/tests/test_code.py#L318-L331
