### PR TITLE
chore: add python 3.12 support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
             evm-type: 'main'
             tox-cmd: 'tox'
           - os: ubuntu-latest
-            python: '3.11'
+            python: '3.12'
             solc: '0.8.21'
             evm-type: 'main'
             tox-cmd: 'tox'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,6 +40,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
+          allow-prereleases: true
       - name: Install solc compiler
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then PLATFORM="linux-amd64"; else PLATFORM="macosx-amd64"; fi

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Generally, specific `t8n` implementations and branches must be used when develop
 
 ### Prerequisites
 
-The following requires a Python 3.10 or Python 3.11 installation.
+The following requires a Python 3.10, 3.11 or 3.12 installation.
 
 ### Quick Start
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 ### 📋 Misc
 
 - ✨ Docs: Changelog updated post release ([#321](https://github.com/ethereum/execution-spec-tests/pull/321)).
+- ✨ Tooling: Add Python 3.12 support ([#309](https://github.com/ethereum/execution-spec-tests/pull/309)).
 
 ## [v1.0.5](https://github.com/ethereum/execution-spec-tests/releases/tag/v1.0.5) - 2023-09-26: 🐍🏖️ Cancun Devnet 9 Release 3
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,18 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 **Key:** ✨ = New, 🐞 = Fixed, 🔀 = Changed, 💥 = Breaking change.
 
+## 🔜 [Unreleased - v1.0.6](https://github.com/ethereum/execution-spec-tests/releases/tag/v1.0.6) - 2023-xx-xx
+
+### 🧪 Test Cases
+
+### 🛠️ Framework
+
+### 🔧 Tools
+
+### 📋 Misc
+
+- ✨ Docs: Changelog updated post release ([#321](https://github.com/ethereum/execution-spec-tests/pull/321)).
+
 ## [v1.0.5](https://github.com/ethereum/execution-spec-tests/releases/tag/v1.0.5) - 2023-09-26: 🐍🏖️ Cancun Devnet 9 Release 3
 
 This release mainly serves to update the EIP-4788 beacon roots address to `0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02`, as updated in [ethereum/EIPs/pull/7672](https://github.com/ethereum/EIPs/pull/7672).
@@ -18,6 +30,17 @@ This release mainly serves to update the EIP-4788 beacon roots address to `0x000
 - ✨ Docs: Changelog added ([#305](https://github.com/ethereum/execution-spec-tests/pull/305)).
 - ✨ CI/CD: Run development fork tests in Github Actions ([#302](https://github.com/ethereum/execution-spec-tests/pull/302)).
 - ✨ CI/CD: Generate test JSON fixtures on push ([#303](https://github.com/ethereum/execution-spec-tests/pull/303)).
+
+---
+
+### 💥 Breaking Change
+
+Please use development fixtures from now on when testing Cancun. These refer to changes that are currently under development within clients:
+
+- fixtures: All tests until the last stable fork (Shanghai)
+- fixtures_develop: All tests until the last development fork (Cancun)
+- fixtures_hive: All tests until the last stable fork (Shanghai) in hive format (Engine API directives instead of the usual BlockchainTest format)
+- fixtures_develop_hive: All tests until the last development fork (Cancun) in hive format
 
 ## [v1.0.4](https://github.com/ethereum/execution-spec-tests/releases/tag/v1.0.4) - 2023-09-21: 🐍 Cancun Devnet 9 Release 2
 

--- a/docs/getting_started/quick_start.md
+++ b/docs/getting_started/quick_start.md
@@ -5,7 +5,7 @@
 
     To test features under active development, start with this base configuration and then follow the steps in [executing tests for features under development](./executing_tests_dev_fork.md). 
 
-The following requires a Python 3.10 or Python 3.11 installation.
+The following requires a Python 3.10, 3.11 or 3.12 installation.
 
 1. Ensure `go-ethereum`'s `evm` tool and `solc` ([0.8.20](https://github.com/ethereum/solidity/releases/tag/v0.8.20) or [0.8.21](https://github.com/ethereum/solidity/releases/tag/v0.8.21)) are in your path. Either build the required versions, or alternatively:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -87,14 +87,15 @@ docs =
 dictionaries=en_US,python,technical
 docstring-convention = google
 extend-ignore = E203, D107, D200, D203, D205,
-    D212, D400, D401, D410, D411, D412, D413,
-    D414, D415, D416, N806 
+    D212, E231, D400, D401, D410, D411, D412,
+    D413, D414, D415, D416, N806
     # Ignore E203: Whitespace before ':'
     # Ignore D107: Missing docstring in __init__
     # Ignore D200: One-line docstring should fit on one line with quotes
     # Ignore D203: 1 blank line required before class docstring
     # Ignore D205: blank line required between summary line and description
     # Ignore D212: Multi-line docstring summary should start at the first line
+    # Ignore E231: Missing whitespace after ':'
     # Ignore D400: First line should end with a period
     # Ignore D401: First line should be in imperative mood
     # Ignore D410: Missing blank line after section

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,8 +24,8 @@ python_requires = >=3.10
 
 install_requires =
     ethereum@git+https://github.com/ethereum/execution-specs.git
-    setuptools==58.3.0
-    types-setuptools==57.4.4
+    setuptools
+    types-setuptools
     requests>=2.31.0
     colorlog>=6.7.0
     pytest==7.3.2
@@ -80,7 +80,7 @@ docs =
     mkdocs-material-extensions>=1.1.1,<2
     mkdocstrings>=0.21.2,<1
     mkdocstrings-python>=1.0.0,<2
-    pillow>=9.5.0,<10  # required for social plugin (material)
+    pillow>=10.0.1,<11  # required for social plugin (material)
     pyspelling>=2.8.2,<3
 
 [flake8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,7 @@ lint =
     black==22.3.0; implementation_name == "cpython"
     flake8-spellcheck>=0.24,<0.25
     flake8-docstrings>=1.6,<2
-    flake8>=5,<=6
+    flake8>=6.1.0,<7
     pep8-naming==0.13.3
     fname8>=0.0.3
 

--- a/src/ethereum_test_tools/common/conversions.py
+++ b/src/ethereum_test_tools/common/conversions.py
@@ -15,7 +15,7 @@ def int_or_none(input: Any, default: Optional[int] = None) -> int | None:
     """
     if input is None:
         return default
-    if type(input) == int:
+    if isinstance(input, int):
         return input
     return int(input, 0)
 
@@ -26,7 +26,7 @@ def str_or_none(input: Any, default: Optional[str] = None) -> str | None:
     """
     if input is None:
         return default
-    if type(input) == str:
+    if isinstance(input, str):
         return input
     return str(input)
 

--- a/src/evm_transition_tool/besu.py
+++ b/src/evm_transition_tool/besu.py
@@ -127,7 +127,7 @@ class BesuTransitionTool(TransitionTool):
                 PORT=${{1:-3000}}
                 curl http://localhost:${{PORT}}/ -X POST -H "Content-Type: application/json" \\
                 --data '{indented_post_data_string}'
-                """
+                """  # noqa: E221
             )
             dump_files_to_directory(
                 debug_output_path,

--- a/tests/cancun/eip4844_blobs/common.py
+++ b/tests/cancun/eip4844_blobs/common.py
@@ -156,7 +156,7 @@ class BlobhashContext:
                     sstore(end, blobhash)
                     return(0, 0)
                 }}
-                """
+                """  # noqa: E272, E201, E202
             ),
             "blobhash_return": cls.yul_compiler(
                 f"""
@@ -167,7 +167,7 @@ class BlobhashContext:
                     mstore(0, blobhash)
                     return(0, 32)
                 }}
-                """
+                """  # noqa: E272, E201, E202
             ),
             "call": cls.yul_compiler(
                 """
@@ -175,7 +175,7 @@ class BlobhashContext:
                     calldatacopy(0, 0, calldatasize())
                     pop(call(gas(), 0x100, 0, 0, calldatasize(), 0, 0))
                 }
-                """
+                """  # noqa: E272, E201, E202
             ),
             "delegatecall": cls.yul_compiler(
                 """
@@ -183,7 +183,7 @@ class BlobhashContext:
                     calldatacopy(0, 0, calldatasize())
                     pop(delegatecall(gas(), 0x100, 0, calldatasize(), 0, 0))
                 }
-                """
+                """  # noqa: E272, E201, E202
             ),
             "callcode": cls.yul_compiler(
                 f"""
@@ -206,7 +206,7 @@ class BlobhashContext:
                     sstore(end, blobhash)
                     return(0, 0)
                 }}
-                """
+                """  # noqa: E272, E201, E202
             ),
             "staticcall": cls.yul_compiler(
                 f"""
@@ -229,7 +229,7 @@ class BlobhashContext:
                     sstore(end, blobhash)
                     return(0, 0)
                 }}
-                """
+                """  # noqa: E272, E201, E202
             ),
             "create": cls.yul_compiler(
                 """
@@ -237,7 +237,7 @@ class BlobhashContext:
                     calldatacopy(0, 0, calldatasize())
                     pop(create(0, 0, calldatasize()))
                 }
-                """
+                """  # noqa: E272, E201, E202
             ),
             "create2": cls.yul_compiler(
                 """
@@ -245,7 +245,7 @@ class BlobhashContext:
                     calldatacopy(0, 0, calldatasize())
                     pop(create2(0, 0, calldatasize(), 0))
                 }
-                """
+                """  # noqa: E272, E201, E202
             ),
             "initcode": cls.yul_compiler(
                 f"""
@@ -258,7 +258,7 @@ class BlobhashContext:
                     }}
                     return(0, 0)
                 }}
-                """
+                """  # noqa: E272, E201, E202
             ),
         }
         code = code.get(context_name)

--- a/tests/cancun/eip4844_blobs/test_excess_blob_gas.py
+++ b/tests/cancun/eip4844_blobs/test_excess_blob_gas.py
@@ -475,7 +475,7 @@ def test_invalid_blob_gas_used_in_header(
         genesis_environment=env,
         tag="-".join(
             [
-                f"correct:{hex(new_blobs *Spec.GAS_PER_BLOB)}",
+                f"correct:{hex(new_blobs * Spec.GAS_PER_BLOB)}",
                 f"header:{hex(header_blob_gas_used)}",
             ]
         ),

--- a/tests/cancun/eip6780_selfdestruct/test_selfdestruct.py
+++ b/tests/cancun/eip6780_selfdestruct/test_selfdestruct.py
@@ -91,7 +91,7 @@ def selfdestruct_code_preset(
                     sstore(0, 0)
                 }}
             }}
-            """
+            """  # noqa: E272, E201, E202, E221
         )
     else:
         # Hard-code the single only possible recipient address
@@ -107,7 +107,7 @@ def selfdestruct_code_preset(
                 selfdestruct({sendall_recipient_addresses[0]})
                 sstore(0, 0)
             }}
-            """
+            """  # noqa: E272, E201, E202, E221
         )
 
 

--- a/tests/cancun/eip6780_selfdestruct/test_selfdestruct_revert.py
+++ b/tests/cancun/eip6780_selfdestruct/test_selfdestruct_revert.py
@@ -124,7 +124,7 @@ def recursive_revert_contract_code(
                 stop()
             }}
         }}
-        """  # noqa: E501
+        """  # noqa: E272, E201, E202, E221, E501
     )
 
 
@@ -162,7 +162,7 @@ def selfdestruct_with_transfer_contract_code(
                 stop()
             }}
         }}
-        """
+        """  # noqa: E272, E201, E202, E221
     )
 
 


### PR DESCRIPTION
## 🗒️ Description
- Adds Python 3.12 support.
- 3.12 tested (currently pre-release) in Github Actions.
- Upgrades flake8.

Tested with 3.12.0rc3 built via pyenv.

The same version of flake8 (6.0.0) produced more warnings on Python 3.12 vs 3.10/3.11 (so these are fixed). But, since our flake8 version requirement in setup.cfg didn't make any sense (`flake8>=5,<=6`, note the `<=6`), I bumped this version to ensure we use patches/improvements in v6. Practically as of now, it means we'll use 6.1.0 instead of 6.0.0.

## ✅ Checklist
- [x] All: Added an entry to [CHANGELOG.md](../docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](../docs/) directory.
- [x] All: Considered squashing commits to improve commit history.