### PR TITLE
forks: Add fork-specific, non-inherited class variables

### DIFF
--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -13,10 +13,21 @@ class Frontier(BaseFork):
     """
 
     @classmethod
-    def fork(cls, block_number: int = 0, timestamp: int = 0) -> str:
+    def transition_tool_name(cls, block_number: int = 0, timestamp: int = 0) -> str:
         """
         Returns fork name as it's meant to be passed to the transition tool for execution.
         """
+        if cls._transition_tool_name is not None:
+            return cls._transition_tool_name
+        return cls.name()
+
+    @classmethod
+    def solc_name(cls, block_number: int = 0, timestamp: int = 0) -> str:
+        """
+        Returns fork name as it's meant to be passed to the solc compiler.
+        """
+        if cls._solc_name is not None:
+            return cls._solc_name
         return cls.name()
 
     @classmethod
@@ -182,7 +193,7 @@ class Constantinople(Byzantium):
         return 2_000_000_000_000_000_000
 
 
-class ConstantinopleFix(Constantinople):
+class ConstantinopleFix(Constantinople, solc_name="Constantinople"):
     """
     Constantinople Fix fork
     """
@@ -262,7 +273,12 @@ class GrayGlacier(ArrowGlacier):
     pass
 
 
-class Merge(London):
+class Merge(
+    London,
+    transition_tool_name="Merge",
+    blockchain_test_network_name="Merge",
+    solc_name="Paris",
+):
     """
     Merge fork
     """

--- a/src/ethereum_test_forks/forks/transition.py
+++ b/src/ethereum_test_forks/forks/transition.py
@@ -16,7 +16,7 @@ class BerlinToLondonAt5(Berlin):
 
 
 @transition_fork(to_fork=Shanghai, at_timestamp=15_000)
-class MergeToShanghaiAtTime15k(Merge):
+class MergeToShanghaiAtTime15k(Merge, blockchain_test_network_name="MergeToShanghaiAtTime15k"):
     """
     Merge to Shanghai transition at Timestamp 15k
     """

--- a/src/ethereum_test_forks/tests/test_forks.py
+++ b/src/ethereum_test_forks/tests/test_forks.py
@@ -36,14 +36,14 @@ def test_transition_forks():
     assert BerlinToLondonAt5.transitions_to() == London
     assert BerlinToLondonAt5.transitions_from() == Berlin
 
-    assert BerlinToLondonAt5.fork(4, 0) == "Berlin"
-    assert BerlinToLondonAt5.fork(5, 0) == "London"
+    assert BerlinToLondonAt5.transition_tool_name(4, 0) == "Berlin"
+    assert BerlinToLondonAt5.transition_tool_name(5, 0) == "London"
     # Default values of transition forks is the transition block
-    assert BerlinToLondonAt5.fork() == "London"
+    assert BerlinToLondonAt5.transition_tool_name() == "London"
 
-    assert MergeToShanghaiAtTime15k.fork(0, 14_999) == "Merge"
-    assert MergeToShanghaiAtTime15k.fork(0, 15_000) == "Shanghai"
-    assert MergeToShanghaiAtTime15k.fork() == "Shanghai"
+    assert MergeToShanghaiAtTime15k.transition_tool_name(0, 14_999) == "Merge"
+    assert MergeToShanghaiAtTime15k.transition_tool_name(0, 15_000) == "Shanghai"
+    assert MergeToShanghaiAtTime15k.transition_tool_name() == "Shanghai"
 
     assert BerlinToLondonAt5.header_base_fee_required(4, 0) is False
     assert BerlinToLondonAt5.header_base_fee_required(5, 0) is True
@@ -78,6 +78,14 @@ def test_forks():
     assert MergeToShanghaiAtTime15k.name() == "MergeToShanghaiAtTime15k"
     assert f"{London}" == "London"
     assert f"{MergeToShanghaiAtTime15k}" == "MergeToShanghaiAtTime15k"
+
+    # Merge name will be changed to paris, but we need to check the inheriting fork name is still
+    # the default
+    assert Merge.transition_tool_name() == "Merge"
+    assert Shanghai.transition_tool_name() == "Shanghai"
+    assert Merge.blockchain_test_network_name() == "Merge"
+    assert Shanghai.blockchain_test_network_name() == "Shanghai"
+    assert MergeToShanghaiAtTime15k.blockchain_test_network_name() == "MergeToShanghaiAtTime15k"
 
     # Test some fork properties
     assert Berlin.header_base_fee_required(0, 0) is False

--- a/src/ethereum_test_forks/transition_base_fork.py
+++ b/src/ethereum_test_forks/transition_base_fork.py
@@ -46,7 +46,14 @@ def transition_fork(to_fork: Fork, at_block: int = 0, at_timestamp: int = 0):
         from_fork = cls.__bases__[0]
         assert issubclass(from_fork, BaseFork)
 
-        class NewTransitionClass(cls, TransitionBaseClass, BaseFork):  # type: ignore
+        class NewTransitionClass(
+            cls,  # type: ignore
+            TransitionBaseClass,
+            BaseFork,
+            transition_tool_name=cls._transition_tool_name,
+            blockchain_test_network_name=cls._blockchain_test_network_name,
+            solc_name=cls._solc_name,
+        ):
             pass
 
         NewTransitionClass.name = lambda: transition_name  # type: ignore

--- a/src/ethereum_test_tools/code/yul.py
+++ b/src/ethereum_test_tools/code/yul.py
@@ -7,7 +7,7 @@ import warnings
 from pathlib import Path
 from shutil import which
 from subprocess import PIPE, run
-from typing import Mapping, Optional, Sized, SupportsBytes, Tuple, Type, Union
+from typing import Optional, Sized, SupportsBytes, Tuple, Type, Union
 
 from semver import Version
 
@@ -33,13 +33,7 @@ def get_evm_version_from_fork(fork: Fork | None):
     """
     if not fork:
         return None
-    fork_to_evm_version_map: Mapping[str, str] = {
-        "Merge": "paris",
-        "ConstantinopleFix": "constantinople",
-    }
-    if fork.name() in fork_to_evm_version_map:
-        return fork_to_evm_version_map[fork.name()]
-    return fork.name().lower()
+    return fork.solc_name().lower()
 
 
 class Yul(SupportsBytes, Sized):

--- a/src/ethereum_test_tools/spec/blockchain_test.py
+++ b/src/ethereum_test_tools/spec/blockchain_test.py
@@ -148,7 +148,9 @@ class BlockchainTest(BaseTest):
             alloc=previous_alloc,
             txs=to_json(txs),
             env=to_json(env),
-            fork_name=fork.fork(block_number=Number(env.number), timestamp=Number(env.timestamp)),
+            fork_name=fork.transition_tool_name(
+                block_number=Number(env.number), timestamp=Number(env.timestamp)
+            ),
             chain_id=self.chain_id,
             reward=fork.get_reward(Number(env.number), Number(env.timestamp)),
             eips=eips,
@@ -199,11 +201,15 @@ class BlockchainTest(BaseTest):
 
         return header, rlp, txs, next_alloc, env
 
-    def network_info(self, fork, eips=None):
+    def network_info(self, fork: Fork, eips: Optional[List[int]] = None):
         """
         Returns fixture network information for the fork & EIP/s.
         """
-        return "+".join([fork.name()] + [str(eip) for eip in eips]) if eips else fork.name()
+        return (
+            "+".join([fork.blockchain_test_network_name()] + [str(eip) for eip in eips])
+            if eips
+            else fork.blockchain_test_network_name()
+        )
 
     def verify_post_state(self, t8n, alloc):
         """

--- a/src/evm_transition_tool/besu.py
+++ b/src/evm_transition_tool/besu.py
@@ -181,4 +181,4 @@ class BesuTransitionTool(TransitionTool):
         """
         Returns True if the fork is supported by the tool
         """
-        return fork.fork() in self.help_string
+        return fork.transition_tool_name() in self.help_string

--- a/src/evm_transition_tool/geth.py
+++ b/src/evm_transition_tool/geth.py
@@ -51,7 +51,7 @@ class GethTransitionTool(TransitionTool):
 
         If the fork is a transition fork, we want to check the fork it transitions to.
         """
-        return fork.fork() in self.help_string
+        return fork.transition_tool_name() in self.help_string
 
     def verify_fixture(
         self, fixture_format: FixtureFormats, fixture_path: Path, debug_output_path: Optional[Path]

--- a/src/evm_transition_tool/nimbus.py
+++ b/src/evm_transition_tool/nimbus.py
@@ -57,4 +57,4 @@ class NimbusTransitionTool(TransitionTool):
 
         If the fork is a transition fork, we want to check the fork it transitions to.
         """
-        return fork.fork() in self.help_string
+        return fork.transition_tool_name() in self.help_string

--- a/src/evm_transition_tool/tests/test_evaluate.py
+++ b/src/evm_transition_tool/tests/test_evaluate.py
@@ -119,7 +119,7 @@ def test_evm_t8n(t8n: TransitionTool, test_dir: str) -> None:  # noqa: D103
             alloc=alloc,
             txs=txs,
             env=env_json,
-            fork_name=Berlin.fork(
+            fork_name=Berlin.transition_tool_name(
                 block_number=int(env_json["currentNumber"], 0),
                 timestamp=int(env_json["currentTimestamp"], 0),
             ),

--- a/src/evm_transition_tool/transition_tool.py
+++ b/src/evm_transition_tool/transition_tool.py
@@ -576,7 +576,7 @@ class TransitionTool:
             alloc=alloc,
             txs=[],
             env=env,
-            fork_name=fork.fork(block_number=0, timestamp=0),
+            fork_name=fork.transition_tool_name(block_number=0, timestamp=0),
             debug_output_path=debug_output_path,
         )
         state_root = result.get("stateRoot")


### PR DESCRIPTION
## 🗒️ Description
Introduces fork-specific variables that are not inherited by subclass forks, containing the following variables:
- `transition_tool_name`: The name that the transition tool (`evm t8n`) expects for this fork.
- `blockchain_test_network_name`: The `network` value that must be included in the `BlockchainTest` fixture format for this fork.
- `solc_name`: The name that the solidity compiler (`solc`) expects for this fork.

This is very useful to name forks differently than the transition tool actually expects (e.g. when we rename `Merge` to `Paris`, the transition tool will still expect `Merge` as the fork to execute the tests).

This was achieved by using the `__init_subclass__` special method in the `BaseFork` class, with the class variables as parameters, and then, when defining the fork subclass, the parameters are passed when sub-classing the parent fork:

```python
class Merge(
    London,
    solc_name="Paris",
):
```
Can be converted to:
```python
class Paris(
    London,
    transition_tool_name="Merge",
    blockchain_test_network_name="Merge",
):
```
And will still behave exactly the same to the transition tool (and to the output of the `BlockchainTest` format).

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](../docs/) directory.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
