### PR TITLE
chore: fix deprecated vs code settings #344

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,6 +6,7 @@
 		"ms-python.python",
 		"ms-python.isort",
 		"ms-python.flake8",
+		"ms-python.mypy-type-checker",
 		"ms-python.black-formatter",
 		"esbenp.prettier-vscode",
 		"njpwerner.autodocstring",  // https://marketplace.visualstudio.com/items?itemName=njpwerner.autodocstring

--- a/.vscode/settings.recommended.json
+++ b/.vscode/settings.recommended.json
@@ -18,8 +18,6 @@
         }
     },
     "python.analysis.autoFormatStrings": true,
-    "python.linting.mypyEnabled": true,
-    "python.linting.flake8Enabled": true,
     "python.testing.promptToConfigure": false,
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,18 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 **Key:** ✨ = New, 🐞 = Fixed, 🔀 = Changed, 💥 = Breaking change.
 
+## 🔜 [Unreleased] https://github.com/ethereum/execution-spec-tests/releases/tag/v-Unreleased) - 2024-xx-xx
+
+### 🧪 Test Cases
+
+### 🛠️ Framework
+
+### 🔧 EVM Tools
+
+### 📋 Misc
+
+- 🐞 Fix deprecation warnings due to outdated config in recommended VS Code project settings ([#420](https://github.com/ethereum/execution-spec-tests/pull/420)).
+
 ## [v2.1.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v2.1.0) - 2024-01-29: 🐍🏖️ Cancun
 
 Release [v2.1.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v2.1.0) primarily fixes a small bug introduced within the previous release where transition forks are used within the new `StateTest` format. This was highlighted by @chfast within #405 (https://github.com/ethereum/execution-spec-tests/issues/405), where the fork name `ShanghaiToCancunAtTime15k` was found within state tests.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,6 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 **Key:** ✨ = New, 🐞 = Fixed, 🔀 = Changed, 💥 = Breaking change.
 
-
 ## 🔜 [Unreleased](https://github.com/ethereum/execution-spec-tests/releases/tag/v-Unreleased) - 2024-xx-xx
 
 ### 🧪 Test Cases


### PR DESCRIPTION
## 🗒️ Description
Removes deprecated settings from our recommended VS Code settings and adds the microsoft mypy extension. This change is necessary since (from the log):
```
Linting features have been moved to separate linter extensions.
```
More info: https://github.com/microsoft/vscode-python/wiki/Migration-to-Python-Tools-Extensions

## 🔗 Related Issues
Fixes #344.

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](../docs/) directory.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
