### PR TITLE
docs: update blockchain test consumption section

### DIFF
--- a/docs/consuming_tests/blockchain_test.md
+++ b/docs/consuming_tests/blockchain_test.md
@@ -31,18 +31,19 @@ For each [`Fixture`](#fixture) test object in the JSON fixture file, perform the
         1. If the [`expectException`](#expectexception-str) field is not present, it is valid, and object must be decoded as a [`FixtureBlock`](#fixtureblock).
         2. If the [`expectException`](#expectexception-str) field is present, it is invalid, and object must be decoded as a [`InvalidFixtureBlock`](#invalidfixtureblock).
 
-    2. Attempt to decode field [`rlp`](#-rlp-bytes) as the current block, and if the block cannot be decoded:
+    2. Attempt to decode field [`rlp`](#-rlp-bytes) as the current block
+        1. If the block cannot be decoded:
+            - If an rlp decoding exception is not expected for the current block, fail the test.
+            - If an rlp decoding error is expected, pass the test (Note: A block with an expected exception will be the last block in the fixture).
+        2. If the block can be decoded, proceed to the next step.
 
-        1. If an exception is not expected for the current block, fail the test.
-        2. Proceed to the next block.
-
-    3. Attempt to apply the current decoded block on top of the current head of the chain, and if the block cannot be applied:
-
-        1. If an exception is not expected for the current block, fail the test.
-        2. Proceed to the next block.
-
-    4. If an exception is expected for the current block, fail the test.
-    5. Set the decoded block as the current head of the chain.
+    3. Attempt to apply the current decoded block on top of the current head of the chain
+        1. If the block cannot be applied:
+            - If an exception is expected on the current block and it matches the exception obtained upon execution, pass the test. (Note: A block with an expected exception will be the last block in the fixture)
+            - If an exception is not expected on the current block, fail the test
+        2. If the block can be applied:
+            - If an exception is expected on the current block, fail the test
+            - If an exception is not expected on the current block, set the decoded block as the current head of the chain and proceed to the next block until you reach the last block in the fixture.
 
 8. Compare the hash of the current head of the chain against [`lastblockhash`](#-lastblockhash-hash), if they do not match, fail the test.
 9. Compare all accounts and the fields described in [`post`](#-post-alloc) against the current state, if any do not match, fail the test.


### PR DESCRIPTION
## 🗒️ Description
Updated the section on Blockchain Tests consumption with more details.


## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](../docs/) directory.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
