### PR TITLE
forks: Implement fork operators, remove `is_fork`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Add a `--single-fixture-per-file` flag to generate one fixture JSON file per test case ([#331](https://github.com/ethereum/execution-spec-tests/pull/331)).
 - 🔀 Rename test fixtures names to match the corresponding pytest node ID as generated using `fill` ([#342](https://github.com/ethereum/execution-spec-tests/pull/342)).
 - 💥 Replace "=" with "_" in pytest node ids and test fixture names ([#342](https://github.com/ethereum/execution-spec-tests/pull/342)).
+- ✨ Fork objects used to write tests can now be compared using the `>`, `>=`, `<`, `<=` operators, to check for a fork being newer than, newer than or equal, older than, older than or equal, respectively when compared against other fork ([#367](https://github.com/ethereum/execution-spec-tests/pull/367))
 
 ### 🔧 EVM Tools
 

--- a/src/ethereum_test_forks/__init__.py
+++ b/src/ethereum_test_forks/__init__.py
@@ -32,7 +32,6 @@ from .helpers import (
     get_development_forks,
     get_forks,
     get_transition_forks,
-    is_fork,
     transition_fork_from_to,
     transition_fork_to,
 )
@@ -64,7 +63,6 @@ __all__ = [
     "get_deployed_forks",
     "get_development_forks",
     "get_forks",
-    "is_fork",
     "transition_fork_from_to",
     "transition_fork_to",
 ]

--- a/src/ethereum_test_forks/base_fork.py
+++ b/src/ethereum_test_forks/base_fork.py
@@ -36,6 +36,30 @@ class BaseForkMeta(ABCMeta):
         """
         return cls.name()
 
+    def __gt__(cls, other: "BaseForkMeta") -> bool:
+        """
+        Compare if a fork is newer than some other fork.
+        """
+        return cls != other and other.__subclasscheck__(cls)
+
+    def __ge__(cls, other: "BaseForkMeta") -> bool:
+        """
+        Compare if a fork is newer than or equal to some other fork.
+        """
+        return other.__subclasscheck__(cls)
+
+    def __lt__(cls, other: "BaseForkMeta") -> bool:
+        """
+        Compare if a fork is older than some other fork.
+        """
+        return cls != other and cls.__subclasscheck__(other)
+
+    def __le__(cls, other: "BaseForkMeta") -> bool:
+        """
+        Compare if a fork is older than or equal to some other fork.
+        """
+        return cls.__subclasscheck__(other)
+
 
 class BaseFork(ABC, metaclass=BaseForkMeta):
     """

--- a/src/ethereum_test_forks/helpers.py
+++ b/src/ethereum_test_forks/helpers.py
@@ -135,18 +135,3 @@ def forks_from(fork: Fork, deployed_only: bool = True) -> List[Fork]:
     else:
         latest_fork = get_forks()[-1]
     return forks_from_until(fork, latest_fork)
-
-
-def is_fork(fork: Fork, which: Fork) -> bool:
-    """
-    Returns `True` if `fork` is `which` or beyond, `False otherwise.
-    """
-    prev_fork = fork
-
-    while prev_fork != BaseFork:
-        if prev_fork == which:
-            return True
-
-        prev_fork = prev_fork.__base__
-
-    return False

--- a/src/ethereum_test_forks/tests/test_forks.py
+++ b/src/ethereum_test_forks/tests/test_forks.py
@@ -13,7 +13,6 @@ from ..helpers import (
     get_deployed_forks,
     get_development_forks,
     get_forks,
-    is_fork,
     transition_fork_from_to,
     transition_fork_to,
 )
@@ -94,9 +93,38 @@ def test_forks():
     assert cast(Fork, MergeToShanghaiAtTime15k).header_withdrawals_required(0, 15_000) is True
     assert cast(Fork, MergeToShanghaiAtTime15k).header_withdrawals_required() is True
 
-    assert is_fork(Berlin, Berlin) is True
-    assert is_fork(London, Berlin) is True
-    assert is_fork(Berlin, Merge) is False
+    # Test fork comparison
+    assert Merge > Berlin
+    assert not Berlin > Merge
+    assert Berlin < Merge
+    assert not Merge < Berlin
+
+    assert Merge >= Berlin
+    assert not Berlin >= Merge
+    assert Berlin <= Merge
+    assert not Merge <= Berlin
+
+    assert London > Berlin
+    assert not Berlin > London
+    assert Berlin < London
+    assert not London < Berlin
+
+    assert London >= Berlin
+    assert not Berlin >= London
+    assert Berlin <= London
+    assert not London <= Berlin
+
+    assert Berlin >= Berlin
+    assert Berlin <= Berlin
+    assert not Berlin > Berlin
+    assert not Berlin < Berlin
+
+    fork = Berlin
+    assert fork >= Berlin
+    assert fork <= Berlin
+    assert not fork > Berlin
+    assert not fork < Berlin
+    assert fork == Berlin
 
 
 def test_get_forks():  # noqa: D103

--- a/tests/berlin/eip2930_access_list/test_acl.py
+++ b/tests/berlin/eip2930_access_list/test_acl.py
@@ -4,7 +4,7 @@ Test ACL Transaction Source Code Examples
 
 import pytest
 
-from ethereum_test_forks import Fork, London, is_fork
+from ethereum_test_forks import Fork, London
 from ethereum_test_tools import AccessList, Account, Environment
 from ethereum_test_tools import Opcodes as Op
 from ethereum_test_tools import StateTestFiller, Transaction
@@ -60,7 +60,7 @@ def test_access_list(state_test: StateTestFiller, fork: Fork):
             nonce=1,
         ),
         "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba": Account(
-            balance=0x1BC16D674EC80000 if is_fork(fork, London) else 0x1BC16D674ECB26CE,
+            balance=0x1BC16D674EC80000 if fork >= London else 0x1BC16D674ECB26CE,
         ),
         "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": Account(
             balance=0x2CD931,

--- a/tests/cancun/eip6780_selfdestruct/test_selfdestruct.py
+++ b/tests/cancun/eip6780_selfdestruct/test_selfdestruct.py
@@ -11,7 +11,7 @@ from typing import Dict, List, SupportsBytes
 import pytest
 from ethereum.crypto.hash import keccak256
 
-from ethereum_test_forks import Cancun, Fork, is_fork
+from ethereum_test_forks import Cancun, Fork
 from ethereum_test_tools import (
     Account,
     Block,
@@ -50,7 +50,7 @@ NO_SELFDESTRUCT = "0x0"
 @pytest.fixture
 def eip_enabled(fork: Fork) -> bool:
     """Whether the EIP is enabled or not."""
-    return is_fork(fork, SELFDESTRUCT_ENABLE_FORK)
+    return fork >= SELFDESTRUCT_ENABLE_FORK
 
 
 @pytest.fixture

--- a/tests/shanghai/eip3651_warm_coinbase/test_warm_coinbase.py
+++ b/tests/shanghai/eip3651_warm_coinbase/test_warm_coinbase.py
@@ -10,7 +10,7 @@ note: Tests ported from:
 
 import pytest
 
-from ethereum_test_forks import Shanghai, is_fork
+from ethereum_test_forks import Shanghai
 from ethereum_test_tools import (
     Account,
     CodeGasMeasure,
@@ -117,7 +117,7 @@ def test_warm_coinbase_call_out_of_gas(
 
     post = {}
 
-    if use_sufficient_gas and is_fork(fork=fork, which=Shanghai):
+    if use_sufficient_gas and fork >= Shanghai:
         post[caller_address] = Account(
             storage={
                 # On shanghai and beyond, calls with only 100 gas to
@@ -244,7 +244,7 @@ def test_warm_coinbase_gas_usage(state_test, fork, opcode, code_gas_measure):
         measure_address: Account(code=code_gas_measure, balance=1000000000000000000000),
     }
 
-    if is_fork(fork, Shanghai):
+    if fork >= Shanghai:
         expected_gas = GAS_REQUIRED_CALL_WARM_ACCOUNT  # Warm account access cost after EIP-3651
     else:
         expected_gas = 2600  # Cold account access cost before EIP-3651

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -235,6 +235,7 @@ stExample
 str
 streetsidesoftware
 subcall
+subclasscheck
 subdirectories
 subdirectory
 subgraph


### PR DESCRIPTION
## 🗒️ Description
Implements the following operators for the fork objects:
- Greater than (>): Fork is newer than other fork
- Greater than or equal to (>=): Fork is at least as newer than other fork
- Less than (<): Fork is older than other fork
- Less than or equal to (<=): Fork is at least as old than other fork

`is_fork` is now removed.

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](../docs/) directory.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
