### PR TITLE
feat(tests): add a test to check that a contract creating blob tx is invalid

### DIFF
--- a/tests/cancun/eip4844_blobs/test_blob_txs.py
+++ b/tests/cancun/eip4844_blobs/test_blob_txs.py
@@ -29,6 +29,7 @@ from ethereum_test_tools import (
     EngineAPIError,
     Environment,
     Header,
+    Initcode,
 )
 from ethereum_test_tools import Opcodes as Op
 from ethereum_test_tools import (
@@ -1031,4 +1032,26 @@ def test_blob_type_tx_pre_fork(
         post={},
         blocks=blocks,
         genesis_environment=Environment(),  # `env` fixture has blob fields
+    )
+
+
+@pytest.mark.valid_from("Cancun")
+@pytest.mark.parametrize("destination_account", [None], ids=[""])
+@pytest.mark.parametrize("tx_calldata", [Initcode(deploy_code=Op.SSTORE(0, 1))], ids=[""])
+@pytest.mark.parametrize("tx_gas", [100_000], ids=[""])
+@pytest.mark.parametrize("tx_error", ["contract creation not possible in blob tx"], ids=[""])
+def test_contract_creating_blob_type_tx(
+    blockchain_test: BlockchainTestFiller,
+    pre: Dict,
+    env: Environment,
+    blocks: List[Block],
+):
+    """
+    Test that a type 3 transaction that creates a contract is rejected.
+    """
+    blockchain_test(
+        pre=pre,
+        post={},
+        blocks=blocks,
+        genesis_environment=env,
     )


### PR DESCRIPTION
## 🗒️ Description
Adds a test that a type 3 transaction that sets the tx `to` field to `nil` is invalid.

t8n tool: https://github.com/marioevz/go-ethereum/pull/4/commits/86b482b7d7d68d33a9277d5a031690f64a72aa93

## 🔗 Related Issues
N/A

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](../docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](../docs/) directory.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.