### PR TITLE
tests/4844: Add EIP-7516, BLOBBASEFEE, verification to excess blob gas tests

### DIFF
--- a/src/ethereum_test_tools/vm/opcode.py
+++ b/src/ethereum_test_tools/vm/opcode.py
@@ -249,6 +249,7 @@ class Opcodes(Opcode, Enum):
     SELFBALANCE = Opcode(0x47, pushed_stack_items=1)
     BASEFEE = Opcode(0x48, pushed_stack_items=1)
     BLOBHASH = Opcode(0x49, popped_stack_items=1, pushed_stack_items=1)
+    BLOBBASEFEE = Opcode(0x4A, popped_stack_items=0, pushed_stack_items=1)
 
     POP = Opcode(0x50, popped_stack_items=1)
     MLOAD = Opcode(0x51, popped_stack_items=1, pushed_stack_items=1)

--- a/tests/cancun/eip4844_blobs/test_excess_blob_gas.py
+++ b/tests/cancun/eip4844_blobs/test_excess_blob_gas.py
@@ -27,13 +27,9 @@ from typing import Dict, Iterator, List, Mapping, Optional, Tuple
 
 import pytest
 
+from ethereum_test_tools import Account, Block, BlockchainTestFiller, Environment, Header
 from ethereum_test_tools import Opcodes as Op
 from ethereum_test_tools import (
-    Account,
-    Block,
-    BlockchainTestFiller,
-    Environment,
-    Header,
     TestAddress,
     TestAddress2,
     Transaction,
@@ -162,9 +158,9 @@ def tx_gas_limit() -> int:  # noqa: D103
 
 
 @pytest.fixture
-def tx_exact_cost(
+def tx_exact_cost(  # noqa: D103
     tx_value: int, tx_max_fee_per_gas: int, tx_data_cost: int, tx_gas_limit: int
-) -> int:  # noqa: D103
+) -> int:
     return (tx_gas_limit * tx_max_fee_per_gas) + tx_value + tx_data_cost
 
 
@@ -180,9 +176,9 @@ def destination_account() -> str:  # noqa: D103
 
 
 @pytest.fixture
-def pre(
+def pre(  # noqa: D103
     destination_account: str, destination_account_bytecode: bytes, tx_exact_cost: int
-) -> Mapping[str, Account]:  # noqa: D103
+) -> Mapping[str, Account]:
     return {
         TestAddress: Account(balance=tx_exact_cost),
         TestAddress2: Account(balance=10**40),
@@ -191,9 +187,9 @@ def pre(
 
 
 @pytest.fixture
-def post(
+def post(  # noqa: D103
     destination_account: str, tx_value: int, block_fee_per_blob_gas: int
-) -> Mapping[str, Account]:  # noqa: D103
+) -> Mapping[str, Account]:
     return {
         destination_account: Account(
             storage={0: block_fee_per_blob_gas},

--- a/tests/cancun/eip7516_blobgasfee/__init__.py
+++ b/tests/cancun/eip7516_blobgasfee/__init__.py
@@ -1,0 +1,3 @@
+"""
+Tests for EIP-7516: BLOBBASEFEE opcode
+"""

--- a/tests/cancun/eip7516_blobgasfee/test_blobgasfee_opcode.py
+++ b/tests/cancun/eip7516_blobgasfee/test_blobgasfee_opcode.py
@@ -1,0 +1,194 @@
+"""
+abstract: Tests [EIP-7516: BLOBBASEFEE opcode](https://eips.ethereum.org/EIPS/eip-7516)
+
+    Test BLOBGASFEE opcode [EIP-7516: BLOBBASEFEE opcode](https://eips.ethereum.org/EIPS/eip-7516)
+
+"""  # noqa: E501
+from itertools import count
+from typing import Dict
+
+import pytest
+
+from ethereum_test_tools import Account, Block, BlockchainTestFiller, Environment
+from ethereum_test_tools import Opcodes as Op
+from ethereum_test_tools import StateTestFiller, Storage, TestAddress, Transaction
+
+REFERENCE_SPEC_GIT_PATH = "EIPS/eip-7516.md"
+REFERENCE_SPEC_VERSION = "2ade0452efe8124378f35284676ddfd16dd56ecd"
+
+# Code address used to call the test bytecode on every test case.
+code_caller_address = 0x100
+code_callee_address = 0x200
+
+BLOBBASEFEE_GAS = 2
+
+
+@pytest.fixture
+def call_gas() -> int:
+    """
+    Amount of gas to use when calling the callee code.
+    """
+    return 0xFFFF
+
+
+@pytest.fixture
+def caller_code(
+    call_gas: int,
+) -> bytes:
+    """
+    Bytecode used to call the bytecode containing the BLOBBASEFEE opcode.
+    """
+    return Op.SSTORE(Op.NUMBER, Op.CALL(call_gas, Op.PUSH20(code_callee_address), 0, 0, 0, 0, 0))
+
+
+@pytest.fixture
+def callee_code() -> bytes:
+    """
+    Bytecode under test, by default, only call the BLOBBASEFEE opcode.
+    """
+    return bytes(Op.BLOBBASEFEE + Op.STOP)
+
+
+@pytest.fixture
+def pre(
+    caller_code: bytes,
+    callee_code: bytes,
+) -> Dict:
+    """
+    Prepares the pre state of all test cases, by setting the balance of the
+    source account of all test transactions, and the required code.
+    """
+    return {
+        TestAddress: Account(balance=10**40),
+        code_caller_address: Account(
+            balance=0,
+            code=caller_code,
+        ),
+        code_callee_address: Account(
+            balance=0,
+            code=callee_code,
+        ),
+    }
+
+
+@pytest.fixture
+def tx() -> Transaction:
+    """
+    Prepares the test transaction, by setting the destination account, the
+    transaction value, the transaction gas limit, and the transaction data.
+    """
+    return Transaction(
+        gas_price=1_000_000_000,
+        gas_limit=1_000_000,
+        to=code_caller_address,
+        value=0,
+        data=b"",
+    )
+
+
+@pytest.mark.parametrize(
+    "callee_code,call_fails",
+    [
+        pytest.param(Op.BLOBBASEFEE * 1024, False, id="no_stack_overflow"),
+        pytest.param(Op.BLOBBASEFEE * 1025, True, id="stack_overflow"),
+    ],
+)
+@pytest.mark.valid_from("Cancun")
+def test_blobbasefee_stack_overflow(
+    state_test: StateTestFiller,
+    pre: Dict,
+    tx: Transaction,
+    call_fails: bool,
+):
+    """
+    Tests that the BLOBBASEFEE opcode produces an stack overflow by using it repatedly.
+    """
+    post = {
+        code_caller_address: Account(
+            storage={1: 0 if call_fails else 1},
+        ),
+        code_callee_address: Account(
+            balance=0,
+        ),
+    }
+    state_test(
+        env=Environment(),
+        pre=pre,
+        txs=[tx],
+        post=post,
+    )
+
+
+@pytest.mark.parametrize(
+    "call_gas,call_fails",
+    [
+        pytest.param(BLOBBASEFEE_GAS, False, id="enough_gas"),
+        pytest.param(BLOBBASEFEE_GAS - 1, True, id="out_of_gas"),
+    ],
+)
+@pytest.mark.valid_from("Cancun")
+def test_blobbasefee_out_of_gas(
+    state_test: StateTestFiller,
+    pre: Dict,
+    tx: Transaction,
+    call_fails: bool,
+):
+    """
+    Tests that the BLOBBASEFEE opcode produces an stack overflow by using it repatedly.
+    """
+    post = {
+        code_caller_address: Account(
+            storage={1: 0 if call_fails else 1},
+        ),
+        code_callee_address: Account(
+            balance=0,
+        ),
+    }
+    state_test(
+        env=Environment(),
+        pre=pre,
+        txs=[tx],
+        post=post,
+    )
+
+
+@pytest.mark.valid_at_transition_to("Cancun")
+def test_blobbasefee_before_fork(
+    blockchain_test: BlockchainTestFiller,
+    pre: Dict,
+    tx: Transaction,
+):
+    """
+    Tests that the BLOBBASEFEE opcode results on exception when called before the fork.
+    """
+    code_caller_storage = Storage()
+
+    nonce = count(0)
+
+    timestamps = [7_500, 14_999, 15_000]
+
+    blocks = []
+
+    for number, timestamp in enumerate(timestamps):
+        blocks.append(
+            Block(
+                txs=[tx.with_nonce(next(nonce))],
+                timestamp=timestamp,
+            ),
+        )
+        code_caller_storage[number + 1] = 0 if timestamp < 15_000 else 1
+
+    post = {
+        code_caller_address: Account(
+            storage=code_caller_storage,
+        ),
+        code_callee_address: Account(
+            balance=0,
+        ),
+    }
+    blockchain_test(
+        genesis_environment=Environment(),
+        pre=pre,
+        blocks=blocks,
+        post=post,
+    )

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -479,6 +479,7 @@ selfdestruct
 selfdestructing
 sendall
 blobhash
+blobbasefee
 mcopy
 precompile
 precompiles


### PR DESCRIPTION
Simple addition to the 4844 tests to verify EIP-7516 alongside it.

~~Since this is not approved for Devnet-9 we should hold-off merging.~~

eip-7516 links:
- [eips.ethereum.org/EIPS/eip-7516](https://eips.ethereum.org/EIPS/eip-7516)
- [ethereum-magicians.org](https://ethereum-magicians.org/t/eip-7516-blobbasefee-opcode/15761) 

t8n tool version: https://github.com/marioevz/go-ethereum/commit/f4ea54d5bef1e9a0516bbcc64dfd3559d4e9139a