### PR TITLE
tests/cancun/eip_4844: Fix invalid blob tx pre cancun tests.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 ### 📋 Misc
 
+- 🐞 Tests: Fix invalid blob txs pre-Cancun engine response ([#306](https://github.com/ethereum/execution-spec-tests/pull/306)).
 - ✨ Docs: Changelog added ([#305](https://github.com/ethereum/execution-spec-tests/pull/305)).
 - ✨ CI/CD: Run development fork tests in Github Actions ([#302](https://github.com/ethereum/execution-spec-tests/pull/302)).
 - ✨ CI/CD: Generate test JSON fixtures on push ([#301](https://github.com/ethereum/execution-spec-tests/pull/303)).

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,13 +8,14 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 ### 🧪 Test Cases
 
+- 🐞 Tests: Fix invalid blob txs pre-Cancun engine response ([#306](https://github.com/ethereum/execution-spec-tests/pull/306)).
+
 ### 🛠️ Framework
 
 ### 🔧 EVM Tools
 
 ### 📋 Misc
 
-- 🐞 Tests: Fix invalid blob txs pre-Cancun engine response ([#306](https://github.com/ethereum/execution-spec-tests/pull/306)).
 - ✨ Docs: Changelog added ([#305](https://github.com/ethereum/execution-spec-tests/pull/305)).
 - ✨ CI/CD: Run development fork tests in Github Actions ([#302](https://github.com/ethereum/execution-spec-tests/pull/302)).
 - ✨ CI/CD: Generate test JSON fixtures on push ([#301](https://github.com/ethereum/execution-spec-tests/pull/303)).

--- a/tests/cancun/eip4844_blobs/test_blob_txs.py
+++ b/tests/cancun/eip4844_blobs/test_blob_txs.py
@@ -1007,11 +1007,10 @@ def test_blob_tx_attribute_gasprice_opcode(
         "parent_excess_blobs",
         "tx_max_fee_per_blob_gas",
         "tx_error",
-        "engine_api_error_code",
     ],
     [
-        ([0], None, 1, "tx type 3 not allowed pre-Cancun", EngineAPIError.InvalidParams),
-        ([1], None, 1, "tx type 3 not allowed pre-Cancun", EngineAPIError.InvalidParams),
+        ([0], None, 1, "tx type 3 not allowed pre-Cancun"),
+        ([1], None, 1, "tx type 3 not allowed pre-Cancun"),
     ],
     ids=["no_blob_tx", "one_blob_tx"],
 )
@@ -1025,7 +1024,7 @@ def test_blob_type_tx_pre_fork(
     Reject blocks with blob type transactions before Cancun fork.
 
     Blocks sent by NewPayloadV2 (Shanghai) that contain blob type transactions, furthermore blobs
-    field within NewPayloadV2 method must be rejected with the `-32602: Invalid params` error.
+    field within NewPayloadV2 method must be computed as INVALID, due to an invalid block hash.
     """
     blockchain_test(
         pre=pre,


### PR DESCRIPTION
`engine_newPayloadV2` should return `INVALID` for the case where blob txs (type 3 txs) exist in the txs rlp.
 