### PR TITLE
feat(fw): add statetest format

### DIFF
--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -903,7 +903,7 @@ class Environment:
         ),
     )
     timestamp: NumberConvertible = field(
-        default=1000,
+        default=12,
         json_encoder=JSONEncoder.Field(
             name="currentTimestamp",
             cast_type=Number,

--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -2110,7 +2110,7 @@ class FixtureHeader:
         source=HeaderFieldSource(
             parse_type=Bytes,
             source_environment="extra_data",
-            default=b"",
+            default=Bytes([0]),
         ),
         json_encoder=JSONEncoder.Field(name="extraData"),
     )

--- a/src/ethereum_test_tools/spec/blockchain_test.py
+++ b/src/ethereum_test_tools/spec/blockchain_test.py
@@ -64,6 +64,24 @@ class BlockchainTest(BaseTest):
         """
         return self.base_test_config.enable_hive
 
+    def block_count(self) -> int:
+        """
+        Returns the number of blocks in the test.
+        """
+        return len(self.blocks)
+
+    def transaction_count_in_block(self, block_index: int) -> int:
+        """
+        Returns the number of transactions in the block at the given index.
+        """
+        assert block_index >= 0, "block index must be >= 0"
+        if block_index >= self.block_count():
+            raise Exception(
+                f'Block index "{block_index}" is out of range for this test '
+                f"which has {self.block_count()} blocks."
+            )
+        return len(self.blocks[block_index].txs)
+
     def make_genesis(
         self,
         t8n: TransitionTool,

--- a/src/ethereum_test_tools/spec/state_test.py
+++ b/src/ethereum_test_tools/spec/state_test.py
@@ -190,6 +190,7 @@ class StateTest(BaseTest):
                 FixtureBlock(
                     rlp=block,
                     block_header=header,
+                    block_number=Number(header.number),
                     txs=txs,
                     ommers=[],
                     withdrawals=self.env.withdrawals,

--- a/src/ethereum_test_tools/tests/test_types.py
+++ b/src/ethereum_test_tools/tests/test_types.py
@@ -425,7 +425,7 @@ CHECKSUM_ADDRESS = "0x8a0A19589531694250d570040a0c4B74576919B8"
                 "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
                 "currentGasLimit": "100000000000000000",
                 "currentNumber": "1",
-                "currentTimestamp": "1000",
+                "currentTimestamp": "12",
                 "blockHashes": {},
                 "ommers": [],
                 "parentUncleHash": (
@@ -457,7 +457,7 @@ CHECKSUM_ADDRESS = "0x8a0A19589531694250d570040a0c4B74576919B8"
                 "currentCoinbase": "0x0000000000000000000000000000000000001234",
                 "currentGasLimit": "100000000000000000",
                 "currentNumber": "1",
-                "currentTimestamp": "1000",
+                "currentTimestamp": "12",
                 "currentDifficulty": "5",
                 "currentRandom": "6",
                 "currentBaseFee": "7",


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](../docs/) directory.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
