### PR TITLE
fix(tools): remove `previousHash` from state test `env`

### DIFF
--- a/src/ethereum_test_tools/spec/state/types.py
+++ b/src/ethereum_test_tools/spec/state/types.py
@@ -87,24 +87,13 @@ class FixtureEnvironment:
             cast_type=ZeroPaddedHexNumber,
         ),
     )
-    previous_hash: Optional[FixedSizeBytesConvertible] = field(
-        default="0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6",
-        json_encoder=JSONEncoder.Field(
-            name="previousHash",
-            cast_type=Hash,
-        ),
-    )
 
     @classmethod
     def from_env(cls, env: Environment) -> "FixtureEnvironment":
         """
         Returns a FixtureEnvironment from an Environment.
         """
-        kwargs = {
-            field.name: getattr(env, field.name)
-            for field in fields(cls)
-            if field.name != "previous_hash"  # define this field for state tests only
-        }
+        kwargs = {field.name: getattr(env, field.name) for field in fields(cls)}
         return cls(**kwargs)
 
 

--- a/src/ethereum_test_tools/tests/test_filling/fixtures/chainid_paris_state_test.json
+++ b/src/ethereum_test_tools/tests/test_filling/fixtures/chainid_paris_state_test.json
@@ -7,8 +7,7 @@
             "currentTimestamp": "0x03e8",
             "currentRandom": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "currentDifficulty": "0x00",
-            "currentBaseFee": "0x07",
-            "previousHash": "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+            "currentBaseFee": "0x07"
         },
         "pre": {
             "0x1000000000000000000000000000000000000000": {

--- a/src/ethereum_test_tools/tests/test_filling/fixtures/chainid_shanghai_state_test.json
+++ b/src/ethereum_test_tools/tests/test_filling/fixtures/chainid_shanghai_state_test.json
@@ -7,8 +7,7 @@
             "currentTimestamp": "0x03e8",
             "currentRandom": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "currentDifficulty": "0x00",
-            "currentBaseFee": "0x07",
-            "previousHash": "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+            "currentBaseFee": "0x07"
         },
         "pre": {
             "0x1000000000000000000000000000000000000000": {


### PR DESCRIPTION
## 🗒️ Description
do not print previousHash field in generated state tests
as it is a legacy field that has no meaning and we never use it 

## 🔗 Related Issues

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](../docs/) directory.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
