### PR TITLE
bug(pytest, forks): fix `yul_test` marker and improve `solc --evm-version` param handling

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,19 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 **Key:** ✨ = New, 🐞 = Fixed, 🔀 = Changed, 💥 = Breaking change.
 
+## 🔜 [Unreleased] https://github.com/ethereum/execution-spec-tests/releases/tag/v-Unreleased) - 2024-xx-xx
+
+### 🧪 Test Cases
+
+### 🛠️ Framework
+
+- ✨ Improve handling of the argument passed to `solc --evm-version` when compiling Yul code ([#418](https://github.com/ethereum/execution-spec-tests/pull/418)).
+- 🐞 Fix `fill -m yul_test` which failed to filter tests that are (dynamically) marked as a yul test ([#418](https://github.com/ethereum/execution-spec-tests/pull/418)).
+
+### 🔧 EVM Tools
+
+### 📋 Misc
+
 ## [v2.1.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v2.1.0) - 2024-01-29: 🐍🏖️ Cancun
 
 Release [v2.1.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v2.1.0) primarily fixes a small bug introduced within the previous release where transition forks are used within the new `StateTest` format. This was highlighted by @chfast within #405 (https://github.com/ethereum/execution-spec-tests/issues/405), where the fork name `ShanghaiToCancunAtTime15k` was found within state tests.

--- a/src/ethereum_test_forks/__init__.py
+++ b/src/ethereum_test_forks/__init__.py
@@ -2,7 +2,7 @@
 Ethereum test fork definitions.
 """
 
-from .base_fork import SOLC_VERSION_TO_SUPPORTED_FORKS, Fork, ForkAttribute
+from .base_fork import Fork, ForkAttribute
 from .forks.forks import (
     ArrowGlacier,
     Berlin,
@@ -40,7 +40,6 @@ from .helpers import (
 )
 
 __all__ = [
-    "SOLC_VERSION_TO_SUPPORTED_FORKS",
     "Fork",
     "ForkAttribute",
     "ArrowGlacier",

--- a/src/ethereum_test_forks/__init__.py
+++ b/src/ethereum_test_forks/__init__.py
@@ -2,7 +2,7 @@
 Ethereum test fork definitions.
 """
 
-from .base_fork import Fork, ForkAttribute
+from .base_fork import SOLC_VERSION_TO_SUPPORTED_FORKS, Fork, ForkAttribute
 from .forks.forks import (
     ArrowGlacier,
     Berlin,
@@ -28,15 +28,19 @@ from .helpers import (
     InvalidForkError,
     forks_from,
     forks_from_until,
+    get_closest_fork_with_solc_support,
     get_deployed_forks,
     get_development_forks,
     get_forks,
+    get_forks_with_solc_support,
+    get_forks_without_solc_support,
     get_transition_forks,
     transition_fork_from_to,
     transition_fork_to,
 )
 
 __all__ = [
+    "SOLC_VERSION_TO_SUPPORTED_FORKS",
     "Fork",
     "ForkAttribute",
     "ArrowGlacier",
@@ -63,6 +67,9 @@ __all__ = [
     "get_deployed_forks",
     "get_development_forks",
     "get_forks",
+    "get_forks_with_solc_support",
+    "get_forks_without_solc_support",
+    "get_closest_fork_with_solc_support",
     "transition_fork_from_to",
     "transition_fork_to",
 ]

--- a/src/ethereum_test_forks/base_fork.py
+++ b/src/ethereum_test_forks/base_fork.py
@@ -8,28 +8,6 @@ from semver import Version
 
 from .base_decorators import prefer_transition_to_method
 
-SOLC_FORKS_0_8_20 = [
-    "homestead",
-    "tangerineWhistle",
-    "spuriousDragon",
-    "byzantium",
-    "constantinople",
-    "petersburg",
-    "istanbul",
-    "berlin",
-    "london",
-    "paris",
-    "shanghai",
-]
-SOLC_VERSION_TO_SUPPORTED_FORKS = {
-    Version.parse("0.8.20"): SOLC_FORKS_0_8_20,
-    Version.parse("0.8.21"): SOLC_FORKS_0_8_20,
-    Version.parse("0.8.22"): SOLC_FORKS_0_8_20,
-    Version.parse("0.8.23"): SOLC_FORKS_0_8_20,
-    # TBA: 0.8.24 is the current dev version.
-    Version.parse("0.8.24"): SOLC_FORKS_0_8_20,
-}
-
 
 class ForkAttribute(Protocol):
     """
@@ -283,14 +261,12 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
         pass
 
     @classmethod
-    def is_supported_by_solc(cls, version: Version) -> bool:
+    @abstractmethod
+    def solc_min_version(cls, block_number: int = 0, timestamp: int = 0) -> Version:
         """
-        Returns True if the fork is supported by solc (--evm-version).
+        Returns the minimum version of solc that supports this fork.
         """
-        assert (
-            version in SOLC_VERSION_TO_SUPPORTED_FORKS.keys()
-        ), f"Unsupported solc version: {version}"
-        return cls.solc_name() in SOLC_VERSION_TO_SUPPORTED_FORKS[version]
+        pass
 
     @classmethod
     def blockchain_test_network_name(cls) -> str:

--- a/src/ethereum_test_forks/base_fork.py
+++ b/src/ethereum_test_forks/base_fork.py
@@ -254,7 +254,7 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
 
     @classmethod
     @abstractmethod
-    def solc_name(cls, block_number: int = 0, timestamp: int = 0) -> str:
+    def solc_name(cls) -> str:
         """
         Returns fork name as it's meant to be passed to the solc compiler.
         """
@@ -262,7 +262,7 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
 
     @classmethod
     @abstractmethod
-    def solc_min_version(cls, block_number: int = 0, timestamp: int = 0) -> Version:
+    def solc_min_version(cls) -> Version:
         """
         Returns the minimum version of solc that supports this fork.
         """

--- a/src/ethereum_test_forks/base_fork.py
+++ b/src/ethereum_test_forks/base_fork.py
@@ -4,7 +4,31 @@ Abstract base class for Ethereum forks
 from abc import ABC, ABCMeta, abstractmethod
 from typing import Any, ClassVar, List, Mapping, Optional, Protocol, Type
 
+from semver import Version
+
 from .base_decorators import prefer_transition_to_method
+
+SOLC_FORKS_0_8_20 = [
+    "homestead",
+    "tangerineWhistle",
+    "spuriousDragon",
+    "byzantium",
+    "constantinople",
+    "petersburg",
+    "istanbul",
+    "berlin",
+    "london",
+    "paris",
+    "shanghai",
+]
+SOLC_VERSION_TO_SUPPORTED_FORKS = {
+    Version.parse("0.8.20"): SOLC_FORKS_0_8_20,
+    Version.parse("0.8.21"): SOLC_FORKS_0_8_20,
+    Version.parse("0.8.22"): SOLC_FORKS_0_8_20,
+    Version.parse("0.8.23"): SOLC_FORKS_0_8_20,
+    # TBA: 0.8.24 is the current dev version.
+    Version.parse("0.8.24"): SOLC_FORKS_0_8_20,
+}
 
 
 class ForkAttribute(Protocol):
@@ -257,6 +281,16 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
         Returns fork name as it's meant to be passed to the solc compiler.
         """
         pass
+
+    @classmethod
+    def is_supported_by_solc(cls, version: Version) -> bool:
+        """
+        Returns True if the fork is supported by solc (--evm-version).
+        """
+        assert (
+            version in SOLC_VERSION_TO_SUPPORTED_FORKS.keys()
+        ), f"Unsupported solc version: {version}"
+        return cls.solc_name() in SOLC_VERSION_TO_SUPPORTED_FORKS[version]
 
     @classmethod
     def blockchain_test_network_name(cls) -> str:

--- a/src/ethereum_test_forks/base_fork.py
+++ b/src/ethereum_test_forks/base_fork.py
@@ -26,8 +26,7 @@ SOLC_VERSION_TO_SUPPORTED_FORKS = {
     Version.parse("0.8.21"): SOLC_FORKS_0_8_20,
     Version.parse("0.8.22"): SOLC_FORKS_0_8_20,
     Version.parse("0.8.23"): SOLC_FORKS_0_8_20,
-    # TBA: 0.8.24 is the current dev version.
-    Version.parse("0.8.24"): SOLC_FORKS_0_8_20,
+    Version.parse("0.8.24"): SOLC_FORKS_0_8_20 + ["cancun"],  # dev version
 }
 
 

--- a/src/ethereum_test_forks/base_fork.py
+++ b/src/ethereum_test_forks/base_fork.py
@@ -26,7 +26,8 @@ SOLC_VERSION_TO_SUPPORTED_FORKS = {
     Version.parse("0.8.21"): SOLC_FORKS_0_8_20,
     Version.parse("0.8.22"): SOLC_FORKS_0_8_20,
     Version.parse("0.8.23"): SOLC_FORKS_0_8_20,
-    Version.parse("0.8.24"): SOLC_FORKS_0_8_20 + ["cancun"],  # dev version
+    # TBA: 0.8.24 is the current dev version.
+    Version.parse("0.8.24"): SOLC_FORKS_0_8_20,
 }
 
 

--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -3,11 +3,13 @@ All Ethereum fork class definitions.
 """
 from typing import List, Mapping, Optional
 
+from semver import Version
+
 from ..base_fork import BaseFork
 
 
 # All forks must be listed here !!! in the order they were introduced !!!
-class Frontier(BaseFork, solc_name=None):
+class Frontier(BaseFork, solc_name="homestead"):
     """
     Frontier fork
     """
@@ -28,7 +30,14 @@ class Frontier(BaseFork, solc_name=None):
         """
         if cls._solc_name is not None:
             return cls._solc_name
-        return cls.name()
+        return cls.name().lower()
+
+    @classmethod
+    def solc_min_version(cls, block_number: int = 0, timestamp: int = 0) -> Version:
+        """
+        Returns the minimum version of solc that supports this fork.
+        """
+        return Version.parse("0.8.20")
 
     @classmethod
     def header_base_fee_required(cls, block_number: int = 0, timestamp: int = 0) -> bool:
@@ -150,7 +159,7 @@ class Frontier(BaseFork, solc_name=None):
         return {}
 
 
-class Homestead(Frontier, solc_name="homestead"):
+class Homestead(Frontier):
     """
     Homestead fork
     """
@@ -163,7 +172,7 @@ class Homestead(Frontier, solc_name="homestead"):
         return [1, 2, 3, 4] + super(Homestead, cls).precompiles(block_number, timestamp)
 
 
-class Byzantium(Homestead, solc_name="byzantium"):
+class Byzantium(Homestead):
     """
     Byzantium fork
     """
@@ -186,7 +195,7 @@ class Byzantium(Homestead, solc_name="byzantium"):
         return [5, 6, 7, 8] + super(Byzantium, cls).precompiles(block_number, timestamp)
 
 
-class Constantinople(Byzantium, solc_name="constantinople"):
+class Constantinople(Byzantium):
     """
     Constantinople fork
     """
@@ -208,7 +217,7 @@ class ConstantinopleFix(Constantinople, solc_name="constantinople"):
     pass
 
 
-class Istanbul(ConstantinopleFix, solc_name="istanbul"):
+class Istanbul(ConstantinopleFix):
     """
     Istanbul fork
     """
@@ -222,7 +231,7 @@ class Istanbul(ConstantinopleFix, solc_name="istanbul"):
 
 
 # Glacier forks skipped, unless explicitly specified
-class MuirGlacier(Istanbul):
+class MuirGlacier(Istanbul, solc_name="istanbul"):
     """
     Muir Glacier fork
     """
@@ -230,7 +239,7 @@ class MuirGlacier(Istanbul):
     pass
 
 
-class Berlin(Istanbul, solc_name="berlin"):
+class Berlin(Istanbul):
     """
     Berlin fork
     """
@@ -243,7 +252,7 @@ class Berlin(Istanbul, solc_name="berlin"):
         return [1] + super(Berlin, cls).tx_types(block_number, timestamp)
 
 
-class London(Berlin, solc_name="london"):
+class London(Berlin):
     """
     London fork
     """
@@ -264,7 +273,7 @@ class London(Berlin, solc_name="london"):
 
 
 # Glacier forks skipped, unless explicitly specified
-class ArrowGlacier(London):
+class ArrowGlacier(London, solc_name="london"):
     """
     Arrow Glacier fork
     """
@@ -272,7 +281,7 @@ class ArrowGlacier(London):
     pass
 
 
-class GrayGlacier(ArrowGlacier):
+class GrayGlacier(ArrowGlacier, solc_name="london"):
     """
     Gray Glacier fork
     """
@@ -282,7 +291,6 @@ class GrayGlacier(ArrowGlacier):
 
 class Paris(
     London,
-    solc_name="paris",
     transition_tool_name="Merge",
     blockchain_test_network_name="Merge",
 ):
@@ -321,7 +329,7 @@ class Paris(
         return 1
 
 
-class Shanghai(Paris, solc_name="shanghai"):
+class Shanghai(Paris):
     """
     Shanghai fork
     """
@@ -343,7 +351,7 @@ class Shanghai(Paris, solc_name="shanghai"):
         return 2
 
 
-class Cancun(Shanghai, solc_name="cancun"):
+class Cancun(Shanghai):
     """
     Cancun fork
     """
@@ -355,6 +363,13 @@ class Cancun(Shanghai, solc_name="cancun"):
         development.
         """
         return False
+
+    @classmethod
+    def solc_min_version(cls, block_number: int = 0, timestamp: int = 0) -> Version:
+        """
+        Returns the minimum version of solc that supports this fork.
+        """
+        return Version.parse("0.8.24")
 
     @classmethod
     def header_excess_blob_gas_required(cls, block_number: int = 0, timestamp: int = 0) -> bool:

--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -24,7 +24,7 @@ class Frontier(BaseFork, solc_name="homestead"):
         return cls.name()
 
     @classmethod
-    def solc_name(cls, block_number: int = 0, timestamp: int = 0) -> str:
+    def solc_name(cls) -> str:
         """
         Returns fork name as it's meant to be passed to the solc compiler.
         """
@@ -33,7 +33,7 @@ class Frontier(BaseFork, solc_name="homestead"):
         return cls.name().lower()
 
     @classmethod
-    def solc_min_version(cls, block_number: int = 0, timestamp: int = 0) -> Version:
+    def solc_min_version(cls) -> Version:
         """
         Returns the minimum version of solc that supports this fork.
         """
@@ -365,7 +365,7 @@ class Cancun(Shanghai):
         return False
 
     @classmethod
-    def solc_min_version(cls, block_number: int = 0, timestamp: int = 0) -> Version:
+    def solc_min_version(cls) -> Version:
         """
         Returns the minimum version of solc that supports this fork.
         """

--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -200,7 +200,7 @@ class Constantinople(Byzantium, solc_name="constantinople"):
         return 2_000_000_000_000_000_000
 
 
-class ConstantinopleFix(Constantinople):
+class ConstantinopleFix(Constantinople, solc_name="constantinople"):
     """
     Constantinople Fix fork
     """

--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -200,7 +200,7 @@ class Constantinople(Byzantium, solc_name="constantinople"):
         return 2_000_000_000_000_000_000
 
 
-class ConstantinopleFix(Constantinople, solc_name="constantinople"):
+class ConstantinopleFix(Constantinople):
     """
     Constantinople Fix fork
     """

--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -7,7 +7,7 @@ from ..base_fork import BaseFork
 
 
 # All forks must be listed here !!! in the order they were introduced !!!
-class Frontier(BaseFork):
+class Frontier(BaseFork, solc_name=None):
     """
     Frontier fork
     """
@@ -150,7 +150,7 @@ class Frontier(BaseFork):
         return {}
 
 
-class Homestead(Frontier):
+class Homestead(Frontier, solc_name="homestead"):
     """
     Homestead fork
     """
@@ -163,7 +163,7 @@ class Homestead(Frontier):
         return [1, 2, 3, 4] + super(Homestead, cls).precompiles(block_number, timestamp)
 
 
-class Byzantium(Homestead):
+class Byzantium(Homestead, solc_name="byzantium"):
     """
     Byzantium fork
     """
@@ -186,7 +186,7 @@ class Byzantium(Homestead):
         return [5, 6, 7, 8] + super(Byzantium, cls).precompiles(block_number, timestamp)
 
 
-class Constantinople(Byzantium):
+class Constantinople(Byzantium, solc_name="constantinople"):
     """
     Constantinople fork
     """
@@ -200,7 +200,7 @@ class Constantinople(Byzantium):
         return 2_000_000_000_000_000_000
 
 
-class ConstantinopleFix(Constantinople, solc_name="Constantinople"):
+class ConstantinopleFix(Constantinople, solc_name="constantinople"):
     """
     Constantinople Fix fork
     """
@@ -208,7 +208,7 @@ class ConstantinopleFix(Constantinople, solc_name="Constantinople"):
     pass
 
 
-class Istanbul(ConstantinopleFix):
+class Istanbul(ConstantinopleFix, solc_name="istanbul"):
     """
     Istanbul fork
     """
@@ -230,7 +230,7 @@ class MuirGlacier(Istanbul):
     pass
 
 
-class Berlin(Istanbul):
+class Berlin(Istanbul, solc_name="berlin"):
     """
     Berlin fork
     """
@@ -243,7 +243,7 @@ class Berlin(Istanbul):
         return [1] + super(Berlin, cls).tx_types(block_number, timestamp)
 
 
-class London(Berlin):
+class London(Berlin, solc_name="london"):
     """
     London fork
     """
@@ -282,6 +282,7 @@ class GrayGlacier(ArrowGlacier):
 
 class Paris(
     London,
+    solc_name="paris",
     transition_tool_name="Merge",
     blockchain_test_network_name="Merge",
 ):
@@ -320,7 +321,7 @@ class Paris(
         return 1
 
 
-class Shanghai(Paris):
+class Shanghai(Paris, solc_name="shanghai"):
     """
     Shanghai fork
     """
@@ -342,7 +343,7 @@ class Shanghai(Paris):
         return 2
 
 
-class Cancun(Shanghai):
+class Cancun(Shanghai, solc_name="cancun"):
     """
     Cancun fork
     """

--- a/src/ethereum_test_forks/helpers.py
+++ b/src/ethereum_test_forks/helpers.py
@@ -33,7 +33,7 @@ def get_forks() -> List[Fork]:
     return all_forks
 
 
-def get_deployed_forks():
+def get_deployed_forks() -> List[Fork]:
     """
     Returns a list of all the fork classes implemented by `ethereum_test_forks`
     that have been deployed to mainnet, chronologically ordered by deployment.
@@ -41,7 +41,7 @@ def get_deployed_forks():
     return [fork for fork in get_forks() if fork.is_deployed()]
 
 
-def get_development_forks():
+def get_development_forks() -> List[Fork]:
     """
     Returns a list of all the fork classes implemented by `ethereum_test_forks`
     that have been not yet deployed to mainnet and are currently under

--- a/src/ethereum_test_forks/tests/test_forks.py
+++ b/src/ethereum_test_forks/tests/test_forks.py
@@ -4,15 +4,19 @@ Test fork utilities.
 
 from typing import Mapping, cast
 
+from semver import Version
+
 from ..base_fork import Fork
 from ..forks.forks import Berlin, Cancun, Frontier, London, Paris, Shanghai
 from ..forks.transition import BerlinToLondonAt5, ParisToShanghaiAtTime15k
 from ..helpers import (
     forks_from,
     forks_from_until,
+    get_closest_fork_with_solc_support,
     get_deployed_forks,
     get_development_forks,
     get_forks,
+    get_forks_with_solc_support,
     transition_fork_from_to,
     transition_fork_to,
 )
@@ -214,3 +218,14 @@ def test_precompiles():
 
 def test_tx_types():
     Cancun.tx_types() == list(range(4))
+
+
+def test_solc_versioning():
+    assert len(get_forks_with_solc_support(Version.parse("0.8.20"))) == 13
+    assert len(get_forks_with_solc_support(Version.parse("0.8.24"))) > 13
+
+
+def test_closest_fork_supported_by_solc():
+    assert get_closest_fork_with_solc_support(Paris, Version.parse("0.8.20")) == Paris
+    assert get_closest_fork_with_solc_support(Cancun, Version.parse("0.8.20")) == Shanghai
+    assert get_closest_fork_with_solc_support(Cancun, Version.parse("0.8.24")) == Cancun

--- a/src/ethereum_test_forks/tests/test_forks.py
+++ b/src/ethereum_test_forks/tests/test_forks.py
@@ -1,40 +1,18 @@
 """
 Test fork utilities.
 """
+
 from typing import Mapping, cast
 
-import pytest
-from semver import Version
-
-from ethereum_test_tools.code import SOLC_SUPPORTED_VERSIONS
-
 from ..base_fork import Fork
-from ..forks.forks import (
-    ArrowGlacier,
-    Berlin,
-    Byzantium,
-    Cancun,
-    Constantinople,
-    ConstantinopleFix,
-    Frontier,
-    GrayGlacier,
-    Homestead,
-    Istanbul,
-    London,
-    MuirGlacier,
-    Paris,
-    Shanghai,
-)
+from ..forks.forks import Berlin, Cancun, Frontier, London, Paris, Shanghai
 from ..forks.transition import BerlinToLondonAt5, ParisToShanghaiAtTime15k
 from ..helpers import (
     forks_from,
     forks_from_until,
-    get_closest_fork_with_solc_support,
     get_deployed_forks,
     get_development_forks,
     get_forks,
-    get_forks_with_solc_support,
-    get_forks_without_solc_support,
     transition_fork_from_to,
     transition_fork_to,
 )
@@ -236,87 +214,3 @@ def test_precompiles():
 
 def test_tx_types():
     Cancun.tx_types() == list(range(4))
-
-
-@pytest.mark.parametrize("solc_version", SOLC_SUPPORTED_VERSIONS)
-def test_get_forks_with_solc_support(solc_version):  # noqa: D103
-    forks_with = get_forks_with_solc_support(solc_version)
-    assert Homestead in forks_with
-    assert Byzantium in forks_with
-    assert Constantinople in forks_with
-    assert Istanbul in forks_with
-    assert Berlin in forks_with
-    assert London in forks_with
-    assert Paris in forks_with
-    assert Shanghai in forks_with
-    if solc_version >= "0.8.24":
-        assert Cancun in forks_with
-    assert solc_version < "0.8.25", "update test for new solc version"
-
-
-@pytest.mark.parametrize("solc_version", SOLC_SUPPORTED_VERSIONS)
-def test_get_forks_without_solc_support(solc_version):  # noqa: D103
-    forks_without = get_forks_without_solc_support(solc_version)
-    assert Frontier in forks_without
-    assert ConstantinopleFix in forks_without
-    assert ArrowGlacier in forks_without
-    assert MuirGlacier in forks_without
-    assert GrayGlacier in forks_without
-    if solc_version < "0.8.24":
-        assert Cancun in forks_without
-    assert solc_version < "0.8.25", "update test for new solc version"
-
-
-@pytest.mark.parametrize("solc_version", SOLC_SUPPORTED_VERSIONS)
-@pytest.mark.parametrize(
-    "fork,closest_fork_with_solc_support",
-    [
-        (Frontier, Homestead),
-        (Homestead, Homestead),
-        (Byzantium, Byzantium),
-        (Constantinople, Constantinople),
-        (ConstantinopleFix, Constantinople),
-        (Istanbul, Istanbul),
-        (MuirGlacier, Istanbul),
-        (Berlin, Berlin),
-        (London, London),
-        (ArrowGlacier, London),
-        (GrayGlacier, London),
-        (Paris, Paris),
-        (Shanghai, Shanghai),
-    ],
-)
-def test_get_closest_fork_with_solc_support_deployed(  # noqa: D103
-    solc_version, fork, closest_fork_with_solc_support
-):
-    """
-    Test get_closest_fork_with_solc_support for deployed forks.
-    """
-    closest_fork_got = get_closest_fork_with_solc_support(fork, solc_version)
-    assert closest_fork_got == closest_fork_with_solc_support
-    assert closest_fork_got.solc_name() == closest_fork_with_solc_support.name().lower()
-
-
-@pytest.mark.parametrize(
-    "solc_version,fork,closest_fork_with_solc_support",
-    [
-        ("0.8.20", Cancun, Shanghai),
-        ("0.8.21", Cancun, Shanghai),
-        ("0.8.22", Cancun, Shanghai),
-        ("0.8.23", Cancun, Shanghai),
-        ("0.8.24", Cancun, Cancun),
-    ],
-)
-def test_get_closest_fork_with_solc_support_development(  # noqa: D103
-    solc_version,
-    fork,
-    closest_fork_with_solc_support,
-):
-    """
-    Test get_closest_fork_with_solc_support for development or recently deployed forks.
-    """
-    assert (
-        get_closest_fork_with_solc_support(fork, Version.parse(solc_version))
-        == closest_fork_with_solc_support
-    )
-    assert solc_version < "0.8.25", "update test for new solc version"

--- a/src/ethereum_test_forks/transition_base_fork.py
+++ b/src/ethereum_test_forks/transition_base_fork.py
@@ -1,9 +1,10 @@
 """
 Base objects used to define transition forks.
 """
-from typing import List, Type
+from inspect import signature
+from typing import Callable, List, Type
 
-from .base_fork import BaseFork, Fork, ForkAttribute
+from .base_fork import BaseFork, Fork
 
 ALWAYS_TRANSITIONED_BLOCK_NUMBER = 10_000
 ALWAYS_TRANSITIONED_BLOCK_TIMESTAMP = 10_000_000
@@ -59,21 +60,29 @@ def transition_fork(to_fork: Fork, at_block: int = 0, at_timestamp: int = 0):
         NewTransitionClass.name = lambda: transition_name  # type: ignore
 
         def make_transition_method(
-            base_method: ForkAttribute,
-            from_fork_method: ForkAttribute,
-            to_fork_method: ForkAttribute,
+            base_method: Callable,
+            from_fork_method: Callable,
+            to_fork_method: Callable,
         ):
+            base_method_parameters = signature(base_method).parameters
+
             def transition_method(
                 cls,
                 block_number: int = ALWAYS_TRANSITIONED_BLOCK_NUMBER,
                 timestamp: int = ALWAYS_TRANSITIONED_BLOCK_TIMESTAMP,
             ):
+                kwargs = {}
+                if "block_number" in base_method_parameters:
+                    kwargs["block_number"] = block_number
+                if "timestamp" in base_method_parameters:
+                    kwargs["timestamp"] = timestamp
+
                 if getattr(base_method, "__prefer_transition_to_method__", False):
-                    return to_fork_method(block_number=block_number, timestamp=timestamp)
+                    return to_fork_method(**kwargs)
                 return (
-                    to_fork_method(block_number=block_number, timestamp=timestamp)
+                    to_fork_method(**kwargs)
                     if block_number >= at_block and timestamp >= at_timestamp
-                    else from_fork_method(block_number=block_number, timestamp=timestamp)
+                    else from_fork_method(**kwargs)
                 )
 
             return classmethod(transition_method)

--- a/src/ethereum_test_tools/code/__init__.py
+++ b/src/ethereum_test_tools/code/__init__.py
@@ -3,10 +3,9 @@ Code related utilities and classes.
 """
 from .code import Code
 from .generators import CalldataCase, Case, CodeGasMeasure, Conditional, Initcode, Switch
-from .yul import SOLC_SUPPORTED_VERSIONS, Yul, YulCompiler
+from .yul import Yul, YulCompiler
 
 __all__ = (
-    "SOLC_SUPPORTED_VERSIONS",
     "Case",
     "CalldataCase",
     "Code",

--- a/src/ethereum_test_tools/code/__init__.py
+++ b/src/ethereum_test_tools/code/__init__.py
@@ -3,9 +3,10 @@ Code related utilities and classes.
 """
 from .code import Code
 from .generators import CalldataCase, Case, CodeGasMeasure, Conditional, Initcode, Switch
-from .yul import Yul, YulCompiler
+from .yul import SOLC_SUPPORTED_VERSIONS, Yul, YulCompiler
 
 __all__ = (
+    "SOLC_SUPPORTED_VERSIONS",
     "Case",
     "CalldataCase",
     "Code",

--- a/src/ethereum_test_tools/code/yul.py
+++ b/src/ethereum_test_tools/code/yul.py
@@ -11,14 +11,12 @@ from typing import Optional, Sized, SupportsBytes, Tuple, Type, Union
 
 from semver import Version
 
-from ethereum_test_forks import SOLC_VERSION_TO_SUPPORTED_FORKS, Fork
+from ethereum_test_forks import Fork
 
 from ..common.conversions import to_bytes
 from .code import Code
 
 DEFAULT_SOLC_ARGS = ("--assemble", "-")
-
-SOLC_SUPPORTED_VERSIONS = list(SOLC_VERSION_TO_SUPPORTED_FORKS.keys())
 
 
 def get_evm_version_from_fork(fork: Fork | None):

--- a/src/ethereum_test_tools/code/yul.py
+++ b/src/ethereum_test_tools/code/yul.py
@@ -11,12 +11,14 @@ from typing import Optional, Sized, SupportsBytes, Tuple, Type, Union
 
 from semver import Version
 
-from ethereum_test_forks import Fork
+from ethereum_test_forks import SOLC_VERSION_TO_SUPPORTED_FORKS, Fork
 
 from ..common.conversions import to_bytes
 from .code import Code
 
 DEFAULT_SOLC_ARGS = ("--assemble", "-")
+
+SOLC_SUPPORTED_VERSIONS = list(SOLC_VERSION_TO_SUPPORTED_FORKS.keys())
 
 
 def get_evm_version_from_fork(fork: Fork | None):
@@ -33,7 +35,7 @@ def get_evm_version_from_fork(fork: Fork | None):
     """
     if not fork:
         return None
-    return fork.solc_name().lower()
+    return fork.solc_name()
 
 
 class Yul(SupportsBytes, Sized):

--- a/src/ethereum_test_tools/tests/conftest.py
+++ b/src/ethereum_test_tools/tests/conftest.py
@@ -5,7 +5,9 @@ Common pytest fixtures for ethereum_test_tools tests.
 import pytest
 from semver import Version
 
-from ..code import SOLC_SUPPORTED_VERSIONS, Yul
+from ethereum_test_forks import Frontier
+
+from ..code import Yul
 
 SOLC_PADDING_VERSION = Version.parse("0.8.21")
 
@@ -14,6 +16,6 @@ SOLC_PADDING_VERSION = Version.parse("0.8.21")
 def solc_version() -> Version:
     """Return the version of solc being used for tests."""
     solc_version = Yul("").version().finalize_version()
-    if solc_version not in SOLC_SUPPORTED_VERSIONS:
+    if solc_version < Frontier.solc_min_version():
         raise Exception("Unsupported solc version: {}".format(solc_version))
     return solc_version

--- a/src/ethereum_test_tools/tests/conftest.py
+++ b/src/ethereum_test_tools/tests/conftest.py
@@ -5,11 +5,7 @@ Common pytest fixtures for ethereum_test_tools tests.
 import pytest
 from semver import Version
 
-from ..code import Yul
-
-SUPPORTED_SOLC_VERSIONS = [
-    Version.parse(v) for v in ["0.8.20", "0.8.21", "0.8.22", "0.8.23", "0.8.24"]
-]
+from ..code import SOLC_SUPPORTED_VERSIONS, Yul
 
 SOLC_PADDING_VERSION = Version.parse("0.8.21")
 
@@ -18,6 +14,6 @@ SOLC_PADDING_VERSION = Version.parse("0.8.21")
 def solc_version() -> Version:
     """Return the version of solc being used for tests."""
     solc_version = Yul("").version().finalize_version()
-    if solc_version not in SUPPORTED_SOLC_VERSIONS:
+    if solc_version not in SOLC_SUPPORTED_VERSIONS:
         raise Exception("Unsupported solc version: {}".format(solc_version))
     return solc_version

--- a/src/ethereum_test_tools/tests/test_code.py
+++ b/src/ethereum_test_tools/tests/test_code.py
@@ -8,26 +8,10 @@ from typing import Mapping, SupportsBytes
 import pytest
 from semver import Version
 
-from ethereum_test_forks import (
-    Fork,
-    Homestead,
-    Shanghai,
-    forks_from_until,
-    get_deployed_forks,
-    get_forks_with_solc_support,
-)
+from ethereum_test_forks import Fork, Homestead, Shanghai, get_deployed_forks
 from evm_transition_tool import FixtureFormats, GethTransitionTool
 
-from ..code import (
-    SOLC_SUPPORTED_VERSIONS,
-    CalldataCase,
-    Case,
-    Code,
-    Conditional,
-    Initcode,
-    Switch,
-    Yul,
-)
+from ..code import CalldataCase, Case, Code, Conditional, Initcode, Switch, Yul
 from ..common import Account, Environment, TestAddress, Transaction, to_hash_bytes
 from ..spec import StateTest
 from ..vm.opcode import Opcodes as Op
@@ -65,7 +49,7 @@ def test_code_operations(code: Code, expected_bytes: bytes):
     assert bytes(code) == expected_bytes
 
 
-@pytest.fixture(params=get_forks_with_solc_support(SOLC_SUPPORTED_VERSIONS[-1]))
+@pytest.fixture(params=get_deployed_forks())
 def fork(request: pytest.FixtureRequest):
     """
     Return the target evm-version (fork) for solc compilation.
@@ -97,7 +81,7 @@ def expected_bytes(request: pytest.FixtureRequest, solc_version: Version, fork: 
     """Return the expected bytes for the test."""
     expected_bytes = request.param
     if isinstance(expected_bytes, Template):
-        if solc_version < SOLC_PADDING_VERSION or fork == Homestead:
+        if solc_version < SOLC_PADDING_VERSION or fork <= Homestead:
             solc_padding = ""
         else:
             solc_padding = "00"
@@ -105,7 +89,7 @@ def expected_bytes(request: pytest.FixtureRequest, solc_version: Version, fork: 
     if isinstance(expected_bytes, bytes):
         if fork == Shanghai:
             expected_bytes = b"\x5f" + expected_bytes[2:]
-        if solc_version < SOLC_PADDING_VERSION or fork == Homestead:
+        if solc_version < SOLC_PADDING_VERSION or fork <= Homestead:
             return expected_bytes
         else:
             return expected_bytes + b"\x00"

--- a/src/ethereum_test_tools/tests/test_code.py
+++ b/src/ethereum_test_tools/tests/test_code.py
@@ -13,7 +13,9 @@ from ethereum_test_forks import (
     Homestead,
     Shanghai,
     forks_from_until,
+    get_closest_fork_with_solc_support,
     get_deployed_forks,
+    get_forks,
     get_forks_with_solc_support,
 )
 from evm_transition_tool import FixtureFormats, GethTransitionTool
@@ -32,6 +34,8 @@ from ..common import Account, Environment, TestAddress, Transaction, to_hash_byt
 from ..spec import StateTest
 from ..vm.opcode import Opcodes as Op
 from .conftest import SOLC_PADDING_VERSION
+
+LAST_DEPLOYED_FORK = Shanghai
 
 
 @pytest.mark.parametrize(
@@ -65,16 +69,12 @@ def test_code_operations(code: Code, expected_bytes: bytes):
     assert bytes(code) == expected_bytes
 
 
-@pytest.fixture(params=get_forks_with_solc_support(SOLC_SUPPORTED_VERSIONS[-1]))
+@pytest.fixture(params=get_forks())
 def fork(request: pytest.FixtureRequest):
     """
     Return the target evm-version (fork) for solc compilation.
-
-    Note:
-    - Homestead.
-    - forks_from_until: Used to remove the Glacier forks
     """
-    return request.param
+    return get_closest_fork_with_solc_support(request.param, Yul("").version())
 
 
 @pytest.fixture()

--- a/src/ethereum_test_tools/tests/test_code.py
+++ b/src/ethereum_test_tools/tests/test_code.py
@@ -13,9 +13,7 @@ from ethereum_test_forks import (
     Homestead,
     Shanghai,
     forks_from_until,
-    get_closest_fork_with_solc_support,
     get_deployed_forks,
-    get_forks,
     get_forks_with_solc_support,
 )
 from evm_transition_tool import FixtureFormats, GethTransitionTool
@@ -34,8 +32,6 @@ from ..common import Account, Environment, TestAddress, Transaction, to_hash_byt
 from ..spec import StateTest
 from ..vm.opcode import Opcodes as Op
 from .conftest import SOLC_PADDING_VERSION
-
-LAST_DEPLOYED_FORK = Shanghai
 
 
 @pytest.mark.parametrize(
@@ -69,12 +65,16 @@ def test_code_operations(code: Code, expected_bytes: bytes):
     assert bytes(code) == expected_bytes
 
 
-@pytest.fixture(params=get_forks())
+@pytest.fixture(params=get_forks_with_solc_support(SOLC_SUPPORTED_VERSIONS[-1]))
 def fork(request: pytest.FixtureRequest):
     """
     Return the target evm-version (fork) for solc compilation.
+
+    Note:
+    - Homestead.
+    - forks_from_until: Used to remove the Glacier forks
     """
-    return get_closest_fork_with_solc_support(request.param, Yul("").version())
+    return request.param
 
 
 @pytest.fixture()

--- a/src/ethereum_test_tools/tests/test_code.py
+++ b/src/ethereum_test_tools/tests/test_code.py
@@ -8,10 +8,26 @@ from typing import Mapping, SupportsBytes
 import pytest
 from semver import Version
 
-from ethereum_test_forks import Fork, Homestead, Shanghai, forks_from_until, get_deployed_forks
+from ethereum_test_forks import (
+    Fork,
+    Homestead,
+    Shanghai,
+    forks_from_until,
+    get_deployed_forks,
+    get_forks_with_solc_support,
+)
 from evm_transition_tool import FixtureFormats, GethTransitionTool
 
-from ..code import CalldataCase, Case, Code, Conditional, Initcode, Switch, Yul
+from ..code import (
+    SOLC_SUPPORTED_VERSIONS,
+    CalldataCase,
+    Case,
+    Code,
+    Conditional,
+    Initcode,
+    Switch,
+    Yul,
+)
 from ..common import Account, Environment, TestAddress, Transaction, to_hash_bytes
 from ..spec import StateTest
 from ..vm.opcode import Opcodes as Op
@@ -49,14 +65,14 @@ def test_code_operations(code: Code, expected_bytes: bytes):
     assert bytes(code) == expected_bytes
 
 
-@pytest.fixture(params=forks_from_until(get_deployed_forks()[1], get_deployed_forks()[-1]))
+@pytest.fixture(params=get_forks_with_solc_support(SOLC_SUPPORTED_VERSIONS[-1]))
 def fork(request: pytest.FixtureRequest):
     """
     Return the target evm-version (fork) for solc compilation.
 
     Note:
-    - get_deployed_forks()[1] (Homestead) is the first fork that solc supports.
-    - forks_from_util: Used to remove the Glacier forks
+    - Homestead.
+    - forks_from_until: Used to remove the Glacier forks
     """
     return request.param
 

--- a/src/pytest_plugins/test_filler/test_filler.py
+++ b/src/pytest_plugins/test_filler/test_filler.py
@@ -353,7 +353,7 @@ def yul(fork: Fork, request):
     Test cases can override the default value by specifying a fixed version
     with the @pytest.mark.compile_yul_with(FORK) marker.
     """
-    solc_target_fork: Fork
+    solc_target_fork: Fork | None
     marker = request.node.get_closest_marker("compile_yul_with")
     if marker:
         if not marker.args[0]:
@@ -364,6 +364,7 @@ def yul(fork: Fork, request):
         assert solc_target_fork in get_forks_with_solc_support(request.config.solc_version)
     else:
         solc_target_fork = get_closest_fork_with_solc_support(fork, request.config.solc_version)
+        assert solc_target_fork is not None, "No fork supports provided solc version."
         if request.config.getoption("verbose") >= 1:
             warnings.warn(f"Compiling Yul for {solc_target_fork}, not {fork}.")
 

--- a/src/pytest_plugins/test_filler/test_filler.py
+++ b/src/pytest_plugins/test_filler/test_filler.py
@@ -11,7 +11,12 @@ from typing import Generator, List, Optional, Type
 
 import pytest
 
-from ethereum_test_forks import Fork, Paris, get_development_forks
+from ethereum_test_forks import (
+    Fork,
+    Paris,
+    get_closest_fork_with_solc_support,
+    get_forks_with_solc_support,
+)
 from ethereum_test_tools import SPEC_TYPES, BaseTest, FixtureCollector, TestInfo, Yul
 from evm_transition_tool import FixtureFormats, TransitionTool
 from pytest_plugins.spec_version_checker.spec_version_checker import EIPSpecTestItem
@@ -161,6 +166,7 @@ def pytest_configure(config):
             "The Besu t8n tool does not work well with the xdist plugin; use -n=0.",
             returncode=pytest.ExitCode.USAGE_ERROR,
         )
+    config.solc_version = Yul("", binary=config.getoption("solc_bin")).version()
 
 
 @pytest.hookimpl(trylast=True)
@@ -170,8 +176,7 @@ def pytest_report_header(config, start_path):
         return
     binary_path = config.getoption("evm_bin")
     t8n = TransitionTool.from_binary_path(binary_path=binary_path)
-    solc_version_string = Yul("", binary=config.getoption("solc_bin")).version()
-    return [f"{t8n.version()}, solc version {solc_version_string}"]
+    return [f"{t8n.version()}, solc version {config.solc_version}"]
 
 
 @pytest.fixture(autouse=True, scope="session")
@@ -348,17 +353,23 @@ def yul(fork: Fork, request):
     Test cases can override the default value by specifying a fixed version
     with the @pytest.mark.compile_yul_with(FORK) marker.
     """
+    solc_target_fork: Fork
     marker = request.node.get_closest_marker("compile_yul_with")
     if marker:
         if not marker.args[0]:
             pytest.fail(
                 f"{request.node.name}: Expected one argument in 'compile_yul_with' marker."
             )
-        fork = request.config.fork_map[marker.args[0]]
+        solc_target_fork = request.config.fork_map[marker.args[0]]
+        assert solc_target_fork in get_forks_with_solc_support(request.config.solc_version)
+    else:
+        solc_target_fork = get_closest_fork_with_solc_support(fork, request.config.solc_version)
+        if request.config.getoption("verbose") >= 1:
+            warnings.warn(f"Compiling Yul for {solc_target_fork}, not {fork}.")
 
     class YulWrapper(Yul):
         def __init__(self, *args, **kwargs):
-            super(YulWrapper, self).__init__(*args, **kwargs, fork=fork)
+            super(YulWrapper, self).__init__(*args, **kwargs, fork=solc_target_fork)
 
     return YulWrapper
 
@@ -462,7 +473,6 @@ def pytest_generate_tests(metafunc):
             )
 
 
-@pytest.hookimpl(trylast=True)
 def pytest_collection_modifyitems(config, items):
     """
     Remove pre-Paris tests parametrized to generate hive type fixtures; these
@@ -487,19 +497,8 @@ def pytest_collection_modifyitems(config, items):
                 "blockchain_test"
             ].name.endswith("HIVE"):
                 items.remove(item)
-
-
-def pytest_runtest_setup(item):
-    """
-    A pytest hook called before setting up each test item.
-    """
-    if "yul" in item.fixturenames:
-        marker = pytest.mark.yul_test()
-        item.add_marker(marker)
-        if any([fork.name() in item.name for fork in get_development_forks()]):
-            if item.config.getoption("verbose") >= 1:
-                warnings.warn("Compiling Yul for with Shanghai, not the target fork.")
-            item.add_marker(pytest.mark.compile_yul_with("Shanghai"))
+        if "yul" in item.fixturenames:
+            item.add_marker(pytest.mark.yul_test)
 
 
 def pytest_make_parametrize_id(config, val, argname):

--- a/src/pytest_plugins/test_filler/test_filler.py
+++ b/src/pytest_plugins/test_filler/test_filler.py
@@ -13,6 +13,7 @@ import pytest
 
 from ethereum_test_forks import (
     Fork,
+    Frontier,
     Paris,
     get_closest_fork_with_solc_support,
     get_forks_with_solc_support,
@@ -167,6 +168,12 @@ def pytest_configure(config):
             returncode=pytest.ExitCode.USAGE_ERROR,
         )
     config.solc_version = Yul("", binary=config.getoption("solc_bin")).version()
+    if config.solc_version < Frontier.solc_min_version():
+        pytest.exit(
+            f"Unsupported solc version: {config.solc_version}. Minimum required version is "
+            f"{Frontier.solc_min_version()}",
+            returncode=pytest.ExitCode.USAGE_ERROR,
+        )
 
 
 @pytest.hookimpl(trylast=True)


### PR DESCRIPTION
## 🗒️ Description

1. Fixes `fill -m yul_test` which failed to filter tests that were (dynamically) marked as a yul test.
2. Defines which forks our supported solc versions can use as an argument to `--evm-version`.
3. Uses the definition from 2. to better pick an argument to `--evm-version` if the current fork is not supported.
4. Exit `fill` early in case of raising an incompatible solc. Previously this would return an error for every collected test:
    ```
    ✦ ➜ fill tests --solc-bin ~/bin/solc-0.8.19
    Exit: Unsupported solc version: 0.8.19+commit.7dd6d404.Linux.gpp. Minimum required version is 0.8.20
    ```

Opened as draft, remaining to do:
- [x] Add tests for new `ethereum_test_forks.helpers`.

Won't add pytest framework tests for `pytest_plugins.test_filler`. Would be nice, but we currently don't currently manage available solc versions, so results are undefined.

## 🔗 Related Issues
None.

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](../docs/) directory.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
