### PR TITLE
improvement: Deprecate empty accounts within framework.

### DIFF
--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -676,6 +676,7 @@ class Account:
                     want=expected_code,
                     got=actual_code,
                 )
+
         if self.storage is not None:
             expected_storage = (
                 self.storage if isinstance(self.storage, Storage) else Storage(self.storage)
@@ -688,10 +689,10 @@ class Account:
         Returns true if an account deemed empty.
         """
         return (
-            (self.nonce == 0 or self.nonce is None) and
-            (self.balance == 0 or self.balance is None) and
-            (not self.code and self.code is None) and
-            (not self.storage or self.storage == {} or self.storage is None)
+            (self.nonce == 0 or self.nonce is None)
+            and (self.balance == 0 or self.balance is None)
+            and (not self.code and self.code is None)
+            and (not self.storage or self.storage == {} or self.storage is None)
         )
 
     @classmethod

--- a/tests/cancun/eip4788_beacon_root/conftest.py
+++ b/tests/cancun/eip4788_beacon_root/conftest.py
@@ -198,7 +198,7 @@ def pre(
     }
     if system_address_balance > 0:
         pre_alloc[to_address(SYSTEM_ADDRESS)] = Account(
-            nonce=1,
+            nonce=0,
             balance=system_address_balance,
         )
     return pre_alloc

--- a/tests/cancun/eip4788_beacon_root/conftest.py
+++ b/tests/cancun/eip4788_beacon_root/conftest.py
@@ -189,17 +189,19 @@ def pre(
     Prepares the pre state of all test cases, by setting the balance of the
     source account of all test transactions, and the contract caller account.
     """
-    return {
+    pre_alloc = {
         TestAddress: Account(
             nonce=0,
             balance=0x10**10,
         ),
         caller_address: contract_call_account,
-        SYSTEM_ADDRESS: Account(
-            nonce=0,
-            balance=system_address_balance,
-        ),
     }
+    if system_address_balance > 0:
+        pre_alloc[to_address(SYSTEM_ADDRESS)] = Account(
+            nonce=1,
+            balance=system_address_balance,
+        )
+    return pre_alloc
 
 
 @pytest.fixture

--- a/tests/cancun/eip4788_beacon_root/test_blocks_beacon_root_contract.py
+++ b/tests/cancun/eip4788_beacon_root/test_blocks_beacon_root_contract.py
@@ -104,7 +104,6 @@ def test_multi_block_beacon_root_timestamp_calls(
     tx: Transaction,
     call_gas: int,
     call_value: int,
-    system_address_balance: int,
 ):
     """
     Tests multiple blocks where each block writes a timestamp to storage and contains one
@@ -124,10 +123,6 @@ def test_multi_block_beacon_root_timestamp_calls(
         TestAddress: Account(
             nonce=0,
             balance=0x10**10,
-        ),
-        SYSTEM_ADDRESS: Account(
-            nonce=0,
-            balance=system_address_balance,
         ),
     }
     post = {}
@@ -235,7 +230,6 @@ def test_beacon_root_transition(
     tx: Transaction,
     call_gas: int,
     call_value: int,
-    system_address_balance: int,
     fork: Fork,
 ):
     """
@@ -247,10 +241,6 @@ def test_beacon_root_transition(
         TestAddress: Account(
             nonce=0,
             balance=0x10**10,
-        ),
-        SYSTEM_ADDRESS: Account(
-            nonce=0,
-            balance=system_address_balance,
         ),
     }
     post = {}

--- a/tests/shanghai/eip4895_withdrawals/test_withdrawals.py
+++ b/tests/shanghai/eip4895_withdrawals/test_withdrawals.py
@@ -109,7 +109,7 @@ class TestUseValueInTx:
         if test_case == "tx_in_withdrawals_block":
             return {}
         if test_case == "tx_after_withdrawals_block":
-            return {TestAddress: Account(balance=ONE_GWEI)}
+            return {TestAddress: Account(balance=ONE_GWEI + 1)}
         raise Exception("Invalid test case.")
 
     def test_use_value_in_tx(
@@ -121,7 +121,7 @@ class TestUseValueInTx:
         """
         Test sending withdrawal value in a transaction.
         """
-        pre = {TestAddress: Account(balance=0)}
+        pre = {TestAddress: Account(balance=1)}
         blockchain_test(pre=pre, post=post, blocks=blocks)
 
 
@@ -137,7 +137,7 @@ def test_use_value_in_contract(blockchain_test: BlockchainTestFiller):
     pre = {
         TestAddress: Account(balance=1000000000000000000000, nonce=0),
         to_address(0x100): Account(balance=0, code=SEND_ONE_GWEI),
-        to_address(0x200): Account(balance=0),
+        to_address(0x200): Account(balance=1),
     }
     tx = Transaction(
         # Transaction sent from the `TestAddress`, which has 0 balance at start
@@ -172,7 +172,7 @@ def test_use_value_in_contract(blockchain_test: BlockchainTestFiller):
             }
         ),
         to_address(0x200): Account(
-            balance=ONE_GWEI,
+            balance=ONE_GWEI + 1,
         ),
     }
 
@@ -384,7 +384,7 @@ def test_self_destructing_account(blockchain_test: BlockchainTestFiller):
             balance=(100 * ONE_GWEI),
         ),
         to_address(0x200): Account(
-            balance=0,
+            balance=1,
         ),
     }
 
@@ -417,7 +417,7 @@ def test_self_destructing_account(blockchain_test: BlockchainTestFiller):
         ),
         to_address(0x200): Account(
             code=None,
-            balance=(100 * ONE_GWEI),
+            balance=(100 * ONE_GWEI) + 1,
         ),
     }
 


### PR DESCRIPTION
Following the future improvement to deprecate empty accounts -> [here](https://notes.ethereum.org/@RG8j1GXNQ-iPkkFqXEouVA/By-ep0ry6), an assertion check has been added to detect empty accounts within the pre and post allocation within tests.

Note that an empty account is one which has zero nonce, code, balance and an empty storage:
``` 
"0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
                "nonce": "0x00",
                "balance": "0x00",
                "code": "0x",
                "storage": {}
            }
 ```
 
The beacon root tests have been updated to account for the latter (due to the inclusion of the system address), alongside a few withdrawals tests.
