### PR TITLE
fix: typo in test_selfdestruct_revert.py

### DIFF
--- a/tests/cancun/eip6780_selfdestruct/test_selfdestruct_revert.py
+++ b/tests/cancun/eip6780_selfdestruct/test_selfdestruct_revert.py
@@ -146,7 +146,7 @@ def selfdestruct_with_transfer_contract_code(
             let operation := calldataload(0)
 
             switch operation
-            case 0 /* no-op used for transfering value to this contract */ {{
+            case 0 /* no-op used for transferring value to this contract */ {{
                 let times_called := sload(0)
                 times_called := add(times_called, 1)
                 sstore(0, times_called)


### PR DESCRIPTION
## 🗒️ Description

fix typo in test_selfdestruct_revert.py



## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](../docs/) directory.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
