### PR TITLE
ci (feature): use `run-parallel` and shared wheel packages for tox

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,12 +12,12 @@ jobs:
             python: '3.10'
             solc: '0.8.20'
             evm-type: 'main'
-            tox-cmd: 'tox'
+            tox-cmd: 'tox run-parallel --parallel-no-spinner'
           - os: ubuntu-latest
             python: '3.12'
             solc: '0.8.23'
             evm-type: 'main'
-            tox-cmd: 'tox'
+            tox-cmd: 'tox run-parallel --parallel-no-spinner'
           - os: ubuntu-latest
             python: '3.11'
             solc: '0.8.21'
@@ -27,7 +27,7 @@ jobs:
             python: '3.11'
             solc: '0.8.22'
             evm-type: 'main'
-            tox-cmd: 'tox'
+            tox-cmd: 'tox run-parallel --parallel-no-spinner'
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     hooks:
       - id: tox
         name: tox
-        entry: tox
+        entry: tox run-parallel
         language: system
         types: [python]
         pass_filenames: false

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,8 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 ### 📋 Misc
 
+- ✨ Use `run-parallel` and shared wheel packages for `tox` ([#408](https://github.com/ethereum/execution-spec-tests/pull/408)).
+
 ### 💥 Breaking Changes
 
 ## [v2.0.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v2.0.0) - 2024-01-25: 🐍🏖️ Cancun

--- a/docs/writing_tests/verifying_changes.md
+++ b/docs/writing_tests/verifying_changes.md
@@ -20,6 +20,12 @@ pip install tox
 Run tox, as executed in Github Actions, with:
 
 ```console
+tox run-parallel
+```
+
+or, with sequential test environment execution and verbose output as:
+
+```console
 tox
 ```
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,10 @@ env_list =
 [main]
 development_fork = Cancun
 
+[testenv]
+package = wheel
+wheel_build_env = .pkg
+
 [testenv:framework]
 description = Run checks on helper libraries and test framework
 


### PR DESCRIPTION
## 🗒️ Description
1. Run `tox` with `run-parallel` in Github Actions and pre-commit.
2. Configure `tox.ini` to use a shared wheel across testenvs instead of individually installing test-filler as a source distribution.

Tricks found in this article https://hynek.me/articles/turbo-charge-tox/.

The speed-up mainly comes from running the `docs` tox `env` in parallel to the `test` env (so you'll never save more time than `docs` takes) - not sure how much of a tangible impact this will have on Github Actions.

But adding `run-parallel` to tox is certainly worthwhile locally. This must be done manually (or via pre-commit).

#### Comparison with Cancun tests (on 69e1d92f):

| Change | Changes in `./src/` | No changes in ./src/ |
|--------| -------------------|----------------------|
| No changes | 1m 7s | 1m 10s |
| tox run-parallel | 40s | 42s |
| Re-use wheel config | 1m 0s | 1m 0s |
| tox run-parallel and re-use wheel config | 37s | 38s |

#### Comparison in Github Actions

There seems to be such a large variance of running times for "Run Tox Verifications" that these changes will unlikely noticeably impact ci/cd:
![image](https://github.com/ethereum/execution-spec-tests/assets/91727015/7eb2beb8-5378-4013-a7e8-01fe37719137)


## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](../docs/) directory.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
