### PR TITLE
chore: fix broken changelog link and tasklist in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,9 +7,7 @@
 ## ✅ Checklist
 - [ ] All: Set appropriate labels for the changes.
 - [ ] All: Considered squashing commits to improve commit history.
-
-
-- [ ] All: Added an entry to [CHANGELOG.md](../docs/CHANGELOG.md).
+- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
 - [ ] All: Considered updating the online docs in the [./docs/](../docs/) directory.
 - [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
 - [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.


### PR DESCRIPTION
## 🗒️ Description
Fix broken the broken link to the changelog and remove the empty lines from within the tasklist in our Github PR template

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](../docs/CHANGELOG.md):  Not necessary.
- [ ] All: Considered updating the online docs in the [./docs/](../docs/) directory.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
