### PR TITLE
move evmone evaluate into t8n base class (stdin and filesystem versions of t8n interaction)

### DIFF
--- a/src/evm_transition_tool/evmone.py
+++ b/src/evm_transition_tool/evmone.py
@@ -1,27 +1,13 @@
 """
 Evmone Transition tool interface.
 """
-import json
-import os
-import shutil
-import subprocess
-import tempfile
-import textwrap
 from pathlib import Path
 from re import compile
 from typing import Any, Dict, List, Optional, Tuple
 
 from ethereum_test_forks import Fork
 
-from .transition_tool import TransitionTool, dump_files_to_directory
-
-
-def write_json_file(data: Dict[str, Any], file_path: str) -> None:
-    """
-    Write a JSON file to the given path.
-    """
-    with open(file_path, "w") as f:
-        json.dump(data, f, ensure_ascii=False, indent=4)
+from .transition_tool import TransitionTool
 
 
 class EvmOneTransitionTool(TransitionTool):
@@ -31,6 +17,7 @@ class EvmOneTransitionTool(TransitionTool):
 
     default_binary = Path("evmone-t8n")
     detect_binary_pattern = compile(r"^evmone-t8n\b")
+    t8n_use_stream = False
 
     binary: Path
     cached_version: Optional[str] = None
@@ -43,132 +30,6 @@ class EvmOneTransitionTool(TransitionTool):
         trace: bool = False,
     ):
         super().__init__(binary=binary, trace=trace)
-
-    def evaluate(
-        self,
-        *,
-        alloc: Any,
-        txs: Any,
-        env: Any,
-        fork_name: str,
-        chain_id: int = 1,
-        reward: int = 0,
-        eips: Optional[List[int]] = None,
-        debug_output_path: str = "",
-    ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
-        """
-        Executes `evmone-t8n` with the specified arguments.
-        """
-        if eips is not None:
-            fork_name = "+".join([fork_name] + [str(eip) for eip in eips])
-
-        temp_dir = tempfile.TemporaryDirectory()
-        os.mkdir(os.path.join(temp_dir.name, "input"))
-        os.mkdir(os.path.join(temp_dir.name, "output"))
-
-        input_contents = {
-            "alloc": alloc,
-            "env": env,
-            "txs": txs,
-        }
-
-        input_paths = {
-            k: os.path.join(temp_dir.name, "input", f"{k}.json") for k in input_contents.keys()
-        }
-        for key, file_path in input_paths.items():
-            write_json_file(input_contents[key], file_path)
-
-        output_paths = {
-            output: os.path.join("output", f"{output}.json") for output in ["alloc", "result"]
-        }
-        output_paths["body"] = os.path.join("output", "txs.rlp")
-
-        # Construct args for evmone-t8n binary
-        args = [
-            str(self.binary),
-            "--state.fork",
-            fork_name,
-            "--input.alloc",
-            input_paths["alloc"],
-            "--input.env",
-            input_paths["env"],
-            "--input.txs",
-            input_paths["txs"],
-            "--output.basedir",
-            temp_dir.name,
-            "--output.result",
-            output_paths["result"],
-            "--output.alloc",
-            output_paths["alloc"],
-            "--output.body",
-            output_paths["body"],
-            "--state.reward",
-            str(reward),
-            "--state.chainid",
-            str(chain_id),
-        ]
-
-        if self.trace:
-            args.append("--trace")
-
-        result = subprocess.run(
-            args,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-
-        if debug_output_path:
-            if os.path.exists(debug_output_path):
-                shutil.rmtree(debug_output_path)
-            shutil.copytree(temp_dir.name, debug_output_path)
-            t8n_output_base_dir = os.path.join(debug_output_path, "t8n.sh.out")
-            t8n_call = " ".join(args)
-            for file_path in input_paths.values():  # update input paths
-                t8n_call = t8n_call.replace(
-                    os.path.dirname(file_path), os.path.join(debug_output_path, "input")
-                )
-            t8n_call = t8n_call.replace(  # use a new output path for basedir and outputs
-                temp_dir.name,
-                t8n_output_base_dir,
-            )
-            t8n_script = textwrap.dedent(
-                f"""\
-                #!/bin/bash
-                rm -rf {debug_output_path}/t8n.sh.out  # hard-coded to avoid surprises
-                mkdir -p {debug_output_path}/t8n.sh.out/output
-                {t8n_call}
-                """
-            )
-            dump_files_to_directory(
-                debug_output_path,
-                {
-                    "args.py": args,
-                    "returncode.txt": result.returncode,
-                    "stdout.txt": result.stdout.decode(),
-                    "stderr.txt": result.stderr.decode(),
-                    "t8n.sh+x": t8n_script,
-                },
-            )
-
-        if result.returncode != 0:
-            raise Exception("failed to evaluate: " + result.stderr.decode())
-
-        for key, file_path in output_paths.items():
-            output_paths[key] = os.path.join(temp_dir.name, file_path)
-
-        output_contents = {}
-        for key, file_path in output_paths.items():
-            if "txs.rlp" in file_path:
-                continue
-            with open(file_path, "r+") as file:
-                output_contents[key] = json.load(file)
-
-        if self.trace:
-            self.collect_traces(output_contents["result"]["receipts"], temp_dir, debug_output_path)
-
-        temp_dir.cleanup()
-
-        return output_contents["alloc"], output_contents["result"]
 
     def is_fork_supported(self, fork: Fork) -> bool:
         """

--- a/src/evm_transition_tool/evmone.py
+++ b/src/evm_transition_tool/evmone.py
@@ -3,7 +3,7 @@ Evmone Transition tool interface.
 """
 from pathlib import Path
 from re import compile
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Optional
 
 from ethereum_test_forks import Fork
 

--- a/src/evm_transition_tool/transition_tool.py
+++ b/src/evm_transition_tool/transition_tool.py
@@ -162,10 +162,12 @@ class TransitionTool:
         cls.default_tool = tool_subclass
 
     @classmethod
-    def get_default_tool(cls) -> "TransitionTool":
+    def get_default_tool(cls) -> Type["TransitionTool"]:
         """
         Returns default transition tool
         """
+        if cls.default_tool is None:
+            raise Exception("The default transition tool was never set.")
         return cls.default_tool
 
     @classmethod

--- a/src/evm_transition_tool/transition_tool.py
+++ b/src/evm_transition_tool/transition_tool.py
@@ -301,7 +301,7 @@ class TransitionTool:
                 traces.append(tx_traces)
         self.append_traces(traces)
 
-    def _evaluateFilesystem(
+    def _evaluate_filesystem(
         self,
         *,
         alloc: Any,
@@ -427,7 +427,7 @@ class TransitionTool:
 
         return output_contents["alloc"], output_contents["result"]
 
-    def _evaluateStream(
+    def _evaluate_stream(
         self,
         *,
         alloc: Any,
@@ -551,7 +551,7 @@ class TransitionTool:
         should be overridden.
         """
         if self.t8n_use_stream:
-            return self._evaluateStream(
+            return self._evaluate_stream(
                 alloc=alloc,
                 txs=txs,
                 env=env,
@@ -562,7 +562,7 @@ class TransitionTool:
                 debug_output_path=debug_output_path,
             )
         else:
-            return self._evaluateFilesystem(
+            return self._evaluate_filesystem(
                 alloc=alloc,
                 txs=txs,
                 env=env,

--- a/src/evm_transition_tool/transition_tool.py
+++ b/src/evm_transition_tool/transition_tool.py
@@ -306,7 +306,7 @@ class TransitionTool:
         debug_output_path: str = "",
     ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
         """
-        Executes `evmone-t8n` with the specified arguments.
+        Executes a transition tool using the filesystem for its inputs and outputs.
         """
         if eips is not None:
             fork_name = "+".join([fork_name] + [str(eip) for eip in eips])
@@ -431,6 +431,9 @@ class TransitionTool:
         eips: Optional[List[int]] = None,
         debug_output_path: str = "",
     ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        """
+        Executes a transition tool using stdin and stdout for its inputs and outputs.
+        """
         if eips is not None:
             fork_name = "+".join([fork_name] + [str(eip) for eip in eips])
 
@@ -537,10 +540,10 @@ class TransitionTool:
         debug_output_path: str = "",
     ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
         """
-        Executes `evm t8n` with the specified arguments.
+        Executes the relevant evaluate method as required by the `t8n` tool.
 
         If a client's `t8n` tool varies from the default behavior, this method
-        should be overridden.
+        can be overridden.
         """
         if self.t8n_use_stream:
             return self._evaluate_stream(

--- a/src/evm_transition_tool/transition_tool.py
+++ b/src/evm_transition_tool/transition_tool.py
@@ -162,15 +162,6 @@ class TransitionTool:
         cls.default_tool = tool_subclass
 
     @classmethod
-    def get_default_tool(cls) -> Type["TransitionTool"]:
-        """
-        Returns default transition tool
-        """
-        if cls.default_tool is None:
-            raise Exception("The default transition tool was never set.")
-        return cls.default_tool
-
-    @classmethod
     def from_binary_path(cls, *, binary_path: Optional[Path], **kwargs) -> "TransitionTool":
         """
         Instantiates the appropriate TransitionTool subclass derived from the
@@ -216,9 +207,8 @@ class TransitionTool:
             for subclass in subclasses:
                 if subclass.detect_binary(binary_output):
                     return subclass(binary=binary, **kwargs)
-        default = cls.get_default_tool()(binary=binary, **kwargs)
-        default.t8n_use_stream = False
-        return default
+
+        raise UnknownTransitionTool(f"Unknown transition tool binary: {binary_path}")
 
     @classmethod
     def detect_binary(cls, binary_output: str) -> bool:

--- a/src/evm_transition_tool/transition_tool.py
+++ b/src/evm_transition_tool/transition_tool.py
@@ -153,6 +153,13 @@ class TransitionTool:
         cls.default_tool = tool_subclass
 
     @classmethod
+    def get_default_tool(cls) -> "TransitionTool":
+        """
+        Returns default transition tool
+        """
+        return cls.default_tool
+
+    @classmethod
     def from_binary_path(cls, *, binary_path: Optional[Path], **kwargs) -> "TransitionTool":
         """
         Instantiates the appropriate TransitionTool subclass derived from the
@@ -198,8 +205,7 @@ class TransitionTool:
             for subclass in subclasses:
                 if subclass.detect_binary(binary_output):
                     return subclass(binary=binary, **kwargs)
-
-        raise UnknownTransitionTool(f"Unknown transition tool binary: {binary_path}")
+        return cls.get_default_tool()(binary=binary, **kwargs)
 
     @classmethod
     def detect_binary(cls, binary_output: str) -> bool:

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -88,6 +88,7 @@ executables
 extcodecopy
 extcodehash
 extcodesize
+filesystem
 fn
 fname
 forkchoice


### PR DESCRIPTION
- Moves the `evaluate()` method from the evmone interface (which receives its input and outputs from the filesytem instead of stdin/stdout) to the base class so that it can be re-used by other transition tools.
- Adds a new attribute `t8n_use_stream` to the base class with a default value of `False`, so that other `t8n` tools still use stdin/stdout.
