### PR TITLE
tools(fix): Storage iterator

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - 🔀 Rename test fixtures names to match the corresponding pytest node ID as generated using `fill` ([#342](https://github.com/ethereum/execution-spec-tests/pull/342)).
 - 💥 Replace "=" with "_" in pytest node ids and test fixture names ([#342](https://github.com/ethereum/execution-spec-tests/pull/342)).
 - ✨ Fork objects used to write tests can now be compared using the `>`, `>=`, `<`, `<=` operators, to check for a fork being newer than, newer than or equal, older than, older than or equal, respectively when compared against other fork ([#367](https://github.com/ethereum/execution-spec-tests/pull/367))
+- 🐞 Storage type iterator is now fixed ([#369](https://github.com/ethereum/execution-spec-tests/pull/369))
 
 ### 🔧 EVM Tools
 

--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -402,7 +402,7 @@ class Storage(SupportsJSON):
             hex_str = "0" + hex_str
         return "0x" + hex_str
 
-    def __init__(self, input: StorageDictType = {}, start_slot: int = 0):
+    def __init__(self, input: StorageDictType | "Storage" = {}, start_slot: int = 0):
         """
         Initializes the storage using a given mapping which can have
         keys and values either as string or int.
@@ -419,6 +419,10 @@ class Storage(SupportsJSON):
     def __len__(self) -> int:
         """Returns number of elements in the storage"""
         return len(self.data)
+
+    def __iter__(self) -> Iterator[int]:
+        """Returns iterator of the storage"""
+        return iter(self.data)
 
     def __contains__(self, key: str | int | bytes) -> bool:
         """Checks for an item in the storage"""

--- a/src/ethereum_test_tools/tests/test_types.py
+++ b/src/ethereum_test_tools/tests/test_types.py
@@ -52,6 +52,10 @@ def test_storage():
     assert 10 in s.data
     assert s.data[10] == 10
 
+    iter_s = iter(Storage({10: 20, "11": "21"}))
+    assert next(iter_s) == 10
+    assert next(iter_s) == 11
+
     s["10"] = "0x10"
     s["0x10"] = "10"
     assert s.data[10] == 16


### PR DESCRIPTION
## 🗒️ Description
Storage iterator was broken, so a for loop could not iterate over it (it returned a zero key even if it didn't have the zero key).

Fix was to return the iterator of the `data` field.

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](../docs/) directory.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
