### PR TITLE
feat(forks,tests): add prague fork and test folder

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 ### 🛠️ Framework
 
+- ✨ Add Prague to forks ([#419](https://github.com/ethereum/execution-spec-tests/pull/419)).
 - ✨ Improve handling of the argument passed to `solc --evm-version` when compiling Yul code ([#418](https://github.com/ethereum/execution-spec-tests/pull/418)).
 - 🐞 Fix `fill -m yul_test` which failed to filter tests that are (dynamically) marked as a yul test ([#418](https://github.com/ethereum/execution-spec-tests/pull/418)).
 

--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -450,3 +450,24 @@ class Cancun(Shanghai):
         Starting at Cancun, payloads must have a parent beacon block root.
         """
         return True
+
+
+class Prague(Cancun):
+    """
+    Prague fork
+    """
+
+    @classmethod
+    def is_deployed(cls) -> bool:
+        """
+        Flags that the fork has not been deployed to mainnet; it is under active
+        development.
+        """
+        return False
+
+    @classmethod
+    def solc_min_version(cls) -> Version:
+        """
+        Returns the minimum version of solc that supports this fork.
+        """
+        return Version.parse("1.0.0")  # set a high version; currently unknown

--- a/src/ethereum_test_forks/tests/test_forks.py
+++ b/src/ethereum_test_forks/tests/test_forks.py
@@ -7,7 +7,7 @@ from typing import Mapping, cast
 from semver import Version
 
 from ..base_fork import Fork
-from ..forks.forks import Berlin, Cancun, Frontier, London, Paris, Shanghai
+from ..forks.forks import Berlin, Cancun, Frontier, London, Paris, Prague, Shanghai
 from ..forks.transition import BerlinToLondonAt5, ParisToShanghaiAtTime15k
 from ..helpers import (
     forks_from,
@@ -24,8 +24,8 @@ from ..transition_base_fork import transition_fork
 
 FIRST_DEPLOYED = Frontier
 LAST_DEPLOYED = Shanghai
-LAST_DEVELOPMENT = Cancun
-DEVELOPMENT_FORKS = [Cancun]
+LAST_DEVELOPMENT = Prague
+DEVELOPMENT_FORKS = [Cancun, Prague]
 
 
 def test_transition_forks():
@@ -229,3 +229,4 @@ def test_closest_fork_supported_by_solc():
     assert get_closest_fork_with_solc_support(Paris, Version.parse("0.8.20")) == Paris
     assert get_closest_fork_with_solc_support(Cancun, Version.parse("0.8.20")) == Shanghai
     assert get_closest_fork_with_solc_support(Cancun, Version.parse("0.8.24")) == Cancun
+    assert get_closest_fork_with_solc_support(Prague, Version.parse("0.8.24")) == Cancun

--- a/tests/cancun/__init__.py
+++ b/tests/cancun/__init__.py
@@ -1,3 +1,6 @@
 """
 Test cases for EVM functionality introduced in Cancun.
+
+See [EIP-7659: Hardfork Meta - Dencun](https://eips.ethereum.org/EIPS/eip-7569)
+for a list of EIPS included in Dencun (Deneb/Cancun).
 """

--- a/tests/prague/__init__.py
+++ b/tests/prague/__init__.py
@@ -1,0 +1,3 @@
+"""
+Test cases for EVM functionality introduced in Prague.
+"""

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -67,6 +67,7 @@ dao
 dataclasses
 datastructures
 delitem
+Dencun
 dev
 devnet
 difficulty
@@ -122,6 +123,7 @@ glightbox
 globals
 go-ethereum's
 gwei
+hardfork
 hash32
 hasher
 HeaderNonce


### PR DESCRIPTION
## 🗒️ Description

1. Adds the Prague fork and an empty tests folder.

Note, does not yet bump Cancun to deployed.

## 🔗 Related Issues
None.

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](../docs/) directory.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
