### PR TITLE
fix(forks,fw): Fix transition forks on state tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,18 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 **Key:** ✨ = New, 🐞 = Fixed, 🔀 = Changed, 💥 = Breaking change.
 
+## [v2.0.1](https://github.com/ethereum/execution-spec-tests/releases/tag/v2.0.1) - 20XX-XX-XX: Unreleased
+
+### 🧪 Test Cases
+
+### 🛠️ Framework
+
+- 🐞 State tests generated with transition forks no longer use the transition fork name in the fixture output, instead they use the actual enabled fork according to the state test's block number and timestamp ([#406](https://github.com/ethereum/execution-spec-tests/pull/406)).
+
+### 📋 Misc
+
+### 💥 Breaking Changes
+
 ## [v2.0.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v2.0.0) - 2024-01-25: 🐍🏖️ Cancun
 
 Release [v2.0.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v2.0.0) contains many important framework changes, including introduction of the `StateTest` format, and some additional Cancun and other test coverage.

--- a/src/ethereum_test_forks/base_fork.py
+++ b/src/ethereum_test_forks/base_fork.py
@@ -235,6 +235,14 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
         return cls.__name__
 
     @classmethod
+    def fork_at(cls, block_number: int = 0, timestamp: int = 0) -> Type["BaseFork"]:
+        """
+        Returns the fork at the given block number and timestamp.
+        Useful only for transition forks, and it's a no-op for normal forks.
+        """
+        return cls
+
+    @classmethod
     @abstractmethod
     def transition_tool_name(cls, block_number: int = 0, timestamp: int = 0) -> str:
         """

--- a/src/ethereum_test_forks/tests/test_forks.py
+++ b/src/ethereum_test_forks/tests/test_forks.py
@@ -54,6 +54,13 @@ def test_transition_forks():
     assert ParisToShanghaiAtTime15k.engine_new_payload_version(0, 14_999) == 1
     assert ParisToShanghaiAtTime15k.engine_new_payload_version(0, 15_000) == 2
 
+    assert BerlinToLondonAt5.fork_at(4, 0) == Berlin
+    assert BerlinToLondonAt5.fork_at(5, 0) == London
+    assert ParisToShanghaiAtTime15k.fork_at(0, 14_999) == Paris
+    assert ParisToShanghaiAtTime15k.fork_at(0, 15_000) == Shanghai
+    assert ParisToShanghaiAtTime15k.fork_at() == Paris
+    assert ParisToShanghaiAtTime15k.fork_at(10_000_000, 14_999) == Paris
+
 
 def test_forks_from():  # noqa: D103
     assert forks_from(Paris) == [Paris, LAST_DEPLOYED]

--- a/src/ethereum_test_forks/transition_base_fork.py
+++ b/src/ethereum_test_forks/transition_base_fork.py
@@ -91,6 +91,9 @@ def transition_fork(to_fork: Fork, at_block: int = 0, at_timestamp: int = 0):
 
         NewTransitionClass.transitions_to = lambda: to_fork  # type: ignore
         NewTransitionClass.transitions_from = lambda: from_fork  # type: ignore
+        NewTransitionClass.fork_at = lambda block_number=0, timestamp=0: (  # type: ignore
+            to_fork if block_number >= at_block and timestamp >= at_timestamp else from_fork
+        )
 
         return NewTransitionClass
 

--- a/src/ethereum_test_tools/spec/state/state_test.py
+++ b/src/ethereum_test_tools/spec/state/state_test.py
@@ -198,6 +198,9 @@ class StateTest(BaseTest):
         if self.fixture_format in BlockchainTest.fixture_formats():
             return self.generate_blockchain_test().generate(t8n, fork, eips)
         elif self.fixture_format == FixtureFormats.STATE_TEST:
+            # We can't generate a state test fixture that names a transition fork,
+            # so we get the fork at the block number and timestamp of the state test
+            fork = fork.fork_at(Number(self.env.number), Number(self.env.timestamp))
             return self.make_state_test_fixture(t8n, fork, eips)
 
         raise Exception(f"Unknown fixture format: {self.fixture_format}")


### PR DESCRIPTION
## 🗒️ Description
Fix state test generated using transition forks, so the transition fork is not named in the output fixture, but the actual Fork that should be enabled according to the state test's block number and timestamp.

## 🔗 Related Issues
Fixes #405

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](../docs/) directory.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
