### PR TITLE
refactor: make post state verification tests more pytesty

### DIFF
--- a/src/ethereum_test_tools/tests/test_filling/test_expect.py
+++ b/src/ethereum_test_tools/tests/test_filling/test_expect.py
@@ -1,5 +1,5 @@
 """
-Test suite for `ethereum_test_tools.filling` fixture post (expect) section.
+Test fixture post state (expect section) during state fixture generation.
 """
 from typing import Any, Mapping
 
@@ -108,7 +108,7 @@ def t8n() -> GethTransitionTool:  # noqa: D103
 )
 def test_post_storage_value_mismatch(pre, post, expected_exception, state_test, t8n, fork):
     """
-    Test `ethereum_test.filler.fill_test` post state storage verification.
+    Test post state `Account.storage` exceptions during state test fixture generation.
     """
     with pytest.raises(Storage.KeyValueMismatch) as e_info:
         state_test.generate(t8n=t8n, fork=fork)
@@ -126,7 +126,8 @@ def test_post_storage_value_mismatch(pre, post, expected_exception, state_test, 
 )
 def test_post_nonce_value_mismatch(pre, post, state_test, t8n, fork):
     """
-    Test `ethereum_test.filler.fill_test` post state nonce verification.
+    Test post state `Account.nonce` verification and exceptions during state test
+    fixture generation.
     """
     pre_nonce = pre[ADDRESS_UNDER_TEST].nonce
     post_nonce = post[ADDRESS_UNDER_TEST].nonce
@@ -152,7 +153,8 @@ def test_post_nonce_value_mismatch(pre, post, state_test, t8n, fork):
 )
 def test_post_code_value_mismatch(pre, post, state_test, t8n, fork):
     """
-    Test `ethereum_test.filler.fill_test` post state code verification.
+    Test post state `Account.code` verification and exceptions during state test
+    fixture generation.
     """
     pre_code = pre[ADDRESS_UNDER_TEST].code
     post_code = post[ADDRESS_UNDER_TEST].code
@@ -178,7 +180,8 @@ def test_post_code_value_mismatch(pre, post, state_test, t8n, fork):
 )
 def test_post_balance_value_mismatch(pre, post, state_test, t8n, fork):
     """
-    Test `ethereum_test.filler.fill_test` post state balance verification.
+    Test post state `Account.balance` verification and exceptions during state test
+    fixture generation.
     """
     pre_balance = pre[ADDRESS_UNDER_TEST].balance
     post_balance = post[ADDRESS_UNDER_TEST].balance
@@ -221,7 +224,8 @@ def test_post_balance_value_mismatch(pre, post, state_test, t8n, fork):
 )
 def test_post_account_mismatch(state_test, t8n, fork, error_str):
     """
-    Test `ethereum_test.filler.fill_test` post state account verification.
+    Test post state `Account` verification and exceptions during state test
+    fixture generation.
     """
     if error_str is None:
         state_test.generate(t8n=t8n, fork=fork)

--- a/src/ethereum_test_tools/tests/test_filling/test_expect.py
+++ b/src/ethereum_test_tools/tests/test_filling/test_expect.py
@@ -1,14 +1,14 @@
 """
 Test suite for `ethereum_test_tools.filling` fixture post (expect) section.
 """
-from typing import Any, Mapping, Optional
+from typing import Any, Mapping
 
 import pytest
 
-from ethereum_test_forks import get_deployed_forks
+from ethereum_test_forks import Fork, get_deployed_forks
 from evm_transition_tool import FixtureFormats, GethTransitionTool
 
-from ...common import Account, Environment, TestAddress, Transaction, to_address
+from ...common import Account, Environment, Transaction, to_address
 from ...common.types import Storage
 from ...spec import StateTest
 
@@ -16,26 +16,31 @@ ADDRESS_UNDER_TEST = to_address(0x01)
 
 
 @pytest.fixture
-def pre() -> Mapping[Any, Any]:  # noqa: D103
-    return {
-        TestAddress: Account(balance=1000000000000000000000),
-    }
+def pre(request) -> Mapping[Any, Any]:
+    """
+    The pre state: Set from the test's indirectly parametrized `pre` parameter.
+    """
+    return request.param
 
 
 @pytest.fixture
-def post() -> Mapping[Any, Any]:  # noqa: D103
-    return {}
+def post(request) -> Mapping[Any, Any]:  # noqa: D103
+    """
+    The post state: Set from the test's indirectly parametrized `post` parameter.
+    """
+    return request.param
 
 
-def run_post_state_mismatch_test(
-    pre: Mapping[Any, Any], post: Mapping[Any, Any], exception: Any
-) -> Optional[pytest.ExceptionInfo]:
-    """
-    Performs test filling and post state verification.
-    """
-    fork = get_deployed_forks()[-1]
-    t8n = GethTransitionTool()
-    state_test = StateTest(
+@pytest.fixture
+def fork() -> Fork:  # noqa: D103
+    return get_deployed_forks()[-1]
+
+
+@pytest.fixture
+def state_test(  # noqa: D103
+    fork: Fork, pre: Mapping[Any, Any], post: Mapping[Any, Any]
+) -> StateTest:
+    return StateTest(
         env=Environment(),
         pre=pre,
         post=post,
@@ -43,140 +48,153 @@ def run_post_state_mismatch_test(
         tag="post_value_mismatch",
         fixture_format=FixtureFormats.STATE_TEST,
     )
-    e_info: pytest.ExceptionInfo
-    if exception:
-        with pytest.raises(exception) as e_info:
-            state_test.generate(t8n=t8n, fork=fork)
-        return e_info
-    else:
-        state_test.generate(t8n=t8n, fork=fork)
-        return None
+
+
+@pytest.fixture
+def t8n() -> GethTransitionTool:  # noqa: D103
+    return GethTransitionTool()
 
 
 # Storage value mismatch tests
 @pytest.mark.parametrize(
-    "pre_storage,post_storage,expected_exception",
+    "pre,post,expected_exception",
     [
         (  # mismatch_1: 1:1 vs 1:2
-            {"0x01": "0x01"},
-            {"0x01": "0x02"},
+            {ADDRESS_UNDER_TEST: Account(storage={"0x01": "0x01"}, nonce=1)},
+            {ADDRESS_UNDER_TEST: Account(storage={"0x01": "0x02"})},
             Storage.KeyValueMismatch(address=ADDRESS_UNDER_TEST, key=1, want=2, got=1),
         ),
         (  # mismatch_2: 1:1 vs 2:1
-            {"0x01": "0x01"},
-            {"0x02": "0x01"},
+            {ADDRESS_UNDER_TEST: Account(storage={"0x01": "0x01"}, nonce=1)},
+            {ADDRESS_UNDER_TEST: Account(storage={"0x02": "0x01"})},
             Storage.KeyValueMismatch(address=ADDRESS_UNDER_TEST, key=1, want=0, got=1),
         ),
         (  # mismatch_2_a: 1:1 vs 0:0
-            {"0x01": "0x01"},
-            {"0x00": "0x00"},
+            {ADDRESS_UNDER_TEST: Account(storage={"0x01": "0x01"}, nonce=1)},
+            {ADDRESS_UNDER_TEST: Account(storage={"0x00": "0x00"})},
             Storage.KeyValueMismatch(address=ADDRESS_UNDER_TEST, key=1, want=0, got=1),
         ),
         (  # mismatch_2_b: 1:1 vs empty
-            {"0x01": "0x01"},
-            {},
+            {ADDRESS_UNDER_TEST: Account(storage={"0x01": "0x01"}, nonce=1)},
+            {ADDRESS_UNDER_TEST: Account(storage={})},
             Storage.KeyValueMismatch(address=ADDRESS_UNDER_TEST, key=1, want=0, got=1),
         ),
         (  # mismatch_3: 0:0 vs 1:2
-            {"0x00": "0x00"},
-            {"0x01": "0x02"},
+            {ADDRESS_UNDER_TEST: Account(storage={"0x00": "0x00"}, nonce=1)},
+            {ADDRESS_UNDER_TEST: Account(storage={"0x01": "0x02"})},
             Storage.KeyValueMismatch(address=ADDRESS_UNDER_TEST, key=1, want=2, got=0),
         ),
         (  # mismatch_3_a: empty vs 1:2
-            {},
-            {"0x01": "0x02"},
+            {ADDRESS_UNDER_TEST: Account(storage={}, nonce=1)},
+            {ADDRESS_UNDER_TEST: Account(storage={"0x01": "0x02"})},
             Storage.KeyValueMismatch(address=ADDRESS_UNDER_TEST, key=1, want=2, got=0),
         ),
         (  # mismatch_4: 0:3, 1:2 vs 1:2
-            {"0x00": "0x03", "0x01": "0x02"},
-            {"0x01": "0x02"},
+            {ADDRESS_UNDER_TEST: Account(storage={"0x00": "0x03", "0x01": "0x02"}, nonce=1)},
+            {ADDRESS_UNDER_TEST: Account(storage={"0x01": "0x02"})},
             Storage.KeyValueMismatch(address=ADDRESS_UNDER_TEST, key=0, want=0, got=3),
         ),
         (  # mismatch_5: 1:2, 2:3 vs 1:2
-            {"0x01": "0x02", "0x02": "0x03"},
-            {"0x01": "0x02"},
+            {ADDRESS_UNDER_TEST: Account(storage={"0x01": "0x02", "0x02": "0x03"}, nonce=1)},
+            {ADDRESS_UNDER_TEST: Account(storage={"0x01": "0x02"})},
             Storage.KeyValueMismatch(address=ADDRESS_UNDER_TEST, key=2, want=0, got=3),
         ),
         (  # mismatch_6: 1:2 vs 1:2, 2:3
-            {"0x01": "0x02"},
-            {"0x01": "0x02", "0x02": "0x03"},
+            {ADDRESS_UNDER_TEST: Account(storage={"0x01": "0x02"}, nonce=1)},
+            {ADDRESS_UNDER_TEST: Account(storage={"0x01": "0x02", "0x02": "0x03"})},
             Storage.KeyValueMismatch(address=ADDRESS_UNDER_TEST, key=2, want=3, got=0),
         ),
     ],
 )
-def test_post_storage_value_mismatch(pre, post, pre_storage, post_storage, expected_exception):
+def test_post_storage_value_mismatch(pre, post, expected_exception, state_test, t8n, fork):
     """
     Test `ethereum_test.filler.fill_test` post state storage verification.
     """
-    pre[ADDRESS_UNDER_TEST] = Account(nonce=1, storage=pre_storage)
-    post[ADDRESS_UNDER_TEST] = Account(storage=post_storage)
-    e_info = run_post_state_mismatch_test(pre, post, Storage.KeyValueMismatch)
+    with pytest.raises(Storage.KeyValueMismatch) as e_info:
+        state_test.generate(t8n=t8n, fork=fork)
     assert e_info.value == expected_exception
 
 
 # Nonce value mismatch tests
 @pytest.mark.parametrize(
-    "pre_nonce,post_nonce",
-    [(1, 2), (1, 0), (1, None)],
+    "pre,post",
+    [
+        ({ADDRESS_UNDER_TEST: Account(nonce=1)}, {ADDRESS_UNDER_TEST: Account(nonce=2)}),
+        ({ADDRESS_UNDER_TEST: Account(nonce=1)}, {ADDRESS_UNDER_TEST: Account(nonce=0)}),
+        ({ADDRESS_UNDER_TEST: Account(nonce=1)}, {ADDRESS_UNDER_TEST: Account(nonce=None)}),
+    ],
 )
-def test_post_nonce_value_mismatch(pre, post, pre_nonce, post_nonce):
+def test_post_nonce_value_mismatch(pre, post, state_test, t8n, fork):
     """
     Test `ethereum_test.filler.fill_test` post state nonce verification.
     """
-    pre[ADDRESS_UNDER_TEST] = Account(nonce=pre_nonce)
-    post[ADDRESS_UNDER_TEST] = Account(nonce=post_nonce)
-    if post_nonce is None:
-        run_post_state_mismatch_test(pre, post, None)
-    else:
-        e_info = run_post_state_mismatch_test(pre, post, Account.NonceMismatch)
-        assert e_info.value == Account.NonceMismatch(
-            address=ADDRESS_UNDER_TEST, want=post_nonce, got=pre_nonce
-        )
+    pre_nonce = pre[ADDRESS_UNDER_TEST].nonce
+    post_nonce = post[ADDRESS_UNDER_TEST].nonce
+    if post_nonce is None:  # no exception
+        state_test.generate(t8n=t8n, fork=fork)
+        return
+    with pytest.raises(Account.NonceMismatch) as e_info:
+        state_test.generate(t8n=t8n, fork=fork)
+    assert e_info.value == Account.NonceMismatch(
+        address=ADDRESS_UNDER_TEST, want=post_nonce, got=pre_nonce
+    )
 
 
 # Code value mismatch tests
 @pytest.mark.parametrize(
-    "pre_code,post_code",
-    [("0x02", "0x01"), ("0x02", "0x"), ("0x02", None)],
+    "pre,post",
+    [
+        ({ADDRESS_UNDER_TEST: Account(code="0x02")}, {ADDRESS_UNDER_TEST: Account(code="0x01")}),
+        ({ADDRESS_UNDER_TEST: Account(code="0x02")}, {ADDRESS_UNDER_TEST: Account(code="0x")}),
+        ({ADDRESS_UNDER_TEST: Account(code="0x02")}, {ADDRESS_UNDER_TEST: Account(code=None)}),
+    ],
+    indirect=["pre", "post"],
 )
-def test_post_code_value_mismatch(pre, post, pre_code, post_code):
+def test_post_code_value_mismatch(pre, post, state_test, t8n, fork):
     """
     Test `ethereum_test.filler.fill_test` post state code verification.
     """
-    pre[ADDRESS_UNDER_TEST] = Account(code=pre_code)
-    post[ADDRESS_UNDER_TEST] = Account(code=post_code)
-    if post_code is None:
-        run_post_state_mismatch_test(pre, post, None)
-    else:
-        e_info = run_post_state_mismatch_test(pre, post, Account.CodeMismatch)
-        assert e_info.value == Account.CodeMismatch(
-            address=ADDRESS_UNDER_TEST, want=post_code, got=pre_code
-        )
+    pre_code = pre[ADDRESS_UNDER_TEST].code
+    post_code = post[ADDRESS_UNDER_TEST].code
+    if post_code is None:  # no exception
+        state_test.generate(t8n=t8n, fork=fork)
+        return
+    with pytest.raises(Account.CodeMismatch) as e_info:
+        state_test.generate(t8n=t8n, fork=fork)
+    assert e_info.value == Account.CodeMismatch(
+        address=ADDRESS_UNDER_TEST, want=post_code, got=pre_code
+    )
 
 
 # Balance value mismatch tests
 @pytest.mark.parametrize(
-    "pre_balance,post_balance",
-    [(1, 2), (1, 0), (1, None)],
+    "pre,post",
+    [
+        ({ADDRESS_UNDER_TEST: Account(balance=1)}, {ADDRESS_UNDER_TEST: Account(balance=2)}),
+        ({ADDRESS_UNDER_TEST: Account(balance=1)}, {ADDRESS_UNDER_TEST: Account(balance=0)}),
+        ({ADDRESS_UNDER_TEST: Account(balance=1)}, {ADDRESS_UNDER_TEST: Account(balance=None)}),
+    ],
+    indirect=["pre", "post"],
 )
-def test_post_balance_value_mismatch(pre, post, pre_balance, post_balance):
+def test_post_balance_value_mismatch(pre, post, state_test, t8n, fork):
     """
     Test `ethereum_test.filler.fill_test` post state balance verification.
     """
-    pre[ADDRESS_UNDER_TEST] = Account(balance=pre_balance)
-    post[ADDRESS_UNDER_TEST] = Account(balance=post_balance)
-    if post_balance is None:
-        run_post_state_mismatch_test(pre, post, None)
-    else:
-        e_info = run_post_state_mismatch_test(pre, post, Account.BalanceMismatch)
-        assert e_info.value == Account.BalanceMismatch(
-            address=ADDRESS_UNDER_TEST, want=post_balance, got=pre_balance
-        )
+    pre_balance = pre[ADDRESS_UNDER_TEST].balance
+    post_balance = post[ADDRESS_UNDER_TEST].balance
+    if post_balance is None:  # no exception
+        state_test.generate(t8n=t8n, fork=fork)
+        return
+    with pytest.raises(Account.BalanceMismatch) as e_info:
+        state_test.generate(t8n=t8n, fork=fork)
+    assert e_info.value == Account.BalanceMismatch(
+        address=ADDRESS_UNDER_TEST, want=post_balance, got=pre_balance
+    )
 
 
 # Account mismatch tests
 @pytest.mark.parametrize(
-    "pre_accounts,post_accounts,error_str",
+    "pre,post,error_str",
     [
         (
             {ADDRESS_UNDER_TEST: Account(balance=1)},
@@ -199,16 +217,15 @@ def test_post_balance_value_mismatch(pre, post, pre_balance, post_balance):
             "found unexpected account",
         ),
     ],
+    indirect=["pre", "post"],
 )
-def test_post_account_mismatch(pre, post, pre_accounts, post_accounts, error_str):
+def test_post_account_mismatch(state_test, t8n, fork, error_str):
     """
     Test `ethereum_test.filler.fill_test` post state account verification.
     """
-    pre.update(pre_accounts)
-    post.update(post_accounts)
     if error_str is None:
-        run_post_state_mismatch_test(pre, post, None)
-    else:
-        e_info = run_post_state_mismatch_test(pre, post, Exception)
-
-        assert error_str in str(e_info.value)
+        state_test.generate(t8n=t8n, fork=fork)
+        return
+    with pytest.raises(Exception) as e_info:
+        state_test.generate(t8n=t8n, fork=fork)
+    assert error_str in str(e_info.value)


### PR DESCRIPTION
## 🗒️ Description
Remove the `run_post_state_mismatch_test` helper function and re-write using fixtures. Having an `if` to handle the exception/no-exception cases both in the helper function and the tests themselves made the tests harder to understand.

## 🔗 Related Issues
PR to #350.

## ✅ Checklist
Checklist handled in #350.