### PR TITLE
feature: Run development fork tests on github actions

### DIFF
--- a/.github/actions/build-evm/action.yaml
+++ b/.github/actions/build-evm/action.yaml
@@ -1,0 +1,37 @@
+name: 'Build EVM'
+description: 'Resolves and builds the requested EVM binary by name'
+inputs:
+  type:
+    description: 'Type of EVM binary to build'
+    required: true
+    default: 'main'
+outputs:
+  impl:
+    description: "Implementation of EVM binary to build"
+    value: ${{ steps.evm-config-reader.outputs.impl }}
+  repo:
+    description: "Repository to use to build the EVM binary"
+    value: ${{ steps.evm-config-reader.outputs.repo }}
+  ref:
+    description: "Reference to branch, commit, or tag to use to build the EVM binary"
+    value: ${{ steps.evm-config-reader.outputs.ref }}
+runs:
+  using: "composite"
+  steps:
+    - name: Get the selected EVM version from the evm-config.yaml
+      id: evm-config-reader
+      uses: christian-ci/action-yaml-github-output@v2
+      with: 
+        file_path: ./evm-config.yaml
+        main_key: ${{ inputs.type }}
+    - name: Print Variables for the selected EVM type
+      run: |
+        echo "Implementation: ${{ steps.evm-config-reader.outputs.impl }}"
+        echo "Repository: ${{ steps.evm-config-reader.outputs.repo }}"
+        echo "Reference: ${{ steps.evm-config-reader.outputs.ref }}"
+    - name: Build the EVM using Geth action
+      if: steps.evm-config-reader.outputs.impl == 'geth'
+      uses: "./.github/actions/build-geth-evm"
+      with:
+        repo: ${{ steps.evm-config-reader.outputs.repo }}
+        ref: ${{ steps.evm-config-reader.outputs.ref }}

--- a/.github/actions/build-evm/action.yaml
+++ b/.github/actions/build-evm/action.yaml
@@ -20,10 +20,10 @@ runs:
   steps:
     - name: Get the selected EVM version from the evm-config.yaml
       id: evm-config-reader
-      uses: christian-ci/action-yaml-github-output@v2
-      with: 
-        file_path: ./evm-config.yaml
-        main_key: ${{ inputs.type }}
+      shell: bash
+      run: |
+        awk "/^${{ inputs.type }}:/{flag=1; next} /^[[:alnum:]]/{flag=0} flag" ./evm-config.yaml \
+        | sed 's/ //g' | sed 's/:/=/g' >> "$GITHUB_OUTPUT"
     - name: Print Variables for the selected EVM type
       shell: bash
       run: |

--- a/.github/actions/build-evm/action.yaml
+++ b/.github/actions/build-evm/action.yaml
@@ -25,13 +25,14 @@ runs:
         file_path: ./evm-config.yaml
         main_key: ${{ inputs.type }}
     - name: Print Variables for the selected EVM type
+      shell: bash
       run: |
         echo "Implementation: ${{ steps.evm-config-reader.outputs.impl }}"
         echo "Repository: ${{ steps.evm-config-reader.outputs.repo }}"
         echo "Reference: ${{ steps.evm-config-reader.outputs.ref }}"
     - name: Build the EVM using Geth action
       if: steps.evm-config-reader.outputs.impl == 'geth'
-      uses: "./.github/actions/build-geth-evm"
+      uses: ./.github/actions/build-geth-evm
       with:
         repo: ${{ steps.evm-config-reader.outputs.repo }}
         ref: ${{ steps.evm-config-reader.outputs.ref }}

--- a/.github/actions/build-geth-evm/action.yaml
+++ b/.github/actions/build-geth-evm/action.yaml
@@ -1,0 +1,35 @@
+name: 'Build Go-Ethereum EVM'
+description: 'Builds the Go-Ethereum EVM binary'
+inputs:
+  repo:
+    description: 'Source repository to use to build the EVM binary'
+    required: true
+    default: 'ethereum/go-ethereum'
+  ref:
+    description: 'Reference to branch, commit, or tag to use to build the EVM binary'
+    required: true
+    default: 'master'
+  golang:
+    description: 'Golang version to use to build Geth'
+    required: false
+    default: '1.20.5'
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout go-ethereum
+      uses: actions/checkout@v3
+      with:
+        repository: ${{ inputs.repo }}
+        ref: ${{ inputs.ref }}
+        path: go-ethereum
+    - name: Setup golang
+      uses: actions/setup-go@v4
+      with:
+        go-version: ${{ inputs.golang }}
+        cache-dependency-path: go-ethereum/go.sum
+    - name: Build evm cmd
+      run: |
+        mkdir -p $GITHUB_WORKSPACE/bin
+        cd $GITHUB_WORKSPACE/go-ethereum/cmd/evm
+        go build .
+        echo $GITHUB_WORKSPACE/go-ethereum/cmd/evm >> $GITHUB_PATH

--- a/.github/actions/build-geth-evm/action.yaml
+++ b/.github/actions/build-geth-evm/action.yaml
@@ -28,6 +28,7 @@ runs:
         go-version: ${{ inputs.golang }}
         cache-dependency-path: go-ethereum/go.sum
     - name: Build evm cmd
+      shell: bash
       run: |
         mkdir -p $GITHUB_WORKSPACE/bin
         cd $GITHUB_WORKSPACE/go-ethereum/cmd/evm

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,36 +10,32 @@ jobs:
         include:
           - os: ubuntu-latest
             python: '3.10'
-            golang: '1.20.5'
             solc: '0.8.20'
+            evm-type: 'main'
+            tox-cmd: 'tox'
           - os: ubuntu-latest
             python: '3.11'
-            golang: '1.20.5'
             solc: '0.8.21'
+            evm-type: 'main'
+            tox-cmd: 'tox'
+          - os: ubuntu-latest
+            python: '3.11'
+            solc: '0.8.21'
+            evm-type: 'develop'
+            tox-cmd: 'tox -e tests-develop'
           - os: macos-latest
             python: '3.11'
-            golang: '1.20.5'
             solc: '0.8.21'
+            evm-type: 'main'
+            tox-cmd: 'tox'
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Checkout go-ethereum
-        uses: actions/checkout@v3
+      - uses: ./.github/actions/build-evm
+        id: evm-builder
         with:
-          repository: ethereum/go-ethereum
-          path: go-ethereum
-      - name: Setup golang
-        uses: actions/setup-go@v4
-        with:
-          go-version: ${{ matrix.golang }}
-          cache-dependency-path: go-ethereum/go.sum
-      - name: Build evm cmd
-        run: |
-          mkdir -p $GITHUB_WORKSPACE/bin
-          cd $GITHUB_WORKSPACE/go-ethereum/cmd/evm
-          go build .
-          echo $GITHUB_WORKSPACE/go-ethereum/cmd/evm >> $GITHUB_PATH
+          type: ${{ matrix.evm-type }}
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
@@ -54,7 +50,7 @@ jobs:
       - name: Setup Tools/Dependencies Ubuntu
         if: runner.os == 'Linux'
         run: |
-          sudo apt-get install aspell aspell-en
+          sudo apt-get update && sudo apt-get install -y aspell aspell-en
       - name: Setup Tools/Dependencies macOS
         if: runner.os == 'macOS'
         run: |
@@ -64,7 +60,7 @@ jobs:
       - name: Install Tox and any other packages
         run: pip install tox
       - name: Run Tox (CPython)
-        run: tox
+        run: ${{ matrix.tox-cmd }}
       - uses: DavidAnson/markdownlint-cli2-action@v11
         with:
           globs: |

--- a/evm-config.yaml
+++ b/evm-config.yaml
@@ -1,0 +1,8 @@
+main:
+  impl: geth
+  repo: ethereum/go-ethereum
+  ref: master
+develop:
+  impl: geth
+  repo: marioevz/go-ethereum
+  ref: cancun-t8n

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,9 @@ env_list =
     tests
     docs
 
+[main]
+development_fork = Cancun
+
 [testenv:framework]
 description = Run checks on helper libraries and test framework
 
@@ -28,9 +31,7 @@ extras = {[testenv:framework]extras}
 allowlist_externals = {[testenv:framework]allowlist_externals}
 commands = {[testenv:framework]commands}
 
-[testenv:tests]
-description = Run checks on the test cases in tests/
-
+[testenv:tests-base]
 extras =
     test
     lint
@@ -41,7 +42,25 @@ commands =
     black tests --check --diff
     flake8 tests
     mypy tests
+
+[testenv:tests]
+description = Run checks on the test cases in tests/
+
+extras =
+    {[testenv:tests-base]extras}
+
+commands =
+    {[testenv:tests-base]commands}
     pytest -n auto
+
+[testenv:tests-develop]
+description = Run checks on the test cases in tests/, including tests for development forks
+
+extras =
+    {[testenv:tests-base]extras}
+
+commands =
+    pytest -n auto --until={[main]development_fork}
 
 [testenv:docs]
 description = Run documentation checks

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ commands =
     mypy tests
 
 [testenv:tests]
-description = Run checks on the test cases in tests/
+description = Execute test cases in tests/
 
 extras =
     {[testenv:tests-base]extras}
@@ -54,7 +54,7 @@ commands =
     pytest -n auto
 
 [testenv:tests-develop]
-description = Run checks on the test cases in tests/, including tests for development forks
+description = Execute test cases in tests/, including tests for development forks
 
 extras =
     {[testenv:tests-base]extras}


### PR DESCRIPTION
Adds a `evm-config.yaml` file which contains a list of possible build configurations for geth's evm binary.

- Main: Runs stable forks using ethereum/go-ethereum@master
- Develop: Runs development forks using marioevz/go-ethereum@cancun-t8n