### PR TITLE
chore(fw): add docstrings to all opcodes in opcodes enum

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Improve handling of the argument passed to `solc --evm-version` when compiling Yul code ([#418](https://github.com/ethereum/execution-spec-tests/pull/418)).
 - 🐞 Fix `fill -m yul_test` which failed to filter tests that are (dynamically) marked as a yul test ([#418](https://github.com/ethereum/execution-spec-tests/pull/418)).
 - 🔀 Helper methods `to_address`, `to_hash` and `to_hash_bytes` have been deprecated in favor of `Address` and `Hash`, which are automatically detected as opcode parameters and pushed to the stack in the resulting bytecode ([#422](https://github.com/ethereum/execution-spec-tests/pull/422)).
+- ✨ `Opcodes` enum now contains docstrings with each opcode's description, including parameters and return values, which show up in many development environments ([#424](https://github.com/ethereum/execution-spec-tests/pull/424)).
 
 ### 🔧 EVM Tools
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,7 +14,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Improve handling of the argument passed to `solc --evm-version` when compiling Yul code ([#418](https://github.com/ethereum/execution-spec-tests/pull/418)).
 - 🐞 Fix `fill -m yul_test` which failed to filter tests that are (dynamically) marked as a yul test ([#418](https://github.com/ethereum/execution-spec-tests/pull/418)).
 - 🔀 Helper methods `to_address`, `to_hash` and `to_hash_bytes` have been deprecated in favor of `Address` and `Hash`, which are automatically detected as opcode parameters and pushed to the stack in the resulting bytecode ([#422](https://github.com/ethereum/execution-spec-tests/pull/422)).
-- ✨ `Opcodes` enum now contains docstrings with each opcode description, including parameters and return values, which show up in many development environments ([#424](https://github.com/ethereum/execution-spec-tests/pull/424)).
+- ✨ `Opcodes` enum now contains docstrings with each opcode description, including parameters and return values, which show up in many development environments ([#424](https://github.com/ethereum/execution-spec-tests/pull/424)) @ThreeHrSleep.
 
 ### 🔧 EVM Tools
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,7 +14,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Improve handling of the argument passed to `solc --evm-version` when compiling Yul code ([#418](https://github.com/ethereum/execution-spec-tests/pull/418)).
 - 🐞 Fix `fill -m yul_test` which failed to filter tests that are (dynamically) marked as a yul test ([#418](https://github.com/ethereum/execution-spec-tests/pull/418)).
 - 🔀 Helper methods `to_address`, `to_hash` and `to_hash_bytes` have been deprecated in favor of `Address` and `Hash`, which are automatically detected as opcode parameters and pushed to the stack in the resulting bytecode ([#422](https://github.com/ethereum/execution-spec-tests/pull/422)).
-- ✨ `Opcodes` enum now contains docstrings with each opcode's description, including parameters and return values, which show up in many development environments ([#424](https://github.com/ethereum/execution-spec-tests/pull/424)).
+- ✨ `Opcodes` enum now contains docstrings with each opcode description, including parameters and return values, which show up in many development environments ([#424](https://github.com/ethereum/execution-spec-tests/pull/424)).
 
 ### 🔧 EVM Tools
 

--- a/src/ethereum_test_tools/vm/opcode.py
+++ b/src/ethereum_test_tools/vm/opcode.py
@@ -205,171 +205,4898 @@ class Opcodes(Opcode, Enum):
     Do !! NOT !! remove or modify existing opcodes from this list.
     """
 
-    STOP = Opcode(0x00)
-    ADD = Opcode(0x01, popped_stack_items=2, pushed_stack_items=1)
-    MUL = Opcode(0x02, popped_stack_items=2, pushed_stack_items=1)
-    SUB = Opcode(0x03, popped_stack_items=2, pushed_stack_items=1)
-    DIV = Opcode(0x04, popped_stack_items=2, pushed_stack_items=1)
-    SDIV = Opcode(0x05, popped_stack_items=2, pushed_stack_items=1)
-    MOD = Opcode(0x06, popped_stack_items=2, pushed_stack_items=1)
-    SMOD = Opcode(0x07, popped_stack_items=2, pushed_stack_items=1)
-    ADDMOD = Opcode(0x08, popped_stack_items=3, pushed_stack_items=1)
-    MULMOD = Opcode(0x09, popped_stack_items=3, pushed_stack_items=1)
-    EXP = Opcode(0x0A, popped_stack_items=2, pushed_stack_items=1)
-    SIGNEXTEND = Opcode(0x0B, popped_stack_items=2, pushed_stack_items=1)
+STOP = Opcode(0x00)
+"""
+STOP() 
+----
 
-    LT = Opcode(0x10, popped_stack_items=2, pushed_stack_items=1)
-    GT = Opcode(0x11, popped_stack_items=2, pushed_stack_items=1)
-    SLT = Opcode(0x12, popped_stack_items=2, pushed_stack_items=1)
-    SGT = Opcode(0x13, popped_stack_items=2, pushed_stack_items=1)
-    EQ = Opcode(0x14, popped_stack_items=2, pushed_stack_items=1)
-    ISZERO = Opcode(0x15, popped_stack_items=1, pushed_stack_items=1)
-    AND = Opcode(0x16, popped_stack_items=2, pushed_stack_items=1)
-    OR = Opcode(0x17, popped_stack_items=2, pushed_stack_items=1)
-    XOR = Opcode(0x18, popped_stack_items=2, pushed_stack_items=1)
-    NOT = Opcode(0x19, popped_stack_items=1, pushed_stack_items=1)
-    BYTE = Opcode(0x1A, popped_stack_items=2, pushed_stack_items=1)
-    SHL = Opcode(0x1B, popped_stack_items=2, pushed_stack_items=1)
-    SHR = Opcode(0x1C, popped_stack_items=2, pushed_stack_items=1)
-    SAR = Opcode(0x1D, popped_stack_items=2, pushed_stack_items=1)
+Description
+----
+Stop execution.
 
-    SHA3 = Opcode(0x20, popped_stack_items=2, pushed_stack_items=1)
+Inputs
+----
+- None
 
-    ADDRESS = Opcode(0x30, pushed_stack_items=1)
-    BALANCE = Opcode(0x31, popped_stack_items=1, pushed_stack_items=1)
-    ORIGIN = Opcode(0x32, pushed_stack_items=1)
-    CALLER = Opcode(0x33, pushed_stack_items=1)
-    CALLVALUE = Opcode(0x34, pushed_stack_items=1)
-    CALLDATALOAD = Opcode(0x35, popped_stack_items=1, pushed_stack_items=1)
-    CALLDATASIZE = Opcode(0x36, pushed_stack_items=1)
-    CALLDATACOPY = Opcode(0x37, popped_stack_items=3)
-    CODESIZE = Opcode(0x38, pushed_stack_items=1)
-    CODECOPY = Opcode(0x39, popped_stack_items=3)
-    GASPRICE = Opcode(0x3A, pushed_stack_items=1)
-    EXTCODESIZE = Opcode(0x3B, popped_stack_items=1, pushed_stack_items=1)
-    EXTCODECOPY = Opcode(0x3C, popped_stack_items=4)
-    RETURNDATASIZE = Opcode(0x3D, pushed_stack_items=1)
-    RETURNDATACOPY = Opcode(0x3E, popped_stack_items=3)
-    EXTCODEHASH = Opcode(0x3F, popped_stack_items=1, pushed_stack_items=1)
+Outputs
+----
+- None
 
-    BLOCKHASH = Opcode(0x40, popped_stack_items=1, pushed_stack_items=1)
-    COINBASE = Opcode(0x41, pushed_stack_items=1)
-    TIMESTAMP = Opcode(0x42, pushed_stack_items=1)
-    NUMBER = Opcode(0x43, pushed_stack_items=1)
-    PREVRANDAO = Opcode(0x44, pushed_stack_items=1)
-    GASLIMIT = Opcode(0x45, pushed_stack_items=1)
-    CHAINID = Opcode(0x46, pushed_stack_items=1)
-    SELFBALANCE = Opcode(0x47, pushed_stack_items=1)
-    BASEFEE = Opcode(0x48, pushed_stack_items=1)
-    BLOBHASH = Opcode(0x49, popped_stack_items=1, pushed_stack_items=1)
-    BLOBBASEFEE = Opcode(0x4A, popped_stack_items=0, pushed_stack_items=1)
+Fork
+----
+Frontier
 
-    POP = Opcode(0x50, popped_stack_items=1)
-    MLOAD = Opcode(0x51, popped_stack_items=1, pushed_stack_items=1)
-    MSTORE = Opcode(0x52, popped_stack_items=2)
-    MSTORE8 = Opcode(0x53, popped_stack_items=2)
-    SLOAD = Opcode(0x54, popped_stack_items=1, pushed_stack_items=1)
-    SSTORE = Opcode(0x55, popped_stack_items=2)
-    JUMP = Opcode(0x56, popped_stack_items=1)
-    JUMPI = Opcode(0x57, popped_stack_items=2)
-    PC = Opcode(0x58, pushed_stack_items=1)
-    MSIZE = Opcode(0x59, pushed_stack_items=1)
-    GAS = Opcode(0x5A, pushed_stack_items=1)
-    JUMPDEST = Opcode(0x5B)
-    TLOAD = Opcode(0x5C, popped_stack_items=1, pushed_stack_items=1)
-    TSTORE = Opcode(0x5D, popped_stack_items=2)
-    MCOPY = Opcode(0x5E, popped_stack_items=3)
-    RETF = Opcode(0x49)
+Gas
+----
+0
 
-    PUSH0 = Opcode(0x5F, pushed_stack_items=1)
-    PUSH1 = Opcode(0x60, pushed_stack_items=1, data_portion_length=1)
-    PUSH2 = Opcode(0x61, pushed_stack_items=1, data_portion_length=2)
-    PUSH3 = Opcode(0x62, pushed_stack_items=1, data_portion_length=3)
-    PUSH4 = Opcode(0x63, pushed_stack_items=1, data_portion_length=4)
-    PUSH5 = Opcode(0x64, pushed_stack_items=1, data_portion_length=5)
-    PUSH6 = Opcode(0x65, pushed_stack_items=1, data_portion_length=6)
-    PUSH7 = Opcode(0x66, pushed_stack_items=1, data_portion_length=7)
-    PUSH8 = Opcode(0x67, pushed_stack_items=1, data_portion_length=8)
-    PUSH9 = Opcode(0x68, pushed_stack_items=1, data_portion_length=9)
-    PUSH10 = Opcode(0x69, pushed_stack_items=1, data_portion_length=10)
-    PUSH11 = Opcode(0x6A, pushed_stack_items=1, data_portion_length=11)
-    PUSH12 = Opcode(0x6B, pushed_stack_items=1, data_portion_length=12)
-    PUSH13 = Opcode(0x6C, pushed_stack_items=1, data_portion_length=13)
-    PUSH14 = Opcode(0x6D, pushed_stack_items=1, data_portion_length=14)
-    PUSH15 = Opcode(0x6E, pushed_stack_items=1, data_portion_length=15)
-    PUSH16 = Opcode(0x6F, pushed_stack_items=1, data_portion_length=16)
-    PUSH17 = Opcode(0x70, pushed_stack_items=1, data_portion_length=17)
-    PUSH18 = Opcode(0x71, pushed_stack_items=1, data_portion_length=18)
-    PUSH19 = Opcode(0x72, pushed_stack_items=1, data_portion_length=19)
-    PUSH20 = Opcode(0x73, pushed_stack_items=1, data_portion_length=20)
-    PUSH21 = Opcode(0x74, pushed_stack_items=1, data_portion_length=21)
-    PUSH22 = Opcode(0x75, pushed_stack_items=1, data_portion_length=22)
-    PUSH23 = Opcode(0x76, pushed_stack_items=1, data_portion_length=23)
-    PUSH24 = Opcode(0x77, pushed_stack_items=1, data_portion_length=24)
-    PUSH25 = Opcode(0x78, pushed_stack_items=1, data_portion_length=25)
-    PUSH26 = Opcode(0x79, pushed_stack_items=1, data_portion_length=26)
-    PUSH27 = Opcode(0x7A, pushed_stack_items=1, data_portion_length=27)
-    PUSH28 = Opcode(0x7B, pushed_stack_items=1, data_portion_length=28)
-    PUSH29 = Opcode(0x7C, pushed_stack_items=1, data_portion_length=29)
-    PUSH30 = Opcode(0x7D, pushed_stack_items=1, data_portion_length=30)
-    PUSH31 = Opcode(0x7E, pushed_stack_items=1, data_portion_length=31)
-    PUSH32 = Opcode(0x7F, pushed_stack_items=1, data_portion_length=32)
+Source: [evm.codes/#00](https://www.evm.codes/#00)
+"""
 
-    DUP1 = Opcode(0x80, pushed_stack_items=1, min_stack_height=1)
-    DUP2 = Opcode(0x81, pushed_stack_items=1, min_stack_height=2)
-    DUP3 = Opcode(0x82, pushed_stack_items=1, min_stack_height=3)
-    DUP4 = Opcode(0x83, pushed_stack_items=1, min_stack_height=4)
-    DUP5 = Opcode(0x84, pushed_stack_items=1, min_stack_height=5)
-    DUP6 = Opcode(0x85, pushed_stack_items=1, min_stack_height=6)
-    DUP7 = Opcode(0x86, pushed_stack_items=1, min_stack_height=7)
-    DUP8 = Opcode(0x87, pushed_stack_items=1, min_stack_height=8)
-    DUP9 = Opcode(0x88, pushed_stack_items=1, min_stack_height=9)
-    DUP10 = Opcode(0x89, pushed_stack_items=1, min_stack_height=10)
-    DUP11 = Opcode(0x8A, pushed_stack_items=1, min_stack_height=11)
-    DUP12 = Opcode(0x8B, pushed_stack_items=1, min_stack_height=12)
-    DUP13 = Opcode(0x8C, pushed_stack_items=1, min_stack_height=13)
-    DUP14 = Opcode(0x8D, pushed_stack_items=1, min_stack_height=14)
-    DUP15 = Opcode(0x8E, pushed_stack_items=1, min_stack_height=15)
-    DUP16 = Opcode(0x8F, pushed_stack_items=1, min_stack_height=16)
+ADD = Opcode(0x01, popped_stack_items=2, pushed_stack_items=1)
+"""
+ADD(a, b) = c
+----
 
-    SWAP1 = Opcode(0x90, min_stack_height=2)
-    SWAP2 = Opcode(0x91, min_stack_height=3)
-    SWAP3 = Opcode(0x92, min_stack_height=4)
-    SWAP4 = Opcode(0x93, min_stack_height=5)
-    SWAP5 = Opcode(0x94, min_stack_height=6)
-    SWAP6 = Opcode(0x95, min_stack_height=7)
-    SWAP7 = Opcode(0x96, min_stack_height=8)
-    SWAP8 = Opcode(0x97, min_stack_height=9)
-    SWAP9 = Opcode(0x98, min_stack_height=10)
-    SWAP10 = Opcode(0x99, min_stack_height=11)
-    SWAP11 = Opcode(0x9A, min_stack_height=12)
-    SWAP12 = Opcode(0x9B, min_stack_height=13)
-    SWAP13 = Opcode(0x9C, min_stack_height=14)
-    SWAP14 = Opcode(0x9D, min_stack_height=15)
-    SWAP15 = Opcode(0x9E, min_stack_height=16)
-    SWAP16 = Opcode(0x9F, min_stack_height=17)
+Description
+----
+Addition operation
 
-    LOG0 = Opcode(0xA0, popped_stack_items=2)
-    LOG1 = Opcode(0xA1, popped_stack_items=3)
-    LOG2 = Opcode(0xA2, popped_stack_items=4)
-    LOG3 = Opcode(0xA3, popped_stack_items=5)
-    LOG4 = Opcode(0xA4, popped_stack_items=6)
+Inputs
+----
+- a: first integer value to add
+- b: second integer value to add
 
-    RJUMP = Opcode(0xE0, data_portion_length=2)
-    RJUMPI = Opcode(0xE1, popped_stack_items=1, data_portion_length=2)
-    RJUMPV = Opcode(0xE2)
+Outputs
+----
+- c: integer result of the addition modulo 2**256
 
-    CREATE = Opcode(0xF0, popped_stack_items=3, pushed_stack_items=1)
-    CALL = Opcode(0xF1, popped_stack_items=7, pushed_stack_items=1)
-    CALLCODE = Opcode(0xF2, popped_stack_items=7, pushed_stack_items=1)
-    RETURN = Opcode(0xF3, popped_stack_items=2)
-    DELEGATECALL = Opcode(0xF4, popped_stack_items=6, pushed_stack_items=1)
-    CREATE2 = Opcode(0xF5, popped_stack_items=4, pushed_stack_items=1)
+Fork
+----
+Frontier
 
-    STATICCALL = Opcode(0xFA, popped_stack_items=6, pushed_stack_items=1)
+Gas
+----
+3
 
-    REVERT = Opcode(0xFD, popped_stack_items=2)
-    INVALID = Opcode(0xFE)
+Source: [evm.codes/#01](https://www.evm.codes/#01)
+"""
 
-    SELFDESTRUCT = Opcode(0xFF, popped_stack_items=1)
-    SENDALL = Opcode(0xFF, popped_stack_items=1)
+MUL = Opcode(0x02, popped_stack_items=2, pushed_stack_items=1)
+"""
+MUL(a, b) = c
+----
+
+Description
+----
+Multiplication operation
+
+Inputs
+----
+- a: first integer value to multiply
+- b: second integer value to multiply
+
+Outputs
+----
+- c: integer result of the multiplication modulo 2**256
+
+Fork
+----
+Frontier
+
+Gas
+----
+5
+
+Source: [evm.codes/#02](https://www.evm.codes/#02)
+"""
+
+SUB = Opcode(0x03, popped_stack_items=2, pushed_stack_items=1)
+"""
+SUB(a, b) = c
+----
+
+Description
+----
+Subtraction operation
+
+Inputs
+----
+- a: first integer value
+- b: second integer value
+
+Outputs
+----
+- c: integer result of the subtraction modulo 2**256
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#03](https://www.evm.codes/#03)
+"""
+
+DIV = Opcode(0x04, popped_stack_items=2, pushed_stack_items=1)
+"""
+DIV(a, b) = c
+----
+
+Description
+----
+Division operation
+
+Inputs
+----
+- a: numerator
+- b: denominator (must be non-zero)
+
+Outputs
+----
+- c: integer result of the division
+
+Fork
+----
+Frontier
+
+Gas
+----
+5
+
+Source: [evm.codes/#04](https://www.evm.codes/#04)
+"""
+
+SDIV = Opcode(0x05, popped_stack_items=2, pushed_stack_items=1)
+"""
+SDIV(a, b) = c
+----
+
+Description
+----
+Signed division operation
+
+Inputs
+----
+- a: signed numerator
+- b: signed denominator (must be non-zero)
+
+Outputs
+----
+- c: signed integer result of the division
+
+Fork
+----
+Frontier
+
+Gas
+----
+5
+
+Source: [evm.codes/#05](https://www.evm.codes/#05)
+"""
+
+MOD = Opcode(0x06, popped_stack_items=2, pushed_stack_items=1)
+"""
+MOD(a, b) = c
+----
+
+Description
+----
+Modulo operation
+
+Inputs
+----
+- a: integer numerator.
+- b: integer denominator
+
+Outputs
+----
+- a % b: integer result of the integer modulo. If the denominator is 0, the result will be 0
+
+Fork
+----
+Frontier
+
+Gas
+----
+5
+
+Source: [evm.codes/#06](https://www.evm.codes/#06)
+"""
+
+SMOD = Opcode(0x07, popped_stack_items=2, pushed_stack_items=1)
+"""
+SMOD(a, b) = c
+----
+
+Description
+----
+Signed modulo remainder operation
+
+Inputs
+----
+- a: integer numerator.
+- b: integer denominator.
+
+Outputs
+----
+- a % b: integer result of the signed integer modulo. If the denominator is 0, the result will be 0
+
+Fork
+----
+Frontier
+
+Gas
+----
+5
+
+Source: [evm.codes/#07](https://www.evm.codes/#07)
+"""
+
+ADDMOD = Opcode(0x08, popped_stack_items=3, pushed_stack_items=1)
+"""
+ADDMOD(a, b, c) = d
+----
+
+Description
+----
+Modular addition operation with overflow check
+
+Inputs
+----
+- a: first integer value
+- b: second integer value
+- c: integer denominator
+
+Outputs
+----
+- (a + b) % N: integer result of the addition followed by a modulo. If the denominator is 0, the result will be 0
+
+Fork
+----
+Frontier
+
+Gas
+----
+8
+
+Source: [evm.codes/#08](https://www.evm.codes/#08)
+"""
+
+MULMOD = Opcode(0x09, popped_stack_items=3, pushed_stack_items=1)
+"""
+MULMOD(a, b, N) = d
+----
+
+Description
+----
+Modulo multiplication operation
+
+Inputs
+----
+- a: first integer value to multiply.
+- b: second integer value to multiply.
+- N: integer denominator
+
+Outputs
+----
+- d: (a * b) % N: integer result of the multiplication followed by a modulo. If the denominator is 0, the result will be 0
+
+Fork
+----
+Frontier
+
+Gas
+----
+8
+
+Source: [evm.codes/#09](https://www.evm.codes/#09)
+"""
+
+EXP = Opcode(0x0A, popped_stack_items=2, pushed_stack_items=1)
+"""
+EXP(base, exponent) = a ** exponent
+----
+
+Description
+----
+Exponential operation
+
+Inputs
+----
+- base: integer base.
+- exponent: integer exponent
+
+Outputs
+----
+- a ** exponent: integer result of the exponential operation modulo 2**256
+
+Fork
+----
+Frontier
+
+Gas
+----
+10 
+
+Source: [evm.codes/#0A](https://www.evm.codes/#0A)
+"""
+
+SIGNEXTEND = Opcode(0x0B, popped_stack_items=2, pushed_stack_items=1)
+"""
+SIGNEXTEND(b, x) = y
+----
+
+Description
+----
+Sign extension operation
+
+Inputs
+----
+- b: size in byte - 1 of the integer to sign extend
+- x: integer value to sign extend
+
+Outputs
+----
+- y: integer result of the sign extend
+
+Fork
+----
+Frontier
+
+Gas
+----
+5
+
+Source: [evm.codes/#0B](https://www.evm.codes/#0B)
+"""
+
+
+
+LT = Opcode(0x10, popped_stack_items=2, pushed_stack_items=1)
+"""
+LT(a, b) = a < b
+----
+
+Description
+----
+Less-than comparison
+
+Inputs
+----
+- a: first integer value
+- b: second integer value
+
+Outputs
+----
+- a < b: 1 if the left side is smaller, 0 otherwise
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#10](https://www.evm.codes/#10)
+"""
+
+GT = Opcode(0x11, popped_stack_items=2, pushed_stack_items=1)
+"""
+GT(a, b) = a > b
+----
+
+Description
+----
+Greater-than comparison
+
+Inputs
+----
+- a: left side integer
+- b: right side integer
+
+Outputs
+----
+- a > b: 1 if the left side is bigger, 0 otherwise
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#11](https://www.evm.codes/#11)
+"""
+
+SLT = Opcode(0x12, popped_stack_items=2, pushed_stack_items=1)
+"""
+SLT(a, b) = a < b
+----
+
+Description
+----
+Signed less-than comparison
+
+Inputs
+----
+- a: eft side signed integer
+- b: right side signed integer
+
+Outputs
+----
+- a < b: 1 if the left side is smaller, 0 otherwise
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#12](https://www.evm.codes/#12)
+"""
+
+SGT = Opcode(0x13, popped_stack_items=2, pushed_stack_items=1)
+"""
+SGT(a, b) = a > b
+----
+
+Description
+----
+Signed greater-than comparison
+
+Inputs
+----
+- a:  left side signed integer.
+- b: right side signed integer
+
+Outputs
+----
+- a > b: 1 if the left side is bigger, 0 otherwise
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#13](https://www.evm.codes/#13)
+"""
+
+EQ = Opcode(0x14, popped_stack_items=2, pushed_stack_items=1)
+"""
+EQ(a, b) = a == b
+----
+
+Description
+----
+Equality comparison
+
+Inputs
+----
+- a: left side integer
+- b: right side integer
+
+Outputs
+----
+- a == b: 1 if the left side is equal to the right side, 0 otherwise
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#14](https://www.evm.codes/#14)
+"""
+
+ISZERO = Opcode(0x15, popped_stack_items=1, pushed_stack_items=1)
+"""
+ISZERO(a) = a == 0
+----
+
+Description
+----
+Is-zero comparison
+
+Inputs
+----
+- a: integer 
+
+Outputs
+----
+- a == 0: 1 if a is 0, 0 otherwise
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#15](https://www.evm.codes/#15)
+"""
+
+AND = Opcode(0x16, popped_stack_items=2, pushed_stack_items=1)
+"""
+AND(a, b) = a & b
+----
+
+Description
+----
+Bitwise AND operation
+
+Inputs
+----
+- a: first binary value.
+- b: second binary value
+
+Outputs
+----
+- a & b: the bitwise AND result
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#16](https://www.evm.codes/#16)
+"""
+
+OR = Opcode(0x17, popped_stack_items=2, pushed_stack_items=1)
+"""
+OR(a, b) = a | b
+----
+
+Description
+----
+Bitwise OR operation
+
+Inputs
+----
+- a: first binary value
+- b: second binary value
+
+Outputs
+----
+- a | b: the bitwise OR result
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#17](https://www.evm.codes/#17)
+"""
+
+XOR = Opcode(0x18, popped_stack_items=2, pushed_stack_items=1)
+"""
+XOR(a, b) = a ^ b
+----
+
+Description
+----
+Bitwise XOR operation
+
+Inputs
+----
+- a:  first binary value
+- b: second binary value
+
+Outputs
+----
+- a ^ b: the bitwise XOR result
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#18](https://www.evm.codes/#18)
+"""
+
+NOT = Opcode(0x19, popped_stack_items=1, pushed_stack_items=1)
+"""
+NOT(a) = ~a
+----
+
+Description
+----
+Bitwise NOT operation
+
+Inputs
+----
+- a: binary value
+
+Outputs
+----
+- ~a: the bitwise NOT result
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#19](https://www.evm.codes/#19)
+"""
+
+BYTE = Opcode(0x1A, popped_stack_items=2, pushed_stack_items=1)
+"""
+BYTE(i, x) = y
+----
+
+Description
+----
+Extract a byte from the given position in the value
+
+Inputs
+----
+- i: byte offset starting from the most significant byte.
+- x: 32-byte value
+
+Outputs
+----
+- y: the indicated byte at the least significant position. If the byte offset is out of range, the result is 0
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#1A](https://www.evm.codes/#1A)
+"""
+
+SHL = Opcode(0x1B, popped_stack_items=2, pushed_stack_items=1)
+"""
+SHL(shift, value) = value << shift
+----
+
+Description
+----
+Shift left operation
+
+Inputs
+----
+- shift: number of bits to shift to the left.
+- value: 32 bytes to shift
+
+Outputs
+----
+- value << shift: the shifted value. If shift is bigger than 255, returns 0
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#1B](https://www.evm.codes/#1B)
+"""
+
+SHR = Opcode(0x1C, popped_stack_items=2, pushed_stack_items=1)
+"""
+SHR(shift, value) = value >> shift
+----
+
+Description
+----
+Logical shift right operation
+
+Inputs
+----
+- shift: number of bits to shift to the right.
+- value: 32 bytes to shift
+
+Outputs
+----
+- value >> shift: the shifted value. If shift is bigger than 255, returns 0
+
+Fork
+----
+Constantinople
+
+Gas
+----
+3
+
+Source: [evm.codes/#1C](https://www.evm.codes/#1C)
+"""
+
+SAR = Opcode(0x1D, popped_stack_items=2, pushed_stack_items=1)
+"""
+SAR(shift, value) = value >> shift
+----
+
+Description
+----
+Arithmetic shift right operation
+
+Inputs
+----
+- shift: number of bits to shift to the right
+- value: integer to shift
+
+Outputs
+----
+- value >> shift: the shifted value
+
+Fork
+----
+Constantinople
+
+Gas
+----
+3
+
+Source: [evm.codes/#1D](https://www.evm.codes/#1D)
+"""
+
+SHA3 = Opcode(0x20, popped_stack_items=2, pushed_stack_items=1)
+"""
+SHA3(start, length) = hash
+----
+
+Description
+----
+Compute Keccak-256 hash 
+
+Inputs
+----
+- offset: byte offset in the memory
+- size: byte size to read in the memory
+
+Outputs
+----
+- hash: Keccak-256 hash of the given data in memory
+
+Fork
+----
+Frontier
+
+Gas
+----
+30 
+
+Source: [evm.codes/#20](https://www.evm.codes/#20)
+"""
+
+
+
+ADDRESS = Opcode(0x30, pushed_stack_items=1)
+"""
+ADDRESS() = address
+----
+
+Description
+----
+Get address of currently executing account
+
+Inputs
+----
+- None
+
+Outputs
+----
+- address: the 20-byte address of the current account
+
+Fork
+----
+Frontier
+
+Gas
+----
+2
+
+Source: [evm.codes/#30](https://www.evm.codes/#30)
+"""
+
+BALANCE = Opcode(0x31, popped_stack_items=1, pushed_stack_items=1)
+"""
+BALANCE(address) = balance
+----
+
+Description
+----
+Get the balance of the specified account
+
+Inputs
+----
+- address: 20-byte address of the account to check
+
+Outputs
+----
+- balance: balance of the given account in wei. Returns 0 if the account doesn't exist
+
+Fork
+----
+Frontier
+
+Gas
+----
+100
+
+Source: [evm.codes/#31](https://www.evm.codes/#31)
+"""
+
+ORIGIN = Opcode(0x32, pushed_stack_items=1)
+"""
+ORIGIN() = address
+----
+
+Description
+----
+Get execution origination address
+
+Inputs
+----
+- None
+
+Outputs
+----
+- address: the 20-byte address of the sender of the transaction. It can only be an account without code
+
+Fork
+----
+Frontier
+
+Gas
+----
+2
+
+Source: [evm.codes/#32](https://www.evm.codes/#32)
+"""
+
+CALLER = Opcode(0x33, pushed_stack_items=1)
+"""
+CALLER() = address 
+----
+
+Description
+----
+Get caller address 
+
+Inputs
+----
+- None
+
+Outputs
+----
+- address: the 20-byte address of the caller account. This is the account that did the last call (except delegate call)
+
+Fork
+----
+Frontier
+
+Gas
+----
+2
+
+Source: [evm.codes/#33](https://www.evm.codes/#33)
+"""
+
+CALLVALUE = Opcode(0x34, pushed_stack_items=1)
+"""
+CALLVALUE() = value
+----
+
+Description
+----
+Get deposited value by the instruction/transaction responsible for this execution
+
+Inputs
+----
+- None
+
+Outputs
+----
+- value: the value of the current call in wei
+
+Fork
+----
+Frontier
+
+Gas
+----
+2
+
+Source: [evm.codes/#34](https://www.evm.codes/#34)
+"""
+
+CALLDATALOAD = Opcode(0x35, popped_stack_items=1, pushed_stack_items=1)
+"""
+CALLDATALOAD(i) = data[i]
+----
+
+Description
+----
+Get input data of current environment
+
+Inputs
+----
+- i: byte offset in the calldata.
+
+Outputs
+----
+- data[i]: 32-byte value starting from the given offset of the calldata. All bytes after the end of the calldata are set to 0
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#35](https://www.evm.codes/#35)
+"""
+
+CALLDATASIZE = Opcode(0x36, pushed_stack_items=1)
+"""
+CALLDATASIZE() = size
+----
+
+Description
+----
+Get size of input data in current environment
+
+Inputs
+----
+- None
+
+Outputs
+----
+- size: byte size of the calldata
+
+Fork
+----
+Frontier
+
+Gas
+----
+2
+
+Source: [evm.codes/#36](https://www.evm.codes/#36)
+"""
+
+CALLDATACOPY = Opcode(0x37, popped_stack_items=3)
+"""
+CALLDATACOPY(destOffset, offset, size)
+----
+
+Description
+----
+Copy input data in current environment to memory
+
+Inputs
+----
+- destOffset: byte offset in the memory where the result will be copied
+- offset: byte offset in the calldata to copy
+- size: byte size to copy
+
+Outputs
+----
+- None
+
+Fork
+----
+Frontier
+
+Gas
+----
+3 
+
+Source: [evm.codes/#37](https://www.evm.codes/#37)
+"""
+
+CODESIZE = Opcode(0x38, pushed_stack_items=1)
+"""
+CODESIZE() = size
+----
+
+Description
+----
+Get size of code running in current environment
+
+Inputs
+----
+- None
+
+Outputs
+----
+- size: byte size of the code
+
+Fork
+----
+Frontier
+
+Gas
+----
+2
+
+Source: [evm.codes/#38](https://www.evm.codes/#38)
+"""
+
+CODECOPY = Opcode(0x39, popped_stack_items=3)
+"""
+CODECOPY(destOffset, offset, size)
+----
+
+Description
+----
+Copy code running in current environment to memory
+
+Inputs
+----
+- destOffset: byte offset in the memory where the result will be copied.
+- offset: byte offset in the code to copy.
+- size: byte size to copy
+
+Fork
+----
+Frontier
+
+Gas
+----
+3 
+
+Source: [evm.codes/#39](https://www.evm.codes/#39)
+"""
+
+GASPRICE = Opcode(0x3A, pushed_stack_items=1)
+"""
+GASPRICE() = price
+----
+
+Description
+----
+Get price of gas in current environment
+
+Outputs
+----
+- price: gas price in wei per gas
+
+Fork
+----
+Frontier
+
+Gas
+----
+2
+
+Source: [evm.codes/#3A](https://www.evm.codes/#3A)
+"""
+
+EXTCODESIZE = Opcode(0x3B, popped_stack_items=1, pushed_stack_items=1)
+"""
+EXTCODESIZE(account) = size
+----
+
+Description
+----
+Get size of an account’s code
+
+Inputs
+----
+- address: 20-byte address of the contract to query
+
+Outputs
+----
+- size: byte size of the code
+
+Fork
+----
+Frontier
+
+Gas
+----
+100
+
+Source: [evm.codes/#3C](https://www.evm.codes/#3B)
+"""
+
+EXTCODECOPY = Opcode(0x3C, popped_stack_items=4)
+"""
+EXTCODESIZE(account)
+----
+
+Description
+----
+Copy an account’s code to memory
+
+Inputs
+----
+- address: 20-byte address of the contract to query
+- destOffset: byte offset in the memory where the result will be copied
+- offset: byte offset in the code to copy
+- size: byte size to copy
+
+Outputs
+----
+- None
+
+Fork
+----
+Frontier
+
+Gas
+----
+minimum_word_size = (size + 31) / 32
+static_gas = 0
+dynamic_gas = 3 * minimum_word_size + memory_expansion_cost + address_access_cost
+
+Source: [evm.codes/#3C](https://www.evm.codes/#3C)
+"""
+
+RETURNDATASIZE = Opcode(0x3D, pushed_stack_items=1)
+"""
+RETURNDATASIZE() = size
+----
+
+Description
+----
+Get size of output data from the previous call from the current environment
+
+Outputs
+----
+- size: byte size of the return data from the last executed sub context
+
+Fork
+----
+Byzantium
+
+Gas
+----
+2
+
+Source: [evm.codes/#3D](https://www.evm.codes/#3D)
+"""
+
+RETURNDATACOPY = Opcode(0x3E, popped_stack_items=3)
+"""
+RETURNDATACOPY(destOffset, offset, size)
+----
+
+Description
+----
+Copy output data from the previous call to memory
+
+Inputs
+----
+- destOffset: byte offset in the memory where the result will be copied.
+- offset: byte offset in the return data from the last executed sub context to copy.
+- size: byte size to copy.
+
+Fork
+----
+Byzantium
+
+Gas
+----
+minimum_word_size = (size + 31) / 32
+
+Gas = 3 + 3 * minimum_word_size + memory_expansion_cost
+
+Source: [evm.codes/#3E](https://www.evm.codes/#3E)
+"""
+
+EXTCODEHASH = Opcode(0x3F, popped_stack_items=1, pushed_stack_items=1)
+"""
+EXTCODEHASH(address) = hash
+----
+
+Description
+----
+Get hash of an account’s code
+
+Inputs
+----
+- address: 20-byte address of the account
+
+Outputs
+----
+- hash: hash of the chosen account's code, the empty hash (0xc5d24601...) if the account has no code, or 0 if the account does not exist or has been destroyed
+
+Fork
+----
+Constantinople
+
+Gas
+----
+100
+
+Source: [evm.codes/#3F](https://www.evm.codes/#3F)
+"""
+
+
+BLOCKHASH = Opcode(0x40, popped_stack_items=1, pushed_stack_items=1)
+"""
+BLOCKHASH(block_number) = hash
+----
+
+Description
+----
+Get the hash of one of the 256 most recent complete blocks
+
+Inputs
+----
+- blockNumber: block number to get the hash from. Valid range is the last 256 blocks (not including the current one). Current block number can be queried with NUMBER
+
+Outputs
+----
+- hash: hash of the chosen block, or 0 if the block number is not in the valid range
+Fork
+----
+Frontier
+
+Gas
+----
+20
+
+Source: [evm.codes/#40](https://www.evm.codes/#40)
+"""
+
+COINBASE = Opcode(0x41, pushed_stack_items=1)
+"""
+COINBASE() = address
+----
+
+Description
+----
+Get the block’s beneficiary address
+
+Inputs
+----
+- None
+
+Outputs
+----
+- address: miner's 20-byte address
+
+Fork
+----
+Frontier
+
+Gas
+----
+2
+
+Source: [evm.codes/#41](https://www.evm.codes/#41)
+"""
+
+TIMESTAMP = Opcode(0x42, pushed_stack_items=1)
+"""
+TIMESTAMP() = timestamp
+----
+
+Description
+----
+Get the block’s timestamp
+
+Inputs
+----
+- None
+
+Outputs
+----
+- timestamp: unix timestamp of the current block
+
+Fork
+----
+Frontier
+
+Gas
+----
+2
+
+Source: [evm.codes/#42](https://www.evm.codes/#42)
+"""
+
+NUMBER = Opcode(0x43, pushed_stack_items=1)
+"""
+NUMBER() = blockNumber
+----
+
+Description
+----
+Get the block’s number
+
+Inputs
+----
+- None
+
+Outputs
+----
+- blockNumber: current block number
+
+Fork
+----
+Frontier
+
+Gas
+----
+2
+
+Source: [evm.codes/#43](https://www.evm.codes/#43)
+"""
+
+PREVRANDAO = Opcode(0x44, pushed_stack_items=1)
+"""
+NUMBER() = prevRandao
+----
+
+Description
+----
+Get the previous block’s RANDAO mix
+
+Inputs
+----
+- None
+
+Outputs
+----
+- prevRandao: previous block's RANDAO mix
+
+Fork
+----
+Merge
+
+Gas
+----
+20
+
+Source: [evm.codes/#44](https://www.evm.codes/#44)
+"""
+
+GASLIMIT = Opcode(0x45, pushed_stack_items=1)
+"""
+GASLIMIT() = gasLimit
+----
+
+Description
+----
+Get the block’s gas limit
+
+Inputs
+----
+- None
+
+Outputs
+----
+- gasLimit: gas limit
+
+Fork
+----
+Frontier
+
+Gas
+----
+2
+
+Source: [evm.codes/#45](https://www.evm.codes/#45)
+"""
+
+CHAINID = Opcode(0x46, pushed_stack_items=1)
+"""
+CHAINID() = chainId
+----
+
+Description
+----
+Get the chain ID
+
+Inputs
+----
+- None
+
+Outputs
+----
+- chainId: chain id of the network
+
+Fork
+----
+Istanbul
+
+Gas
+----
+2
+
+Source: [evm.codes/#46](https://www.evm.codes/#46)
+"""
+
+SELFBALANCE = Opcode(0x47, pushed_stack_items=1)
+"""
+SELFBALANCE() = balance
+----
+
+Description
+----
+Get balance of currently executing account
+
+Inputs
+----
+- None
+
+Outputs
+----
+- balance: balance of the current account in wei
+
+Fork
+----
+Istanbul
+
+Gas
+----
+5
+
+Source: [evm.codes/#47](https://www.evm.codes/#47)
+"""
+BASEFEE = Opcode(0x48, pushed_stack_items=1)
+"""
+BASEFEE() = baseFee
+----
+
+Description
+----
+Get the base fee
+
+Outputs
+----
+- baseFee: base fee in wei
+
+Fork
+----
+London
+
+Gas
+----
+2
+
+Source: [evm.codes/#48](https://www.evm.codes/#48)
+"""
+
+BLOBHASH = Opcode(0x49, popped_stack_items=1, pushed_stack_items=1)
+"""
+BLOBHASH(data) = h
+----
+
+Description
+----
+Returns hashes of blobs in the transaction
+
+Inputs
+----
+- data: data to hash
+
+Outputs
+----
+- h: keccak256 hash of the data
+
+Fork
+----
+Dencun
+
+Gas
+----
+HASH_OPCODE_GAS
+
+Source: [eips.ethereum.org/EIPS/eip-4844](https://eips.ethereum.org/EIPS/eip-4844)
+"""
+
+BLOBBASEFEE = Opcode(0x4A, popped_stack_items=0, pushed_stack_items=1)
+"""
+BLOBBASEFEE() = fee
+----
+
+Description
+----
+Returns the value of the blob base-fee of the current block it is executing in
+
+Inputs
+----
+- None
+
+Outputs
+----
+- fee: base fee per gas
+
+Fork
+----
+Dencun
+
+Gas
+----
+2
+
+Source: [eips.ethereum.org/EIPS/eip-7516(https://eips.ethereum.org/EIPS/eip-7516)
+"""
+
+POP = Opcode(0x50, popped_stack_items=1)
+"""
+POP(y)
+----
+
+Description
+----
+Remove item from stack
+
+Inputs
+----
+- y: a stack item
+
+Outputs
+----
+- None
+
+Inputs
+----
+- None
+
+Fork
+----
+Frontier
+
+Gas
+----
+2
+
+Source: [evm.codes/#50](https://www.evm.codes/#50)
+"""
+
+MLOAD = Opcode(0x51, popped_stack_items=1, pushed_stack_items=1)
+"""
+MLOAD(offset) = value
+----
+
+Description
+----
+Load word from memory
+
+Inputs
+----
+- offset: offset in the memory in bytes
+
+Outputs
+----
+- value: the 32 bytes in memory starting at that offset. If it goes beyond its current size (see MSIZE), writes 0s
+
+Fork
+----
+Frontier
+
+Gas
+----
+3 + memory_expansion_cost
+
+Source: [evm.codes/#51](https://www.evm.codes/#51)
+"""
+
+MSTORE = Opcode(0x52, popped_stack_items=2)
+"""
+MSTORE(offset, value)
+----
+
+Description
+----
+Save word to memory
+
+Inputs
+----
+- offset: offset in the memory in bytes.
+- value: 32-byte value to write in the memory.
+
+Outputs
+----
+- None
+
+Fork
+----
+Frontier
+
+Gas
+----
+3 + memory_expansion_cost
+
+Source: [evm.codes/#52](https://www.evm.codes/#52)
+"""
+
+MSTORE8 = Opcode(0x53, popped_stack_items=2)
+"""
+MSTORE8(offset, value)
+----
+
+Description
+----
+Save byte to memory
+
+Inputs
+----
+- offset: offset in the memory in bytes
+- value: 1-byte value to write in the memory (the least significant byte of the 32-byte stack value
+
+Fork
+----
+Frontier
+
+Gas
+----
+3 + memory_expansion_cost
+
+Source: [evm.codes/#53](https://www.evm.codes/#53)
+"""
+
+SLOAD = Opcode(0x54, popped_stack_items=1, pushed_stack_items=1)
+"""
+SLOAD(key) = value
+----
+
+Description
+----
+Load word from storage
+
+Inputs
+----
+- key: 32-byte key in storage
+
+Outputs
+----
+- value: 32-byte value corresponding to that key. 0 if that key was never written before
+
+Fork
+----
+Frontier
+
+Gas
+----
+100
+
+Source: [evm.codes/#54](https://www.evm.codes/#54)
+"""
+
+SSTORE = Opcode(0x55, popped_stack_items=2)
+"""
+SSTORE(key, value)
+----
+
+Description
+----
+Save word to storage
+
+Inputs
+----
+- key: 32-byte key in storage
+- value: 32-byte value to store
+
+Outputs
+----
+- None
+
+Fork
+----
+Frontier
+
+Gas
+----
+100 
+
+Source: [evm.codes/#55](https://www.evm.codes/#55)
+"""
+
+JUMP = Opcode(0x56, popped_stack_items=1)
+"""
+JUMP(counter)
+----
+
+Description
+----
+Alter the program counter
+
+Inputs
+----
+- counter: byte offset in the deployed code where execution will continue from. Must be a JUMPDEST instruction.
+
+Outputs
+----
+- None
+
+Fork
+----
+Frontier
+
+Gas
+----
+8
+
+Source: [evm.codes/#56](https://www.evm.codes/#56)
+"""
+
+JUMPI = Opcode(0x57, popped_stack_items=2)
+"""
+JUMPI(counter, b)
+----
+
+Description
+----
+Conditionally alter the program counter
+
+Inputs
+----
+- counter: byte offset in the deployed code where execution will continue from. Must be a JUMPDEST instruction.
+- b: the program counter will be altered with the new value only if this value is different from 0. Otherwise, the program counter is simply incremented and the next instruction will be executed.
+
+Fork
+----
+Frontier
+
+Gas
+----
+10
+
+Source: [evm.codes/#57](https://www.evm.codes/#57)
+"""
+
+PC = Opcode(0x58, pushed_stack_items=1)
+"""
+PC() = counter
+----
+
+Description
+----
+Get the value of the program counter prior to the increment corresponding to this instruction
+
+Inputs
+----
+- None
+
+Outputs
+----
+- counter: PC of this instruction in the current program.
+
+Fork
+----
+Frontier
+
+Gas
+----
+2
+
+Source: [evm.codes/#58](https://www.evm.codes/#58)
+"""
+
+MSIZE = Opcode(0x59, pushed_stack_items=1)
+"""
+MSIZE() = size
+----
+
+Description
+----
+Get the size of active memory in bytes
+
+Outputs
+----
+- size: current memory size in bytes (higher offset accessed until now + 1)
+
+Fork
+----
+Frontier
+
+Gas
+----
+2
+
+Source: [evm.codes/#59](https://www.evm.codes/#59)
+"""
+
+GAS = Opcode(0x5A, pushed_stack_items=1)
+"""
+GAS() = gas_remaining
+----
+
+Description
+----
+Get the amount of available gas, including the corresponding reduction for the cost of this instruction
+
+Inputs
+----
+- None
+
+Outputs
+----
+- Source: [evm.codes/#5A](https://www.evm.codes/#5A)
+
+Fork
+----
+Frontier
+
+Gas
+----
+2
+
+Source: [evm.codes/#5A](https://www.evm.codes/#5A)
+"""
+
+JUMPDEST = Opcode(0x5B)
+"""
+JUMPDEST()
+----
+
+Description
+----
+Mark a valid destination for jumps
+
+Inputs
+----
+- None
+
+Outputs
+----
+- None
+
+Fork
+----
+Frontier
+
+Gas
+----
+1
+
+Source: [evm.codes/#5B](https://www.evm.codes/#5B)
+"""
+
+TLOAD = Opcode(0x5C, popped_stack_items=1, pushed_stack_items=1)
+"""
+TLOAD(key) = value
+----
+
+Description
+----
+Load a value from the storage at the specified key.
+
+Inputs
+----
+- key: The key in storage.
+
+Outputs
+----
+- value: The value associated with the given key.
+
+Fork
+----
+
+
+Gas
+----
+100
+
+Source: [eips.ethereum.org/EIPS/eip-1153](https://eips.ethereum.org/EIPS/eip-1153)
+"""
+
+TSTORE = Opcode(0x5D, popped_stack_items=2)
+"""
+TSTORE(key, value)
+----
+
+Description
+----
+Store a value in the storage at the specified key.
+
+Inputs
+----
+- key: The key in storage.
+- value: The value to be stored.
+
+Fork
+----
+
+
+Gas
+----
+100
+
+Source: [eips.ethereum.org/EIPS/eip-1153](https://eips.ethereum.org/EIPS/eip-1153)
+"""
+
+MCOPY = Opcode(0x5E, popped_stack_items=3)
+"""
+MCOPY(dst, src ,length)
+----
+
+Description
+----
+Copies memory
+
+Inputs
+----
+- dst: byte offset in the memory where the result will be copied.
+- src: byte offset in the calldata to copy.
+- length: byte size to copy
+
+Outputs
+----
+- None
+
+Fork
+----
+Frontier
+
+Gas
+----
+words_copied = (length + 31) // 32
+g_verylow    = 3
+g_copy       = 3 * words_copied + memory_expansion_cost
+gas_cost     = g_verylow + g_copy
+
+Source: [eips.ethereum.org/EIPS/eip-5656](https://eips.ethereum.org/EIPS/eip-5656)
+"""
+
+RETF = Opcode(0x49)
+"""
+RETF()
+----
+
+Description
+----
+Return from a function
+
+Inputs
+----
+- None
+
+Outputs
+----
+- None
+
+Fork
+----
+
+
+Gas
+----
+3 
+
+Source: [evm.codes/#5F](https://www.evm.codes/#5F)
+"""
+
+
+PUSH0 = Opcode(0x5F, pushed_stack_items=1)
+"""
+PUSH0() = value
+----
+
+Description
+----
+Place value 0 on stack
+
+Inputs
+----
+- None
+
+Outputs
+----
+- value: pushed value, equal to 0
+
+Fork
+----
+Frontier
+
+Gas
+----
+2
+
+Source: [evm.codes/#5F](https://www.evm.codes/#5F)
+"""
+
+PUSH1 = Opcode(0x60, pushed_stack_items=1, data_portion_length=1)
+"""
+PUSH1() = value
+----
+
+Description
+----
+Place 1 byte item on stack
+
+Inputs
+----
+- None
+
+Outputs
+----
+- value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#60](https://www.evm.codes/#60)
+"""
+
+PUSH2 = Opcode(0x61, pushed_stack_items=1, data_portion_length=2)
+"""
+PUSH2() = value
+----
+
+Description
+----
+Place 2 byte item on stack
+
+Inputs
+----
+- None
+
+Outputs
+----
+- value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#61](https://www.evm.codes/#61)
+"""
+
+PUSH3 = Opcode(0x62, pushed_stack_items=1, data_portion_length=3)
+"""
+PUSH3() = value
+----
+
+Description
+----
+Place 3 byte item on stack
+
+Inputs
+----
+- None
+
+Outputs
+----
+- value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#62](https://www.evm.codes/#62)
+"""
+
+PUSH4 = Opcode(0x63, pushed_stack_items=1, data_portion_length=4)
+"""
+PUSH4() = value
+----
+
+Description
+----
+Place 4 byte item on stack
+
+Inputs
+----
+- None
+
+Outputs
+----
+- value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#63](https://www.evm.codes/#63)
+"""
+
+PUSH5 = Opcode(0x64, pushed_stack_items=1, data_portion_length=5)
+"""
+PUSH5() = value
+----
+
+Description
+----
+Place 5 byte item on stack
+
+Inputs
+----
+- None
+
+Outputs
+----
+- value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#64](https://www.evm.codes/#64)
+"""
+
+PUSH6 = Opcode(0x65, pushed_stack_items=1, data_portion_length=6)
+"""
+PUSH6() = value
+----
+
+Description
+----
+Place 6 byte item on stack
+
+Inputs
+----
+- None
+
+Outputs
+----
+- value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#65](https://www.evm.codes/#65)
+"""
+
+PUSH7 = Opcode(0x66, pushed_stack_items=1, data_portion_length=7)
+"""
+PUSH7() = value
+----
+
+Description
+----
+Place 7 byte item on stack
+
+Inputs
+----
+- None
+
+Outputs
+----
+- value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#66](https://www.evm.codes/#66)
+"""
+PUSH8 = Opcode(0x77, pushed_stack_items=1, data_portion_length=8)
+"""
+PUSH8() = value
+----
+
+Description
+----
+Place 8 byte item on stack
+
+Inputs
+----
+- None
+
+Outputs
+----
+- value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#67](https://www.evm.codes/#67)
+"""
+
+PUSH9 = Opcode(0x78, pushed_stack_items=1, data_portion_length=9)
+"""
+PUSH9() = value
+----
+
+Description
+----
+Place 9 byte item on stack
+
+Inputs
+----
+- None
+
+Outputs
+----
+- value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#68](https://www.evm.codes/#68)
+"""
+
+PUSH10 = Opcode(0x79, pushed_stack_items=1, data_portion_length=10)
+"""
+PUSH10() = value
+----
+
+Description
+----
+Place 10 byte item on stack
+
+Inputs
+----
+- None
+
+Outputs
+----
+- value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#69](https://www.evm.codes/#69)
+"""
+
+PUSH11 = Opcode(0x7A, pushed_stack_items=1, data_portion_length=11)
+"""
+PUSH11() = value
+----
+
+Description
+----
+Place 11 byte item on stack
+
+Inputs
+----
+- None
+
+Outputs
+----
+- value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#6A](https://www.evm.codes/#6A)
+"""
+
+PUSH12 = Opcode(0x7B, pushed_stack_items=1, data_portion_length=12)
+"""
+PUSH12() = value
+----
+
+Description
+----
+Place 12 byte item on stack
+
+Inputs
+----
+- None
+
+Outputs
+----
+- value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#6B](https://www.evm.codes/#6B)
+"""
+
+PUSH13 = Opcode(0x7C, pushed_stack_items=1, data_portion_length=13)
+"""
+PUSH13() = value
+----
+
+Description
+----
+Place 13 byte item on stack
+
+Inputs
+----
+- None
+
+Outputs
+----
+- value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#6C](https://www.evm.codes/#6C)
+"""
+
+PUSH14 = Opcode(0x7D, pushed_stack_items=1, data_portion_length=14)
+"""
+PUSH14() = value
+----
+
+Description
+----
+Place 14 byte item on stack
+
+Inputs
+----
+- None
+
+Outputs
+----
+- value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+Fork
+----
+Frontier
+
+
+Gas
+----
+3
+
+Source: [evm.codes/#6D](https://www.evm.codes/#6D)
+"""
+
+PUSH15 = Opcode(0x7E, pushed_stack_items=1, data_portion_length=15)
+"""
+PUSH15() = value
+----
+
+Description
+----
+Place 15 byte item on stack
+
+Inputs
+----
+- None
+
+Outputs
+----
+- value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#6E](https://www.evm.codes/#6E)
+"""
+
+PUSH16 = Opcode(0x7F, pushed_stack_items=1, data_portion_length=16)
+"""
+PUSH16() = value
+----
+
+Description
+----
+Place 16 byte item on stack
+
+Inputs
+----
+- None
+
+Outputs
+----
+- value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#6F](https://www.evm.codes/#6F)
+"""
+
+PUSH17 = Opcode(0x80, pushed_stack_items=1, data_portion_length=17)
+"""
+PUSH17() = value
+----
+
+Description
+----
+Place 17 byte item on stack
+
+Inputs
+----
+- None
+
+Outputs
+----
+- value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#70](https://www.evm.codes/#70)
+"""
+
+PUSH18 = Opcode(0x81, pushed_stack_items=1, data_portion_length=18)
+"""
+PUSH18() = value
+----
+
+Description
+----
+Place 18 byte item on stack
+
+Inputs
+----
+- None
+
+Outputs
+----
+- value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#71](https://www.evm.codes/#71)
+"""
+
+PUSH19 = Opcode(0x82, pushed_stack_items=1, data_portion_length=19)
+"""
+PUSH19() = value
+----
+
+Description
+----
+Place 19 byte item on stack
+
+Inputs
+----
+- None
+
+Outputs
+----
+- value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#72](https://www.evm.codes/#72)
+"""
+
+PUSH20 = Opcode(0x83, pushed_stack_items=1, data_portion_length=20)
+"""
+PUSH20() = value
+----
+
+Description
+----
+Place 20 byte item on stack
+
+Inputs
+----
+- None
+
+Outputs
+----
+- value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#73](https://www.evm.codes/#73)
+"""
+
+PUSH21 = Opcode(0x84, pushed_stack_items=1, data_portion_length=21)
+"""
+PUSH21() = value
+----
+
+Description
+----
+Place 21 byte item on stack
+
+Inputs
+----
+- None
+
+Outputs
+----
+- value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#74](https://www.evm.codes/#74)
+"""
+
+PUSH22 = Opcode(0x85, pushed_stack_items=1, data_portion_length=22)
+"""
+PUSH22() = value
+----
+
+Description
+----
+Place 22 byte item on stack
+
+Inputs
+----
+- None
+
+Outputs
+----
+- value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#75](https://www.evm.codes/#75)
+"""
+
+PUSH23 = Opcode(0x86, pushed_stack_items=1, data_portion_length=23)
+"""
+PUSH23() = value
+----
+
+Description
+----
+Place 23 byte item on stack
+
+Inputs
+----
+- None
+
+Outputs
+----
+- value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#76](https://www.evm.codes/#76)
+"""
+
+PUSH24 = Opcode(0x87, pushed_stack_items=1, data_portion_length=24)
+"""
+PUSH24() = value
+----
+
+Description
+----
+Place 24 byte item on stack
+
+Inputs
+----
+- None
+
+Outputs
+----
+- value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#77](https://www.evm.codes/#77)
+"""
+
+PUSH25 = Opcode(0x88, pushed_stack_items=1, data_portion_length=25)
+"""
+PUSH25() = value
+----
+
+Description
+----
+Place 25 byte item on stack
+
+Inputs
+----
+- None
+
+Outputs
+----
+- value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#78](https://www.evm.codes/#78)
+"""
+
+PUSH26 = Opcode(0x89, pushed_stack_items=1, data_portion_length=26)
+"""
+PUSH26() = value
+----
+
+Description
+----
+Place 26 byte item on stack
+
+Inputs
+----
+- None
+
+Outputs
+----
+- value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#79](https://www.evm.codes/#79)
+"""
+
+PUSH27 = Opcode(0x8A, pushed_stack_items=1, data_portion_length=27)
+"""
+PUSH27() = value
+----
+
+Description
+----
+Place 27 byte item on stack
+
+Inputs
+----
+- None
+
+Outputs
+----
+- value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#7A](https://www.evm.codes/#7A)
+"""
+
+PUSH28 = Opcode(0x8B, pushed_stack_items=1, data_portion_length=28)
+"""
+PUSH28() = value
+----
+
+Description
+----
+Place 28 byte item on stack
+
+Inputs
+----
+- None
+
+Outputs
+----
+- value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#7B](https://www.evm.codes/#7B)
+"""
+
+PUSH29 = Opcode(0x8C, pushed_stack_items=1, data_portion_length=29)
+"""
+PUSH29() = value
+----
+
+Description
+----
+Place 29 byte item on stack
+
+Inputs
+----
+- None
+
+Outputs
+----
+- value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#7C](https://www.evm.codes/#7C)
+"""
+
+PUSH30 = Opcode(0x8D, pushed_stack_items=1, data_portion_length=30)
+"""
+PUSH30() = value
+----
+
+Description
+----
+Place 30 byte item on stack
+
+Inputs
+----
+- None
+
+Outputs
+----
+- value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#7D](https://www.evm.codes/#7D)
+"""
+
+PUSH31 = Opcode(0x8E, pushed_stack_items=1, data_portion_length=31)
+"""
+PUSH31() = value
+----
+
+Description
+----
+Place 31 byte item on stack
+
+Inputs
+----
+- None
+
+Outputs
+----
+- value: pushed value.
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#7E](https://www.evm.codes/#7E)
+"""
+
+PUSH32 = Opcode(0x8F, pushed_stack_items=1, data_portion_length=32)
+"""
+PUSH32() = value
+----
+
+Description
+----
+Place 32 byte item on stack
+
+Inputs
+----
+- None
+
+Outputs
+----
+- value: pushed value.
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#7F](https://www.evm.codes/#7F)
+"""
+
+DUP1 = Opcode(0x80, pushed_stack_items=1, min_stack_height=1)
+"""
+DUP1(value) = value
+----
+
+Description
+----
+Duplicate 1st stack item
+
+Inputs
+----
+- value: value to duplicate
+
+Outputs
+----
+- value: duplicated value.
+- value: original value
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#80](https://www.evm.codes/#80)
+"""
+
+DUP2 = Opcode(0x81, pushed_stack_items=1, min_stack_height=2)
+"""
+DUP2(a, b) = b,a,b
+----
+
+Description
+----
+Duplicate 2nd stack item
+
+Inputs
+----
+- a: ignored value.
+- b: value to duplicate.
+
+Outputs
+----
+- b: duplicated value.
+- a: ignored value.
+- b: original value.
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#81](https://www.evm.codes/#81)
+"""
+
+DUP3 = Opcode(0x82, pushed_stack_items=1, min_stack_height=3)
+"""
+DUP15(a, b, c) = c, a, b, c
+----
+
+Description
+----
+Duplicate 3rd stack item
+
+Inputs
+----
+- a: ignored value.
+- b: ignored value.
+- c: value to duplicate.
+
+Outputs
+----
+- c: duplicated value.
+- a: ignored value.
+- b: ignored value.
+- c: original value.
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#82](https://www.evm.codes/#82)
+"""
+
+DUP4 = Opcode(0x83, pushed_stack_items=1, min_stack_height=4)
+"""
+DUP15(value1, value2, value3, value) = value, value2, value3, value
+----
+
+Description
+----
+Duplicate 4th stack item
+
+Inputs
+----
+- ignored value.
+- ignored value.
+- ignored value.
+- value: value to duplicate
+
+Outputs
+----
+- value: duplicated value
+- ignored value.
+- ignored value.
+- ignored value.
+- value: value to duplicate
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#83](https://www.evm.codes/#83)
+"""
+
+DUP5 = Opcode(0x84, pushed_stack_items=1, min_stack_height=5)
+"""
+DUP15(value1, value2, value3, value4, value) = value, value2, value3, value4, value
+----
+
+Description
+----
+Duplicate 5th stack item
+
+Inputs
+----
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- value: value to duplicate
+
+Outputs
+----
+- value: duplicated value
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- value: value to duplicate
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#84](https://www.evm.codes/#84)
+"""
+
+DUP6 = Opcode(0x85, pushed_stack_items=1, min_stack_height=6)
+"""
+DUP15(value1, value2, value3, value4, value5, value) = value, value2, value3, value4, value5, value
+----
+
+Description
+----
+Duplicate 6th stack item
+
+Inputs
+----
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- value: value to duplicate
+
+Outputs
+----
+- value: duplicated value
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- value: value to duplicate
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#85](https://www.evm.codes/#85)
+"""
+
+DUP7 = Opcode(0x86, pushed_stack_items=1, min_stack_height=7)
+"""
+DUP15(value1, value2, value3, value4, value5, value6, value) = value, value2, value3, value4, value5, value6, value
+----
+
+Description
+----
+Duplicate 7th stack item
+
+Inputs
+----
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- value: value to duplicate
+
+Outputs
+----
+- value: duplicated value
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- value: value to duplicate
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#86](https://www.evm.codes/#86)
+"""
+
+DUP8 = Opcode(0x87, pushed_stack_items=1, min_stack_height=8)
+"""
+DUP15(value1, value2, value3, value4, value5, value6, value7, value) = value, value2, value3, value4, value5, value6, value7, value
+----
+
+Description
+----
+Duplicate 8th stack item
+
+Inputs
+----
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- value: value to duplicate
+
+Outputs
+----
+- value: duplicated value
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- value: value to duplicate
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#87](https://www.evm.codes/#87)
+"""
+
+DUP9 = Opcode(0x88, pushed_stack_items=1, min_stack_height=9)
+"""
+DUP15(value1, value2, value3, value4, value5, value6, value7, value8, value) = value, value2, value3, value4, value5, value6, value7, value8, value
+----
+
+Description
+----
+Duplicate 9th stack item
+
+Inputs
+----
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- value: value to duplicate
+
+Outputs
+----
+- value: duplicated value
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- value: value to duplicate
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#88](https://www.evm.codes/#88)
+"""
+DUP10 = Opcode(0x89, pushed_stack_items=1, min_stack_height=10)
+"""
+DUP10(value1, value2, value3, value4, value5, value6, value7, value8, value9, value) = value, value2, value3, value4, value5, value6, value7, value8, value9, value
+----
+
+Description
+----
+Duplicate 10th stack item
+
+Inputs
+----
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- value: value to duplicate
+
+Outputs
+----
+- value: duplicated value
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- value: value to duplicate
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#89](https://www.evm.codes/#89)
+"""
+
+DUP11 = Opcode(0x8A, pushed_stack_items=1, min_stack_height=11)
+"""
+DUP11(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value) = value, value2, value3, value4, value5, value6, value7, value8, value9, value10, value
+----
+
+Description
+----
+Duplicate 11th stack item
+
+Inputs
+----
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- value: value to duplicate
+
+Outputs
+----
+- value: duplicated value
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- value: value to duplicate
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#8A](https://www.evm.codes/#8A)
+"""
+
+DUP12 = Opcode(0x8B, pushed_stack_items=1, min_stack_height=12)
+"""
+DUP12(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value) = value, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value
+----
+
+Description
+----
+Duplicate 12th stack item
+
+Inputs
+----
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- value: value to duplicate
+
+Outputs
+----
+- value: duplicated value
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- value: value to duplicate
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#8B](https://www.evm.codes/#8B)
+"""
+
+DUP13 = Opcode(0x8C, pushed_stack_items=1, min_stack_height=13)
+"""
+DUP15(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value) = value, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value
+----
+
+Description
+----
+Duplicate 13th stack item
+
+Inputs
+----
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- value: value to duplicate
+
+Outputs
+----
+- value: duplicated value
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- value: value to duplicate
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#8C](https://www.evm.codes/#8C)
+"""
+
+DUP14 = Opcode(0x8D, pushed_stack_items=1, min_stack_height=14)
+"""
+DUP15(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value) = value, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value
+----
+
+Description
+----
+Duplicate 14th stack item
+
+Inputs
+----
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- value: value to duplicate
+
+Outputs
+----
+- value: duplicated value
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- value: value to duplicate
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#8D](https://www.evm.codes/#8D)
+"""
+
+DUP15 = Opcode(0x8E, pushed_stack_items=1, min_stack_height=15)
+"""
+DUP15(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value) = value, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value
+----
+
+Description
+----
+Duplicate 15th stack item
+
+Inputs
+----
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- value: value to duplicate
+
+Outputs
+----
+- value: duplicated value
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- value: value to duplicate
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#8E](https://www.evm.codes/#8E)
+"""
+
+DUP16 = Opcode(0x8F, pushed_stack_items=1, min_stack_height=16)
+"""
+DUP16(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, value) = value, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, value
+----
+
+Description
+----
+Duplicate 16th stack item
+
+Inputs
+----
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- value: value to duplicate
+
+Outputs
+----
+- value: duplicated value
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- value: value to duplicate
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#8F](https://www.evm.codes/#8F)
+"""
+
+SWAP1 = Opcode(0x90, min_stack_height=2)
+"""
+SWAP1(a, b) = b, a
+----
+
+Description
+----
+Exchange the top stack item with the second stack item.
+
+Inputs
+----
+- a: value to swap
+- b: value to swap
+
+Outputs
+----
+- b: swapped value.
+- a: swapped value.
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#90](https://www.evm.codes/#90)
+"""
+
+SWAP2 = Opcode(0x91, min_stack_height=3)
+"""
+SWAP2(a, value2, b) = b, value2, a
+----
+
+Description
+----
+Exchange 1st and 3rd stack items
+
+Inputs
+----
+- a: value to swap
+- ignored value.
+- b: value to swap
+
+Outputs
+----
+- b: swapped value
+- ignored value
+- a: swapped value
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#91](https://www.evm.codes/#91)
+"""
+
+SWAP3 = Opcode(0x92, min_stack_height=4)
+"""
+SWAP3(a, value2, value3, b) = b value2, value3, a
+----
+
+Description
+----
+Exchange 1st and 4th stack items
+
+Inputs
+----
+- a: value to swap
+- ignored value.
+- ignored value.
+- b: value to swap
+
+Outputs
+----
+- b: swapped value.
+- ignored value.
+- ignored value.
+- a: swapped value.
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#92](https://www.evm.codes/#92)
+"""
+
+SWAP4 = Opcode(0x93, min_stack_height=5)
+"""
+SWAP4(a, value2, value3, value4, b) = b value2, value3, value4, a
+----
+
+Description
+----
+Exchange 1st and 5th stack items
+
+Inputs
+----
+- a: value to swap
+- ignored value.
+- ignored value.
+- ignored value.
+- b: value to swap
+
+Outputs
+----
+- b: swapped value.
+- ignored value.
+- ignored value.
+- ignored value.
+- a: swapped value.
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#93](https://www.evm.codes/#93)
+"""
+
+SWAP5 = Opcode(0x94, min_stack_height=6)
+"""
+SWAP5(a, value2, value3, value4, value5, b) = b, value2, value3, value4, value5, a
+----
+
+Description
+----
+Exchange 1st and 6th stack items
+
+Inputs
+----
+- a: value to swap
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- b: value to swap
+
+Outputs
+----
+- b: swapped value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- a: swapped value.
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#94](https://www.evm.codes/#94)
+"""
+
+SWAP6 = Opcode(0x95, min_stack_height=7)
+"""
+SWAP6(a, value2, value3, value4, value5, value6, b) = b, value2, value3, value4, value5, value6, a
+----
+
+Description
+----
+Exchange 1st and 7th stack items
+
+Inputs
+----
+- a: value to swap
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- b: value to swap
+
+Outputs
+----
+- b: swapped value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- a: swapped value.
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#95](https://www.evm.codes/#95)
+"""
+
+SWAP7 = Opcode(0x96, min_stack_height=8)
+"""
+SWAP7(a, value2, value3, value4, value5, value6, value7, b) = b, value2, value3, value4, value5, value6, value7, a
+----
+
+Description
+----
+Exchange 1st and 8th stack items
+
+Inputs
+----
+- a: value to swap
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- b: value to swap
+
+Outputs
+----
+- b: swapped value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- a: swapped value.
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#96](https://www.evm.codes/#96)
+"""
+
+SWAP8 = Opcode(0x97, min_stack_height=9)
+"""
+SWAP8(a, value2, value3, value4, value5, value6, value7, value8, b) = b, value2, value3, value4, value5, value6, value7, value8, a
+----
+
+Description
+----
+Exchange 1st and 9th stack items
+
+Inputs
+----
+- a: value to swap
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- b: value to swap
+
+Outputs
+----
+- b: swapped value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- a: swapped value.
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#97](https://www.evm.codes/#97)
+"""
+
+SWAP9 = Opcode(0x98, min_stack_height=10)
+"""
+SWAP9(a, value2, value3, value4, value5, value6, value7, value8, value9, b) = b, value2, value3, value4, value5, value6, value7, value8, value9, a
+----
+
+Description
+----
+Exchange 1st and 10th stack items
+
+Inputs
+----
+- a: value to swap
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- b: value to swap
+
+Outputs
+----
+- b: swapped value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- a: swapped value.
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#98](https://www.evm.codes/#98)
+"""
+
+SWAP10 = Opcode(0x99, min_stack_height=11)
+"""
+SWAP10(a, value2, value3, value4, value5, value6, value7, value8, value9, value10, b) = b, value2, value3, value4, value5, value6, value7, value8, value9, value10, a
+----
+
+Description
+----
+Exchange 1st and 11th stack items
+
+Inputs
+----
+- a: value to swap
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- b: value to swap
+
+Outputs
+----
+- b: swapped value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- a: swapped value.
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#99](https://www.evm.codes/#99)
+"""
+
+SWAP11 = Opcode(0x9A, min_stack_height=12)
+"""
+SWAP11(a, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, b) = b, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, a
+----
+
+Description
+----
+Exchange 1st and 12th stack items
+
+Inputs
+----
+- a: value to swap
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- b: value to swap
+
+Outputs
+----
+- b: swapped value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- a: swapped value.
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#9A](https://www.evm.codes/#9A)
+"""
+
+SWAP12 = Opcode(0x9B, min_stack_height=13)
+"""
+SWAP12(a, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, b) = b, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, a
+----
+
+Description
+----
+Exchange 1st and 13th stack items
+
+Inputs
+----
+- a: value to swap
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- b: value to swap
+
+Outputs
+----
+- b: swapped value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- a: swapped value.
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#9B](https://www.evm.codes/#9B)
+"""
+
+SWAP13 = Opcode(0x9C, min_stack_height=14)
+"""
+SWAP13(a, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, b) = b, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12,a) 
+----
+
+Description
+----
+Exchange 1st and 14th stack items
+
+Inputs
+----
+- a: value to swap.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- b: value to swap.
+
+Outputs
+----
+- b: swapped value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- a: swapped value.
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#9C](https://www.evm.codes/#9C)
+"""
+
+SWAP14 = Opcode(0x9D, min_stack_height=15)
+"""
+SWAP14(a, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, b) = b, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, a) 
+----
+
+Description
+----
+Exchange 1st and 15th stack items
+
+Inputs
+----
+- a: value to swap.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- b: value to swap.
+
+Outputs
+----
+- b: swapped value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- a: swapped value.
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#9D](https://www.evm.codes/#9D)
+"""
+
+SWAP15 = Opcode(0x9E, min_stack_height=16)
+"""
+SWAP15(a, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, b) = b, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, a) 
+----
+
+Description
+----
+Exchange 1st and 16th stack items
+
+Inputs
+----
+- a: value to swap.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- b: value to swap.
+
+Outputs
+----
+- b: swapped value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- a: swapped value.
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#9E](https://www.evm.codes/#9E)
+"""
+
+
+SWAP16 = Opcode(0x9F, min_stack_height=17)
+"""
+SWAP16(a, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, b) = b, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, a) 
+----
+
+Description
+----
+Exchange 1st and 17th stack items
+
+Inputs
+----
+- a: value to swap.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- b: value to swap.
+
+Outputs
+----
+- b: swapped value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- ignored value.
+- a: swapped value.
+
+Fork
+----
+Frontier
+
+Gas
+----
+3
+
+Source: [evm.codes/#9F](https://www.evm.codes/#9F)
+"""
+
+
+LOG0 = Opcode(0xA0, popped_stack_items=2)
+"""
+LOG3(offset, size) 
+----
+
+Description
+----
+Append log record with no topics
+
+Inputs
+----
+- offset: byte offset in the memory in bytes
+- size: byte size to copy
+
+Outputs
+----
+- None
+
+Fork
+----
+Frontier
+
+Gas
+----
+375 + 375 * topic_count + 8 * size + memory_expansion_cost
+
+Source: [evm.codes/#A0](https://www.evm.codes/#A0)
+"""
+
+LOG1 = Opcode(0xA1, popped_stack_items=3)
+"""
+LOG1(offset, size, topic1) 
+----
+
+Description
+----
+Append log record with one topics
+
+Inputs
+----
+- offset: byte offset in the memory in bytes
+- size: byte size to copy
+- topic1: 32-byte value
+
+Outputs
+----
+- None
+
+Fork
+----
+Frontier
+
+Gas
+----
+375 + 375 * topic_count + 8 * size + memory_expansion_cost
+
+Source: [evm.codes/#A1](https://www.evm.codes/#A1)
+"""
+
+LOG2 = Opcode(0xA2, popped_stack_items=4)
+"""
+LOG2(offset, size, topic1, topic2) 
+----
+
+Description
+----
+Append log record with two topics
+
+Inputs
+----
+- offset: byte offset in the memory in bytes
+- size: byte size to copy
+- topic1: 32-byte value
+- topic2: 32-byte value
+
+Outputs
+----
+- None
+
+Fork
+----
+Frontier
+
+Gas
+----
+375 + 375 * topic_count + 8 * size + memory_expansion_cost
+
+Source: [evm.codes/#A2](https://www.evm.codes/#A2)
+"""
+
+LOG3 = Opcode(0xA3, popped_stack_items=5)
+"""
+LOG3(offset, size, topic1, topic2, topic3) 
+----
+
+Description
+----
+Append log record with three topics
+
+Inputs
+----
+- offset: byte offset in the memory in bytes
+- size: byte size to copy
+- topic1: 32-byte value
+- topic2: 32-byte value
+- topic3: 32-byte value
+
+Outputs
+----
+- None
+
+Fork
+----
+Frontier
+
+Gas
+----
+375 + 375 * topic_count + 8 * size + memory_expansion_cost
+
+Source: [evm.codes/#A3](https://www.evm.codes/#A3)
+"""
+
+LOG4 = Opcode(0xA4, popped_stack_items=6)
+"""
+LOG4(offset, size, topic1, topic2, topic3, topic4) 
+----
+
+Description
+----
+Append log record with four topics
+
+Inputs
+----
+- offset: byte offset in the memory in bytes
+- size: byte size to copy
+- topic1: 32-byte value
+- topic2: 32-byte value
+- topic3: 32-byte value
+- topic4: 32-byte value
+
+Outputs
+----
+- None
+
+Fork
+----
+Frontier
+
+Gas
+----
+375 + 375 * topic_count + 8 * size + memory_expansion_cost
+
+Source: [evm.codes/#A4](https://www.evm.codes/#A4)
+"""
+
+
+RJUMP = Opcode(0xE0, data_portion_length=2)
+"""
+RJUMP(destination)
+----
+
+Description
+----
+Jump to a relative position in code.
+
+Inputs
+----
+- destination: The relative position to jump to.
+
+Fork
+----
+Revolution
+"""
+
+RJUMPI = Opcode(0xE1, popped_stack_items=1, data_portion_length=2)
+"""
+RJUMPI() 
+----
+
+Description
+----
+
+
+Inputs
+----
+
+
+Outputs
+----
+
+
+Fork
+----
+
+Gas
+----
+
+
+Source: 
+
+"""
+
+RJUMPV = Opcode(0xE2)
+"""
+RJUMPV  
+----
+
+Description
+----
+
+
+Inputs
+----
+- 
+
+Outputs
+----
+- 
+
+Fork
+----
+
+
+Gas
+----
+
+
+Source: 
+"""
+
+
+CREATE = Opcode(0xF0, popped_stack_items=3, pushed_stack_items=1)
+"""
+CREATE(value, offset, length) = contract_address
+----
+
+Description
+----
+Create a new contract with the given code.
+
+Inputs
+----
+- value: value in wei to send to the new account
+- offset: byte offset in the memory in bytes, the initialisation code for the new account
+- size: byte size to copy (size of the initialisation code)
+
+Outputs
+----
+- contract_address: The address of the newly created contract.
+
+Fork
+----
+Homestead
+
+Gas
+----
+32000 + init_code_cost + memory_expansion_cost + deployment_code_execution_cost + code_deposit_cost
+
+Source: [evm.codes/#F0](https://www.evm.codes/#F0)
+"""
+
+CALL = Opcode(0xF1, popped_stack_items=7, pushed_stack_items=1)
+"""
+CALL(gas, address, value, argsOffset, argsSize, retOffset, retSize) = success
+----
+
+Description
+----
+Message-call into an account
+
+Inputs
+----
+- gas: amount of gas to send to the sub context to execute. The gas that is not used by the sub context is returned to this one
+- address: the account which context to execute
+- value: value in wei to send to the account
+- argsOffset: byte offset in the memory in bytes, the calldata of the sub context
+- argsSize: byte size to copy (size of the calldata)
+- retOffset: byte offset in the memory in bytes, where to store the return data of the sub context
+- retSize: byte size to copy (size of the return data)
+
+Outputs
+----
+- success: return 0 if the sub context reverted, 1 otherwise
+
+Fork
+----
+Frontier
+
+Gas
+----
+memory_expansion_cost + code_execution_cost + address_access_cost + positive_value_cost + value_to_empty_account_cost
+
+Source: [evm.codes/#F1](https://www.evm.codes/#F1)
+"""
+
+CALLCODE = Opcode(0xF2, popped_stack_items=7, pushed_stack_items=1)
+"""
+CALLCODE(gas, address, value, argsOffset, argsSize, retOffset, retSize) = success
+----
+
+Description
+----
+Message-call into this account with an alternative account's code. Executes code starting at the address to which the call is made.
+
+Inputs
+----
+- gas: amount of gas to send to the sub context to execute. The gas that is not used by the sub context is returned to this one.
+- address: the account which code to execute
+- value: value in wei to send to the account
+- argsOffset: byte offset in the memory in bytes, the calldata of the sub context
+- argsSize: byte size to copy (size of the calldata)
+- retOffset: byte offset in the memory in bytes, where to store the return data of the sub context
+- retSize: byte size to copy (size of the return data)
+Outputs
+----
+- success: return 0 if the sub context reverted, 1 otherwise
+
+Fork
+----
+Frontier
+
+Gas
+----
+memory_expansion_cost + code_execution_cost + address_access_cost + positive_value_cost
+
+Source: [evm.codes/#F2](https://www.evm.codes/#F2)
+"""
+
+RETURN = Opcode(0xF3, popped_stack_items=2)
+"""
+RETURN(offset, size)  
+----
+
+Description
+----
+Halt execution returning output data.
+
+Inputs
+----
+- offset: The memory offset to the output data.
+- size: The size of the output data.
+
+Outputs
+----
+- None
+
+Fork
+----
+Frontier
+
+Gas
+----
+memory_expansion_cost
+
+Source: [evm.codes/#F3](https://www.evm.codes/#F3)
+"""
+
+DELEGATECALL = Opcode(0xF4, popped_stack_items=6, pushed_stack_items=1)
+"""
+DELEGATECALL(gas, address, argsOffset, argsSize, retOffset, retSize) = success
+----
+
+Description
+----
+Message-call into this account with an alternative account’s code, but persisting the current values for sender and value
+
+Inputs
+----
+- gas: amount of gas to send to the sub context to execute. The gas that is not used by the sub context is returned to this one
+- address: the account which code to execute
+- argsOffset: byte offset in the memory in bytes, the calldata of the sub context
+- argsSize: byte size to copy (size of the calldata)
+- retOffset: byte offset in the memory in bytes, where to store the return data of the sub context.
+- retSize: byte size to copy (size of the return data)
+
+Outputs
+----
+- success: return 0 if the sub context reverted, 1 otherwise
+
+Fork
+----
+Byzantium
+
+Gas
+----
+memory_expansion_cost + code_execution_cost + address_access_cost
+
+Source: [evm.codes/#F4](https://www.evm.codes/#F4)
+"""
+
+CREATE2 = Opcode(0xF5, popped_stack_items=4, pushed_stack_items=1)
+"""
+CREATE2(value, offset, size, salt) = address
+----
+
+Description
+----
+Creates a new contract.
+
+Inputs
+----
+- value: value in wei to send to the new account.
+- offset: byte offset in the memory in bytes, the initialisation code of the new account.
+- size: byte size to copy (size of the initialisation code).
+- salt: 32-byte value used to create the new account at a deterministic address
+
+Outputs
+----
+- address: the address of the deployed contract, 0 if the deployment failed
+
+Fork
+----
+Constantinople
+
+Gas
+----
+minimum_word_size = (size + 31) / 32
+init_code_cost = 2 * minimum_word_size
+hash_cost = 6 * minimum_word_size
+code_deposit_cost = 200 * deployed_code_size
+
+32000 + init_code_cost + hash_cost + memory_expansion_cost + deployment_code_execution_cost + code_deposit_cost
+
+Source: [evm.codes/#F5](https://www.evm.codes/#F5)
+"""
+
+STATICCALL = Opcode(0xFA, popped_stack_items=6, pushed_stack_items=1)
+"""
+STATICCALL(gas, address, argsOffset, argsSize, retOffset , retSize) = success
+----
+
+Description
+----
+Static message-call into an account
+
+Inputs
+----
+- gas: amount of gas to send to the sub context to execute. The gas that is not used by the sub context is returned to this one.
+- address: the account which context to execute.
+- argsOffset: byte offset in the memory in bytes, the calldata of the sub context.
+- argsSize: byte size to copy (size of the calldata).
+- retOffset: byte offset in the memory in bytes, where to store the return data of the sub context.
+- retSize: byte size to copy (size of the return data)
+
+Outputs
+----
+- success: return 0 if the sub context reverted, 1 otherwise
+
+Fork
+----
+Byzantium
+
+Gas
+----
+memory_expansion_cost + code_execution_cost + address_access_cost
+
+Source: [evm.codes/#FA](https://www.evm.codes/#FA)
+"""
+
+
+
+REVERT = Opcode(0xFD, popped_stack_items=2)
+"""
+REVERT(offset, length)
+----
+
+Description
+----
+Stop execution and revert changes.
+
+Inputs
+----
+- offset: byte offset in the memory in bytes. The return data of the calling context.
+- size: byte size to copy (size of the return data).
+
+Fork
+----
+Byzantium
+
+Gas
+----
+0
+
+Source: [evm.codes/#FD](https://www.evm.codes/#FD)
+"""
+
+INVALID = Opcode(0xFE)
+"""
+INVALID()
+----
+
+Description
+----
+Invalid opcode.
+
+Inputs
+----
+None
+
+Outputs
+----
+None
+
+Fork
+----
+Homestead
+
+Gas
+----
+All the remaining gas in this context is consumed
+
+Source: [evm.codes/#FE](https://www.evm.codes/#FE)
+"""
+
+SELFDESTRUCT = Opcode(0xFF, popped_stack_items=1)
+"""
+SELFDESTRUCT(to)
+----
+
+Description
+----
+Halt execution and register the account for later deletion.
+
+Inputs
+----
+- to: The address to which any remaining funds are transferred.
+
+Fork
+----
+Frontier
+
+Gas
+----
+5000
+
+Source: [evm.codes/#FF](https://www.evm.codes/#FF)
+"""
+
+SENDALL = Opcode(0xFF, popped_stack_items=1)
+"""
+SENDALL(to) = success
+----
+
+Description
+----
+Send all ether to the target address.
+
+Inputs
+----
+- to: Target address
+
+Outputs
+----
+- None
+
+Fork
+----
+Frontier
+
+Gas
+----
+
+
+Source: [eips.ethereum.org/EIPS/eip-4758](https://eips.ethereum.org/EIPS/eip-4758)
+"""
+
+

--- a/src/ethereum_test_tools/vm/opcode.py
+++ b/src/ethereum_test_tools/vm/opcode.py
@@ -1321,7 +1321,7 @@ class Opcodes(Opcode, Enum):
 
     EXTCODECOPY = Opcode(0x3C, popped_stack_items=4)
     """
-    EXTCODESIZE(account)
+    EXTCODECOPY(addr, destOffset, offset, size)
     ----
 
     Description
@@ -1681,24 +1681,24 @@ class Opcodes(Opcode, Enum):
 
     BLOBHASH = Opcode(0x49, popped_stack_items=1, pushed_stack_items=1)
     """
-    BLOBHASH(data) = h
+    BLOBHASH(index) = versionedHash
     ----
 
     Description
     ----
-    Returns hashes of blobs in the transaction
+    Returns the versioned hash of a single blob contained in the type-3 transaction
 
     Inputs
     ----
-    - data: data to hash
+    - index: index of the blob
 
     Outputs
     ----
-    - h: keccak256 hash of the data
+    - versionedHash: versioned hash of the blob
 
     Fork
     ----
-    Dencun
+    Cancun
 
     Gas
     ----
@@ -1722,11 +1722,11 @@ class Opcodes(Opcode, Enum):
 
     Outputs
     ----
-    - fee: base fee per gas
+    - fee: base fee per blob gas
 
     Fork
     ----
-    Dencun
+    Cancun
 
     Gas
     ----
@@ -1737,7 +1737,7 @@ class Opcodes(Opcode, Enum):
 
     POP = Opcode(0x50, popped_stack_items=1)
     """
-    POP(y)
+    POP()
     ----
 
     Description
@@ -1746,13 +1746,9 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - y: a stack item
-
-    Outputs
-    ----
     - None
 
-    Inputs
+    Outputs
     ----
     - None
 
@@ -1874,7 +1870,8 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    100
+    warm: 100
+    cold: 2100
 
     Source: [evm.codes/#54](https://www.evm.codes/#54)
     """
@@ -1903,7 +1900,8 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    100
+    set: 20000
+    reset: 2900
 
     Source: [evm.codes/#55](https://www.evm.codes/#55)
     """
@@ -2033,7 +2031,7 @@ class Opcodes(Opcode, Enum):
 
     Outputs
     ----
-    - Source: [evm.codes/#5A](https://www.evm.codes/#5A)
+    - gas_remaining: remaining gas for the current call frame
 
     Fork
     ----
@@ -2093,7 +2091,7 @@ class Opcodes(Opcode, Enum):
 
     Fork
     ----
-
+    Cancun
 
     Gas
     ----
@@ -2118,7 +2116,7 @@ class Opcodes(Opcode, Enum):
 
     Fork
     ----
-
+    Cancun
 
     Gas
     ----
@@ -2148,7 +2146,7 @@ class Opcodes(Opcode, Enum):
 
     Fork
     ----
-    Frontier
+    Cancun
 
     Gas
     ----
@@ -2205,7 +2203,7 @@ class Opcodes(Opcode, Enum):
 
     Fork
     ----
-    Frontier
+    Shanghai
 
     Gas
     ----
@@ -4734,7 +4732,7 @@ class Opcodes(Opcode, Enum):
 
     Fork
     ----
-    Revolution
+    
     """
 
     RJUMPI = Opcode(0xE1, popped_stack_items=1, data_portion_length=2)
@@ -5076,7 +5074,7 @@ class Opcodes(Opcode, Enum):
 
     Fork
     ----
-    Homestead
+    Frontier
 
     Gas
     ----
@@ -5111,12 +5109,12 @@ class Opcodes(Opcode, Enum):
 
     SENDALL = Opcode(0xFF, popped_stack_items=1)
     """
-    SENDALL(to) = success
+    SENDALL(to)
     ----
 
     Description
     ----
-    Send all ether to the target address.
+    Send all ether to the target address and halt execution.
 
     Inputs
     ----
@@ -5132,7 +5130,7 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
+    5000
 
-
-    Source: [eips.ethereum.org/EIPS/eip-4758](https://eips.ethereum.org/EIPS/eip-4758)
+    Source: [eips.ethereum.org/EIPS/eip-6780](https://eips.ethereum.org/EIPS/eip-6780)
     """

--- a/src/ethereum_test_tools/vm/opcode.py
+++ b/src/ethereum_test_tools/vm/opcode.py
@@ -1,7 +1,10 @@
 """
 Ethereum Virtual Machine opcode definitions.
 
-Acknowledgments: The individual opcode documentation below is due to the work by [smlXL](https://github.com/smlxl) on [evm.codes](https://www.evm.codes/), available as open source [github.com/smlxl/evm.codes](https://github.com/smlxl/evm.codes) - thank you! And thanks to @ThreeHrSleep for integrating it in the docstrings.
+Acknowledgments: The individual opcode documentation below is due to the work by
+[smlXL](https://github.com/smlxl) on [evm.codes](https://www.evm.codes/), available as open
+source [github.com/smlxl/evm.codes](https://github.com/smlxl/evm.codes) - thank you! And thanks
+to @ThreeHrSleep for integrating it in the docstrings.
 """
 
 from enum import Enum
@@ -207,7 +210,7 @@ class Opcodes(Opcode, Enum):
 
     Description
     ----
-    Stop execution.
+    Stop execution
 
     Inputs
     ----
@@ -356,11 +359,12 @@ class Opcodes(Opcode, Enum):
     Inputs
     ----
     - a: signed numerator
-    - b: signed denominator (must be non-zero)
+    - b: signed denominator
 
     Outputs
     ----
-    - c: signed integer result of the division
+    - c: signed integer result of the division. If the denominator is 0, the result will be 0
+    ----
 
     Fork
     ----
@@ -384,7 +388,7 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - a: integer numerator.
+    - a: integer numerator
     - b: integer denominator
 
     Outputs
@@ -413,13 +417,13 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - a: integer numerator.
-    - b: integer denominator.
+    - a: integer numerator
+    - b: integer denominator
 
     Outputs
     ----
     - a % b: integer result of the signed integer modulo. If the denominator is 0, the result will
-      be 0
+        be 0
 
     Fork
     ----
@@ -450,7 +454,7 @@ class Opcodes(Opcode, Enum):
     Outputs
     ----
     - (a + b) % N: integer result of the addition followed by a modulo. If the denominator is 0,
-      the result will be 0
+        the result will be 0
 
     Fork
     ----
@@ -474,14 +478,14 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - a: first integer value to multiply.
-    - b: second integer value to multiply.
+    - a: first integer value to multiply
+    - b: second integer value to multiply
     - N: integer denominator
 
     Outputs
     ----
-    - d: (a * b) % N: integer result of the multiplication followed by a modulo. If the denominator
-      is 0, the result will be 0
+    - (a * b) % N: integer result of the multiplication followed by a modulo. If the denominator
+        is 0, the result will be 0
 
     Fork
     ----
@@ -505,7 +509,7 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - a: integer base.
+    - a: integer base
     - exponent: integer exponent
 
     Outputs
@@ -518,9 +522,8 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    static_gas = 10
-    dynamic_gas = 50 * exponent_byte_size
-    gas = static_gas + dynamic_gas
+    - static_gas = 10
+    - dynamic_gas = 50 * exponent_byte_size
 
     Source: [evm.codes/#0A](https://www.evm.codes/#0A)
     """
@@ -565,8 +568,8 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - a: first integer value
-    - b: second integer value
+    - a: left side integer value
+    - b: right side integer value
 
     Outputs
     ----
@@ -623,7 +626,7 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - a: eft side signed integer
+    - a: left side signed integer
     - b: right side signed integer
 
     Outputs
@@ -652,7 +655,7 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - a:  left side signed integer.
+    - a: left side signed integer
     - b: right side signed integer
 
     Outputs
@@ -738,7 +741,7 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - a: first binary value.
+    - a: first binary value
     - b: second binary value
 
     Outputs
@@ -796,7 +799,7 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - a:  first binary value
+    - a: first binary value
     - b: second binary value
 
     Outputs
@@ -853,13 +856,13 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - i: byte offset starting from the most significant byte.
+    - i: byte offset starting from the most significant byte
     - x: 32-byte value
 
     Outputs
     ----
     - y: the indicated byte at the least significant position. If the byte offset is out of range,
-      the result is 0
+        the result is 0
 
     Fork
     ----
@@ -883,7 +886,7 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - shift: number of bits to shift to the left.
+    - shift: number of bits to shift to the left
     - value: 32 bytes to shift
 
     Outputs
@@ -892,7 +895,7 @@ class Opcodes(Opcode, Enum):
 
     Fork
     ----
-    Frontier
+    Constantinople
 
     Gas
     ----
@@ -983,10 +986,9 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    minimum_word_size = (size + 31) / 32
-
-    static_gas = 30
-    dynamic_gas = 6 * minimum_word_size + memory_expansion_cost   
+    - minimum_word_size = (size + 31) / 32
+    - static_gas = 30
+    - dynamic_gas = 6 * minimum_word_size + memory_expansion_cost
 
     Source: [evm.codes/#20](https://www.evm.codes/#20)
     """
@@ -1042,8 +1044,8 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    warm: 100
-    cold: 2600
+    - static_gas = 0
+    - dynamic_gas = 100 if warm_address, 2600 if cold_address
 
     Source: [evm.codes/#31](https://www.evm.codes/#31)
     """
@@ -1064,7 +1066,7 @@ class Opcodes(Opcode, Enum):
     Outputs
     ----
     - address: the 20-byte address of the sender of the transaction. It can only be an account
-      without code
+        without code
 
     Fork
     ----
@@ -1093,7 +1095,7 @@ class Opcodes(Opcode, Enum):
     Outputs
     ----
     - address: the 20-byte address of the caller account. This is the account that did the last
-      call (except delegate call)
+        call (except delegate call)
 
     Fork
     ----
@@ -1145,12 +1147,12 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - i: byte offset in the calldata.
+    - i: byte offset in the calldata
 
     Outputs
     ----
     - data[i]: 32-byte value starting from the given offset of the calldata. All bytes after the
-      end of the calldata are set to 0
+        end of the calldata are set to 0
 
     Fork
     ----
@@ -1216,10 +1218,9 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    minimum_word_size = (size + 31) / 32
-
-    static_gas = 3
-    dynamic_gas = 3 * minimum_word_size + memory_expansion_cost
+    - minimum_word_size = (size + 31) / 32
+    - static_gas = 3
+    - dynamic_gas = 3 * minimum_word_size + memory_expansion_cost
 
     Source: [evm.codes/#37](https://www.evm.codes/#37)
     """
@@ -1273,10 +1274,9 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    minimum_word_size = (size + 31) / 32
-
-    static_gas = 3
-    dynamic_gas = 3 * minimum_word_size + memory_expansion_cost
+    - minimum_word_size = (size + 31) / 32
+    - static_gas = 3
+    - dynamic_gas = 3 * minimum_word_size + memory_expansion_cost
 
     Source: [evm.codes/#39](https://www.evm.codes/#39)
     """
@@ -1328,8 +1328,8 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    warm: 100
-    cold: 2600
+    - static_gas = 0
+    - dynamic_gas = 100 if warm_address, 2600 if cold_address
 
     Source: [evm.codes/#3B](https://www.evm.codes/#3B)
     """
@@ -1360,9 +1360,9 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    minimum_word_size = (size + 31) / 32
-    static_gas = 0
-    dynamic_gas = 3 * minimum_word_size + memory_expansion_cost + address_access_cost
+    - minimum_word_size = (size + 31) / 32
+    - static_gas = 0
+    - dynamic_gas = 3 * minimum_word_size + memory_expansion_cost + address_access_cost
 
     Source: [evm.codes/#3C](https://www.evm.codes/#3C)
     """
@@ -1402,9 +1402,9 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - destOffset: byte offset in the memory where the result will be copied.
-    - offset: byte offset in the return data from the last executed sub context to copy.
-    - size: byte size to copy.
+    - destOffset: byte offset in the memory where the result will be copied
+    - offset: byte offset in the return data from the last executed sub context to copy
+    - size: byte size to copy
 
     Fork
     ----
@@ -1412,9 +1412,9 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    minimum_word_size = (size + 31) / 32
-
-    Gas = 3 + 3 * minimum_word_size + memory_expansion_cost
+    - minimum_word_size = (size + 31) / 32
+    - static_gas = 3
+    - dynamic_gas = 3 * minimum_word_size + memory_expansion_cost
 
     Source: [evm.codes/#3E](https://www.evm.codes/#3E)
     """
@@ -1435,7 +1435,7 @@ class Opcodes(Opcode, Enum):
     Outputs
     ----
     - hash: hash of the chosen account's code, the empty hash (0xc5d24601...) if the account has no
-      code, or 0 if the account does not exist or has been destroyed
+        code, or 0 if the account does not exist or has been destroyed
 
     Fork
     ----
@@ -1443,8 +1443,8 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    warm: 100
-    cold: 2600
+    - static_gas = 0
+    - dynamic_gas = 100 if warm_address, 2600 if cold_address
 
     Source: [evm.codes/#3F](https://www.evm.codes/#3F)
     """
@@ -1461,11 +1461,12 @@ class Opcodes(Opcode, Enum):
     Inputs
     ----
     - blockNumber: block number to get the hash from. Valid range is the last 256 blocks (not
-      including the current one). Current block number can be queried with NUMBER
+        including the current one). Current block number can be queried with NUMBER
 
     Outputs
     ----
     - hash: hash of the chosen block, or 0 if the block number is not in the valid range
+
     Fork
     ----
     Frontier
@@ -1563,7 +1564,7 @@ class Opcodes(Opcode, Enum):
 
     PREVRANDAO = Opcode(0x44, pushed_stack_items=1)
     """
-    NUMBER() = prevRandao
+    PREVRANDAO() = prevRandao
     ----
 
     Description
@@ -1672,6 +1673,7 @@ class Opcodes(Opcode, Enum):
 
     Source: [evm.codes/#47](https://www.evm.codes/#47)
     """
+
     BASEFEE = Opcode(0x48, pushed_stack_items=1)
     """
     BASEFEE() = baseFee
@@ -1719,7 +1721,7 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    HASH_OPCODE_GAS
+    3
 
     Source: [eips.ethereum.org/EIPS/eip-4844](https://eips.ethereum.org/EIPS/eip-4844)
     """
@@ -1731,7 +1733,7 @@ class Opcodes(Opcode, Enum):
 
     Description
     ----
-    Returns the value of the blob base-fee of the current block it is executing in
+    Returns the value of the blob base fee of the block it is executing in
 
     Inputs
     ----
@@ -1739,7 +1741,7 @@ class Opcodes(Opcode, Enum):
 
     Outputs
     ----
-    - fee: base fee per blob gas
+    - baseFeePerBlobGas: base fee for the blob gas in wei
 
     Fork
     ----
@@ -1796,7 +1798,7 @@ class Opcodes(Opcode, Enum):
     Outputs
     ----
     - value: the 32 bytes in memory starting at that offset. If it goes beyond its current size
-      (see MSIZE), writes 0s
+        (see MSIZE), writes 0s
 
     Fork
     ----
@@ -1804,8 +1806,8 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    static_gas = 3
-    3 + memory_expansion_cost
+    - static_gas = 3
+    - dynamic_gas = memory_expansion_cost
 
     Source: [evm.codes/#51](https://www.evm.codes/#51)
     """
@@ -1821,8 +1823,8 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - offset: offset in the memory in bytes.
-    - value: 32-byte value to write in the memory.
+    - offset: offset in the memory in bytes
+    - value: 32-byte value to write in the memory
 
     Outputs
     ----
@@ -1834,7 +1836,8 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    3 + memory_expansion_cost
+    - static_gas = 3
+    - dynamic_gas = memory_expansion_cost
 
     Source: [evm.codes/#52](https://www.evm.codes/#52)
     """
@@ -1852,7 +1855,7 @@ class Opcodes(Opcode, Enum):
     ----
     - offset: offset in the memory in bytes
     - value: 1-byte value to write in the memory (the least significant byte of the 32-byte stack
-      value
+        value)
 
     Fork
     ----
@@ -1860,7 +1863,8 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    3 + memory_expansion_cost
+    - static_gas = 3
+    - dynamic_gas = memory_expansion_cost
 
     Source: [evm.codes/#53](https://www.evm.codes/#53)
     """
@@ -1888,8 +1892,8 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    warm: 100
-    cold: 2100
+    - static_gas = 0
+    - dynamic_gas = 100 if warm_address, 2600 if cold_address
 
     Source: [evm.codes/#54](https://www.evm.codes/#54)
     """
@@ -1918,6 +1922,7 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
+    ```
     static_gas = 0
 
     if value == current_value
@@ -1930,9 +1935,12 @@ class Opcodes(Opcode, Enum):
             base_dynamic_gas = 20000
         else
             base_dynamic_gas = 2900
+    else
+        base_dynamic_gas = 100
 
     if key is cold:
         base_dynamic_gas += 2100
+    ```
 
     Source: [evm.codes/#55](https://www.evm.codes/#55)
     """
@@ -1949,7 +1957,7 @@ class Opcodes(Opcode, Enum):
     Inputs
     ----
     - counter: byte offset in the deployed code where execution will continue from. Must be a
-      JUMPDEST instruction.
+        JUMPDEST instruction
 
     Outputs
     ----
@@ -1978,10 +1986,10 @@ class Opcodes(Opcode, Enum):
     Inputs
     ----
     - counter: byte offset in the deployed code where execution will continue from. Must be a
-      JUMPDEST instruction.
+        JUMPDEST instruction
     - b: the program counter will be altered with the new value only if this value is different
-      from 0. Otherwise, the program counter is simply incremented and the next instruction will be
-      executed.
+        from 0. Otherwise, the program counter is simply incremented and the next instruction will
+        be executed
 
     Fork
     ----
@@ -2062,7 +2070,7 @@ class Opcodes(Opcode, Enum):
 
     Outputs
     ----
-    - gas_remaining: remaining gas for the current call frame
+    - gas: remaining gas (after this instruction)
 
     Fork
     ----
@@ -2110,15 +2118,15 @@ class Opcodes(Opcode, Enum):
 
     Description
     ----
-    Load a value from the storage at the specified key.
+    Load word from transient storage
 
     Inputs
     ----
-    - key: The key in storage.
+    - key: 32-byte key in transient storage
 
     Outputs
     ----
-    - value: The value associated with the given key.
+    - value: 32-byte value corresponding to that key. 0 if that key was never written
 
     Fork
     ----
@@ -2138,12 +2146,12 @@ class Opcodes(Opcode, Enum):
 
     Description
     ----
-    Store a value in the storage at the specified key.
+    Save word to transient storage
 
     Inputs
     ----
-    - key: The key in storage.
-    - value: The value to be stored.
+    - key: 32-byte key in transient storage
+    - value: 32-byte value to store
 
     Fork
     ----
@@ -2158,17 +2166,17 @@ class Opcodes(Opcode, Enum):
 
     MCOPY = Opcode(0x5E, popped_stack_items=3)
     """
-    MCOPY(dst, src ,length)
+    MCOPY(dst, src, length)
     ----
 
     Description
     ----
-    Copies memory
+    Copies areas in memory
 
     Inputs
     ----
-    - dst: byte offset in the memory where the result will be copied.
-    - src: byte offset in the calldata to copy.
+    - dst: byte offset in the memory where the result will be copied
+    - src: byte offset in the calldata to copy
     - length: byte size to copy
 
     Outputs
@@ -2181,36 +2189,11 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    words_copied = (length + 31) // 32 g_verylow    = 3 g_copy       = 3 * words_copied +
-    memory_expansion_cost gas_cost     = g_verylow + g_copy
+    - minimum_word_size = (length + 31) / 32
+    - static_gas = 3
+    - dynamic_gas = 3 * minimum_word_size + memory_expansion_cost
 
     Source: [eips.ethereum.org/EIPS/eip-5656](https://eips.ethereum.org/EIPS/eip-5656)
-    """
-
-    RETF = Opcode(0x49)
-    """
-    RETF()
-    ----
-
-    Description
-    ----
-    Return from a function
-
-    Inputs
-    ----
-    - None
-
-    Outputs
-    ----
-    - None
-
-    Fork
-    ----
-
-
-    Gas
-    ----
-    3
     """
 
     PUSH0 = Opcode(0x5F, pushed_stack_items=1)
@@ -3097,7 +3080,7 @@ class Opcodes(Opcode, Enum):
 
     Outputs
     ----
-    - value: pushed value.
+    - value: pushed value, aligned to the right (put in the lowest significant bytes)
 
     Fork
     ----
@@ -3125,7 +3108,7 @@ class Opcodes(Opcode, Enum):
 
     Outputs
     ----
-    - value: pushed value.
+    - value: pushed value, aligned to the right (put in the lowest significant bytes)
 
     Fork
     ----
@@ -3140,7 +3123,7 @@ class Opcodes(Opcode, Enum):
 
     DUP1 = Opcode(0x80, pushed_stack_items=1, min_stack_height=1)
     """
-    DUP1(value) = value
+    DUP1(value) = value, value
     ----
 
     Description
@@ -3153,7 +3136,7 @@ class Opcodes(Opcode, Enum):
 
     Outputs
     ----
-    - value: duplicated value.
+    - value: duplicated value
     - value: original value
 
     Fork
@@ -3169,7 +3152,7 @@ class Opcodes(Opcode, Enum):
 
     DUP2 = Opcode(0x81, pushed_stack_items=1, min_stack_height=2)
     """
-    DUP2(a, b) = b,a,b
+    DUP2(v1, v2) = v2, v1, v2
     ----
 
     Description
@@ -3178,14 +3161,14 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - a: ignored value.
-    - b: value to duplicate.
+    - v1: ignored value
+    - v2: value to duplicate
 
     Outputs
     ----
-    - b: duplicated value.
-    - a: ignored value.
-    - b: original value.
+    - v2: duplicated value
+    - v1: ignored value
+    - v2: original value
 
     Fork
     ----
@@ -3200,7 +3183,7 @@ class Opcodes(Opcode, Enum):
 
     DUP3 = Opcode(0x82, pushed_stack_items=1, min_stack_height=3)
     """
-    DUP15(a, b, c) = c, a, b, c
+    DUP3(v1, v2, v3) = v3, v1, v2, v3
     ----
 
     Description
@@ -3209,16 +3192,16 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - a: ignored value.
-    - b: ignored value.
-    - c: value to duplicate.
+    - v1: ignored value
+    - v2: ignored value
+    - v3: value to duplicate
 
     Outputs
     ----
-    - c: duplicated value.
-    - a: ignored value.
-    - b: ignored value.
-    - c: original value.
+    - v3: duplicated value
+    - v1: ignored value
+    - v2: ignored value
+    - v3: original value
 
     Fork
     ----
@@ -3233,7 +3216,7 @@ class Opcodes(Opcode, Enum):
 
     DUP4 = Opcode(0x83, pushed_stack_items=1, min_stack_height=4)
     """
-    DUP15(value1, value2, value3, value) = value, value2, value3, value
+    DUP4(v1, v2, v3, v4) = v4, v1, v2, v3, v4
     ----
 
     Description
@@ -3242,18 +3225,18 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - value: value to duplicate
+    - v1: ignored value
+    - v2: ignored value
+    - v3: ignored value
+    - v4: value to duplicate
 
     Outputs
     ----
-    - value: duplicated value
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - value: value to duplicate
+    - v4: duplicated value
+    - v1: ignored value
+    - v2: ignored value
+    - v3: ignored value
+    - v4: original value
 
     Fork
     ----
@@ -3268,7 +3251,7 @@ class Opcodes(Opcode, Enum):
 
     DUP5 = Opcode(0x84, pushed_stack_items=1, min_stack_height=5)
     """
-    DUP15(value1, value2, value3, value4, value) = value, value2, value3, value4, value
+    DUP5(v1, v2, v3, v4, v5) = v5, v1, v2, v3, v4, v5
     ----
 
     Description
@@ -3277,20 +3260,20 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - value: value to duplicate
+    - v1: ignored value
+    - v2: ignored value
+    - v3: ignored value
+    - v4: ignored value
+    - v5: value to duplicate
 
     Outputs
     ----
-    - value: duplicated value
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - value: value to duplicate
+    - v5: duplicated value
+    - v1: ignored value
+    - v2: ignored value
+    - v3: ignored value
+    - v4: ignored value
+    - v5: original value
 
     Fork
     ----
@@ -3305,8 +3288,7 @@ class Opcodes(Opcode, Enum):
 
     DUP6 = Opcode(0x85, pushed_stack_items=1, min_stack_height=6)
     """
-    DUP15(value1, value2, value3, value4, value5, value) = value, value2, value3, value4, value5,
-    value
+    DUP6(v1, v2, ..., v5, v6) = v6, v1, v2, ..., v5, v6
     ----
 
     Description
@@ -3315,22 +3297,20 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - value: value to duplicate
+    - v1: ignored value
+    - v2: ignored value
+    - ...
+    - v5: ignored value
+    - v6: value to duplicate
 
     Outputs
     ----
-    - value: duplicated value
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - value: value to duplicate
+    - v6: duplicated value
+    - v1: ignored value
+    - v2: ignored value
+    - ...
+    - v5: ignored value
+    - v6: original value
 
     Fork
     ----
@@ -3345,8 +3325,7 @@ class Opcodes(Opcode, Enum):
 
     DUP7 = Opcode(0x86, pushed_stack_items=1, min_stack_height=7)
     """
-    DUP15(value1, value2, value3, value4, value5, value6, value) = value, value2, value3, value4,
-    value5, value6, value
+    DUP7(v1, v2, ..., v6, v7) = v7, v1, v2, ..., v6, v7
     ----
 
     Description
@@ -3355,24 +3334,20 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - value: value to duplicate
+    - v1: ignored value
+    - v2: ignored value
+    - ...
+    - v6: ignored value
+    - v7: value to duplicate
 
     Outputs
     ----
-    - value: duplicated value
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - value: value to duplicate
+    - v7: duplicated value
+    - v1: ignored value
+    - v2: ignored value
+    - ...
+    - v6: ignored value
+    - v7: original value
 
     Fork
     ----
@@ -3387,8 +3362,7 @@ class Opcodes(Opcode, Enum):
 
     DUP8 = Opcode(0x87, pushed_stack_items=1, min_stack_height=8)
     """
-    DUP15(value1, value2, value3, value4, value5, value6, value7, value) = value, value2, value3,
-    value4, value5, value6, value7, value
+    DUP8(v1, v2, ..., v7, v8) = v8, v1, v2, ..., v7, v8
     ----
 
     Description
@@ -3397,26 +3371,20 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - value: value to duplicate
+    - v1: ignored value
+    - v2: ignored value
+    - ...
+    - v7: ignored value
+    - v8: value to duplicate
 
     Outputs
     ----
-    - value: duplicated value
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - value: value to duplicate
+    - v8: duplicated value
+    - v1: ignored value
+    - v2: ignored value
+    - ...
+    - v7: ignored value
+    - v8: original value
 
     Fork
     ----
@@ -3431,8 +3399,7 @@ class Opcodes(Opcode, Enum):
 
     DUP9 = Opcode(0x88, pushed_stack_items=1, min_stack_height=9)
     """
-    DUP15(value1, value2, value3, value4, value5, value6, value7, value8, value) = value, value2,
-    value3, value4, value5, value6, value7, value8, value
+    DUP9(v1, v2, ..., v8, v9) = v9, v1, v2, ..., v8, v9
     ----
 
     Description
@@ -3441,28 +3408,20 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - value: value to duplicate
+    - v1: ignored value
+    - v2: ignored value
+    - ...
+    - v8: ignored value
+    - v9: value to duplicate
 
     Outputs
     ----
-    - value: duplicated value
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - value: value to duplicate
+    - v9: duplicated value
+    - v1: ignored value
+    - v2: ignored value
+    - ...
+    - v8: ignored value
+    - v9: original value
 
     Fork
     ----
@@ -3476,8 +3435,7 @@ class Opcodes(Opcode, Enum):
     """
     DUP10 = Opcode(0x89, pushed_stack_items=1, min_stack_height=10)
     """
-    DUP10(value1, value2, value3, value4, value5, value6, value7, value8, value9, value) = value,
-    value2, value3, value4, value5, value6, value7, value8, value9, value
+    DUP10(v1, v2, ..., v9, v10) = v10, v1, v2, ..., v9, v10
     ----
 
     Description
@@ -3486,30 +3444,20 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - value: value to duplicate
+    - v1: ignored value
+    - v2: ignored value
+    - ...
+    - v9: ignored value
+    - v10: value to duplicate
 
     Outputs
     ----
-    - value: duplicated value
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - value: value to duplicate
+    - v10: duplicated value
+    - v1: ignored value
+    - v2: ignored value
+    - ...
+    - v9: ignored value
+    - v10: original value
 
     Fork
     ----
@@ -3524,8 +3472,7 @@ class Opcodes(Opcode, Enum):
 
     DUP11 = Opcode(0x8A, pushed_stack_items=1, min_stack_height=11)
     """
-    DUP11(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value) =
-    value, value2, value3, value4, value5, value6, value7, value8, value9, value10, value
+    DUP11(v1, v2, ..., v10, v11) = v11, v1, v2, ..., v10, v11
     ----
 
     Description
@@ -3534,32 +3481,20 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - value: value to duplicate
+    - v1: ignored value
+    - v2: ignored value
+    - ...
+    - v10: ignored value
+    - v11: value to duplicate
 
     Outputs
     ----
-    - value: duplicated value
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - value: value to duplicate
+    - v11: duplicated value
+    - v1: ignored value
+    - v2: ignored value
+    - ...
+    - v10: ignored value
+    - v11: original value
 
     Fork
     ----
@@ -3574,9 +3509,7 @@ class Opcodes(Opcode, Enum):
 
     DUP12 = Opcode(0x8B, pushed_stack_items=1, min_stack_height=12)
     """
-    DUP12(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11,
-    value) = value, value2, value3, value4, value5, value6, value7, value8, value9, value10,
-    value11, value
+    DUP12(v1, v2, ..., v11, v12) = v12, v1, v2, ..., v11, v12
     ----
 
     Description
@@ -3585,34 +3518,20 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - value: value to duplicate
+    - v1: ignored value
+    - v2: ignored value
+    - ...
+    - v11: ignored value
+    - v12: value to duplicate
 
     Outputs
     ----
-    - value: duplicated value
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - value: value to duplicate
+    - v12: duplicated value
+    - v1: ignored value
+    - v2: ignored value
+    - ...
+    - v11: ignored value
+    - v12: original value
 
     Fork
     ----
@@ -3627,9 +3546,7 @@ class Opcodes(Opcode, Enum):
 
     DUP13 = Opcode(0x8C, pushed_stack_items=1, min_stack_height=13)
     """
-    DUP15(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11,
-    value12, value) = value, value2, value3, value4, value5, value6, value7, value8, value9,
-    value10,value11, value12, value
+    DUP13(v1, v2, ..., v12, v13) = v13, v1, v2, ..., v12, v13
     ----
 
     Description
@@ -3638,36 +3555,20 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - value: value to duplicate
+    - v1: ignored value
+    - v2: ignored value
+    - ...
+    - v12: ignored value
+    - v13: value to duplicate
 
     Outputs
     ----
-    - value: duplicated value
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - value: value to duplicate
+    - v13: duplicated value
+    - v1: ignored value
+    - v2: ignored value
+    - ...
+    - v12: ignored value
+    - v13: original value
 
     Fork
     ----
@@ -3682,9 +3583,7 @@ class Opcodes(Opcode, Enum):
 
     DUP14 = Opcode(0x8D, pushed_stack_items=1, min_stack_height=14)
     """
-    DUP15(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11,
-    value12, value13, value) = value, value2, value3, value4, value5, value6, value7, value8,
-    value9, value10, value11, value12, value13, value
+    DUP14(v1, v2, ..., v13, v14) = v14, v1, v2, ..., v13, v14
     ----
 
     Description
@@ -3693,38 +3592,20 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - value: value to duplicate
+    - v1: ignored value
+    - v2: ignored value
+    - ...
+    - v13: ignored value
+    - v14: value to duplicate
 
     Outputs
     ----
-    - value: duplicated value
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - value: value to duplicate
+    - v14: duplicated value
+    - v1: ignored value
+    - v2: ignored value
+    - ...
+    - v13: ignored value
+    - v14: original value
 
     Fork
     ----
@@ -3739,9 +3620,7 @@ class Opcodes(Opcode, Enum):
 
     DUP15 = Opcode(0x8E, pushed_stack_items=1, min_stack_height=15)
     """
-    DUP15(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11,
-    value12, value13, value14, value) = value, value2, value3, value4, value5, value6, value7,
-    value8, value9, value10, value11, value12, value13, value14, value
+    DUP15(v1, v2, ..., v14, v15) = v15, v1, v2, ..., v14, v15
     ----
 
     Description
@@ -3750,40 +3629,20 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - value: value to duplicate
+    - v1: ignored value
+    - v2: ignored value
+    - ...
+    - v14: ignored value
+    - v15: value to duplicate
 
     Outputs
     ----
-    - value: duplicated value
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - value: value to duplicate
+    - v15: duplicated value
+    - v1: ignored value
+    - v2: ignored value
+    - ...
+    - v14: ignored value
+    - v15: original value
 
     Fork
     ----
@@ -3798,9 +3657,7 @@ class Opcodes(Opcode, Enum):
 
     DUP16 = Opcode(0x8F, pushed_stack_items=1, min_stack_height=16)
     """
-    DUP16(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11,
-    value12, value13, value14, value15, value) = value, value2, value3, value4, value5, value6,
-    value7, value8, value9, value10, value11, value12, value13, value14, value15, value
+    DUP16(v1, v2, ..., v15, v16) = v16, v1, v2, ..., v15, v16
     ----
 
     Description
@@ -3809,42 +3666,20 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - value: value to duplicate
+    - v1: ignored value
+    - v2: ignored value
+    - ...
+    - v15: ignored value
+    - v16: value to duplicate
 
     Outputs
     ----
-    - value: duplicated value
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - value: value to duplicate
+    - v16: duplicated value
+    - v1: ignored value
+    - v2: ignored value
+    - ...
+    - v15: ignored value
+    - v16: original value
 
     Fork
     ----
@@ -3859,7 +3694,7 @@ class Opcodes(Opcode, Enum):
 
     SWAP1 = Opcode(0x90, min_stack_height=2)
     """
-    SWAP1(a, b) = b, a
+    SWAP1(v1, v2) = v2, v1
     ----
 
     Description
@@ -3868,13 +3703,13 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - a: value to swap
-    - b: value to swap
+    - v1: value to swap
+    - v2: value to swap
 
     Outputs
     ----
-    - b: swapped value.
-    - a: swapped value.
+    - v1: swapped value
+    - v2: swapped value
 
     Fork
     ----
@@ -3889,7 +3724,7 @@ class Opcodes(Opcode, Enum):
 
     SWAP2 = Opcode(0x91, min_stack_height=3)
     """
-    SWAP2(a, value2, b) = b, value2, a
+    SWAP2(v1, v2, v3) = v3, v2, v1
     ----
 
     Description
@@ -3898,15 +3733,15 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - a: value to swap
-    - ignored value.
-    - b: value to swap
+    - v1: value to swap
+    - v2: ignored value
+    - v3: value to swap
 
     Outputs
     ----
-    - b: swapped value
-    - ignored value
-    - a: swapped value
+    - v3: swapped value
+    - v2: ignored value
+    - v1: swapped value
 
     Fork
     ----
@@ -3921,7 +3756,7 @@ class Opcodes(Opcode, Enum):
 
     SWAP3 = Opcode(0x92, min_stack_height=4)
     """
-    SWAP3(a, value2, value3, b) = b value2, value3, a
+    SWAP3(v1, v2, v3, v4) = v4, v2, v3, v1
     ----
 
     Description
@@ -3930,17 +3765,17 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - a: value to swap
-    - ignored value.
-    - ignored value.
-    - b: value to swap
+    - v1: value to swap
+    - v2: ignored value
+    - v3: ignored value
+    - v4: value to swap
 
     Outputs
     ----
-    - b: swapped value.
-    - ignored value.
-    - ignored value.
-    - a: swapped value.
+    - v4: swapped value
+    - v2: ignored value
+    - v3: ignored value
+    - v1: swapped value
 
     Fork
     ----
@@ -3955,7 +3790,7 @@ class Opcodes(Opcode, Enum):
 
     SWAP4 = Opcode(0x93, min_stack_height=5)
     """
-    SWAP4(a, value2, value3, value4, b) = b value2, value3, value4, a
+    SWAP4(v1, v2, ..., v4, v5) = v5, v2, ..., v4, v1
     ----
 
     Description
@@ -3964,19 +3799,19 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - a: value to swap
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - b: value to swap
+    - v1: value to swap
+    - v2: ignored value
+    - ...
+    - v4: ignored value
+    - v5: value to swap
 
     Outputs
     ----
-    - b: swapped value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - a: swapped value.
+    - v5: swapped value
+    - v2: ignored value
+    - ...
+    - v4: ignored value
+    - v1: swapped value
 
     Fork
     ----
@@ -3991,7 +3826,7 @@ class Opcodes(Opcode, Enum):
 
     SWAP5 = Opcode(0x94, min_stack_height=6)
     """
-    SWAP5(a, value2, value3, value4, value5, b) = b, value2, value3, value4, value5, a
+    SWAP5(v1, v2, ..., v5, v6) = v6, v2, ..., v5, v1
     ----
 
     Description
@@ -4000,21 +3835,19 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - a: value to swap
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - b: value to swap
+    - v1: value to swap
+    - v2: ignored value
+    - ...
+    - v5: ignored value
+    - v6: value to swap
 
     Outputs
     ----
-    - b: swapped value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - a: swapped value.
+    - v6: swapped value
+    - v2: ignored value
+    - ...
+    - v5: ignored value
+    - v1: swapped value
 
     Fork
     ----
@@ -4029,8 +3862,7 @@ class Opcodes(Opcode, Enum):
 
     SWAP6 = Opcode(0x95, min_stack_height=7)
     """
-    SWAP6(a, value2, value3, value4, value5, value6, b) = b, value2, value3, value4, value5,
-    value6, a
+    SWAP6(v1, v2, ..., v6, v7) = v7, v2, ..., v6, v1
     ----
 
     Description
@@ -4039,23 +3871,19 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - a: value to swap
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - b: value to swap
+    - v1: value to swap
+    - v2: ignored value
+    - ...
+    - v6: ignored value
+    - v7: value to swap
 
     Outputs
     ----
-    - b: swapped value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - a: swapped value.
+    - v7: swapped value
+    - v2: ignored value
+    - ...
+    - v6: ignored value
+    - v1: swapped value
 
     Fork
     ----
@@ -4070,8 +3898,7 @@ class Opcodes(Opcode, Enum):
 
     SWAP7 = Opcode(0x96, min_stack_height=8)
     """
-    SWAP7(a, value2, value3, value4, value5, value6, value7, b) = b, value2, value3, value4,
-    value5, value6, value7, a
+    SWAP7(v1, v2, ..., v7, v8) = v8, v2, ..., v7, v1
     ----
 
     Description
@@ -4080,25 +3907,19 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - a: value to swap
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - b: value to swap
+    - v1: value to swap
+    - v2: ignored value
+    - ...
+    - v7: ignored value
+    - v8: value to swap
 
     Outputs
     ----
-    - b: swapped value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - a: swapped value.
+    - v8: swapped value
+    - v2: ignored value
+    - ...
+    - v7: ignored value
+    - v1: swapped value
 
     Fork
     ----
@@ -4113,8 +3934,7 @@ class Opcodes(Opcode, Enum):
 
     SWAP8 = Opcode(0x97, min_stack_height=9)
     """
-    SWAP8(a, value2, value3, value4, value5, value6, value7, value8, b) = b, value2, value3,
-    value4,value5, value6, value7, value8, a
+    SWAP8(v1, v2, ..., v8, v9) = v9, v2, ..., v8, v1
     ----
 
     Description
@@ -4123,27 +3943,19 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - a: value to swap
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - b: value to swap
+    - v1: value to swap
+    - v2: ignored value
+    - ...
+    - v8: ignored value
+    - v9: value to swap
 
     Outputs
     ----
-    - b: swapped value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - a: swapped value.
+    - v9: swapped value
+    - v2: ignored value
+    - ...
+    - v8: ignored value
+    - v1: swapped value
 
     Fork
     ----
@@ -4158,8 +3970,7 @@ class Opcodes(Opcode, Enum):
 
     SWAP9 = Opcode(0x98, min_stack_height=10)
     """
-    SWAP9(a, value2, value3, value4, value5, value6, value7, value8, value9, b) = b, value2,
-    value3,value4, value5, value6, value7, value8, value9, a
+    SWAP9(v1, v2, ..., v9, v10) = v10, v2, ..., v9, v1
     ----
 
     Description
@@ -4168,29 +3979,19 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - a: value to swap
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - b: value to swap
+    - v1: value to swap
+    - v2: ignored value
+    - ...
+    - v9: ignored value
+    - v10: value to swap
 
     Outputs
     ----
-    - b: swapped value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - a: swapped value.
+    - v10: swapped value
+    - v2: ignored value
+    - ...
+    - v9: ignored value
+    - v1: swapped value
 
     Fork
     ----
@@ -4205,8 +4006,7 @@ class Opcodes(Opcode, Enum):
 
     SWAP10 = Opcode(0x99, min_stack_height=11)
     """
-    SWAP10(a, value2, value3, value4, value5, value6, value7, value8, value9, value10, b) =
-    b, value2, value3, value4, value5, value6, value7, value8, value9, value10, a
+    SWAP10(v1, v2, ..., v10, v11) = v11, v2, ..., v10, v1
     ----
 
     Description
@@ -4215,31 +4015,19 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - a: value to swap
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - b: value to swap
+    - v1: value to swap
+    - v2: ignored value
+    - ...
+    - v10: ignored value
+    - v11: value to swap
 
     Outputs
     ----
-    - b: swapped value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - a: swapped value.
+    - v11: swapped value
+    - v2: ignored value
+    - ...
+    - v10: ignored value
+    - v1: swapped value
 
     Fork
     ----
@@ -4254,8 +4042,7 @@ class Opcodes(Opcode, Enum):
 
     SWAP11 = Opcode(0x9A, min_stack_height=12)
     """
-    SWAP11(a, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, b)
-    = b, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, a
+    SWAP11(v1, v2, ..., v11, v12) = v12, v2, ..., v11, v1
     ----
 
     Description
@@ -4264,33 +4051,19 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - a: value to swap
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - b: value to swap
+    - v1: value to swap
+    - v2: ignored value
+    - ...
+    - v11: ignored value
+    - v12: value to swap
 
     Outputs
     ----
-    - b: swapped value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - a: swapped value.
+    - v12: swapped value
+    - v2: ignored value
+    - ...
+    - v11: ignored value
+    - v1: swapped value
 
     Fork
     ----
@@ -4305,9 +4078,7 @@ class Opcodes(Opcode, Enum):
 
     SWAP12 = Opcode(0x9B, min_stack_height=13)
     """
-    SWAP12(a, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11,
-    value12, b) = b, value2, value3, value4, value5, value6, value7, value8, value9, value10,
-    value11, value12, a
+    SWAP12(v1, v2, ..., v12, v13) = v13, v2, ..., v12, v1
     ----
 
     Description
@@ -4316,33 +4087,19 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - a: value to swap
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - b: value to swap
+    - v1: value to swap
+    - v2: ignored value
+    - ...
+    - v12: ignored value
+    - v13: value to swap
 
     Outputs
     ----
-    - b: swapped value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - a: swapped value.
+    - v13: swapped value
+    - v2: ignored value
+    - ...
+    - v12: ignored value
+    - v1: swapped value
 
     Fork
     ----
@@ -4357,9 +4114,7 @@ class Opcodes(Opcode, Enum):
 
     SWAP13 = Opcode(0x9C, min_stack_height=14)
     """
-    SWAP13(a, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10,
-    value11, value12, b) = b, value1, value2, value3, value4, value5, value6, value7, value8,
-    value9, value10, value11, value12,a)
+    SWAP13(v1, v2, ..., v13, v14) = v14, v2, ..., v13, v1
     ----
 
     Description
@@ -4368,37 +4123,19 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - a: value to swap.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - b: value to swap.
+    - v1: value to swap
+    - v2: ignored value
+    - ...
+    - v13: ignored value
+    - v14: value to swap
 
     Outputs
     ----
-    - b: swapped value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - a: swapped value.
+    - v14: swapped value
+    - v2: ignored value
+    - ...
+    - v13: ignored value
+    - v1: swapped value
 
     Fork
     ----
@@ -4413,9 +4150,7 @@ class Opcodes(Opcode, Enum):
 
     SWAP14 = Opcode(0x9D, min_stack_height=15)
     """
-    SWAP14(a, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10,
-    value11, value12, value13, b) = b, value1, value2, value3, value4, value5, value6, value7,
-    value8, value9, value10, value11, value12, value13, a)
+    SWAP14(v1, v2, ..., v14, v15) = v15, v2, ..., v14, v1
     ----
 
     Description
@@ -4424,39 +4159,19 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - a: value to swap.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - b: value to swap.
+    - v1: value to swap
+    - v2: ignored value
+    - ...
+    - v14: ignored value
+    - v15: value to swap
 
     Outputs
     ----
-    - b: swapped value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - a: swapped value.
+    - v15: swapped value
+    - v2: ignored value
+    - ...
+    - v14: ignored value
+    - v1: swapped value
 
     Fork
     ----
@@ -4471,9 +4186,7 @@ class Opcodes(Opcode, Enum):
 
     SWAP15 = Opcode(0x9E, min_stack_height=16)
     """
-    SWAP15(a, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10,
-    value11, value12, value13, value14, b) = b, value1, value2, value3, value4, value5, value6,
-    value7, value8, value9, value10, value11, value12, value13, value14, a)
+    SWAP15(v1, v2, ..., v15, v16) = v16, v2, ..., v15, v1
     ----
 
     Description
@@ -4482,41 +4195,19 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - a: value to swap.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - b: value to swap.
+    - v1: value to swap
+    - v2: ignored value
+    - ...
+    - v15: ignored value
+    - v16: value to swap
 
     Outputs
     ----
-    - b: swapped value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - a: swapped value.
+    - v16: swapped value
+    - v2: ignored value
+    - ...
+    - v15: ignored value
+    - v1: swapped value
 
     Fork
     ----
@@ -4531,9 +4222,7 @@ class Opcodes(Opcode, Enum):
 
     SWAP16 = Opcode(0x9F, min_stack_height=17)
     """
-    SWAP16(a, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10,
-    value11, value12, value13, value14, value15, b) = b, value1, value2, value3, value4, value5,
-    value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, a)
+    SWAP16(v1, v2, ..., v16, v17) = v17, v2, ..., v16, v1
     ----
 
     Description
@@ -4542,43 +4231,19 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - a: value to swap.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - b: value to swap.
+    - v1: value to swap
+    - v2: ignored value
+    - ...
+    - v16: ignored value
+    - v17: value to swap
 
     Outputs
     ----
-    - b: swapped value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - ignored value.
-    - a: swapped value.
+    - v17: swapped value
+    - v2: ignored value
+    - ...
+    - v16: ignored value
+    - v1: swapped value
 
     Fork
     ----
@@ -4593,7 +4258,7 @@ class Opcodes(Opcode, Enum):
 
     LOG0 = Opcode(0xA0, popped_stack_items=2)
     """
-    LOG3(offset, size)
+    LOG0(offset, size)
     ----
 
     Description
@@ -4615,7 +4280,8 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    375 + 375 * topic_count + 8 * size + memory_expansion_cost
+    - static_gas = 375
+    - dynamic_gas = 375 * topic_count + 8 * size + memory_expansion_cost
 
     Source: [evm.codes/#A0](https://www.evm.codes/#A0)
     """
@@ -4627,7 +4293,7 @@ class Opcodes(Opcode, Enum):
 
     Description
     ----
-    Append log record with one topics
+    Append log record with one topic
 
     Inputs
     ----
@@ -4645,7 +4311,8 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    375 + 375 * topic_count + 8 * size + memory_expansion_cost
+    - static_gas = 375
+    - dynamic_gas = 375 * topic_count + 8 * size + memory_expansion_cost
 
     Source: [evm.codes/#A1](https://www.evm.codes/#A1)
     """
@@ -4676,7 +4343,8 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    375 + 375 * topic_count + 8 * size + memory_expansion_cost
+    - static_gas = 375
+    - dynamic_gas = 375 * topic_count + 8 * size + memory_expansion_cost
 
     Source: [evm.codes/#A2](https://www.evm.codes/#A2)
     """
@@ -4708,7 +4376,8 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    375 + 375 * topic_count + 8 * size + memory_expansion_cost
+    - static_gas = 375
+    - dynamic_gas = 375 * topic_count + 8 * size + memory_expansion_cost
 
     Source: [evm.codes/#A3](https://www.evm.codes/#A3)
     """
@@ -4741,93 +4410,125 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    375 + 375 * topic_count + 8 * size + memory_expansion_cost
+    - static_gas = 375
+    - dynamic_gas = 375 * topic_count + 8 * size + memory_expansion_cost
 
     Source: [evm.codes/#A4](https://www.evm.codes/#A4)
     """
 
     RJUMP = Opcode(0xE0, data_portion_length=2)
     """
-    RJUMP(destination)
+    !!! Note: This opcode is under development
+
+    RJUMP()
     ----
 
     Description
     ----
-    Jump to a relative position in code.
 
     Inputs
     ----
-    - destination: The relative position to jump to.
+
+    Outputs
+    ----
 
     Fork
     ----
+    EOF Fork
 
+    Gas
+    ----
+
+    Source: [eips.ethereum.org/EIPS/eip-4200](https://eips.ethereum.org/EIPS/eip-4200)
     """
 
     RJUMPI = Opcode(0xE1, popped_stack_items=1, data_portion_length=2)
     """
+    !!! Note: This opcode is under development
+
     RJUMPI()
     ----
 
     Description
     ----
 
-
     Inputs
     ----
-
 
     Outputs
     ----
 
-
     Fork
     ----
+    EOF Fork
 
     Gas
     ----
 
-
-    Source:
-
+    Source: [eips.ethereum.org/EIPS/eip-4200](https://eips.ethereum.org/EIPS/eip-4200)
     """
 
     RJUMPV = Opcode(0xE2)
     """
-    RJUMPV
+    !!! Note: This opcode is under development
+
+    RJUMPV()
     ----
 
     Description
     ----
 
-
     Inputs
     ----
-    -
 
     Outputs
     ----
-    -
 
     Fork
     ----
-
+    EOF Fork
 
     Gas
     ----
 
-
-    Source:
+    Source: [eips.ethereum.org/EIPS/eip-4200](https://eips.ethereum.org/EIPS/eip-4200)
     """
 
-    CREATE = Opcode(0xF0, popped_stack_items=3, pushed_stack_items=1)
+    RETF = Opcode(0xE4)
     """
-    CREATE(value, offset, length) = contract_address
+    !!! Note: This opcode is under development
+
+    RETF()
     ----
 
     Description
     ----
-    Create a new contract with the given code.
+
+    Inputs
+    ----
+
+    Outputs
+    ----
+
+    Fork
+    ----
+    EOF Fork
+
+    Gas
+    ----
+    3
+
+    Source: [eips.ethereum.org/EIPS/eip-4750](https://eips.ethereum.org/EIPS/eip-4750)
+    """
+
+    CREATE = Opcode(0xF0, popped_stack_items=3, pushed_stack_items=1)
+    """
+    CREATE(value, offset, length) = address
+    ----
+
+    Description
+    ----
+    Create a new contract with the given code
 
     Inputs
     ----
@@ -4837,16 +4538,23 @@ class Opcodes(Opcode, Enum):
 
     Outputs
     ----
-    - contract_address: The address of the newly created contract.
+    - address: the address of the deployed contract, 0 if the deployment failed
 
     Fork
     ----
-    Homestead
+    Frontier
 
     Gas
     ----
-    32000 + init_code_cost + memory_expansion_cost + deployment_code_execution_cost +
-    code_deposit_cost
+    ```
+    minimum_word_size = (size + 31) / 32
+    init_code_cost = 2 * minimum_word_size
+    code_deposit_cost = 200 * deployed_code_size
+
+    static_gas = 32000
+    dynamic_gas = init_code_cost + memory_expansion_cost + deployment_code_execution_cost
+        + code_deposit_cost
+    ```
 
     Source: [evm.codes/#F0](https://www.evm.codes/#F0)
     """
@@ -4863,13 +4571,13 @@ class Opcodes(Opcode, Enum):
     Inputs
     ----
     - gas: amount of gas to send to the sub context to execute. The gas that is not used by the sub
-      context is returned to this one
+        context is returned to this one
     - address: the account which context to execute
     - value: value in wei to send to the account
     - argsOffset: byte offset in the memory in bytes, the calldata of the sub context
     - argsSize: byte size to copy (size of the calldata)
     - retOffset: byte offset in the memory in bytes, where to store the return data of the sub
-      context
+        context
     - retSize: byte size to copy (size of the return data)
 
     Outputs
@@ -4882,8 +4590,11 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    memory_expansion_cost + code_execution_cost + address_access_cost + positive_value_cost +
-    value_to_empty_account_cost
+    ```
+    static_gas = 0
+    dynamic_gas = memory_expansion_cost + code_execution_cost + address_access_cost
+        + positive_value_cost + value_to_empty_account_cost
+    ```
 
     Source: [evm.codes/#F1](https://www.evm.codes/#F1)
     """
@@ -4901,14 +4612,15 @@ class Opcodes(Opcode, Enum):
     Inputs
     ----
     - gas: amount of gas to send to the sub context to execute. The gas that is not used by the sub
-      context is returned to this one.
+        context is returned to this one
     - address: the account which code to execute
     - value: value in wei to send to the account
     - argsOffset: byte offset in the memory in bytes, the calldata of the sub context
     - argsSize: byte size to copy (size of the calldata)
     - retOffset: byte offset in the memory in bytes, where to store the return data of the sub
-      context
+        context
     - retSize: byte size to copy (size of the return data)
+
     Outputs
     ----
     - success: return 0 if the sub context reverted, 1 otherwise
@@ -4919,7 +4631,11 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    memory_expansion_cost + code_execution_cost + address_access_cost + positive_value_cost
+    ```
+    static_gas = 0
+    dynamic_gas = memory_expansion_cost + code_execution_cost + address_access_cost
+        + positive_value_cost
+    ```
 
     Source: [evm.codes/#F2](https://www.evm.codes/#F2)
     """
@@ -4931,12 +4647,13 @@ class Opcodes(Opcode, Enum):
 
     Description
     ----
-    Halt execution returning output data.
+    Halt execution returning output data
 
     Inputs
     ----
-    - offset: The memory offset to the output data.
-    - size: The size of the output data.
+    - offset: byte offset in the memory in bytes, to copy what will be the return data of this
+        context
+    - size: byte size to copy (size of the return data)
 
     Outputs
     ----
@@ -4948,7 +4665,8 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    memory_expansion_cost
+    - static_gas = 0
+    - dynamic_gas = memory_expansion_cost
 
     Source: [evm.codes/#F3](https://www.evm.codes/#F3)
     """
@@ -4966,12 +4684,12 @@ class Opcodes(Opcode, Enum):
     Inputs
     ----
     - gas: amount of gas to send to the sub context to execute. The gas that is not used by the sub
-      context is returned to this one
+        context is returned to this one
     - address: the account which code to execute
     - argsOffset: byte offset in the memory in bytes, the calldata of the sub context
     - argsSize: byte size to copy (size of the calldata)
     - retOffset: byte offset in the memory in bytes, where to store the return data of the sub
-      context.
+        context
     - retSize: byte size to copy (size of the return data)
 
     Outputs
@@ -4984,7 +4702,8 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    memory_expansion_cost + code_execution_cost + address_access_cost
+    - static_gas = 0
+    - dynamic_gas = memory_expansion_cost + code_execution_cost + address_access_cost
 
     Source: [evm.codes/#F4](https://www.evm.codes/#F4)
     """
@@ -4996,13 +4715,13 @@ class Opcodes(Opcode, Enum):
 
     Description
     ----
-    Creates a new contract.
+    Creates a new contract
 
     Inputs
     ----
-    - value: value in wei to send to the new account.
-    - offset: byte offset in the memory in bytes, the initialisation code of the new account.
-    - size: byte size to copy (size of the initialisation code).
+    - value: value in wei to send to the new account
+    - offset: byte offset in the memory in bytes, the initialisation code of the new account
+    - size: byte size to copy (size of the initialisation code)
     - salt: 32-byte value used to create the new account at a deterministic address
 
     Outputs
@@ -5015,18 +4734,23 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    minimum_word_size = (size + 31) / 32 init_code_cost = 2 * minimum_word_size hash_cost = 6 *
-    minimum_word_size code_deposit_cost = 200 * deployed_code_size
+    ```
+    minimum_word_size = (size + 31) / 32
+    init_code_cost = 2 * minimum_word_size
+    hash_cost = 6 * minimum_word_size
+    code_deposit_cost = 200 * deployed_code_size
 
-    32000 + init_code_cost + hash_cost + memory_expansion_cost + deployment_code_execution_cost +
-    code_deposit_cost
+    static_gas = 32000
+    dynamic_gas = init_code_cost + hash_cost + memory_expansion_cost
+        + deployment_code_execution_cost + code_deposit_cost
+    ```
 
     Source: [evm.codes/#F5](https://www.evm.codes/#F5)
     """
 
     STATICCALL = Opcode(0xFA, popped_stack_items=6, pushed_stack_items=1)
     """
-    STATICCALL(gas, address, argsOffset, argsSize, retOffset , retSize) = success
+    STATICCALL(gas, address, argsOffset, argsSize, retOffset, retSize) = success
     ----
 
     Description
@@ -5036,12 +4760,12 @@ class Opcodes(Opcode, Enum):
     Inputs
     ----
     - gas: amount of gas to send to the sub context to execute. The gas that is not used by the sub
-      context is returned to this one.
-    - address: the account which context to execute.
-    - argsOffset: byte offset in the memory in bytes, the calldata of the sub context.
-    - argsSize: byte size to copy (size of the calldata).
+        context is returned to this one
+    - address: the account which context to execute
+    - argsOffset: byte offset in the memory in bytes, the calldata of the sub context
+    - argsSize: byte size to copy (size of the calldata)
     - retOffset: byte offset in the memory in bytes, where to store the return data of the sub
-      context.
+        context
     - retSize: byte size to copy (size of the return data)
 
     Outputs
@@ -5054,24 +4778,25 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    memory_expansion_cost + code_execution_cost + address_access_cost
+    - static_gas = 0
+    - dynamic_gas = memory_expansion_cost + code_execution_cost + address_access_cost
 
     Source: [evm.codes/#FA](https://www.evm.codes/#FA)
     """
 
     REVERT = Opcode(0xFD, popped_stack_items=2)
     """
-    REVERT(offset, length)
+    REVERT(offset, size)
     ----
 
     Description
     ----
-    Stop execution and revert changes.
+    Halt execution reverting state changes but returning data and remaining gas
 
     Inputs
     ----
-    - offset: byte offset in the memory in bytes. The return data of the calling context.
-    - size: byte size to copy (size of the return data).
+    - offset: byte offset in the memory in bytes. The return data of the calling context
+    - size: byte size to copy (size of the return data)
 
     Fork
     ----
@@ -5079,7 +4804,8 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    memory_expansion_cost
+    static_gas = 0
+    dynamic_gas = memory_expansion_cost
 
     Source: [evm.codes/#FD](https://www.evm.codes/#FD)
     """
@@ -5091,7 +4817,7 @@ class Opcodes(Opcode, Enum):
 
     Description
     ----
-    Invalid opcode.
+    Designated invalid instruction
 
     Inputs
     ----
@@ -5114,16 +4840,16 @@ class Opcodes(Opcode, Enum):
 
     SELFDESTRUCT = Opcode(0xFF, popped_stack_items=1)
     """
-    SELFDESTRUCT(to)
+    SELFDESTRUCT(address)
     ----
 
     Description
     ----
-    Halt execution and register the account for later deletion.
+    Halt execution and register the account for later deletion
 
     Inputs
     ----
-    - to: The address to which any remaining funds are transferred.
+    - address: account to send the current balance to
 
     Fork
     ----
@@ -5134,32 +4860,4 @@ class Opcodes(Opcode, Enum):
     5000
 
     Source: [evm.codes/#FF](https://www.evm.codes/#FF)
-    """
-
-    SENDALL = Opcode(0xFF, popped_stack_items=1)
-    """
-    SENDALL(to)
-    ----
-
-    Description
-    ----
-    Send all ether to the target address and halt execution.
-
-    Inputs
-    ----
-    - to: Target address
-
-    Outputs
-    ----
-    - None
-
-    Fork
-    ----
-    Frontier
-
-    Gas
-    ----
-    5000
-
-    Source: [eips.ethereum.org/EIPS/eip-6780](https://eips.ethereum.org/EIPS/eip-6780)
     """

--- a/src/ethereum_test_tools/vm/opcode.py
+++ b/src/ethereum_test_tools/vm/opcode.py
@@ -1,5 +1,7 @@
 """
 Ethereum Virtual Machine opcode definitions.
+
+Acknowledgments: The individual opcode documentation below is due to the work by [smlXL](https://github.com/smlxl) on [evm.codes](https://www.evm.codes/), available as open source [github.com/smlxl/evm.codes](https://github.com/smlxl/evm.codes) - thank you! And thanks to @ThreeHrSleep for integrating it in the docstrings.
 """
 
 from enum import Enum
@@ -494,7 +496,7 @@ class Opcodes(Opcode, Enum):
 
     EXP = Opcode(0x0A, popped_stack_items=2, pushed_stack_items=1)
     """
-    EXP(base, exponent) = a ** exponent
+    EXP(a, exponent) = a ** exponent
     ----
 
     Description
@@ -503,7 +505,7 @@ class Opcodes(Opcode, Enum):
 
     Inputs
     ----
-    - base: integer base.
+    - a: integer base.
     - exponent: integer exponent
 
     Outputs
@@ -516,7 +518,9 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    10
+    static_gas = 10
+    dynamic_gas = 50 * exponent_byte_size
+    gas = static_gas + dynamic_gas
 
     Source: [evm.codes/#0A](https://www.evm.codes/#0A)
     """
@@ -979,7 +983,10 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    30
+    minimum_word_size = (size + 31) / 32
+
+    static_gas = 30
+    dynamic_gas = 6 * minimum_word_size + memory_expansion_cost   
 
     Source: [evm.codes/#20](https://www.evm.codes/#20)
     """
@@ -1035,7 +1042,8 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    100
+    warm: 100
+    cold: 2600
 
     Source: [evm.codes/#31](https://www.evm.codes/#31)
     """
@@ -1208,7 +1216,10 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    3
+    minimum_word_size = (size + 31) / 32
+
+    static_gas = 3
+    dynamic_gas = 3 * minimum_word_size + memory_expansion_cost
 
     Source: [evm.codes/#37](https://www.evm.codes/#37)
     """
@@ -1262,7 +1273,10 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    3
+    minimum_word_size = (size + 31) / 32
+
+    static_gas = 3
+    dynamic_gas = 3 * minimum_word_size + memory_expansion_cost
 
     Source: [evm.codes/#39](https://www.evm.codes/#39)
     """
@@ -1314,9 +1328,10 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    100
+    warm: 100
+    cold: 2600
 
-    Source: [evm.codes/#3C](https://www.evm.codes/#3B)
+    Source: [evm.codes/#3B](https://www.evm.codes/#3B)
     """
 
     EXTCODECOPY = Opcode(0x3C, popped_stack_items=4)
@@ -1345,8 +1360,9 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    minimum_word_size = (size + 31) / 32 static_gas = 0 dynamic_gas = 3 * minimum_word_size +
-    memory_expansion_cost + address_access_cost
+    minimum_word_size = (size + 31) / 32
+    static_gas = 0
+    dynamic_gas = 3 * minimum_word_size + memory_expansion_cost + address_access_cost
 
     Source: [evm.codes/#3C](https://www.evm.codes/#3C)
     """
@@ -1427,7 +1443,8 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    100
+    warm: 100
+    cold: 2600
 
     Source: [evm.codes/#3F](https://www.evm.codes/#3F)
     """
@@ -1567,7 +1584,7 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    20
+    2
 
     Source: [evm.codes/#44](https://www.evm.codes/#44)
     """
@@ -1732,7 +1749,7 @@ class Opcodes(Opcode, Enum):
     ----
     2
 
-    Source: [eips.ethereum.org/EIPS/eip-7516(https://eips.ethereum.org/EIPS/eip-7516)
+    Source: [eips.ethereum.org/EIPS/eip-7516](https://eips.ethereum.org/EIPS/eip-7516)
     """
 
     POP = Opcode(0x50, popped_stack_items=1)
@@ -1787,6 +1804,7 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
+    static_gas = 3
     3 + memory_expansion_cost
 
     Source: [evm.codes/#51](https://www.evm.codes/#51)
@@ -1900,8 +1918,21 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    set: 20000
-    reset: 2900
+    static_gas = 0
+
+    if value == current_value
+        if key is warm
+            base_dynamic_gas = 100
+        else
+            base_dynamic_gas = 100
+    else if current_value == original_value
+        if original_value == 0
+            base_dynamic_gas = 20000
+        else
+            base_dynamic_gas = 2900
+
+    if key is cold:
+        base_dynamic_gas += 2100
 
     Source: [evm.codes/#55](https://www.evm.codes/#55)
     """
@@ -2180,8 +2211,6 @@ class Opcodes(Opcode, Enum):
     Gas
     ----
     3
-
-    Source: [evm.codes/#5F](https://www.evm.codes/#5F)
     """
 
     PUSH0 = Opcode(0x5F, pushed_stack_items=1)
@@ -5050,7 +5079,7 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    0
+    memory_expansion_cost
 
     Source: [evm.codes/#FD](https://www.evm.codes/#FD)
     """

--- a/src/ethereum_test_tools/vm/opcode.py
+++ b/src/ethereum_test_tools/vm/opcode.py
@@ -4732,7 +4732,7 @@ class Opcodes(Opcode, Enum):
 
     Fork
     ----
-    
+
     """
 
     RJUMPI = Opcode(0xE1, popped_stack_items=1, data_portion_length=2)

--- a/src/ethereum_test_tools/vm/opcode.py
+++ b/src/ethereum_test_tools/vm/opcode.py
@@ -1298,7 +1298,7 @@ class Opcodes(Opcode, Enum):
 
     Description
     ----
-    Get size of an account’s code
+    Get size of an account's code
 
     Inputs
     ----
@@ -1326,7 +1326,7 @@ class Opcodes(Opcode, Enum):
 
     Description
     ----
-    Copy an account’s code to memory
+    Copy an account's code to memory
 
     Inputs
     ----
@@ -1410,7 +1410,7 @@ class Opcodes(Opcode, Enum):
 
     Description
     ----
-    Get hash of an account’s code
+    Get hash of an account's code
 
     Inputs
     ----
@@ -1467,7 +1467,7 @@ class Opcodes(Opcode, Enum):
 
     Description
     ----
-    Get the block’s beneficiary address
+    Get the block's beneficiary address
 
     Inputs
     ----
@@ -1495,7 +1495,7 @@ class Opcodes(Opcode, Enum):
 
     Description
     ----
-    Get the block’s timestamp
+    Get the block's timestamp
 
     Inputs
     ----
@@ -1523,7 +1523,7 @@ class Opcodes(Opcode, Enum):
 
     Description
     ----
-    Get the block’s number
+    Get the block's number
 
     Inputs
     ----
@@ -1551,7 +1551,7 @@ class Opcodes(Opcode, Enum):
 
     Description
     ----
-    Get the previous block’s RANDAO mix
+    Get the previous block's RANDAO mix
 
     Inputs
     ----
@@ -1579,7 +1579,7 @@ class Opcodes(Opcode, Enum):
 
     Description
     ----
-    Get the block’s gas limit
+    Get the block's gas limit
 
     Inputs
     ----
@@ -4931,7 +4931,7 @@ class Opcodes(Opcode, Enum):
 
     Description
     ----
-    Message-call into this account with an alternative account’s code, but persisting the current
+    Message-call into this account with an alternative account's code, but persisting the current
     values for sender and value
 
     Inputs

--- a/src/ethereum_test_tools/vm/opcode.py
+++ b/src/ethereum_test_tools/vm/opcode.py
@@ -1,6 +1,7 @@
 """
 Ethereum Virtual Machine opcode definitions.
 """
+
 from enum import Enum
 from typing import List, Union
 
@@ -12,8 +13,7 @@ def _get_int_size(n: int) -> int:
     Returns the size of an integer in bytes.
     """
     if n < 0:
-        # Negative numbers in the EVM are represented as two's complement
-        # of 32 bytes
+        # Negative numbers in the EVM are represented as two's complement of 32 bytes
         return 32
     byte_count = 0
     while n:
@@ -27,8 +27,8 @@ _push_opcodes_byte_list = [bytes([0x5F + x]) for x in range(33)]
 
 class Opcode(bytes):
     """
-    Represents a single Opcode instruction in the EVM, with extra
-    metadata useful to parametrize tests.
+    Represents a single Opcode instruction in the EVM, with extra metadata useful to parametrize
+    tests.
 
     Parameters
     ----------
@@ -58,8 +58,8 @@ class Opcode(bytes):
         Creates a new opcode instance.
         """
         if type(opcode_or_byte) is Opcode:
-            # Required because Enum class calls the base class with the
-            # instantiated object as parameter.
+            # Required because Enum class calls the base class with the instantiated object as
+            # parameter.
             return opcode_or_byte
         elif isinstance(opcode_or_byte, int):
             obj = super().__new__(cls, [opcode_or_byte])
@@ -71,34 +71,30 @@ class Opcode(bytes):
 
     def __call__(self, *args_t: Union[int, bytes, str, "Opcode", FixedSizeBytes]) -> bytes:
         """
-        Makes all opcode instances callable to return formatted bytecode,
-        which constitutes a data portion, that is located after the opcode
-        byte, and pre-opcode bytecode, which is normally used to set up the
-        stack.
+        Makes all opcode instances callable to return formatted bytecode, which constitutes a data
+        portion, that is located after the opcode byte, and pre-opcode bytecode, which is normally
+        used to set up the stack.
 
-        This useful to automatically format, e.g., push opcodes and their
-        data sections as `Opcodes.PUSH1(0x00)`.
+        This useful to automatically format, e.g., push opcodes and their data sections as
+        `Opcodes.PUSH1(0x00)`.
 
-        Data sign is automatically detected but for this reason the range
-        of the input must be:
-        `[-2^(data_portion_bits-1), 2^(data_portion_bits)]`
-        where:
-        `data_portion_bits == data_portion_length * 8`
+        Data sign is automatically detected but for this reason the range of the input must be:
+        `[-2^(data_portion_bits-1), 2^(data_portion_bits)]` where: `data_portion_bits ==
+        data_portion_length * 8`
 
-        For the stack, the arguments are set up in the opposite order they are
-        given, so the first argument is the last item pushed to the stack.
+        For the stack, the arguments are set up in the opposite order they are given, so the first
+        argument is the last item pushed to the stack.
 
-        The resulting stack arrangement does not take into account opcode stack
-        element consumption, so the stack height is not guaranteed to be
-        correct and the user must take this into consideration.
+        The resulting stack arrangement does not take into account opcode stack element
+        consumption, so the stack height is not guaranteed to be correct and the user must take
+        this into consideration.
 
-        Integers can also be used as stack elements, in which case they are
-        automatically converted to PUSH operations, and negative numbers always
-        use a PUSH32 operation.
+        Integers can also be used as stack elements, in which case they are automatically converted
+        to PUSH operations, and negative numbers always use a PUSH32 operation.
 
-        `FixedSizeBytes` can also be used as stack elements, which includes
-        `Address` and `Hash` types, for each of which a PUSH operation is
-        automatically generated, `PUSH20` and `PUSH32` respectively.
+        `FixedSizeBytes` can also be used as stack elements, which includes `Address` and `Hash`
+        types, for each of which a PUSH operation is automatically generated, `PUSH20` and `PUSH32`
+        respectively.
 
         Hex-strings will automatically be converted to bytes.
 
@@ -108,8 +104,8 @@ class Opcode(bytes):
         data_portion = bytes()
 
         if self.data_portion_length > 0:
-            # For opcodes with a data portion, the first argument is the data
-            # and the rest of the arguments form the stack.
+            # For opcodes with a data portion, the first argument is the data and the rest of the
+            # arguments form the stack.
             if len(args) == 0:
                 raise ValueError("Opcode with data portion requires at least one argument")
             data = args.pop(0)
@@ -142,8 +138,7 @@ class Opcode(bytes):
                     if data_size > 32:
                         raise ValueError("Opcode stack data must be less than 32 bytes")
                     elif data_size == 0:
-                        # Pushing 0 is done with the PUSH1 opcode for compatibility
-                        # reasons.
+                        # Pushing 0 is done with the PUSH1 opcode for compatibility reasons.
                         data_size = 1
                     data = data.to_bytes(
                         length=data_size,
@@ -171,8 +166,7 @@ class Opcode(bytes):
 
     def __len__(self) -> int:
         """
-        Returns the total bytecode length of the opcode, taking into account
-        its data portion.
+        Returns the total bytecode length of the opcode, taking into account its data portion.
         """
         return self.data_portion_length + 1
 
@@ -198,4905 +192,4947 @@ class Opcodes(Opcode, Enum):
 
     Contains deprecated and not yet implemented opcodes.
 
-    This enum is !! NOT !! meant to be iterated over by the tests. Instead,
-    create a list with cherry-picked opcodes from this Enum within the test
-    if iteration is needed.
+    This enum is !! NOT !! meant to be iterated over by the tests. Instead, create a list with
+    cherry-picked opcodes from this Enum within the test if iteration is needed.
 
     Do !! NOT !! remove or modify existing opcodes from this list.
     """
 
-STOP = Opcode(0x00)
-"""
-STOP() 
-----
-
-Description
-----
-Stop execution.
-
-Inputs
-----
-- None
-
-Outputs
-----
-- None
-
-Fork
-----
-Frontier
-
-Gas
-----
-0
-
-Source: [evm.codes/#00](https://www.evm.codes/#00)
-"""
-
-ADD = Opcode(0x01, popped_stack_items=2, pushed_stack_items=1)
-"""
-ADD(a, b) = c
-----
-
-Description
-----
-Addition operation
-
-Inputs
-----
-- a: first integer value to add
-- b: second integer value to add
-
-Outputs
-----
-- c: integer result of the addition modulo 2**256
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#01](https://www.evm.codes/#01)
-"""
-
-MUL = Opcode(0x02, popped_stack_items=2, pushed_stack_items=1)
-"""
-MUL(a, b) = c
-----
-
-Description
-----
-Multiplication operation
-
-Inputs
-----
-- a: first integer value to multiply
-- b: second integer value to multiply
-
-Outputs
-----
-- c: integer result of the multiplication modulo 2**256
-
-Fork
-----
-Frontier
-
-Gas
-----
-5
-
-Source: [evm.codes/#02](https://www.evm.codes/#02)
-"""
-
-SUB = Opcode(0x03, popped_stack_items=2, pushed_stack_items=1)
-"""
-SUB(a, b) = c
-----
-
-Description
-----
-Subtraction operation
-
-Inputs
-----
-- a: first integer value
-- b: second integer value
-
-Outputs
-----
-- c: integer result of the subtraction modulo 2**256
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#03](https://www.evm.codes/#03)
-"""
-
-DIV = Opcode(0x04, popped_stack_items=2, pushed_stack_items=1)
-"""
-DIV(a, b) = c
-----
-
-Description
-----
-Division operation
-
-Inputs
-----
-- a: numerator
-- b: denominator (must be non-zero)
-
-Outputs
-----
-- c: integer result of the division
-
-Fork
-----
-Frontier
-
-Gas
-----
-5
-
-Source: [evm.codes/#04](https://www.evm.codes/#04)
-"""
-
-SDIV = Opcode(0x05, popped_stack_items=2, pushed_stack_items=1)
-"""
-SDIV(a, b) = c
-----
-
-Description
-----
-Signed division operation
-
-Inputs
-----
-- a: signed numerator
-- b: signed denominator (must be non-zero)
-
-Outputs
-----
-- c: signed integer result of the division
-
-Fork
-----
-Frontier
-
-Gas
-----
-5
-
-Source: [evm.codes/#05](https://www.evm.codes/#05)
-"""
-
-MOD = Opcode(0x06, popped_stack_items=2, pushed_stack_items=1)
-"""
-MOD(a, b) = c
-----
-
-Description
-----
-Modulo operation
-
-Inputs
-----
-- a: integer numerator.
-- b: integer denominator
-
-Outputs
-----
-- a % b: integer result of the integer modulo. If the denominator is 0, the result will be 0
-
-Fork
-----
-Frontier
-
-Gas
-----
-5
-
-Source: [evm.codes/#06](https://www.evm.codes/#06)
-"""
-
-SMOD = Opcode(0x07, popped_stack_items=2, pushed_stack_items=1)
-"""
-SMOD(a, b) = c
-----
-
-Description
-----
-Signed modulo remainder operation
-
-Inputs
-----
-- a: integer numerator.
-- b: integer denominator.
-
-Outputs
-----
-- a % b: integer result of the signed integer modulo. If the denominator is 0, the result will be 0
-
-Fork
-----
-Frontier
-
-Gas
-----
-5
-
-Source: [evm.codes/#07](https://www.evm.codes/#07)
-"""
-
-ADDMOD = Opcode(0x08, popped_stack_items=3, pushed_stack_items=1)
-"""
-ADDMOD(a, b, c) = d
-----
-
-Description
-----
-Modular addition operation with overflow check
-
-Inputs
-----
-- a: first integer value
-- b: second integer value
-- c: integer denominator
-
-Outputs
-----
-- (a + b) % N: integer result of the addition followed by a modulo. If the denominator is 0, the result will be 0
-
-Fork
-----
-Frontier
-
-Gas
-----
-8
-
-Source: [evm.codes/#08](https://www.evm.codes/#08)
-"""
-
-MULMOD = Opcode(0x09, popped_stack_items=3, pushed_stack_items=1)
-"""
-MULMOD(a, b, N) = d
-----
-
-Description
-----
-Modulo multiplication operation
-
-Inputs
-----
-- a: first integer value to multiply.
-- b: second integer value to multiply.
-- N: integer denominator
-
-Outputs
-----
-- d: (a * b) % N: integer result of the multiplication followed by a modulo. If the denominator is 0, the result will be 0
-
-Fork
-----
-Frontier
-
-Gas
-----
-8
-
-Source: [evm.codes/#09](https://www.evm.codes/#09)
-"""
-
-EXP = Opcode(0x0A, popped_stack_items=2, pushed_stack_items=1)
-"""
-EXP(base, exponent) = a ** exponent
-----
-
-Description
-----
-Exponential operation
-
-Inputs
-----
-- base: integer base.
-- exponent: integer exponent
-
-Outputs
-----
-- a ** exponent: integer result of the exponential operation modulo 2**256
-
-Fork
-----
-Frontier
-
-Gas
-----
-10 
-
-Source: [evm.codes/#0A](https://www.evm.codes/#0A)
-"""
-
-SIGNEXTEND = Opcode(0x0B, popped_stack_items=2, pushed_stack_items=1)
-"""
-SIGNEXTEND(b, x) = y
-----
-
-Description
-----
-Sign extension operation
-
-Inputs
-----
-- b: size in byte - 1 of the integer to sign extend
-- x: integer value to sign extend
-
-Outputs
-----
-- y: integer result of the sign extend
-
-Fork
-----
-Frontier
-
-Gas
-----
-5
-
-Source: [evm.codes/#0B](https://www.evm.codes/#0B)
-"""
-
-
-
-LT = Opcode(0x10, popped_stack_items=2, pushed_stack_items=1)
-"""
-LT(a, b) = a < b
-----
-
-Description
-----
-Less-than comparison
-
-Inputs
-----
-- a: first integer value
-- b: second integer value
-
-Outputs
-----
-- a < b: 1 if the left side is smaller, 0 otherwise
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#10](https://www.evm.codes/#10)
-"""
-
-GT = Opcode(0x11, popped_stack_items=2, pushed_stack_items=1)
-"""
-GT(a, b) = a > b
-----
-
-Description
-----
-Greater-than comparison
-
-Inputs
-----
-- a: left side integer
-- b: right side integer
-
-Outputs
-----
-- a > b: 1 if the left side is bigger, 0 otherwise
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#11](https://www.evm.codes/#11)
-"""
-
-SLT = Opcode(0x12, popped_stack_items=2, pushed_stack_items=1)
-"""
-SLT(a, b) = a < b
-----
-
-Description
-----
-Signed less-than comparison
-
-Inputs
-----
-- a: eft side signed integer
-- b: right side signed integer
-
-Outputs
-----
-- a < b: 1 if the left side is smaller, 0 otherwise
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#12](https://www.evm.codes/#12)
-"""
-
-SGT = Opcode(0x13, popped_stack_items=2, pushed_stack_items=1)
-"""
-SGT(a, b) = a > b
-----
-
-Description
-----
-Signed greater-than comparison
-
-Inputs
-----
-- a:  left side signed integer.
-- b: right side signed integer
-
-Outputs
-----
-- a > b: 1 if the left side is bigger, 0 otherwise
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#13](https://www.evm.codes/#13)
-"""
-
-EQ = Opcode(0x14, popped_stack_items=2, pushed_stack_items=1)
-"""
-EQ(a, b) = a == b
-----
-
-Description
-----
-Equality comparison
-
-Inputs
-----
-- a: left side integer
-- b: right side integer
-
-Outputs
-----
-- a == b: 1 if the left side is equal to the right side, 0 otherwise
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#14](https://www.evm.codes/#14)
-"""
-
-ISZERO = Opcode(0x15, popped_stack_items=1, pushed_stack_items=1)
-"""
-ISZERO(a) = a == 0
-----
-
-Description
-----
-Is-zero comparison
-
-Inputs
-----
-- a: integer 
-
-Outputs
-----
-- a == 0: 1 if a is 0, 0 otherwise
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#15](https://www.evm.codes/#15)
-"""
-
-AND = Opcode(0x16, popped_stack_items=2, pushed_stack_items=1)
-"""
-AND(a, b) = a & b
-----
-
-Description
-----
-Bitwise AND operation
-
-Inputs
-----
-- a: first binary value.
-- b: second binary value
-
-Outputs
-----
-- a & b: the bitwise AND result
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#16](https://www.evm.codes/#16)
-"""
-
-OR = Opcode(0x17, popped_stack_items=2, pushed_stack_items=1)
-"""
-OR(a, b) = a | b
-----
-
-Description
-----
-Bitwise OR operation
-
-Inputs
-----
-- a: first binary value
-- b: second binary value
-
-Outputs
-----
-- a | b: the bitwise OR result
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#17](https://www.evm.codes/#17)
-"""
-
-XOR = Opcode(0x18, popped_stack_items=2, pushed_stack_items=1)
-"""
-XOR(a, b) = a ^ b
-----
-
-Description
-----
-Bitwise XOR operation
-
-Inputs
-----
-- a:  first binary value
-- b: second binary value
-
-Outputs
-----
-- a ^ b: the bitwise XOR result
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#18](https://www.evm.codes/#18)
-"""
-
-NOT = Opcode(0x19, popped_stack_items=1, pushed_stack_items=1)
-"""
-NOT(a) = ~a
-----
-
-Description
-----
-Bitwise NOT operation
-
-Inputs
-----
-- a: binary value
-
-Outputs
-----
-- ~a: the bitwise NOT result
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#19](https://www.evm.codes/#19)
-"""
-
-BYTE = Opcode(0x1A, popped_stack_items=2, pushed_stack_items=1)
-"""
-BYTE(i, x) = y
-----
-
-Description
-----
-Extract a byte from the given position in the value
-
-Inputs
-----
-- i: byte offset starting from the most significant byte.
-- x: 32-byte value
-
-Outputs
-----
-- y: the indicated byte at the least significant position. If the byte offset is out of range, the result is 0
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#1A](https://www.evm.codes/#1A)
-"""
-
-SHL = Opcode(0x1B, popped_stack_items=2, pushed_stack_items=1)
-"""
-SHL(shift, value) = value << shift
-----
-
-Description
-----
-Shift left operation
-
-Inputs
-----
-- shift: number of bits to shift to the left.
-- value: 32 bytes to shift
-
-Outputs
-----
-- value << shift: the shifted value. If shift is bigger than 255, returns 0
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#1B](https://www.evm.codes/#1B)
-"""
-
-SHR = Opcode(0x1C, popped_stack_items=2, pushed_stack_items=1)
-"""
-SHR(shift, value) = value >> shift
-----
-
-Description
-----
-Logical shift right operation
-
-Inputs
-----
-- shift: number of bits to shift to the right.
-- value: 32 bytes to shift
-
-Outputs
-----
-- value >> shift: the shifted value. If shift is bigger than 255, returns 0
-
-Fork
-----
-Constantinople
-
-Gas
-----
-3
-
-Source: [evm.codes/#1C](https://www.evm.codes/#1C)
-"""
-
-SAR = Opcode(0x1D, popped_stack_items=2, pushed_stack_items=1)
-"""
-SAR(shift, value) = value >> shift
-----
-
-Description
-----
-Arithmetic shift right operation
-
-Inputs
-----
-- shift: number of bits to shift to the right
-- value: integer to shift
-
-Outputs
-----
-- value >> shift: the shifted value
-
-Fork
-----
-Constantinople
-
-Gas
-----
-3
-
-Source: [evm.codes/#1D](https://www.evm.codes/#1D)
-"""
-
-SHA3 = Opcode(0x20, popped_stack_items=2, pushed_stack_items=1)
-"""
-SHA3(start, length) = hash
-----
-
-Description
-----
-Compute Keccak-256 hash 
-
-Inputs
-----
-- offset: byte offset in the memory
-- size: byte size to read in the memory
-
-Outputs
-----
-- hash: Keccak-256 hash of the given data in memory
-
-Fork
-----
-Frontier
-
-Gas
-----
-30 
-
-Source: [evm.codes/#20](https://www.evm.codes/#20)
-"""
-
-
-
-ADDRESS = Opcode(0x30, pushed_stack_items=1)
-"""
-ADDRESS() = address
-----
-
-Description
-----
-Get address of currently executing account
-
-Inputs
-----
-- None
-
-Outputs
-----
-- address: the 20-byte address of the current account
-
-Fork
-----
-Frontier
-
-Gas
-----
-2
-
-Source: [evm.codes/#30](https://www.evm.codes/#30)
-"""
-
-BALANCE = Opcode(0x31, popped_stack_items=1, pushed_stack_items=1)
-"""
-BALANCE(address) = balance
-----
-
-Description
-----
-Get the balance of the specified account
-
-Inputs
-----
-- address: 20-byte address of the account to check
-
-Outputs
-----
-- balance: balance of the given account in wei. Returns 0 if the account doesn't exist
-
-Fork
-----
-Frontier
-
-Gas
-----
-100
-
-Source: [evm.codes/#31](https://www.evm.codes/#31)
-"""
-
-ORIGIN = Opcode(0x32, pushed_stack_items=1)
-"""
-ORIGIN() = address
-----
-
-Description
-----
-Get execution origination address
-
-Inputs
-----
-- None
-
-Outputs
-----
-- address: the 20-byte address of the sender of the transaction. It can only be an account without code
-
-Fork
-----
-Frontier
-
-Gas
-----
-2
-
-Source: [evm.codes/#32](https://www.evm.codes/#32)
-"""
-
-CALLER = Opcode(0x33, pushed_stack_items=1)
-"""
-CALLER() = address 
-----
-
-Description
-----
-Get caller address 
-
-Inputs
-----
-- None
-
-Outputs
-----
-- address: the 20-byte address of the caller account. This is the account that did the last call (except delegate call)
-
-Fork
-----
-Frontier
-
-Gas
-----
-2
-
-Source: [evm.codes/#33](https://www.evm.codes/#33)
-"""
-
-CALLVALUE = Opcode(0x34, pushed_stack_items=1)
-"""
-CALLVALUE() = value
-----
-
-Description
-----
-Get deposited value by the instruction/transaction responsible for this execution
-
-Inputs
-----
-- None
-
-Outputs
-----
-- value: the value of the current call in wei
-
-Fork
-----
-Frontier
-
-Gas
-----
-2
-
-Source: [evm.codes/#34](https://www.evm.codes/#34)
-"""
-
-CALLDATALOAD = Opcode(0x35, popped_stack_items=1, pushed_stack_items=1)
-"""
-CALLDATALOAD(i) = data[i]
-----
-
-Description
-----
-Get input data of current environment
-
-Inputs
-----
-- i: byte offset in the calldata.
-
-Outputs
-----
-- data[i]: 32-byte value starting from the given offset of the calldata. All bytes after the end of the calldata are set to 0
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#35](https://www.evm.codes/#35)
-"""
-
-CALLDATASIZE = Opcode(0x36, pushed_stack_items=1)
-"""
-CALLDATASIZE() = size
-----
-
-Description
-----
-Get size of input data in current environment
-
-Inputs
-----
-- None
-
-Outputs
-----
-- size: byte size of the calldata
-
-Fork
-----
-Frontier
-
-Gas
-----
-2
-
-Source: [evm.codes/#36](https://www.evm.codes/#36)
-"""
-
-CALLDATACOPY = Opcode(0x37, popped_stack_items=3)
-"""
-CALLDATACOPY(destOffset, offset, size)
-----
-
-Description
-----
-Copy input data in current environment to memory
-
-Inputs
-----
-- destOffset: byte offset in the memory where the result will be copied
-- offset: byte offset in the calldata to copy
-- size: byte size to copy
-
-Outputs
-----
-- None
-
-Fork
-----
-Frontier
-
-Gas
-----
-3 
-
-Source: [evm.codes/#37](https://www.evm.codes/#37)
-"""
-
-CODESIZE = Opcode(0x38, pushed_stack_items=1)
-"""
-CODESIZE() = size
-----
-
-Description
-----
-Get size of code running in current environment
-
-Inputs
-----
-- None
-
-Outputs
-----
-- size: byte size of the code
-
-Fork
-----
-Frontier
-
-Gas
-----
-2
-
-Source: [evm.codes/#38](https://www.evm.codes/#38)
-"""
-
-CODECOPY = Opcode(0x39, popped_stack_items=3)
-"""
-CODECOPY(destOffset, offset, size)
-----
-
-Description
-----
-Copy code running in current environment to memory
-
-Inputs
-----
-- destOffset: byte offset in the memory where the result will be copied.
-- offset: byte offset in the code to copy.
-- size: byte size to copy
-
-Fork
-----
-Frontier
-
-Gas
-----
-3 
-
-Source: [evm.codes/#39](https://www.evm.codes/#39)
-"""
-
-GASPRICE = Opcode(0x3A, pushed_stack_items=1)
-"""
-GASPRICE() = price
-----
-
-Description
-----
-Get price of gas in current environment
-
-Outputs
-----
-- price: gas price in wei per gas
-
-Fork
-----
-Frontier
-
-Gas
-----
-2
-
-Source: [evm.codes/#3A](https://www.evm.codes/#3A)
-"""
-
-EXTCODESIZE = Opcode(0x3B, popped_stack_items=1, pushed_stack_items=1)
-"""
-EXTCODESIZE(account) = size
-----
-
-Description
-----
-Get size of an account’s code
-
-Inputs
-----
-- address: 20-byte address of the contract to query
-
-Outputs
-----
-- size: byte size of the code
-
-Fork
-----
-Frontier
-
-Gas
-----
-100
-
-Source: [evm.codes/#3C](https://www.evm.codes/#3B)
-"""
-
-EXTCODECOPY = Opcode(0x3C, popped_stack_items=4)
-"""
-EXTCODESIZE(account)
-----
-
-Description
-----
-Copy an account’s code to memory
-
-Inputs
-----
-- address: 20-byte address of the contract to query
-- destOffset: byte offset in the memory where the result will be copied
-- offset: byte offset in the code to copy
-- size: byte size to copy
-
-Outputs
-----
-- None
-
-Fork
-----
-Frontier
-
-Gas
-----
-minimum_word_size = (size + 31) / 32
-static_gas = 0
-dynamic_gas = 3 * minimum_word_size + memory_expansion_cost + address_access_cost
-
-Source: [evm.codes/#3C](https://www.evm.codes/#3C)
-"""
-
-RETURNDATASIZE = Opcode(0x3D, pushed_stack_items=1)
-"""
-RETURNDATASIZE() = size
-----
-
-Description
-----
-Get size of output data from the previous call from the current environment
-
-Outputs
-----
-- size: byte size of the return data from the last executed sub context
-
-Fork
-----
-Byzantium
-
-Gas
-----
-2
-
-Source: [evm.codes/#3D](https://www.evm.codes/#3D)
-"""
-
-RETURNDATACOPY = Opcode(0x3E, popped_stack_items=3)
-"""
-RETURNDATACOPY(destOffset, offset, size)
-----
-
-Description
-----
-Copy output data from the previous call to memory
-
-Inputs
-----
-- destOffset: byte offset in the memory where the result will be copied.
-- offset: byte offset in the return data from the last executed sub context to copy.
-- size: byte size to copy.
-
-Fork
-----
-Byzantium
-
-Gas
-----
-minimum_word_size = (size + 31) / 32
-
-Gas = 3 + 3 * minimum_word_size + memory_expansion_cost
-
-Source: [evm.codes/#3E](https://www.evm.codes/#3E)
-"""
-
-EXTCODEHASH = Opcode(0x3F, popped_stack_items=1, pushed_stack_items=1)
-"""
-EXTCODEHASH(address) = hash
-----
-
-Description
-----
-Get hash of an account’s code
-
-Inputs
-----
-- address: 20-byte address of the account
-
-Outputs
-----
-- hash: hash of the chosen account's code, the empty hash (0xc5d24601...) if the account has no code, or 0 if the account does not exist or has been destroyed
-
-Fork
-----
-Constantinople
-
-Gas
-----
-100
-
-Source: [evm.codes/#3F](https://www.evm.codes/#3F)
-"""
-
-
-BLOCKHASH = Opcode(0x40, popped_stack_items=1, pushed_stack_items=1)
-"""
-BLOCKHASH(block_number) = hash
-----
-
-Description
-----
-Get the hash of one of the 256 most recent complete blocks
-
-Inputs
-----
-- blockNumber: block number to get the hash from. Valid range is the last 256 blocks (not including the current one). Current block number can be queried with NUMBER
-
-Outputs
-----
-- hash: hash of the chosen block, or 0 if the block number is not in the valid range
-Fork
-----
-Frontier
-
-Gas
-----
-20
-
-Source: [evm.codes/#40](https://www.evm.codes/#40)
-"""
-
-COINBASE = Opcode(0x41, pushed_stack_items=1)
-"""
-COINBASE() = address
-----
-
-Description
-----
-Get the block’s beneficiary address
-
-Inputs
-----
-- None
-
-Outputs
-----
-- address: miner's 20-byte address
-
-Fork
-----
-Frontier
-
-Gas
-----
-2
-
-Source: [evm.codes/#41](https://www.evm.codes/#41)
-"""
-
-TIMESTAMP = Opcode(0x42, pushed_stack_items=1)
-"""
-TIMESTAMP() = timestamp
-----
-
-Description
-----
-Get the block’s timestamp
-
-Inputs
-----
-- None
-
-Outputs
-----
-- timestamp: unix timestamp of the current block
-
-Fork
-----
-Frontier
-
-Gas
-----
-2
-
-Source: [evm.codes/#42](https://www.evm.codes/#42)
-"""
-
-NUMBER = Opcode(0x43, pushed_stack_items=1)
-"""
-NUMBER() = blockNumber
-----
-
-Description
-----
-Get the block’s number
-
-Inputs
-----
-- None
-
-Outputs
-----
-- blockNumber: current block number
-
-Fork
-----
-Frontier
-
-Gas
-----
-2
-
-Source: [evm.codes/#43](https://www.evm.codes/#43)
-"""
-
-PREVRANDAO = Opcode(0x44, pushed_stack_items=1)
-"""
-NUMBER() = prevRandao
-----
-
-Description
-----
-Get the previous block’s RANDAO mix
-
-Inputs
-----
-- None
-
-Outputs
-----
-- prevRandao: previous block's RANDAO mix
-
-Fork
-----
-Merge
-
-Gas
-----
-20
-
-Source: [evm.codes/#44](https://www.evm.codes/#44)
-"""
-
-GASLIMIT = Opcode(0x45, pushed_stack_items=1)
-"""
-GASLIMIT() = gasLimit
-----
-
-Description
-----
-Get the block’s gas limit
-
-Inputs
-----
-- None
-
-Outputs
-----
-- gasLimit: gas limit
-
-Fork
-----
-Frontier
-
-Gas
-----
-2
-
-Source: [evm.codes/#45](https://www.evm.codes/#45)
-"""
-
-CHAINID = Opcode(0x46, pushed_stack_items=1)
-"""
-CHAINID() = chainId
-----
-
-Description
-----
-Get the chain ID
-
-Inputs
-----
-- None
-
-Outputs
-----
-- chainId: chain id of the network
-
-Fork
-----
-Istanbul
-
-Gas
-----
-2
-
-Source: [evm.codes/#46](https://www.evm.codes/#46)
-"""
-
-SELFBALANCE = Opcode(0x47, pushed_stack_items=1)
-"""
-SELFBALANCE() = balance
-----
-
-Description
-----
-Get balance of currently executing account
-
-Inputs
-----
-- None
-
-Outputs
-----
-- balance: balance of the current account in wei
-
-Fork
-----
-Istanbul
-
-Gas
-----
-5
-
-Source: [evm.codes/#47](https://www.evm.codes/#47)
-"""
-BASEFEE = Opcode(0x48, pushed_stack_items=1)
-"""
-BASEFEE() = baseFee
-----
-
-Description
-----
-Get the base fee
-
-Outputs
-----
-- baseFee: base fee in wei
-
-Fork
-----
-London
-
-Gas
-----
-2
-
-Source: [evm.codes/#48](https://www.evm.codes/#48)
-"""
-
-BLOBHASH = Opcode(0x49, popped_stack_items=1, pushed_stack_items=1)
-"""
-BLOBHASH(data) = h
-----
-
-Description
-----
-Returns hashes of blobs in the transaction
-
-Inputs
-----
-- data: data to hash
-
-Outputs
-----
-- h: keccak256 hash of the data
-
-Fork
-----
-Dencun
-
-Gas
-----
-HASH_OPCODE_GAS
-
-Source: [eips.ethereum.org/EIPS/eip-4844](https://eips.ethereum.org/EIPS/eip-4844)
-"""
-
-BLOBBASEFEE = Opcode(0x4A, popped_stack_items=0, pushed_stack_items=1)
-"""
-BLOBBASEFEE() = fee
-----
-
-Description
-----
-Returns the value of the blob base-fee of the current block it is executing in
-
-Inputs
-----
-- None
-
-Outputs
-----
-- fee: base fee per gas
-
-Fork
-----
-Dencun
-
-Gas
-----
-2
-
-Source: [eips.ethereum.org/EIPS/eip-7516(https://eips.ethereum.org/EIPS/eip-7516)
-"""
-
-POP = Opcode(0x50, popped_stack_items=1)
-"""
-POP(y)
-----
-
-Description
-----
-Remove item from stack
-
-Inputs
-----
-- y: a stack item
-
-Outputs
-----
-- None
-
-Inputs
-----
-- None
-
-Fork
-----
-Frontier
-
-Gas
-----
-2
-
-Source: [evm.codes/#50](https://www.evm.codes/#50)
-"""
-
-MLOAD = Opcode(0x51, popped_stack_items=1, pushed_stack_items=1)
-"""
-MLOAD(offset) = value
-----
-
-Description
-----
-Load word from memory
-
-Inputs
-----
-- offset: offset in the memory in bytes
-
-Outputs
-----
-- value: the 32 bytes in memory starting at that offset. If it goes beyond its current size (see MSIZE), writes 0s
-
-Fork
-----
-Frontier
-
-Gas
-----
-3 + memory_expansion_cost
-
-Source: [evm.codes/#51](https://www.evm.codes/#51)
-"""
-
-MSTORE = Opcode(0x52, popped_stack_items=2)
-"""
-MSTORE(offset, value)
-----
-
-Description
-----
-Save word to memory
-
-Inputs
-----
-- offset: offset in the memory in bytes.
-- value: 32-byte value to write in the memory.
-
-Outputs
-----
-- None
-
-Fork
-----
-Frontier
-
-Gas
-----
-3 + memory_expansion_cost
-
-Source: [evm.codes/#52](https://www.evm.codes/#52)
-"""
-
-MSTORE8 = Opcode(0x53, popped_stack_items=2)
-"""
-MSTORE8(offset, value)
-----
-
-Description
-----
-Save byte to memory
-
-Inputs
-----
-- offset: offset in the memory in bytes
-- value: 1-byte value to write in the memory (the least significant byte of the 32-byte stack value
-
-Fork
-----
-Frontier
-
-Gas
-----
-3 + memory_expansion_cost
-
-Source: [evm.codes/#53](https://www.evm.codes/#53)
-"""
-
-SLOAD = Opcode(0x54, popped_stack_items=1, pushed_stack_items=1)
-"""
-SLOAD(key) = value
-----
-
-Description
-----
-Load word from storage
-
-Inputs
-----
-- key: 32-byte key in storage
-
-Outputs
-----
-- value: 32-byte value corresponding to that key. 0 if that key was never written before
-
-Fork
-----
-Frontier
-
-Gas
-----
-100
-
-Source: [evm.codes/#54](https://www.evm.codes/#54)
-"""
-
-SSTORE = Opcode(0x55, popped_stack_items=2)
-"""
-SSTORE(key, value)
-----
-
-Description
-----
-Save word to storage
-
-Inputs
-----
-- key: 32-byte key in storage
-- value: 32-byte value to store
-
-Outputs
-----
-- None
-
-Fork
-----
-Frontier
-
-Gas
-----
-100 
-
-Source: [evm.codes/#55](https://www.evm.codes/#55)
-"""
-
-JUMP = Opcode(0x56, popped_stack_items=1)
-"""
-JUMP(counter)
-----
-
-Description
-----
-Alter the program counter
-
-Inputs
-----
-- counter: byte offset in the deployed code where execution will continue from. Must be a JUMPDEST instruction.
-
-Outputs
-----
-- None
-
-Fork
-----
-Frontier
-
-Gas
-----
-8
-
-Source: [evm.codes/#56](https://www.evm.codes/#56)
-"""
-
-JUMPI = Opcode(0x57, popped_stack_items=2)
-"""
-JUMPI(counter, b)
-----
-
-Description
-----
-Conditionally alter the program counter
-
-Inputs
-----
-- counter: byte offset in the deployed code where execution will continue from. Must be a JUMPDEST instruction.
-- b: the program counter will be altered with the new value only if this value is different from 0. Otherwise, the program counter is simply incremented and the next instruction will be executed.
-
-Fork
-----
-Frontier
-
-Gas
-----
-10
-
-Source: [evm.codes/#57](https://www.evm.codes/#57)
-"""
-
-PC = Opcode(0x58, pushed_stack_items=1)
-"""
-PC() = counter
-----
-
-Description
-----
-Get the value of the program counter prior to the increment corresponding to this instruction
-
-Inputs
-----
-- None
-
-Outputs
-----
-- counter: PC of this instruction in the current program.
-
-Fork
-----
-Frontier
-
-Gas
-----
-2
-
-Source: [evm.codes/#58](https://www.evm.codes/#58)
-"""
-
-MSIZE = Opcode(0x59, pushed_stack_items=1)
-"""
-MSIZE() = size
-----
-
-Description
-----
-Get the size of active memory in bytes
-
-Outputs
-----
-- size: current memory size in bytes (higher offset accessed until now + 1)
-
-Fork
-----
-Frontier
-
-Gas
-----
-2
-
-Source: [evm.codes/#59](https://www.evm.codes/#59)
-"""
-
-GAS = Opcode(0x5A, pushed_stack_items=1)
-"""
-GAS() = gas_remaining
-----
-
-Description
-----
-Get the amount of available gas, including the corresponding reduction for the cost of this instruction
-
-Inputs
-----
-- None
-
-Outputs
-----
-- Source: [evm.codes/#5A](https://www.evm.codes/#5A)
-
-Fork
-----
-Frontier
-
-Gas
-----
-2
-
-Source: [evm.codes/#5A](https://www.evm.codes/#5A)
-"""
-
-JUMPDEST = Opcode(0x5B)
-"""
-JUMPDEST()
-----
-
-Description
-----
-Mark a valid destination for jumps
-
-Inputs
-----
-- None
-
-Outputs
-----
-- None
-
-Fork
-----
-Frontier
-
-Gas
-----
-1
-
-Source: [evm.codes/#5B](https://www.evm.codes/#5B)
-"""
-
-TLOAD = Opcode(0x5C, popped_stack_items=1, pushed_stack_items=1)
-"""
-TLOAD(key) = value
-----
-
-Description
-----
-Load a value from the storage at the specified key.
-
-Inputs
-----
-- key: The key in storage.
-
-Outputs
-----
-- value: The value associated with the given key.
-
-Fork
-----
-
-
-Gas
-----
-100
-
-Source: [eips.ethereum.org/EIPS/eip-1153](https://eips.ethereum.org/EIPS/eip-1153)
-"""
-
-TSTORE = Opcode(0x5D, popped_stack_items=2)
-"""
-TSTORE(key, value)
-----
-
-Description
-----
-Store a value in the storage at the specified key.
-
-Inputs
-----
-- key: The key in storage.
-- value: The value to be stored.
-
-Fork
-----
-
-
-Gas
-----
-100
-
-Source: [eips.ethereum.org/EIPS/eip-1153](https://eips.ethereum.org/EIPS/eip-1153)
-"""
-
-MCOPY = Opcode(0x5E, popped_stack_items=3)
-"""
-MCOPY(dst, src ,length)
-----
-
-Description
-----
-Copies memory
-
-Inputs
-----
-- dst: byte offset in the memory where the result will be copied.
-- src: byte offset in the calldata to copy.
-- length: byte size to copy
-
-Outputs
-----
-- None
-
-Fork
-----
-Frontier
-
-Gas
-----
-words_copied = (length + 31) // 32
-g_verylow    = 3
-g_copy       = 3 * words_copied + memory_expansion_cost
-gas_cost     = g_verylow + g_copy
-
-Source: [eips.ethereum.org/EIPS/eip-5656](https://eips.ethereum.org/EIPS/eip-5656)
-"""
-
-RETF = Opcode(0x49)
-"""
-RETF()
-----
-
-Description
-----
-Return from a function
-
-Inputs
-----
-- None
-
-Outputs
-----
-- None
-
-Fork
-----
-
-
-Gas
-----
-3 
-
-Source: [evm.codes/#5F](https://www.evm.codes/#5F)
-"""
-
-
-PUSH0 = Opcode(0x5F, pushed_stack_items=1)
-"""
-PUSH0() = value
-----
-
-Description
-----
-Place value 0 on stack
-
-Inputs
-----
-- None
-
-Outputs
-----
-- value: pushed value, equal to 0
-
-Fork
-----
-Frontier
-
-Gas
-----
-2
-
-Source: [evm.codes/#5F](https://www.evm.codes/#5F)
-"""
-
-PUSH1 = Opcode(0x60, pushed_stack_items=1, data_portion_length=1)
-"""
-PUSH1() = value
-----
-
-Description
-----
-Place 1 byte item on stack
-
-Inputs
-----
-- None
-
-Outputs
-----
-- value: pushed value, aligned to the right (put in the lowest significant bytes)
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#60](https://www.evm.codes/#60)
-"""
-
-PUSH2 = Opcode(0x61, pushed_stack_items=1, data_portion_length=2)
-"""
-PUSH2() = value
-----
-
-Description
-----
-Place 2 byte item on stack
-
-Inputs
-----
-- None
-
-Outputs
-----
-- value: pushed value, aligned to the right (put in the lowest significant bytes)
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#61](https://www.evm.codes/#61)
-"""
-
-PUSH3 = Opcode(0x62, pushed_stack_items=1, data_portion_length=3)
-"""
-PUSH3() = value
-----
-
-Description
-----
-Place 3 byte item on stack
-
-Inputs
-----
-- None
-
-Outputs
-----
-- value: pushed value, aligned to the right (put in the lowest significant bytes)
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#62](https://www.evm.codes/#62)
-"""
-
-PUSH4 = Opcode(0x63, pushed_stack_items=1, data_portion_length=4)
-"""
-PUSH4() = value
-----
-
-Description
-----
-Place 4 byte item on stack
-
-Inputs
-----
-- None
-
-Outputs
-----
-- value: pushed value, aligned to the right (put in the lowest significant bytes)
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#63](https://www.evm.codes/#63)
-"""
-
-PUSH5 = Opcode(0x64, pushed_stack_items=1, data_portion_length=5)
-"""
-PUSH5() = value
-----
-
-Description
-----
-Place 5 byte item on stack
-
-Inputs
-----
-- None
-
-Outputs
-----
-- value: pushed value, aligned to the right (put in the lowest significant bytes)
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#64](https://www.evm.codes/#64)
-"""
-
-PUSH6 = Opcode(0x65, pushed_stack_items=1, data_portion_length=6)
-"""
-PUSH6() = value
-----
-
-Description
-----
-Place 6 byte item on stack
-
-Inputs
-----
-- None
-
-Outputs
-----
-- value: pushed value, aligned to the right (put in the lowest significant bytes)
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#65](https://www.evm.codes/#65)
-"""
-
-PUSH7 = Opcode(0x66, pushed_stack_items=1, data_portion_length=7)
-"""
-PUSH7() = value
-----
-
-Description
-----
-Place 7 byte item on stack
-
-Inputs
-----
-- None
-
-Outputs
-----
-- value: pushed value, aligned to the right (put in the lowest significant bytes)
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#66](https://www.evm.codes/#66)
-"""
-PUSH8 = Opcode(0x77, pushed_stack_items=1, data_portion_length=8)
-"""
-PUSH8() = value
-----
-
-Description
-----
-Place 8 byte item on stack
-
-Inputs
-----
-- None
-
-Outputs
-----
-- value: pushed value, aligned to the right (put in the lowest significant bytes)
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#67](https://www.evm.codes/#67)
-"""
-
-PUSH9 = Opcode(0x78, pushed_stack_items=1, data_portion_length=9)
-"""
-PUSH9() = value
-----
-
-Description
-----
-Place 9 byte item on stack
-
-Inputs
-----
-- None
-
-Outputs
-----
-- value: pushed value, aligned to the right (put in the lowest significant bytes)
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#68](https://www.evm.codes/#68)
-"""
-
-PUSH10 = Opcode(0x79, pushed_stack_items=1, data_portion_length=10)
-"""
-PUSH10() = value
-----
-
-Description
-----
-Place 10 byte item on stack
-
-Inputs
-----
-- None
-
-Outputs
-----
-- value: pushed value, aligned to the right (put in the lowest significant bytes)
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#69](https://www.evm.codes/#69)
-"""
-
-PUSH11 = Opcode(0x7A, pushed_stack_items=1, data_portion_length=11)
-"""
-PUSH11() = value
-----
-
-Description
-----
-Place 11 byte item on stack
-
-Inputs
-----
-- None
-
-Outputs
-----
-- value: pushed value, aligned to the right (put in the lowest significant bytes)
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#6A](https://www.evm.codes/#6A)
-"""
-
-PUSH12 = Opcode(0x7B, pushed_stack_items=1, data_portion_length=12)
-"""
-PUSH12() = value
-----
-
-Description
-----
-Place 12 byte item on stack
-
-Inputs
-----
-- None
-
-Outputs
-----
-- value: pushed value, aligned to the right (put in the lowest significant bytes)
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#6B](https://www.evm.codes/#6B)
-"""
-
-PUSH13 = Opcode(0x7C, pushed_stack_items=1, data_portion_length=13)
-"""
-PUSH13() = value
-----
-
-Description
-----
-Place 13 byte item on stack
-
-Inputs
-----
-- None
-
-Outputs
-----
-- value: pushed value, aligned to the right (put in the lowest significant bytes)
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#6C](https://www.evm.codes/#6C)
-"""
-
-PUSH14 = Opcode(0x7D, pushed_stack_items=1, data_portion_length=14)
-"""
-PUSH14() = value
-----
-
-Description
-----
-Place 14 byte item on stack
-
-Inputs
-----
-- None
-
-Outputs
-----
-- value: pushed value, aligned to the right (put in the lowest significant bytes)
-
-Fork
-----
-Frontier
-
-
-Gas
-----
-3
-
-Source: [evm.codes/#6D](https://www.evm.codes/#6D)
-"""
-
-PUSH15 = Opcode(0x7E, pushed_stack_items=1, data_portion_length=15)
-"""
-PUSH15() = value
-----
-
-Description
-----
-Place 15 byte item on stack
-
-Inputs
-----
-- None
-
-Outputs
-----
-- value: pushed value, aligned to the right (put in the lowest significant bytes)
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#6E](https://www.evm.codes/#6E)
-"""
-
-PUSH16 = Opcode(0x7F, pushed_stack_items=1, data_portion_length=16)
-"""
-PUSH16() = value
-----
-
-Description
-----
-Place 16 byte item on stack
-
-Inputs
-----
-- None
-
-Outputs
-----
-- value: pushed value, aligned to the right (put in the lowest significant bytes)
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#6F](https://www.evm.codes/#6F)
-"""
-
-PUSH17 = Opcode(0x80, pushed_stack_items=1, data_portion_length=17)
-"""
-PUSH17() = value
-----
-
-Description
-----
-Place 17 byte item on stack
-
-Inputs
-----
-- None
-
-Outputs
-----
-- value: pushed value, aligned to the right (put in the lowest significant bytes)
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#70](https://www.evm.codes/#70)
-"""
-
-PUSH18 = Opcode(0x81, pushed_stack_items=1, data_portion_length=18)
-"""
-PUSH18() = value
-----
-
-Description
-----
-Place 18 byte item on stack
-
-Inputs
-----
-- None
-
-Outputs
-----
-- value: pushed value, aligned to the right (put in the lowest significant bytes)
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#71](https://www.evm.codes/#71)
-"""
-
-PUSH19 = Opcode(0x82, pushed_stack_items=1, data_portion_length=19)
-"""
-PUSH19() = value
-----
-
-Description
-----
-Place 19 byte item on stack
-
-Inputs
-----
-- None
-
-Outputs
-----
-- value: pushed value, aligned to the right (put in the lowest significant bytes)
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#72](https://www.evm.codes/#72)
-"""
-
-PUSH20 = Opcode(0x83, pushed_stack_items=1, data_portion_length=20)
-"""
-PUSH20() = value
-----
-
-Description
-----
-Place 20 byte item on stack
-
-Inputs
-----
-- None
-
-Outputs
-----
-- value: pushed value, aligned to the right (put in the lowest significant bytes)
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#73](https://www.evm.codes/#73)
-"""
-
-PUSH21 = Opcode(0x84, pushed_stack_items=1, data_portion_length=21)
-"""
-PUSH21() = value
-----
-
-Description
-----
-Place 21 byte item on stack
-
-Inputs
-----
-- None
-
-Outputs
-----
-- value: pushed value, aligned to the right (put in the lowest significant bytes)
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#74](https://www.evm.codes/#74)
-"""
-
-PUSH22 = Opcode(0x85, pushed_stack_items=1, data_portion_length=22)
-"""
-PUSH22() = value
-----
-
-Description
-----
-Place 22 byte item on stack
-
-Inputs
-----
-- None
-
-Outputs
-----
-- value: pushed value, aligned to the right (put in the lowest significant bytes)
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#75](https://www.evm.codes/#75)
-"""
-
-PUSH23 = Opcode(0x86, pushed_stack_items=1, data_portion_length=23)
-"""
-PUSH23() = value
-----
-
-Description
-----
-Place 23 byte item on stack
-
-Inputs
-----
-- None
-
-Outputs
-----
-- value: pushed value, aligned to the right (put in the lowest significant bytes)
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#76](https://www.evm.codes/#76)
-"""
-
-PUSH24 = Opcode(0x87, pushed_stack_items=1, data_portion_length=24)
-"""
-PUSH24() = value
-----
-
-Description
-----
-Place 24 byte item on stack
-
-Inputs
-----
-- None
-
-Outputs
-----
-- value: pushed value, aligned to the right (put in the lowest significant bytes)
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#77](https://www.evm.codes/#77)
-"""
-
-PUSH25 = Opcode(0x88, pushed_stack_items=1, data_portion_length=25)
-"""
-PUSH25() = value
-----
-
-Description
-----
-Place 25 byte item on stack
-
-Inputs
-----
-- None
-
-Outputs
-----
-- value: pushed value, aligned to the right (put in the lowest significant bytes)
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#78](https://www.evm.codes/#78)
-"""
-
-PUSH26 = Opcode(0x89, pushed_stack_items=1, data_portion_length=26)
-"""
-PUSH26() = value
-----
-
-Description
-----
-Place 26 byte item on stack
-
-Inputs
-----
-- None
-
-Outputs
-----
-- value: pushed value, aligned to the right (put in the lowest significant bytes)
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#79](https://www.evm.codes/#79)
-"""
-
-PUSH27 = Opcode(0x8A, pushed_stack_items=1, data_portion_length=27)
-"""
-PUSH27() = value
-----
-
-Description
-----
-Place 27 byte item on stack
-
-Inputs
-----
-- None
-
-Outputs
-----
-- value: pushed value, aligned to the right (put in the lowest significant bytes)
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#7A](https://www.evm.codes/#7A)
-"""
-
-PUSH28 = Opcode(0x8B, pushed_stack_items=1, data_portion_length=28)
-"""
-PUSH28() = value
-----
-
-Description
-----
-Place 28 byte item on stack
-
-Inputs
-----
-- None
-
-Outputs
-----
-- value: pushed value, aligned to the right (put in the lowest significant bytes)
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#7B](https://www.evm.codes/#7B)
-"""
-
-PUSH29 = Opcode(0x8C, pushed_stack_items=1, data_portion_length=29)
-"""
-PUSH29() = value
-----
-
-Description
-----
-Place 29 byte item on stack
-
-Inputs
-----
-- None
-
-Outputs
-----
-- value: pushed value, aligned to the right (put in the lowest significant bytes)
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#7C](https://www.evm.codes/#7C)
-"""
-
-PUSH30 = Opcode(0x8D, pushed_stack_items=1, data_portion_length=30)
-"""
-PUSH30() = value
-----
-
-Description
-----
-Place 30 byte item on stack
-
-Inputs
-----
-- None
-
-Outputs
-----
-- value: pushed value, aligned to the right (put in the lowest significant bytes)
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#7D](https://www.evm.codes/#7D)
-"""
-
-PUSH31 = Opcode(0x8E, pushed_stack_items=1, data_portion_length=31)
-"""
-PUSH31() = value
-----
-
-Description
-----
-Place 31 byte item on stack
-
-Inputs
-----
-- None
-
-Outputs
-----
-- value: pushed value.
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#7E](https://www.evm.codes/#7E)
-"""
-
-PUSH32 = Opcode(0x8F, pushed_stack_items=1, data_portion_length=32)
-"""
-PUSH32() = value
-----
-
-Description
-----
-Place 32 byte item on stack
-
-Inputs
-----
-- None
-
-Outputs
-----
-- value: pushed value.
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#7F](https://www.evm.codes/#7F)
-"""
-
-DUP1 = Opcode(0x80, pushed_stack_items=1, min_stack_height=1)
-"""
-DUP1(value) = value
-----
-
-Description
-----
-Duplicate 1st stack item
-
-Inputs
-----
-- value: value to duplicate
-
-Outputs
-----
-- value: duplicated value.
-- value: original value
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#80](https://www.evm.codes/#80)
-"""
-
-DUP2 = Opcode(0x81, pushed_stack_items=1, min_stack_height=2)
-"""
-DUP2(a, b) = b,a,b
-----
-
-Description
-----
-Duplicate 2nd stack item
-
-Inputs
-----
-- a: ignored value.
-- b: value to duplicate.
-
-Outputs
-----
-- b: duplicated value.
-- a: ignored value.
-- b: original value.
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#81](https://www.evm.codes/#81)
-"""
-
-DUP3 = Opcode(0x82, pushed_stack_items=1, min_stack_height=3)
-"""
-DUP15(a, b, c) = c, a, b, c
-----
-
-Description
-----
-Duplicate 3rd stack item
-
-Inputs
-----
-- a: ignored value.
-- b: ignored value.
-- c: value to duplicate.
-
-Outputs
-----
-- c: duplicated value.
-- a: ignored value.
-- b: ignored value.
-- c: original value.
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#82](https://www.evm.codes/#82)
-"""
-
-DUP4 = Opcode(0x83, pushed_stack_items=1, min_stack_height=4)
-"""
-DUP15(value1, value2, value3, value) = value, value2, value3, value
-----
-
-Description
-----
-Duplicate 4th stack item
-
-Inputs
-----
-- ignored value.
-- ignored value.
-- ignored value.
-- value: value to duplicate
-
-Outputs
-----
-- value: duplicated value
-- ignored value.
-- ignored value.
-- ignored value.
-- value: value to duplicate
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#83](https://www.evm.codes/#83)
-"""
-
-DUP5 = Opcode(0x84, pushed_stack_items=1, min_stack_height=5)
-"""
-DUP15(value1, value2, value3, value4, value) = value, value2, value3, value4, value
-----
-
-Description
-----
-Duplicate 5th stack item
-
-Inputs
-----
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- value: value to duplicate
-
-Outputs
-----
-- value: duplicated value
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- value: value to duplicate
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#84](https://www.evm.codes/#84)
-"""
-
-DUP6 = Opcode(0x85, pushed_stack_items=1, min_stack_height=6)
-"""
-DUP15(value1, value2, value3, value4, value5, value) = value, value2, value3, value4, value5, value
-----
-
-Description
-----
-Duplicate 6th stack item
-
-Inputs
-----
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- value: value to duplicate
-
-Outputs
-----
-- value: duplicated value
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- value: value to duplicate
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#85](https://www.evm.codes/#85)
-"""
-
-DUP7 = Opcode(0x86, pushed_stack_items=1, min_stack_height=7)
-"""
-DUP15(value1, value2, value3, value4, value5, value6, value) = value, value2, value3, value4, value5, value6, value
-----
-
-Description
-----
-Duplicate 7th stack item
-
-Inputs
-----
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- value: value to duplicate
-
-Outputs
-----
-- value: duplicated value
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- value: value to duplicate
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#86](https://www.evm.codes/#86)
-"""
-
-DUP8 = Opcode(0x87, pushed_stack_items=1, min_stack_height=8)
-"""
-DUP15(value1, value2, value3, value4, value5, value6, value7, value) = value, value2, value3, value4, value5, value6, value7, value
-----
-
-Description
-----
-Duplicate 8th stack item
-
-Inputs
-----
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- value: value to duplicate
-
-Outputs
-----
-- value: duplicated value
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- value: value to duplicate
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#87](https://www.evm.codes/#87)
-"""
-
-DUP9 = Opcode(0x88, pushed_stack_items=1, min_stack_height=9)
-"""
-DUP15(value1, value2, value3, value4, value5, value6, value7, value8, value) = value, value2, value3, value4, value5, value6, value7, value8, value
-----
-
-Description
-----
-Duplicate 9th stack item
-
-Inputs
-----
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- value: value to duplicate
-
-Outputs
-----
-- value: duplicated value
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- value: value to duplicate
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#88](https://www.evm.codes/#88)
-"""
-DUP10 = Opcode(0x89, pushed_stack_items=1, min_stack_height=10)
-"""
-DUP10(value1, value2, value3, value4, value5, value6, value7, value8, value9, value) = value, value2, value3, value4, value5, value6, value7, value8, value9, value
-----
-
-Description
-----
-Duplicate 10th stack item
-
-Inputs
-----
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- value: value to duplicate
-
-Outputs
-----
-- value: duplicated value
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- value: value to duplicate
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#89](https://www.evm.codes/#89)
-"""
-
-DUP11 = Opcode(0x8A, pushed_stack_items=1, min_stack_height=11)
-"""
-DUP11(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value) = value, value2, value3, value4, value5, value6, value7, value8, value9, value10, value
-----
-
-Description
-----
-Duplicate 11th stack item
-
-Inputs
-----
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- value: value to duplicate
-
-Outputs
-----
-- value: duplicated value
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- value: value to duplicate
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#8A](https://www.evm.codes/#8A)
-"""
-
-DUP12 = Opcode(0x8B, pushed_stack_items=1, min_stack_height=12)
-"""
-DUP12(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value) = value, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value
-----
-
-Description
-----
-Duplicate 12th stack item
-
-Inputs
-----
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- value: value to duplicate
-
-Outputs
-----
-- value: duplicated value
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- value: value to duplicate
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#8B](https://www.evm.codes/#8B)
-"""
-
-DUP13 = Opcode(0x8C, pushed_stack_items=1, min_stack_height=13)
-"""
-DUP15(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value) = value, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value
-----
-
-Description
-----
-Duplicate 13th stack item
-
-Inputs
-----
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- value: value to duplicate
-
-Outputs
-----
-- value: duplicated value
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- value: value to duplicate
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#8C](https://www.evm.codes/#8C)
-"""
-
-DUP14 = Opcode(0x8D, pushed_stack_items=1, min_stack_height=14)
-"""
-DUP15(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value) = value, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value
-----
-
-Description
-----
-Duplicate 14th stack item
-
-Inputs
-----
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- value: value to duplicate
-
-Outputs
-----
-- value: duplicated value
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- value: value to duplicate
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#8D](https://www.evm.codes/#8D)
-"""
-
-DUP15 = Opcode(0x8E, pushed_stack_items=1, min_stack_height=15)
-"""
-DUP15(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value) = value, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value
-----
-
-Description
-----
-Duplicate 15th stack item
-
-Inputs
-----
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- value: value to duplicate
-
-Outputs
-----
-- value: duplicated value
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- value: value to duplicate
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#8E](https://www.evm.codes/#8E)
-"""
-
-DUP16 = Opcode(0x8F, pushed_stack_items=1, min_stack_height=16)
-"""
-DUP16(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, value) = value, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, value
-----
-
-Description
-----
-Duplicate 16th stack item
-
-Inputs
-----
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- value: value to duplicate
-
-Outputs
-----
-- value: duplicated value
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- value: value to duplicate
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#8F](https://www.evm.codes/#8F)
-"""
-
-SWAP1 = Opcode(0x90, min_stack_height=2)
-"""
-SWAP1(a, b) = b, a
-----
-
-Description
-----
-Exchange the top stack item with the second stack item.
-
-Inputs
-----
-- a: value to swap
-- b: value to swap
-
-Outputs
-----
-- b: swapped value.
-- a: swapped value.
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#90](https://www.evm.codes/#90)
-"""
-
-SWAP2 = Opcode(0x91, min_stack_height=3)
-"""
-SWAP2(a, value2, b) = b, value2, a
-----
-
-Description
-----
-Exchange 1st and 3rd stack items
-
-Inputs
-----
-- a: value to swap
-- ignored value.
-- b: value to swap
-
-Outputs
-----
-- b: swapped value
-- ignored value
-- a: swapped value
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#91](https://www.evm.codes/#91)
-"""
-
-SWAP3 = Opcode(0x92, min_stack_height=4)
-"""
-SWAP3(a, value2, value3, b) = b value2, value3, a
-----
-
-Description
-----
-Exchange 1st and 4th stack items
-
-Inputs
-----
-- a: value to swap
-- ignored value.
-- ignored value.
-- b: value to swap
-
-Outputs
-----
-- b: swapped value.
-- ignored value.
-- ignored value.
-- a: swapped value.
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#92](https://www.evm.codes/#92)
-"""
-
-SWAP4 = Opcode(0x93, min_stack_height=5)
-"""
-SWAP4(a, value2, value3, value4, b) = b value2, value3, value4, a
-----
-
-Description
-----
-Exchange 1st and 5th stack items
-
-Inputs
-----
-- a: value to swap
-- ignored value.
-- ignored value.
-- ignored value.
-- b: value to swap
-
-Outputs
-----
-- b: swapped value.
-- ignored value.
-- ignored value.
-- ignored value.
-- a: swapped value.
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#93](https://www.evm.codes/#93)
-"""
-
-SWAP5 = Opcode(0x94, min_stack_height=6)
-"""
-SWAP5(a, value2, value3, value4, value5, b) = b, value2, value3, value4, value5, a
-----
-
-Description
-----
-Exchange 1st and 6th stack items
-
-Inputs
-----
-- a: value to swap
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- b: value to swap
-
-Outputs
-----
-- b: swapped value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- a: swapped value.
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#94](https://www.evm.codes/#94)
-"""
-
-SWAP6 = Opcode(0x95, min_stack_height=7)
-"""
-SWAP6(a, value2, value3, value4, value5, value6, b) = b, value2, value3, value4, value5, value6, a
-----
-
-Description
-----
-Exchange 1st and 7th stack items
-
-Inputs
-----
-- a: value to swap
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- b: value to swap
-
-Outputs
-----
-- b: swapped value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- a: swapped value.
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#95](https://www.evm.codes/#95)
-"""
-
-SWAP7 = Opcode(0x96, min_stack_height=8)
-"""
-SWAP7(a, value2, value3, value4, value5, value6, value7, b) = b, value2, value3, value4, value5, value6, value7, a
-----
-
-Description
-----
-Exchange 1st and 8th stack items
-
-Inputs
-----
-- a: value to swap
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- b: value to swap
-
-Outputs
-----
-- b: swapped value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- a: swapped value.
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#96](https://www.evm.codes/#96)
-"""
-
-SWAP8 = Opcode(0x97, min_stack_height=9)
-"""
-SWAP8(a, value2, value3, value4, value5, value6, value7, value8, b) = b, value2, value3, value4, value5, value6, value7, value8, a
-----
-
-Description
-----
-Exchange 1st and 9th stack items
-
-Inputs
-----
-- a: value to swap
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- b: value to swap
-
-Outputs
-----
-- b: swapped value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- a: swapped value.
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#97](https://www.evm.codes/#97)
-"""
-
-SWAP9 = Opcode(0x98, min_stack_height=10)
-"""
-SWAP9(a, value2, value3, value4, value5, value6, value7, value8, value9, b) = b, value2, value3, value4, value5, value6, value7, value8, value9, a
-----
-
-Description
-----
-Exchange 1st and 10th stack items
-
-Inputs
-----
-- a: value to swap
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- b: value to swap
-
-Outputs
-----
-- b: swapped value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- a: swapped value.
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#98](https://www.evm.codes/#98)
-"""
-
-SWAP10 = Opcode(0x99, min_stack_height=11)
-"""
-SWAP10(a, value2, value3, value4, value5, value6, value7, value8, value9, value10, b) = b, value2, value3, value4, value5, value6, value7, value8, value9, value10, a
-----
-
-Description
-----
-Exchange 1st and 11th stack items
-
-Inputs
-----
-- a: value to swap
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- b: value to swap
-
-Outputs
-----
-- b: swapped value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- a: swapped value.
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#99](https://www.evm.codes/#99)
-"""
-
-SWAP11 = Opcode(0x9A, min_stack_height=12)
-"""
-SWAP11(a, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, b) = b, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, a
-----
-
-Description
-----
-Exchange 1st and 12th stack items
-
-Inputs
-----
-- a: value to swap
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- b: value to swap
-
-Outputs
-----
-- b: swapped value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- a: swapped value.
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#9A](https://www.evm.codes/#9A)
-"""
-
-SWAP12 = Opcode(0x9B, min_stack_height=13)
-"""
-SWAP12(a, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, b) = b, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, a
-----
-
-Description
-----
-Exchange 1st and 13th stack items
-
-Inputs
-----
-- a: value to swap
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- b: value to swap
-
-Outputs
-----
-- b: swapped value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- a: swapped value.
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#9B](https://www.evm.codes/#9B)
-"""
-
-SWAP13 = Opcode(0x9C, min_stack_height=14)
-"""
-SWAP13(a, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, b) = b, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12,a) 
-----
-
-Description
-----
-Exchange 1st and 14th stack items
-
-Inputs
-----
-- a: value to swap.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- b: value to swap.
-
-Outputs
-----
-- b: swapped value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- a: swapped value.
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#9C](https://www.evm.codes/#9C)
-"""
-
-SWAP14 = Opcode(0x9D, min_stack_height=15)
-"""
-SWAP14(a, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, b) = b, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, a) 
-----
-
-Description
-----
-Exchange 1st and 15th stack items
-
-Inputs
-----
-- a: value to swap.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- b: value to swap.
-
-Outputs
-----
-- b: swapped value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- a: swapped value.
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#9D](https://www.evm.codes/#9D)
-"""
-
-SWAP15 = Opcode(0x9E, min_stack_height=16)
-"""
-SWAP15(a, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, b) = b, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, a) 
-----
-
-Description
-----
-Exchange 1st and 16th stack items
-
-Inputs
-----
-- a: value to swap.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- b: value to swap.
-
-Outputs
-----
-- b: swapped value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- a: swapped value.
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#9E](https://www.evm.codes/#9E)
-"""
-
-
-SWAP16 = Opcode(0x9F, min_stack_height=17)
-"""
-SWAP16(a, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, b) = b, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, a) 
-----
-
-Description
-----
-Exchange 1st and 17th stack items
-
-Inputs
-----
-- a: value to swap.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- b: value to swap.
-
-Outputs
-----
-- b: swapped value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- ignored value.
-- a: swapped value.
-
-Fork
-----
-Frontier
-
-Gas
-----
-3
-
-Source: [evm.codes/#9F](https://www.evm.codes/#9F)
-"""
-
-
-LOG0 = Opcode(0xA0, popped_stack_items=2)
-"""
-LOG3(offset, size) 
-----
-
-Description
-----
-Append log record with no topics
-
-Inputs
-----
-- offset: byte offset in the memory in bytes
-- size: byte size to copy
-
-Outputs
-----
-- None
-
-Fork
-----
-Frontier
-
-Gas
-----
-375 + 375 * topic_count + 8 * size + memory_expansion_cost
-
-Source: [evm.codes/#A0](https://www.evm.codes/#A0)
-"""
-
-LOG1 = Opcode(0xA1, popped_stack_items=3)
-"""
-LOG1(offset, size, topic1) 
-----
-
-Description
-----
-Append log record with one topics
-
-Inputs
-----
-- offset: byte offset in the memory in bytes
-- size: byte size to copy
-- topic1: 32-byte value
-
-Outputs
-----
-- None
-
-Fork
-----
-Frontier
-
-Gas
-----
-375 + 375 * topic_count + 8 * size + memory_expansion_cost
-
-Source: [evm.codes/#A1](https://www.evm.codes/#A1)
-"""
-
-LOG2 = Opcode(0xA2, popped_stack_items=4)
-"""
-LOG2(offset, size, topic1, topic2) 
-----
-
-Description
-----
-Append log record with two topics
-
-Inputs
-----
-- offset: byte offset in the memory in bytes
-- size: byte size to copy
-- topic1: 32-byte value
-- topic2: 32-byte value
-
-Outputs
-----
-- None
-
-Fork
-----
-Frontier
-
-Gas
-----
-375 + 375 * topic_count + 8 * size + memory_expansion_cost
-
-Source: [evm.codes/#A2](https://www.evm.codes/#A2)
-"""
-
-LOG3 = Opcode(0xA3, popped_stack_items=5)
-"""
-LOG3(offset, size, topic1, topic2, topic3) 
-----
-
-Description
-----
-Append log record with three topics
-
-Inputs
-----
-- offset: byte offset in the memory in bytes
-- size: byte size to copy
-- topic1: 32-byte value
-- topic2: 32-byte value
-- topic3: 32-byte value
-
-Outputs
-----
-- None
-
-Fork
-----
-Frontier
-
-Gas
-----
-375 + 375 * topic_count + 8 * size + memory_expansion_cost
-
-Source: [evm.codes/#A3](https://www.evm.codes/#A3)
-"""
-
-LOG4 = Opcode(0xA4, popped_stack_items=6)
-"""
-LOG4(offset, size, topic1, topic2, topic3, topic4) 
-----
-
-Description
-----
-Append log record with four topics
-
-Inputs
-----
-- offset: byte offset in the memory in bytes
-- size: byte size to copy
-- topic1: 32-byte value
-- topic2: 32-byte value
-- topic3: 32-byte value
-- topic4: 32-byte value
-
-Outputs
-----
-- None
-
-Fork
-----
-Frontier
-
-Gas
-----
-375 + 375 * topic_count + 8 * size + memory_expansion_cost
-
-Source: [evm.codes/#A4](https://www.evm.codes/#A4)
-"""
-
-
-RJUMP = Opcode(0xE0, data_portion_length=2)
-"""
-RJUMP(destination)
-----
-
-Description
-----
-Jump to a relative position in code.
-
-Inputs
-----
-- destination: The relative position to jump to.
-
-Fork
-----
-Revolution
-"""
-
-RJUMPI = Opcode(0xE1, popped_stack_items=1, data_portion_length=2)
-"""
-RJUMPI() 
-----
-
-Description
-----
-
-
-Inputs
-----
-
-
-Outputs
-----
-
-
-Fork
-----
-
-Gas
-----
-
-
-Source: 
-
-"""
-
-RJUMPV = Opcode(0xE2)
-"""
-RJUMPV  
-----
-
-Description
-----
-
-
-Inputs
-----
-- 
-
-Outputs
-----
-- 
-
-Fork
-----
-
-
-Gas
-----
-
-
-Source: 
-"""
-
-
-CREATE = Opcode(0xF0, popped_stack_items=3, pushed_stack_items=1)
-"""
-CREATE(value, offset, length) = contract_address
-----
-
-Description
-----
-Create a new contract with the given code.
-
-Inputs
-----
-- value: value in wei to send to the new account
-- offset: byte offset in the memory in bytes, the initialisation code for the new account
-- size: byte size to copy (size of the initialisation code)
-
-Outputs
-----
-- contract_address: The address of the newly created contract.
-
-Fork
-----
-Homestead
-
-Gas
-----
-32000 + init_code_cost + memory_expansion_cost + deployment_code_execution_cost + code_deposit_cost
-
-Source: [evm.codes/#F0](https://www.evm.codes/#F0)
-"""
-
-CALL = Opcode(0xF1, popped_stack_items=7, pushed_stack_items=1)
-"""
-CALL(gas, address, value, argsOffset, argsSize, retOffset, retSize) = success
-----
-
-Description
-----
-Message-call into an account
-
-Inputs
-----
-- gas: amount of gas to send to the sub context to execute. The gas that is not used by the sub context is returned to this one
-- address: the account which context to execute
-- value: value in wei to send to the account
-- argsOffset: byte offset in the memory in bytes, the calldata of the sub context
-- argsSize: byte size to copy (size of the calldata)
-- retOffset: byte offset in the memory in bytes, where to store the return data of the sub context
-- retSize: byte size to copy (size of the return data)
-
-Outputs
-----
-- success: return 0 if the sub context reverted, 1 otherwise
-
-Fork
-----
-Frontier
-
-Gas
-----
-memory_expansion_cost + code_execution_cost + address_access_cost + positive_value_cost + value_to_empty_account_cost
-
-Source: [evm.codes/#F1](https://www.evm.codes/#F1)
-"""
-
-CALLCODE = Opcode(0xF2, popped_stack_items=7, pushed_stack_items=1)
-"""
-CALLCODE(gas, address, value, argsOffset, argsSize, retOffset, retSize) = success
-----
-
-Description
-----
-Message-call into this account with an alternative account's code. Executes code starting at the address to which the call is made.
-
-Inputs
-----
-- gas: amount of gas to send to the sub context to execute. The gas that is not used by the sub context is returned to this one.
-- address: the account which code to execute
-- value: value in wei to send to the account
-- argsOffset: byte offset in the memory in bytes, the calldata of the sub context
-- argsSize: byte size to copy (size of the calldata)
-- retOffset: byte offset in the memory in bytes, where to store the return data of the sub context
-- retSize: byte size to copy (size of the return data)
-Outputs
-----
-- success: return 0 if the sub context reverted, 1 otherwise
-
-Fork
-----
-Frontier
-
-Gas
-----
-memory_expansion_cost + code_execution_cost + address_access_cost + positive_value_cost
-
-Source: [evm.codes/#F2](https://www.evm.codes/#F2)
-"""
-
-RETURN = Opcode(0xF3, popped_stack_items=2)
-"""
-RETURN(offset, size)  
-----
-
-Description
-----
-Halt execution returning output data.
-
-Inputs
-----
-- offset: The memory offset to the output data.
-- size: The size of the output data.
-
-Outputs
-----
-- None
-
-Fork
-----
-Frontier
-
-Gas
-----
-memory_expansion_cost
-
-Source: [evm.codes/#F3](https://www.evm.codes/#F3)
-"""
-
-DELEGATECALL = Opcode(0xF4, popped_stack_items=6, pushed_stack_items=1)
-"""
-DELEGATECALL(gas, address, argsOffset, argsSize, retOffset, retSize) = success
-----
-
-Description
-----
-Message-call into this account with an alternative account’s code, but persisting the current values for sender and value
-
-Inputs
-----
-- gas: amount of gas to send to the sub context to execute. The gas that is not used by the sub context is returned to this one
-- address: the account which code to execute
-- argsOffset: byte offset in the memory in bytes, the calldata of the sub context
-- argsSize: byte size to copy (size of the calldata)
-- retOffset: byte offset in the memory in bytes, where to store the return data of the sub context.
-- retSize: byte size to copy (size of the return data)
-
-Outputs
-----
-- success: return 0 if the sub context reverted, 1 otherwise
-
-Fork
-----
-Byzantium
-
-Gas
-----
-memory_expansion_cost + code_execution_cost + address_access_cost
-
-Source: [evm.codes/#F4](https://www.evm.codes/#F4)
-"""
-
-CREATE2 = Opcode(0xF5, popped_stack_items=4, pushed_stack_items=1)
-"""
-CREATE2(value, offset, size, salt) = address
-----
-
-Description
-----
-Creates a new contract.
-
-Inputs
-----
-- value: value in wei to send to the new account.
-- offset: byte offset in the memory in bytes, the initialisation code of the new account.
-- size: byte size to copy (size of the initialisation code).
-- salt: 32-byte value used to create the new account at a deterministic address
-
-Outputs
-----
-- address: the address of the deployed contract, 0 if the deployment failed
-
-Fork
-----
-Constantinople
-
-Gas
-----
-minimum_word_size = (size + 31) / 32
-init_code_cost = 2 * minimum_word_size
-hash_cost = 6 * minimum_word_size
-code_deposit_cost = 200 * deployed_code_size
-
-32000 + init_code_cost + hash_cost + memory_expansion_cost + deployment_code_execution_cost + code_deposit_cost
-
-Source: [evm.codes/#F5](https://www.evm.codes/#F5)
-"""
-
-STATICCALL = Opcode(0xFA, popped_stack_items=6, pushed_stack_items=1)
-"""
-STATICCALL(gas, address, argsOffset, argsSize, retOffset , retSize) = success
-----
-
-Description
-----
-Static message-call into an account
-
-Inputs
-----
-- gas: amount of gas to send to the sub context to execute. The gas that is not used by the sub context is returned to this one.
-- address: the account which context to execute.
-- argsOffset: byte offset in the memory in bytes, the calldata of the sub context.
-- argsSize: byte size to copy (size of the calldata).
-- retOffset: byte offset in the memory in bytes, where to store the return data of the sub context.
-- retSize: byte size to copy (size of the return data)
-
-Outputs
-----
-- success: return 0 if the sub context reverted, 1 otherwise
-
-Fork
-----
-Byzantium
-
-Gas
-----
-memory_expansion_cost + code_execution_cost + address_access_cost
-
-Source: [evm.codes/#FA](https://www.evm.codes/#FA)
-"""
-
-
-
-REVERT = Opcode(0xFD, popped_stack_items=2)
-"""
-REVERT(offset, length)
-----
-
-Description
-----
-Stop execution and revert changes.
-
-Inputs
-----
-- offset: byte offset in the memory in bytes. The return data of the calling context.
-- size: byte size to copy (size of the return data).
-
-Fork
-----
-Byzantium
-
-Gas
-----
-0
-
-Source: [evm.codes/#FD](https://www.evm.codes/#FD)
-"""
-
-INVALID = Opcode(0xFE)
-"""
-INVALID()
-----
-
-Description
-----
-Invalid opcode.
-
-Inputs
-----
-None
-
-Outputs
-----
-None
-
-Fork
-----
-Homestead
-
-Gas
-----
-All the remaining gas in this context is consumed
-
-Source: [evm.codes/#FE](https://www.evm.codes/#FE)
-"""
-
-SELFDESTRUCT = Opcode(0xFF, popped_stack_items=1)
-"""
-SELFDESTRUCT(to)
-----
-
-Description
-----
-Halt execution and register the account for later deletion.
-
-Inputs
-----
-- to: The address to which any remaining funds are transferred.
-
-Fork
-----
-Frontier
-
-Gas
-----
-5000
-
-Source: [evm.codes/#FF](https://www.evm.codes/#FF)
-"""
-
-SENDALL = Opcode(0xFF, popped_stack_items=1)
-"""
-SENDALL(to) = success
-----
-
-Description
-----
-Send all ether to the target address.
-
-Inputs
-----
-- to: Target address
-
-Outputs
-----
-- None
-
-Fork
-----
-Frontier
-
-Gas
-----
-
-
-Source: [eips.ethereum.org/EIPS/eip-4758](https://eips.ethereum.org/EIPS/eip-4758)
-"""
-
-
+    STOP = Opcode(0x00)
+    """
+    STOP()
+    ----
+
+    Description
+    ----
+    Stop execution.
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - None
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    0
+
+    Source: [evm.codes/#00](https://www.evm.codes/#00)
+    """
+
+    ADD = Opcode(0x01, popped_stack_items=2, pushed_stack_items=1)
+    """
+    ADD(a, b) = c
+    ----
+
+    Description
+    ----
+    Addition operation
+
+    Inputs
+    ----
+    - a: first integer value to add
+    - b: second integer value to add
+
+    Outputs
+    ----
+    - c: integer result of the addition modulo 2**256
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#01](https://www.evm.codes/#01)
+    """
+
+    MUL = Opcode(0x02, popped_stack_items=2, pushed_stack_items=1)
+    """
+    MUL(a, b) = c
+    ----
+
+    Description
+    ----
+    Multiplication operation
+
+    Inputs
+    ----
+    - a: first integer value to multiply
+    - b: second integer value to multiply
+
+    Outputs
+    ----
+    - c: integer result of the multiplication modulo 2**256
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    5
+
+    Source: [evm.codes/#02](https://www.evm.codes/#02)
+    """
+
+    SUB = Opcode(0x03, popped_stack_items=2, pushed_stack_items=1)
+    """
+    SUB(a, b) = c
+    ----
+
+    Description
+    ----
+    Subtraction operation
+
+    Inputs
+    ----
+    - a: first integer value
+    - b: second integer value
+
+    Outputs
+    ----
+    - c: integer result of the subtraction modulo 2**256
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#03](https://www.evm.codes/#03)
+    """
+
+    DIV = Opcode(0x04, popped_stack_items=2, pushed_stack_items=1)
+    """
+    DIV(a, b) = c
+    ----
+
+    Description
+    ----
+    Division operation
+
+    Inputs
+    ----
+    - a: numerator
+    - b: denominator (must be non-zero)
+
+    Outputs
+    ----
+    - c: integer result of the division
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    5
+
+    Source: [evm.codes/#04](https://www.evm.codes/#04)
+    """
+
+    SDIV = Opcode(0x05, popped_stack_items=2, pushed_stack_items=1)
+    """
+    SDIV(a, b) = c
+    ----
+
+    Description
+    ----
+    Signed division operation
+
+    Inputs
+    ----
+    - a: signed numerator
+    - b: signed denominator (must be non-zero)
+
+    Outputs
+    ----
+    - c: signed integer result of the division
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    5
+
+    Source: [evm.codes/#05](https://www.evm.codes/#05)
+    """
+
+    MOD = Opcode(0x06, popped_stack_items=2, pushed_stack_items=1)
+    """
+    MOD(a, b) = c
+    ----
+
+    Description
+    ----
+    Modulo operation
+
+    Inputs
+    ----
+    - a: integer numerator.
+    - b: integer denominator
+
+    Outputs
+    ----
+    - a % b: integer result of the integer modulo. If the denominator is 0, the result will be 0
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    5
+
+    Source: [evm.codes/#06](https://www.evm.codes/#06)
+    """
+
+    SMOD = Opcode(0x07, popped_stack_items=2, pushed_stack_items=1)
+    """
+    SMOD(a, b) = c
+    ----
+
+    Description
+    ----
+    Signed modulo remainder operation
+
+    Inputs
+    ----
+    - a: integer numerator.
+    - b: integer denominator.
+
+    Outputs
+    ----
+    - a % b: integer result of the signed integer modulo. If the denominator is 0, the result will
+      be 0
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    5
+
+    Source: [evm.codes/#07](https://www.evm.codes/#07)
+    """
+
+    ADDMOD = Opcode(0x08, popped_stack_items=3, pushed_stack_items=1)
+    """
+    ADDMOD(a, b, c) = d
+    ----
+
+    Description
+    ----
+    Modular addition operation with overflow check
+
+    Inputs
+    ----
+    - a: first integer value
+    - b: second integer value
+    - c: integer denominator
+
+    Outputs
+    ----
+    - (a + b) % N: integer result of the addition followed by a modulo. If the denominator is 0,
+      the result will be 0
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    8
+
+    Source: [evm.codes/#08](https://www.evm.codes/#08)
+    """
+
+    MULMOD = Opcode(0x09, popped_stack_items=3, pushed_stack_items=1)
+    """
+    MULMOD(a, b, N) = d
+    ----
+
+    Description
+    ----
+    Modulo multiplication operation
+
+    Inputs
+    ----
+    - a: first integer value to multiply.
+    - b: second integer value to multiply.
+    - N: integer denominator
+
+    Outputs
+    ----
+    - d: (a * b) % N: integer result of the multiplication followed by a modulo. If the denominator
+      is 0, the result will be 0
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    8
+
+    Source: [evm.codes/#09](https://www.evm.codes/#09)
+    """
+
+    EXP = Opcode(0x0A, popped_stack_items=2, pushed_stack_items=1)
+    """
+    EXP(base, exponent) = a ** exponent
+    ----
+
+    Description
+    ----
+    Exponential operation
+
+    Inputs
+    ----
+    - base: integer base.
+    - exponent: integer exponent
+
+    Outputs
+    ----
+    - a ** exponent: integer result of the exponential operation modulo 2**256
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    10
+
+    Source: [evm.codes/#0A](https://www.evm.codes/#0A)
+    """
+
+    SIGNEXTEND = Opcode(0x0B, popped_stack_items=2, pushed_stack_items=1)
+    """
+    SIGNEXTEND(b, x) = y
+    ----
+
+    Description
+    ----
+    Sign extension operation
+
+    Inputs
+    ----
+    - b: size in byte - 1 of the integer to sign extend
+    - x: integer value to sign extend
+
+    Outputs
+    ----
+    - y: integer result of the sign extend
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    5
+
+    Source: [evm.codes/#0B](https://www.evm.codes/#0B)
+    """
+
+    LT = Opcode(0x10, popped_stack_items=2, pushed_stack_items=1)
+    """
+    LT(a, b) = a < b
+    ----
+
+    Description
+    ----
+    Less-than comparison
+
+    Inputs
+    ----
+    - a: first integer value
+    - b: second integer value
+
+    Outputs
+    ----
+    - a < b: 1 if the left side is smaller, 0 otherwise
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#10](https://www.evm.codes/#10)
+    """
+
+    GT = Opcode(0x11, popped_stack_items=2, pushed_stack_items=1)
+    """
+    GT(a, b) = a > b
+    ----
+
+    Description
+    ----
+    Greater-than comparison
+
+    Inputs
+    ----
+    - a: left side integer
+    - b: right side integer
+
+    Outputs
+    ----
+    - a > b: 1 if the left side is bigger, 0 otherwise
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#11](https://www.evm.codes/#11)
+    """
+
+    SLT = Opcode(0x12, popped_stack_items=2, pushed_stack_items=1)
+    """
+    SLT(a, b) = a < b
+    ----
+
+    Description
+    ----
+    Signed less-than comparison
+
+    Inputs
+    ----
+    - a: eft side signed integer
+    - b: right side signed integer
+
+    Outputs
+    ----
+    - a < b: 1 if the left side is smaller, 0 otherwise
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#12](https://www.evm.codes/#12)
+    """
+
+    SGT = Opcode(0x13, popped_stack_items=2, pushed_stack_items=1)
+    """
+    SGT(a, b) = a > b
+    ----
+
+    Description
+    ----
+    Signed greater-than comparison
+
+    Inputs
+    ----
+    - a:  left side signed integer.
+    - b: right side signed integer
+
+    Outputs
+    ----
+    - a > b: 1 if the left side is bigger, 0 otherwise
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#13](https://www.evm.codes/#13)
+    """
+
+    EQ = Opcode(0x14, popped_stack_items=2, pushed_stack_items=1)
+    """
+    EQ(a, b) = a == b
+    ----
+
+    Description
+    ----
+    Equality comparison
+
+    Inputs
+    ----
+    - a: left side integer
+    - b: right side integer
+
+    Outputs
+    ----
+    - a == b: 1 if the left side is equal to the right side, 0 otherwise
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#14](https://www.evm.codes/#14)
+    """
+
+    ISZERO = Opcode(0x15, popped_stack_items=1, pushed_stack_items=1)
+    """
+    ISZERO(a) = a == 0
+    ----
+
+    Description
+    ----
+    Is-zero comparison
+
+    Inputs
+    ----
+    - a: integer
+
+    Outputs
+    ----
+    - a == 0: 1 if a is 0, 0 otherwise
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#15](https://www.evm.codes/#15)
+    """
+
+    AND = Opcode(0x16, popped_stack_items=2, pushed_stack_items=1)
+    """
+    AND(a, b) = a & b
+    ----
+
+    Description
+    ----
+    Bitwise AND operation
+
+    Inputs
+    ----
+    - a: first binary value.
+    - b: second binary value
+
+    Outputs
+    ----
+    - a & b: the bitwise AND result
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#16](https://www.evm.codes/#16)
+    """
+
+    OR = Opcode(0x17, popped_stack_items=2, pushed_stack_items=1)
+    """
+    OR(a, b) = a | b
+    ----
+
+    Description
+    ----
+    Bitwise OR operation
+
+    Inputs
+    ----
+    - a: first binary value
+    - b: second binary value
+
+    Outputs
+    ----
+    - a | b: the bitwise OR result
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#17](https://www.evm.codes/#17)
+    """
+
+    XOR = Opcode(0x18, popped_stack_items=2, pushed_stack_items=1)
+    """
+    XOR(a, b) = a ^ b
+    ----
+
+    Description
+    ----
+    Bitwise XOR operation
+
+    Inputs
+    ----
+    - a:  first binary value
+    - b: second binary value
+
+    Outputs
+    ----
+    - a ^ b: the bitwise XOR result
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#18](https://www.evm.codes/#18)
+    """
+
+    NOT = Opcode(0x19, popped_stack_items=1, pushed_stack_items=1)
+    """
+    NOT(a) = ~a
+    ----
+
+    Description
+    ----
+    Bitwise NOT operation
+
+    Inputs
+    ----
+    - a: binary value
+
+    Outputs
+    ----
+    - ~a: the bitwise NOT result
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#19](https://www.evm.codes/#19)
+    """
+
+    BYTE = Opcode(0x1A, popped_stack_items=2, pushed_stack_items=1)
+    """
+    BYTE(i, x) = y
+    ----
+
+    Description
+    ----
+    Extract a byte from the given position in the value
+
+    Inputs
+    ----
+    - i: byte offset starting from the most significant byte.
+    - x: 32-byte value
+
+    Outputs
+    ----
+    - y: the indicated byte at the least significant position. If the byte offset is out of range,
+      the result is 0
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#1A](https://www.evm.codes/#1A)
+    """
+
+    SHL = Opcode(0x1B, popped_stack_items=2, pushed_stack_items=1)
+    """
+    SHL(shift, value) = value << shift
+    ----
+
+    Description
+    ----
+    Shift left operation
+
+    Inputs
+    ----
+    - shift: number of bits to shift to the left.
+    - value: 32 bytes to shift
+
+    Outputs
+    ----
+    - value << shift: the shifted value. If shift is bigger than 255, returns 0
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#1B](https://www.evm.codes/#1B)
+    """
+
+    SHR = Opcode(0x1C, popped_stack_items=2, pushed_stack_items=1)
+    """
+    SHR(shift, value) = value >> shift
+    ----
+
+    Description
+    ----
+    Logical shift right operation
+
+    Inputs
+    ----
+    - shift: number of bits to shift to the right.
+    - value: 32 bytes to shift
+
+    Outputs
+    ----
+    - value >> shift: the shifted value. If shift is bigger than 255, returns 0
+
+    Fork
+    ----
+    Constantinople
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#1C](https://www.evm.codes/#1C)
+    """
+
+    SAR = Opcode(0x1D, popped_stack_items=2, pushed_stack_items=1)
+    """
+    SAR(shift, value) = value >> shift
+    ----
+
+    Description
+    ----
+    Arithmetic shift right operation
+
+    Inputs
+    ----
+    - shift: number of bits to shift to the right
+    - value: integer to shift
+
+    Outputs
+    ----
+    - value >> shift: the shifted value
+
+    Fork
+    ----
+    Constantinople
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#1D](https://www.evm.codes/#1D)
+    """
+
+    SHA3 = Opcode(0x20, popped_stack_items=2, pushed_stack_items=1)
+    """
+    SHA3(start, length) = hash
+    ----
+
+    Description
+    ----
+    Compute Keccak-256 hash
+
+    Inputs
+    ----
+    - offset: byte offset in the memory
+    - size: byte size to read in the memory
+
+    Outputs
+    ----
+    - hash: Keccak-256 hash of the given data in memory
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    30
+
+    Source: [evm.codes/#20](https://www.evm.codes/#20)
+    """
+
+    ADDRESS = Opcode(0x30, pushed_stack_items=1)
+    """
+    ADDRESS() = address
+    ----
+
+    Description
+    ----
+    Get address of currently executing account
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - address: the 20-byte address of the current account
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    2
+
+    Source: [evm.codes/#30](https://www.evm.codes/#30)
+    """
+
+    BALANCE = Opcode(0x31, popped_stack_items=1, pushed_stack_items=1)
+    """
+    BALANCE(address) = balance
+    ----
+
+    Description
+    ----
+    Get the balance of the specified account
+
+    Inputs
+    ----
+    - address: 20-byte address of the account to check
+
+    Outputs
+    ----
+    - balance: balance of the given account in wei. Returns 0 if the account doesn't exist
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    100
+
+    Source: [evm.codes/#31](https://www.evm.codes/#31)
+    """
+
+    ORIGIN = Opcode(0x32, pushed_stack_items=1)
+    """
+    ORIGIN() = address
+    ----
+
+    Description
+    ----
+    Get execution origination address
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - address: the 20-byte address of the sender of the transaction. It can only be an account
+      without code
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    2
+
+    Source: [evm.codes/#32](https://www.evm.codes/#32)
+    """
+
+    CALLER = Opcode(0x33, pushed_stack_items=1)
+    """
+    CALLER() = address
+    ----
+
+    Description
+    ----
+    Get caller address
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - address: the 20-byte address of the caller account. This is the account that did the last
+      call (except delegate call)
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    2
+
+    Source: [evm.codes/#33](https://www.evm.codes/#33)
+    """
+
+    CALLVALUE = Opcode(0x34, pushed_stack_items=1)
+    """
+    CALLVALUE() = value
+    ----
+
+    Description
+    ----
+    Get deposited value by the instruction/transaction responsible for this execution
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - value: the value of the current call in wei
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    2
+
+    Source: [evm.codes/#34](https://www.evm.codes/#34)
+    """
+
+    CALLDATALOAD = Opcode(0x35, popped_stack_items=1, pushed_stack_items=1)
+    """
+    CALLDATALOAD(i) = data[i]
+    ----
+
+    Description
+    ----
+    Get input data of current environment
+
+    Inputs
+    ----
+    - i: byte offset in the calldata.
+
+    Outputs
+    ----
+    - data[i]: 32-byte value starting from the given offset of the calldata. All bytes after the
+      end of the calldata are set to 0
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#35](https://www.evm.codes/#35)
+    """
+
+    CALLDATASIZE = Opcode(0x36, pushed_stack_items=1)
+    """
+    CALLDATASIZE() = size
+    ----
+
+    Description
+    ----
+    Get size of input data in current environment
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - size: byte size of the calldata
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    2
+
+    Source: [evm.codes/#36](https://www.evm.codes/#36)
+    """
+
+    CALLDATACOPY = Opcode(0x37, popped_stack_items=3)
+    """
+    CALLDATACOPY(destOffset, offset, size)
+    ----
+
+    Description
+    ----
+    Copy input data in current environment to memory
+
+    Inputs
+    ----
+    - destOffset: byte offset in the memory where the result will be copied
+    - offset: byte offset in the calldata to copy
+    - size: byte size to copy
+
+    Outputs
+    ----
+    - None
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#37](https://www.evm.codes/#37)
+    """
+
+    CODESIZE = Opcode(0x38, pushed_stack_items=1)
+    """
+    CODESIZE() = size
+    ----
+
+    Description
+    ----
+    Get size of code running in current environment
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - size: byte size of the code
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    2
+
+    Source: [evm.codes/#38](https://www.evm.codes/#38)
+    """
+
+    CODECOPY = Opcode(0x39, popped_stack_items=3)
+    """
+    CODECOPY(destOffset, offset, size)
+    ----
+
+    Description
+    ----
+    Copy code running in current environment to memory
+
+    Inputs
+    ----
+    - destOffset: byte offset in the memory where the result will be copied.
+    - offset: byte offset in the code to copy.
+    - size: byte size to copy
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#39](https://www.evm.codes/#39)
+    """
+
+    GASPRICE = Opcode(0x3A, pushed_stack_items=1)
+    """
+    GASPRICE() = price
+    ----
+
+    Description
+    ----
+    Get price of gas in current environment
+
+    Outputs
+    ----
+    - price: gas price in wei per gas
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    2
+
+    Source: [evm.codes/#3A](https://www.evm.codes/#3A)
+    """
+
+    EXTCODESIZE = Opcode(0x3B, popped_stack_items=1, pushed_stack_items=1)
+    """
+    EXTCODESIZE(account) = size
+    ----
+
+    Description
+    ----
+    Get size of an account’s code
+
+    Inputs
+    ----
+    - address: 20-byte address of the contract to query
+
+    Outputs
+    ----
+    - size: byte size of the code
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    100
+
+    Source: [evm.codes/#3C](https://www.evm.codes/#3B)
+    """
+
+    EXTCODECOPY = Opcode(0x3C, popped_stack_items=4)
+    """
+    EXTCODESIZE(account)
+    ----
+
+    Description
+    ----
+    Copy an account’s code to memory
+
+    Inputs
+    ----
+    - address: 20-byte address of the contract to query
+    - destOffset: byte offset in the memory where the result will be copied
+    - offset: byte offset in the code to copy
+    - size: byte size to copy
+
+    Outputs
+    ----
+    - None
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    minimum_word_size = (size + 31) / 32 static_gas = 0 dynamic_gas = 3 * minimum_word_size +
+    memory_expansion_cost + address_access_cost
+
+    Source: [evm.codes/#3C](https://www.evm.codes/#3C)
+    """
+
+    RETURNDATASIZE = Opcode(0x3D, pushed_stack_items=1)
+    """
+    RETURNDATASIZE() = size
+    ----
+
+    Description
+    ----
+    Get size of output data from the previous call from the current environment
+
+    Outputs
+    ----
+    - size: byte size of the return data from the last executed sub context
+
+    Fork
+    ----
+    Byzantium
+
+    Gas
+    ----
+    2
+
+    Source: [evm.codes/#3D](https://www.evm.codes/#3D)
+    """
+
+    RETURNDATACOPY = Opcode(0x3E, popped_stack_items=3)
+    """
+    RETURNDATACOPY(destOffset, offset, size)
+    ----
+
+    Description
+    ----
+    Copy output data from the previous call to memory
+
+    Inputs
+    ----
+    - destOffset: byte offset in the memory where the result will be copied.
+    - offset: byte offset in the return data from the last executed sub context to copy.
+    - size: byte size to copy.
+
+    Fork
+    ----
+    Byzantium
+
+    Gas
+    ----
+    minimum_word_size = (size + 31) / 32
+
+    Gas = 3 + 3 * minimum_word_size + memory_expansion_cost
+
+    Source: [evm.codes/#3E](https://www.evm.codes/#3E)
+    """
+
+    EXTCODEHASH = Opcode(0x3F, popped_stack_items=1, pushed_stack_items=1)
+    """
+    EXTCODEHASH(address) = hash
+    ----
+
+    Description
+    ----
+    Get hash of an account’s code
+
+    Inputs
+    ----
+    - address: 20-byte address of the account
+
+    Outputs
+    ----
+    - hash: hash of the chosen account's code, the empty hash (0xc5d24601...) if the account has no
+      code, or 0 if the account does not exist or has been destroyed
+
+    Fork
+    ----
+    Constantinople
+
+    Gas
+    ----
+    100
+
+    Source: [evm.codes/#3F](https://www.evm.codes/#3F)
+    """
+
+    BLOCKHASH = Opcode(0x40, popped_stack_items=1, pushed_stack_items=1)
+    """
+    BLOCKHASH(block_number) = hash
+    ----
+
+    Description
+    ----
+    Get the hash of one of the 256 most recent complete blocks
+
+    Inputs
+    ----
+    - blockNumber: block number to get the hash from. Valid range is the last 256 blocks (not
+      including the current one). Current block number can be queried with NUMBER
+
+    Outputs
+    ----
+    - hash: hash of the chosen block, or 0 if the block number is not in the valid range
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    20
+
+    Source: [evm.codes/#40](https://www.evm.codes/#40)
+    """
+
+    COINBASE = Opcode(0x41, pushed_stack_items=1)
+    """
+    COINBASE() = address
+    ----
+
+    Description
+    ----
+    Get the block’s beneficiary address
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - address: miner's 20-byte address
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    2
+
+    Source: [evm.codes/#41](https://www.evm.codes/#41)
+    """
+
+    TIMESTAMP = Opcode(0x42, pushed_stack_items=1)
+    """
+    TIMESTAMP() = timestamp
+    ----
+
+    Description
+    ----
+    Get the block’s timestamp
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - timestamp: unix timestamp of the current block
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    2
+
+    Source: [evm.codes/#42](https://www.evm.codes/#42)
+    """
+
+    NUMBER = Opcode(0x43, pushed_stack_items=1)
+    """
+    NUMBER() = blockNumber
+    ----
+
+    Description
+    ----
+    Get the block’s number
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - blockNumber: current block number
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    2
+
+    Source: [evm.codes/#43](https://www.evm.codes/#43)
+    """
+
+    PREVRANDAO = Opcode(0x44, pushed_stack_items=1)
+    """
+    NUMBER() = prevRandao
+    ----
+
+    Description
+    ----
+    Get the previous block’s RANDAO mix
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - prevRandao: previous block's RANDAO mix
+
+    Fork
+    ----
+    Merge
+
+    Gas
+    ----
+    20
+
+    Source: [evm.codes/#44](https://www.evm.codes/#44)
+    """
+
+    GASLIMIT = Opcode(0x45, pushed_stack_items=1)
+    """
+    GASLIMIT() = gasLimit
+    ----
+
+    Description
+    ----
+    Get the block’s gas limit
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - gasLimit: gas limit
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    2
+
+    Source: [evm.codes/#45](https://www.evm.codes/#45)
+    """
+
+    CHAINID = Opcode(0x46, pushed_stack_items=1)
+    """
+    CHAINID() = chainId
+    ----
+
+    Description
+    ----
+    Get the chain ID
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - chainId: chain id of the network
+
+    Fork
+    ----
+    Istanbul
+
+    Gas
+    ----
+    2
+
+    Source: [evm.codes/#46](https://www.evm.codes/#46)
+    """
+
+    SELFBALANCE = Opcode(0x47, pushed_stack_items=1)
+    """
+    SELFBALANCE() = balance
+    ----
+
+    Description
+    ----
+    Get balance of currently executing account
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - balance: balance of the current account in wei
+
+    Fork
+    ----
+    Istanbul
+
+    Gas
+    ----
+    5
+
+    Source: [evm.codes/#47](https://www.evm.codes/#47)
+    """
+    BASEFEE = Opcode(0x48, pushed_stack_items=1)
+    """
+    BASEFEE() = baseFee
+    ----
+
+    Description
+    ----
+    Get the base fee
+
+    Outputs
+    ----
+    - baseFee: base fee in wei
+
+    Fork
+    ----
+    London
+
+    Gas
+    ----
+    2
+
+    Source: [evm.codes/#48](https://www.evm.codes/#48)
+    """
+
+    BLOBHASH = Opcode(0x49, popped_stack_items=1, pushed_stack_items=1)
+    """
+    BLOBHASH(data) = h
+    ----
+
+    Description
+    ----
+    Returns hashes of blobs in the transaction
+
+    Inputs
+    ----
+    - data: data to hash
+
+    Outputs
+    ----
+    - h: keccak256 hash of the data
+
+    Fork
+    ----
+    Dencun
+
+    Gas
+    ----
+    HASH_OPCODE_GAS
+
+    Source: [eips.ethereum.org/EIPS/eip-4844](https://eips.ethereum.org/EIPS/eip-4844)
+    """
+
+    BLOBBASEFEE = Opcode(0x4A, popped_stack_items=0, pushed_stack_items=1)
+    """
+    BLOBBASEFEE() = fee
+    ----
+
+    Description
+    ----
+    Returns the value of the blob base-fee of the current block it is executing in
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - fee: base fee per gas
+
+    Fork
+    ----
+    Dencun
+
+    Gas
+    ----
+    2
+
+    Source: [eips.ethereum.org/EIPS/eip-7516(https://eips.ethereum.org/EIPS/eip-7516)
+    """
+
+    POP = Opcode(0x50, popped_stack_items=1)
+    """
+    POP(y)
+    ----
+
+    Description
+    ----
+    Remove item from stack
+
+    Inputs
+    ----
+    - y: a stack item
+
+    Outputs
+    ----
+    - None
+
+    Inputs
+    ----
+    - None
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    2
+
+    Source: [evm.codes/#50](https://www.evm.codes/#50)
+    """
+
+    MLOAD = Opcode(0x51, popped_stack_items=1, pushed_stack_items=1)
+    """
+    MLOAD(offset) = value
+    ----
+
+    Description
+    ----
+    Load word from memory
+
+    Inputs
+    ----
+    - offset: offset in the memory in bytes
+
+    Outputs
+    ----
+    - value: the 32 bytes in memory starting at that offset. If it goes beyond its current size
+      (see MSIZE), writes 0s
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3 + memory_expansion_cost
+
+    Source: [evm.codes/#51](https://www.evm.codes/#51)
+    """
+
+    MSTORE = Opcode(0x52, popped_stack_items=2)
+    """
+    MSTORE(offset, value)
+    ----
+
+    Description
+    ----
+    Save word to memory
+
+    Inputs
+    ----
+    - offset: offset in the memory in bytes.
+    - value: 32-byte value to write in the memory.
+
+    Outputs
+    ----
+    - None
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3 + memory_expansion_cost
+
+    Source: [evm.codes/#52](https://www.evm.codes/#52)
+    """
+
+    MSTORE8 = Opcode(0x53, popped_stack_items=2)
+    """
+    MSTORE8(offset, value)
+    ----
+
+    Description
+    ----
+    Save byte to memory
+
+    Inputs
+    ----
+    - offset: offset in the memory in bytes
+    - value: 1-byte value to write in the memory (the least significant byte of the 32-byte stack
+      value
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3 + memory_expansion_cost
+
+    Source: [evm.codes/#53](https://www.evm.codes/#53)
+    """
+
+    SLOAD = Opcode(0x54, popped_stack_items=1, pushed_stack_items=1)
+    """
+    SLOAD(key) = value
+    ----
+
+    Description
+    ----
+    Load word from storage
+
+    Inputs
+    ----
+    - key: 32-byte key in storage
+
+    Outputs
+    ----
+    - value: 32-byte value corresponding to that key. 0 if that key was never written before
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    100
+
+    Source: [evm.codes/#54](https://www.evm.codes/#54)
+    """
+
+    SSTORE = Opcode(0x55, popped_stack_items=2)
+    """
+    SSTORE(key, value)
+    ----
+
+    Description
+    ----
+    Save word to storage
+
+    Inputs
+    ----
+    - key: 32-byte key in storage
+    - value: 32-byte value to store
+
+    Outputs
+    ----
+    - None
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    100
+
+    Source: [evm.codes/#55](https://www.evm.codes/#55)
+    """
+
+    JUMP = Opcode(0x56, popped_stack_items=1)
+    """
+    JUMP(counter)
+    ----
+
+    Description
+    ----
+    Alter the program counter
+
+    Inputs
+    ----
+    - counter: byte offset in the deployed code where execution will continue from. Must be a
+      JUMPDEST instruction.
+
+    Outputs
+    ----
+    - None
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    8
+
+    Source: [evm.codes/#56](https://www.evm.codes/#56)
+    """
+
+    JUMPI = Opcode(0x57, popped_stack_items=2)
+    """
+    JUMPI(counter, b)
+    ----
+
+    Description
+    ----
+    Conditionally alter the program counter
+
+    Inputs
+    ----
+    - counter: byte offset in the deployed code where execution will continue from. Must be a
+      JUMPDEST instruction.
+    - b: the program counter will be altered with the new value only if this value is different
+      from 0. Otherwise, the program counter is simply incremented and the next instruction will be
+      executed.
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    10
+
+    Source: [evm.codes/#57](https://www.evm.codes/#57)
+    """
+
+    PC = Opcode(0x58, pushed_stack_items=1)
+    """
+    PC() = counter
+    ----
+
+    Description
+    ----
+    Get the value of the program counter prior to the increment corresponding to this instruction
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - counter: PC of this instruction in the current program.
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    2
+
+    Source: [evm.codes/#58](https://www.evm.codes/#58)
+    """
+
+    MSIZE = Opcode(0x59, pushed_stack_items=1)
+    """
+    MSIZE() = size
+    ----
+
+    Description
+    ----
+    Get the size of active memory in bytes
+
+    Outputs
+    ----
+    - size: current memory size in bytes (higher offset accessed until now + 1)
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    2
+
+    Source: [evm.codes/#59](https://www.evm.codes/#59)
+    """
+
+    GAS = Opcode(0x5A, pushed_stack_items=1)
+    """
+    GAS() = gas_remaining
+    ----
+
+    Description
+    ----
+    Get the amount of available gas, including the corresponding reduction for the cost of this
+    instruction
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - Source: [evm.codes/#5A](https://www.evm.codes/#5A)
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    2
+
+    Source: [evm.codes/#5A](https://www.evm.codes/#5A)
+    """
+
+    JUMPDEST = Opcode(0x5B)
+    """
+    JUMPDEST()
+    ----
+
+    Description
+    ----
+    Mark a valid destination for jumps
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - None
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    1
+
+    Source: [evm.codes/#5B](https://www.evm.codes/#5B)
+    """
+
+    TLOAD = Opcode(0x5C, popped_stack_items=1, pushed_stack_items=1)
+    """
+    TLOAD(key) = value
+    ----
+
+    Description
+    ----
+    Load a value from the storage at the specified key.
+
+    Inputs
+    ----
+    - key: The key in storage.
+
+    Outputs
+    ----
+    - value: The value associated with the given key.
+
+    Fork
+    ----
+
+
+    Gas
+    ----
+    100
+
+    Source: [eips.ethereum.org/EIPS/eip-1153](https://eips.ethereum.org/EIPS/eip-1153)
+    """
+
+    TSTORE = Opcode(0x5D, popped_stack_items=2)
+    """
+    TSTORE(key, value)
+    ----
+
+    Description
+    ----
+    Store a value in the storage at the specified key.
+
+    Inputs
+    ----
+    - key: The key in storage.
+    - value: The value to be stored.
+
+    Fork
+    ----
+
+
+    Gas
+    ----
+    100
+
+    Source: [eips.ethereum.org/EIPS/eip-1153](https://eips.ethereum.org/EIPS/eip-1153)
+    """
+
+    MCOPY = Opcode(0x5E, popped_stack_items=3)
+    """
+    MCOPY(dst, src ,length)
+    ----
+
+    Description
+    ----
+    Copies memory
+
+    Inputs
+    ----
+    - dst: byte offset in the memory where the result will be copied.
+    - src: byte offset in the calldata to copy.
+    - length: byte size to copy
+
+    Outputs
+    ----
+    - None
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    words_copied = (length + 31) // 32 g_verylow    = 3 g_copy       = 3 * words_copied +
+    memory_expansion_cost gas_cost     = g_verylow + g_copy
+
+    Source: [eips.ethereum.org/EIPS/eip-5656](https://eips.ethereum.org/EIPS/eip-5656)
+    """
+
+    RETF = Opcode(0x49)
+    """
+    RETF()
+    ----
+
+    Description
+    ----
+    Return from a function
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - None
+
+    Fork
+    ----
+
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#5F](https://www.evm.codes/#5F)
+    """
+
+    PUSH0 = Opcode(0x5F, pushed_stack_items=1)
+    """
+    PUSH0() = value
+    ----
+
+    Description
+    ----
+    Place value 0 on stack
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - value: pushed value, equal to 0
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    2
+
+    Source: [evm.codes/#5F](https://www.evm.codes/#5F)
+    """
+
+    PUSH1 = Opcode(0x60, pushed_stack_items=1, data_portion_length=1)
+    """
+    PUSH1() = value
+    ----
+
+    Description
+    ----
+    Place 1 byte item on stack
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#60](https://www.evm.codes/#60)
+    """
+
+    PUSH2 = Opcode(0x61, pushed_stack_items=1, data_portion_length=2)
+    """
+    PUSH2() = value
+    ----
+
+    Description
+    ----
+    Place 2 byte item on stack
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#61](https://www.evm.codes/#61)
+    """
+
+    PUSH3 = Opcode(0x62, pushed_stack_items=1, data_portion_length=3)
+    """
+    PUSH3() = value
+    ----
+
+    Description
+    ----
+    Place 3 byte item on stack
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#62](https://www.evm.codes/#62)
+    """
+
+    PUSH4 = Opcode(0x63, pushed_stack_items=1, data_portion_length=4)
+    """
+    PUSH4() = value
+    ----
+
+    Description
+    ----
+    Place 4 byte item on stack
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#63](https://www.evm.codes/#63)
+    """
+
+    PUSH5 = Opcode(0x64, pushed_stack_items=1, data_portion_length=5)
+    """
+    PUSH5() = value
+    ----
+
+    Description
+    ----
+    Place 5 byte item on stack
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#64](https://www.evm.codes/#64)
+    """
+
+    PUSH6 = Opcode(0x65, pushed_stack_items=1, data_portion_length=6)
+    """
+    PUSH6() = value
+    ----
+
+    Description
+    ----
+    Place 6 byte item on stack
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#65](https://www.evm.codes/#65)
+    """
+
+    PUSH7 = Opcode(0x66, pushed_stack_items=1, data_portion_length=7)
+    """
+    PUSH7() = value
+    ----
+
+    Description
+    ----
+    Place 7 byte item on stack
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#66](https://www.evm.codes/#66)
+    """
+
+    PUSH8 = Opcode(0x67, pushed_stack_items=1, data_portion_length=8)
+    """
+    PUSH8() = value
+    ----
+
+    Description
+    ----
+    Place 8 byte item on stack
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#67](https://www.evm.codes/#67)
+    """
+
+    PUSH9 = Opcode(0x68, pushed_stack_items=1, data_portion_length=9)
+    """
+    PUSH9() = value
+    ----
+
+    Description
+    ----
+    Place 9 byte item on stack
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#68](https://www.evm.codes/#68)
+    """
+
+    PUSH10 = Opcode(0x69, pushed_stack_items=1, data_portion_length=10)
+    """
+    PUSH10() = value
+    ----
+
+    Description
+    ----
+    Place 10 byte item on stack
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#69](https://www.evm.codes/#69)
+    """
+
+    PUSH11 = Opcode(0x6A, pushed_stack_items=1, data_portion_length=11)
+    """
+    PUSH11() = value
+    ----
+
+    Description
+    ----
+    Place 11 byte item on stack
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#6A](https://www.evm.codes/#6A)
+    """
+
+    PUSH12 = Opcode(0x6B, pushed_stack_items=1, data_portion_length=12)
+    """
+    PUSH12() = value
+    ----
+
+    Description
+    ----
+    Place 12 byte item on stack
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#6B](https://www.evm.codes/#6B)
+    """
+
+    PUSH13 = Opcode(0x6C, pushed_stack_items=1, data_portion_length=13)
+    """
+    PUSH13() = value
+    ----
+
+    Description
+    ----
+    Place 13 byte item on stack
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#6C](https://www.evm.codes/#6C)
+    """
+
+    PUSH14 = Opcode(0x6D, pushed_stack_items=1, data_portion_length=14)
+    """
+    PUSH14() = value
+    ----
+
+    Description
+    ----
+    Place 14 byte item on stack
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+    Fork
+    ----
+    Frontier
+
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#6D](https://www.evm.codes/#6D)
+    """
+
+    PUSH15 = Opcode(0x6E, pushed_stack_items=1, data_portion_length=15)
+    """
+    PUSH15() = value
+    ----
+
+    Description
+    ----
+    Place 15 byte item on stack
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#6E](https://www.evm.codes/#6E)
+    """
+
+    PUSH16 = Opcode(0x6F, pushed_stack_items=1, data_portion_length=16)
+    """
+    PUSH16() = value
+    ----
+
+    Description
+    ----
+    Place 16 byte item on stack
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#6F](https://www.evm.codes/#6F)
+    """
+
+    PUSH17 = Opcode(0x70, pushed_stack_items=1, data_portion_length=17)
+    """
+    PUSH17() = value
+    ----
+
+    Description
+    ----
+    Place 17 byte item on stack
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#70](https://www.evm.codes/#70)
+    """
+
+    PUSH18 = Opcode(0x71, pushed_stack_items=1, data_portion_length=18)
+    """
+    PUSH18() = value
+    ----
+
+    Description
+    ----
+    Place 18 byte item on stack
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#71](https://www.evm.codes/#71)
+    """
+
+    PUSH19 = Opcode(0x72, pushed_stack_items=1, data_portion_length=19)
+    """
+    PUSH19() = value
+    ----
+
+    Description
+    ----
+    Place 19 byte item on stack
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#72](https://www.evm.codes/#72)
+    """
+
+    PUSH20 = Opcode(0x73, pushed_stack_items=1, data_portion_length=20)
+    """
+    PUSH20() = value
+    ----
+
+    Description
+    ----
+    Place 20 byte item on stack
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#73](https://www.evm.codes/#73)
+    """
+
+    PUSH21 = Opcode(0x74, pushed_stack_items=1, data_portion_length=21)
+    """
+    PUSH21() = value
+    ----
+
+    Description
+    ----
+    Place 21 byte item on stack
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#74](https://www.evm.codes/#74)
+    """
+
+    PUSH22 = Opcode(0x75, pushed_stack_items=1, data_portion_length=22)
+    """
+    PUSH22() = value
+    ----
+
+    Description
+    ----
+    Place 22 byte item on stack
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#75](https://www.evm.codes/#75)
+    """
+
+    PUSH23 = Opcode(0x76, pushed_stack_items=1, data_portion_length=23)
+    """
+    PUSH23() = value
+    ----
+
+    Description
+    ----
+    Place 23 byte item on stack
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#76](https://www.evm.codes/#76)
+    """
+
+    PUSH24 = Opcode(0x77, pushed_stack_items=1, data_portion_length=24)
+    """
+    PUSH24() = value
+    ----
+
+    Description
+    ----
+    Place 24 byte item on stack
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#77](https://www.evm.codes/#77)
+    """
+
+    PUSH25 = Opcode(0x78, pushed_stack_items=1, data_portion_length=25)
+    """
+    PUSH25() = value
+    ----
+
+    Description
+    ----
+    Place 25 byte item on stack
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#78](https://www.evm.codes/#78)
+    """
+
+    PUSH26 = Opcode(0x79, pushed_stack_items=1, data_portion_length=26)
+    """
+    PUSH26() = value
+    ----
+
+    Description
+    ----
+    Place 26 byte item on stack
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#79](https://www.evm.codes/#79)
+    """
+
+    PUSH27 = Opcode(0x7A, pushed_stack_items=1, data_portion_length=27)
+    """
+    PUSH27() = value
+    ----
+
+    Description
+    ----
+    Place 27 byte item on stack
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#7A](https://www.evm.codes/#7A)
+    """
+
+    PUSH28 = Opcode(0x7B, pushed_stack_items=1, data_portion_length=28)
+    """
+    PUSH28() = value
+    ----
+
+    Description
+    ----
+    Place 28 byte item on stack
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#7B](https://www.evm.codes/#7B)
+    """
+
+    PUSH29 = Opcode(0x7C, pushed_stack_items=1, data_portion_length=29)
+    """
+    PUSH29() = value
+    ----
+
+    Description
+    ----
+    Place 29 byte item on stack
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#7C](https://www.evm.codes/#7C)
+    """
+
+    PUSH30 = Opcode(0x7D, pushed_stack_items=1, data_portion_length=30)
+    """
+    PUSH30() = value
+    ----
+
+    Description
+    ----
+    Place 30 byte item on stack
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - value: pushed value, aligned to the right (put in the lowest significant bytes)
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#7D](https://www.evm.codes/#7D)
+    """
+
+    PUSH31 = Opcode(0x7E, pushed_stack_items=1, data_portion_length=31)
+    """
+    PUSH31() = value
+    ----
+
+    Description
+    ----
+    Place 31 byte item on stack
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - value: pushed value.
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#7E](https://www.evm.codes/#7E)
+    """
+
+    PUSH32 = Opcode(0x7F, pushed_stack_items=1, data_portion_length=32)
+    """
+    PUSH32() = value
+    ----
+
+    Description
+    ----
+    Place 32 byte item on stack
+
+    Inputs
+    ----
+    - None
+
+    Outputs
+    ----
+    - value: pushed value.
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#7F](https://www.evm.codes/#7F)
+    """
+
+    DUP1 = Opcode(0x80, pushed_stack_items=1, min_stack_height=1)
+    """
+    DUP1(value) = value
+    ----
+
+    Description
+    ----
+    Duplicate 1st stack item
+
+    Inputs
+    ----
+    - value: value to duplicate
+
+    Outputs
+    ----
+    - value: duplicated value.
+    - value: original value
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#80](https://www.evm.codes/#80)
+    """
+
+    DUP2 = Opcode(0x81, pushed_stack_items=1, min_stack_height=2)
+    """
+    DUP2(a, b) = b,a,b
+    ----
+
+    Description
+    ----
+    Duplicate 2nd stack item
+
+    Inputs
+    ----
+    - a: ignored value.
+    - b: value to duplicate.
+
+    Outputs
+    ----
+    - b: duplicated value.
+    - a: ignored value.
+    - b: original value.
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#81](https://www.evm.codes/#81)
+    """
+
+    DUP3 = Opcode(0x82, pushed_stack_items=1, min_stack_height=3)
+    """
+    DUP15(a, b, c) = c, a, b, c
+    ----
+
+    Description
+    ----
+    Duplicate 3rd stack item
+
+    Inputs
+    ----
+    - a: ignored value.
+    - b: ignored value.
+    - c: value to duplicate.
+
+    Outputs
+    ----
+    - c: duplicated value.
+    - a: ignored value.
+    - b: ignored value.
+    - c: original value.
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#82](https://www.evm.codes/#82)
+    """
+
+    DUP4 = Opcode(0x83, pushed_stack_items=1, min_stack_height=4)
+    """
+    DUP15(value1, value2, value3, value) = value, value2, value3, value
+    ----
+
+    Description
+    ----
+    Duplicate 4th stack item
+
+    Inputs
+    ----
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - value: value to duplicate
+
+    Outputs
+    ----
+    - value: duplicated value
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - value: value to duplicate
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#83](https://www.evm.codes/#83)
+    """
+
+    DUP5 = Opcode(0x84, pushed_stack_items=1, min_stack_height=5)
+    """
+    DUP15(value1, value2, value3, value4, value) = value, value2, value3, value4, value
+    ----
+
+    Description
+    ----
+    Duplicate 5th stack item
+
+    Inputs
+    ----
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - value: value to duplicate
+
+    Outputs
+    ----
+    - value: duplicated value
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - value: value to duplicate
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#84](https://www.evm.codes/#84)
+    """
+
+    DUP6 = Opcode(0x85, pushed_stack_items=1, min_stack_height=6)
+    """
+    DUP15(value1, value2, value3, value4, value5, value) = value, value2, value3, value4, value5,
+    value
+    ----
+
+    Description
+    ----
+    Duplicate 6th stack item
+
+    Inputs
+    ----
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - value: value to duplicate
+
+    Outputs
+    ----
+    - value: duplicated value
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - value: value to duplicate
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#85](https://www.evm.codes/#85)
+    """
+
+    DUP7 = Opcode(0x86, pushed_stack_items=1, min_stack_height=7)
+    """
+    DUP15(value1, value2, value3, value4, value5, value6, value) = value, value2, value3, value4,
+    value5, value6, value
+    ----
+
+    Description
+    ----
+    Duplicate 7th stack item
+
+    Inputs
+    ----
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - value: value to duplicate
+
+    Outputs
+    ----
+    - value: duplicated value
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - value: value to duplicate
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#86](https://www.evm.codes/#86)
+    """
+
+    DUP8 = Opcode(0x87, pushed_stack_items=1, min_stack_height=8)
+    """
+    DUP15(value1, value2, value3, value4, value5, value6, value7, value) = value, value2, value3,
+    value4, value5, value6, value7, value
+    ----
+
+    Description
+    ----
+    Duplicate 8th stack item
+
+    Inputs
+    ----
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - value: value to duplicate
+
+    Outputs
+    ----
+    - value: duplicated value
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - value: value to duplicate
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#87](https://www.evm.codes/#87)
+    """
+
+    DUP9 = Opcode(0x88, pushed_stack_items=1, min_stack_height=9)
+    """
+    DUP15(value1, value2, value3, value4, value5, value6, value7, value8, value) = value, value2,
+    value3, value4, value5, value6, value7, value8, value
+    ----
+
+    Description
+    ----
+    Duplicate 9th stack item
+
+    Inputs
+    ----
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - value: value to duplicate
+
+    Outputs
+    ----
+    - value: duplicated value
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - value: value to duplicate
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#88](https://www.evm.codes/#88)
+    """
+    DUP10 = Opcode(0x89, pushed_stack_items=1, min_stack_height=10)
+    """
+    DUP10(value1, value2, value3, value4, value5, value6, value7, value8, value9, value) = value,
+    value2, value3, value4, value5, value6, value7, value8, value9, value
+    ----
+
+    Description
+    ----
+    Duplicate 10th stack item
+
+    Inputs
+    ----
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - value: value to duplicate
+
+    Outputs
+    ----
+    - value: duplicated value
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - value: value to duplicate
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#89](https://www.evm.codes/#89)
+    """
+
+    DUP11 = Opcode(0x8A, pushed_stack_items=1, min_stack_height=11)
+    """
+    DUP11(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value) =
+    value, value2, value3, value4, value5, value6, value7, value8, value9, value10, value
+    ----
+
+    Description
+    ----
+    Duplicate 11th stack item
+
+    Inputs
+    ----
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - value: value to duplicate
+
+    Outputs
+    ----
+    - value: duplicated value
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - value: value to duplicate
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#8A](https://www.evm.codes/#8A)
+    """
+
+    DUP12 = Opcode(0x8B, pushed_stack_items=1, min_stack_height=12)
+    """
+    DUP12(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11,
+    value) = value, value2, value3, value4, value5, value6, value7, value8, value9, value10,
+    value11, value
+    ----
+
+    Description
+    ----
+    Duplicate 12th stack item
+
+    Inputs
+    ----
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - value: value to duplicate
+
+    Outputs
+    ----
+    - value: duplicated value
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - value: value to duplicate
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#8B](https://www.evm.codes/#8B)
+    """
+
+    DUP13 = Opcode(0x8C, pushed_stack_items=1, min_stack_height=13)
+    """
+    DUP15(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11,
+    value12, value) = value, value2, value3, value4, value5, value6, value7, value8, value9,
+    value10,value11, value12, value
+    ----
+
+    Description
+    ----
+    Duplicate 13th stack item
+
+    Inputs
+    ----
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - value: value to duplicate
+
+    Outputs
+    ----
+    - value: duplicated value
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - value: value to duplicate
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#8C](https://www.evm.codes/#8C)
+    """
+
+    DUP14 = Opcode(0x8D, pushed_stack_items=1, min_stack_height=14)
+    """
+    DUP15(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11,
+    value12, value13, value) = value, value2, value3, value4, value5, value6, value7, value8,
+    value9, value10, value11, value12, value13, value
+    ----
+
+    Description
+    ----
+    Duplicate 14th stack item
+
+    Inputs
+    ----
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - value: value to duplicate
+
+    Outputs
+    ----
+    - value: duplicated value
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - value: value to duplicate
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#8D](https://www.evm.codes/#8D)
+    """
+
+    DUP15 = Opcode(0x8E, pushed_stack_items=1, min_stack_height=15)
+    """
+    DUP15(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11,
+    value12, value13, value14, value) = value, value2, value3, value4, value5, value6, value7,
+    value8, value9, value10, value11, value12, value13, value14, value
+    ----
+
+    Description
+    ----
+    Duplicate 15th stack item
+
+    Inputs
+    ----
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - value: value to duplicate
+
+    Outputs
+    ----
+    - value: duplicated value
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - value: value to duplicate
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#8E](https://www.evm.codes/#8E)
+    """
+
+    DUP16 = Opcode(0x8F, pushed_stack_items=1, min_stack_height=16)
+    """
+    DUP16(value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11,
+    value12, value13, value14, value15, value) = value, value2, value3, value4, value5, value6,
+    value7, value8, value9, value10, value11, value12, value13, value14, value15, value
+    ----
+
+    Description
+    ----
+    Duplicate 16th stack item
+
+    Inputs
+    ----
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - value: value to duplicate
+
+    Outputs
+    ----
+    - value: duplicated value
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - value: value to duplicate
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#8F](https://www.evm.codes/#8F)
+    """
+
+    SWAP1 = Opcode(0x90, min_stack_height=2)
+    """
+    SWAP1(a, b) = b, a
+    ----
+
+    Description
+    ----
+    Exchange the top stack item with the second stack item.
+
+    Inputs
+    ----
+    - a: value to swap
+    - b: value to swap
+
+    Outputs
+    ----
+    - b: swapped value.
+    - a: swapped value.
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#90](https://www.evm.codes/#90)
+    """
+
+    SWAP2 = Opcode(0x91, min_stack_height=3)
+    """
+    SWAP2(a, value2, b) = b, value2, a
+    ----
+
+    Description
+    ----
+    Exchange 1st and 3rd stack items
+
+    Inputs
+    ----
+    - a: value to swap
+    - ignored value.
+    - b: value to swap
+
+    Outputs
+    ----
+    - b: swapped value
+    - ignored value
+    - a: swapped value
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#91](https://www.evm.codes/#91)
+    """
+
+    SWAP3 = Opcode(0x92, min_stack_height=4)
+    """
+    SWAP3(a, value2, value3, b) = b value2, value3, a
+    ----
+
+    Description
+    ----
+    Exchange 1st and 4th stack items
+
+    Inputs
+    ----
+    - a: value to swap
+    - ignored value.
+    - ignored value.
+    - b: value to swap
+
+    Outputs
+    ----
+    - b: swapped value.
+    - ignored value.
+    - ignored value.
+    - a: swapped value.
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#92](https://www.evm.codes/#92)
+    """
+
+    SWAP4 = Opcode(0x93, min_stack_height=5)
+    """
+    SWAP4(a, value2, value3, value4, b) = b value2, value3, value4, a
+    ----
+
+    Description
+    ----
+    Exchange 1st and 5th stack items
+
+    Inputs
+    ----
+    - a: value to swap
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - b: value to swap
+
+    Outputs
+    ----
+    - b: swapped value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - a: swapped value.
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#93](https://www.evm.codes/#93)
+    """
+
+    SWAP5 = Opcode(0x94, min_stack_height=6)
+    """
+    SWAP5(a, value2, value3, value4, value5, b) = b, value2, value3, value4, value5, a
+    ----
+
+    Description
+    ----
+    Exchange 1st and 6th stack items
+
+    Inputs
+    ----
+    - a: value to swap
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - b: value to swap
+
+    Outputs
+    ----
+    - b: swapped value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - a: swapped value.
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#94](https://www.evm.codes/#94)
+    """
+
+    SWAP6 = Opcode(0x95, min_stack_height=7)
+    """
+    SWAP6(a, value2, value3, value4, value5, value6, b) = b, value2, value3, value4, value5,
+    value6, a
+    ----
+
+    Description
+    ----
+    Exchange 1st and 7th stack items
+
+    Inputs
+    ----
+    - a: value to swap
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - b: value to swap
+
+    Outputs
+    ----
+    - b: swapped value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - a: swapped value.
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#95](https://www.evm.codes/#95)
+    """
+
+    SWAP7 = Opcode(0x96, min_stack_height=8)
+    """
+    SWAP7(a, value2, value3, value4, value5, value6, value7, b) = b, value2, value3, value4,
+    value5, value6, value7, a
+    ----
+
+    Description
+    ----
+    Exchange 1st and 8th stack items
+
+    Inputs
+    ----
+    - a: value to swap
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - b: value to swap
+
+    Outputs
+    ----
+    - b: swapped value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - a: swapped value.
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#96](https://www.evm.codes/#96)
+    """
+
+    SWAP8 = Opcode(0x97, min_stack_height=9)
+    """
+    SWAP8(a, value2, value3, value4, value5, value6, value7, value8, b) = b, value2, value3,
+    value4,value5, value6, value7, value8, a
+    ----
+
+    Description
+    ----
+    Exchange 1st and 9th stack items
+
+    Inputs
+    ----
+    - a: value to swap
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - b: value to swap
+
+    Outputs
+    ----
+    - b: swapped value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - a: swapped value.
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#97](https://www.evm.codes/#97)
+    """
+
+    SWAP9 = Opcode(0x98, min_stack_height=10)
+    """
+    SWAP9(a, value2, value3, value4, value5, value6, value7, value8, value9, b) = b, value2,
+    value3,value4, value5, value6, value7, value8, value9, a
+    ----
+
+    Description
+    ----
+    Exchange 1st and 10th stack items
+
+    Inputs
+    ----
+    - a: value to swap
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - b: value to swap
+
+    Outputs
+    ----
+    - b: swapped value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - a: swapped value.
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#98](https://www.evm.codes/#98)
+    """
+
+    SWAP10 = Opcode(0x99, min_stack_height=11)
+    """
+    SWAP10(a, value2, value3, value4, value5, value6, value7, value8, value9, value10, b) =
+    b, value2, value3, value4, value5, value6, value7, value8, value9, value10, a
+    ----
+
+    Description
+    ----
+    Exchange 1st and 11th stack items
+
+    Inputs
+    ----
+    - a: value to swap
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - b: value to swap
+
+    Outputs
+    ----
+    - b: swapped value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - a: swapped value.
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#99](https://www.evm.codes/#99)
+    """
+
+    SWAP11 = Opcode(0x9A, min_stack_height=12)
+    """
+    SWAP11(a, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, b)
+    = b, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, a
+    ----
+
+    Description
+    ----
+    Exchange 1st and 12th stack items
+
+    Inputs
+    ----
+    - a: value to swap
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - b: value to swap
+
+    Outputs
+    ----
+    - b: swapped value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - a: swapped value.
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#9A](https://www.evm.codes/#9A)
+    """
+
+    SWAP12 = Opcode(0x9B, min_stack_height=13)
+    """
+    SWAP12(a, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11,
+    value12, b) = b, value2, value3, value4, value5, value6, value7, value8, value9, value10,
+    value11, value12, a
+    ----
+
+    Description
+    ----
+    Exchange 1st and 13th stack items
+
+    Inputs
+    ----
+    - a: value to swap
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - b: value to swap
+
+    Outputs
+    ----
+    - b: swapped value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - a: swapped value.
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#9B](https://www.evm.codes/#9B)
+    """
+
+    SWAP13 = Opcode(0x9C, min_stack_height=14)
+    """
+    SWAP13(a, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10,
+    value11, value12, b) = b, value1, value2, value3, value4, value5, value6, value7, value8,
+    value9, value10, value11, value12,a)
+    ----
+
+    Description
+    ----
+    Exchange 1st and 14th stack items
+
+    Inputs
+    ----
+    - a: value to swap.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - b: value to swap.
+
+    Outputs
+    ----
+    - b: swapped value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - a: swapped value.
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#9C](https://www.evm.codes/#9C)
+    """
+
+    SWAP14 = Opcode(0x9D, min_stack_height=15)
+    """
+    SWAP14(a, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10,
+    value11, value12, value13, b) = b, value1, value2, value3, value4, value5, value6, value7,
+    value8, value9, value10, value11, value12, value13, a)
+    ----
+
+    Description
+    ----
+    Exchange 1st and 15th stack items
+
+    Inputs
+    ----
+    - a: value to swap.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - b: value to swap.
+
+    Outputs
+    ----
+    - b: swapped value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - a: swapped value.
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#9D](https://www.evm.codes/#9D)
+    """
+
+    SWAP15 = Opcode(0x9E, min_stack_height=16)
+    """
+    SWAP15(a, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10,
+    value11, value12, value13, value14, b) = b, value1, value2, value3, value4, value5, value6,
+    value7, value8, value9, value10, value11, value12, value13, value14, a)
+    ----
+
+    Description
+    ----
+    Exchange 1st and 16th stack items
+
+    Inputs
+    ----
+    - a: value to swap.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - b: value to swap.
+
+    Outputs
+    ----
+    - b: swapped value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - a: swapped value.
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#9E](https://www.evm.codes/#9E)
+    """
+
+    SWAP16 = Opcode(0x9F, min_stack_height=17)
+    """
+    SWAP16(a, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10,
+    value11, value12, value13, value14, value15, b) = b, value1, value2, value3, value4, value5,
+    value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, a)
+    ----
+
+    Description
+    ----
+    Exchange 1st and 17th stack items
+
+    Inputs
+    ----
+    - a: value to swap.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - b: value to swap.
+
+    Outputs
+    ----
+    - b: swapped value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - ignored value.
+    - a: swapped value.
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    3
+
+    Source: [evm.codes/#9F](https://www.evm.codes/#9F)
+    """
+
+    LOG0 = Opcode(0xA0, popped_stack_items=2)
+    """
+    LOG3(offset, size)
+    ----
+
+    Description
+    ----
+    Append log record with no topics
+
+    Inputs
+    ----
+    - offset: byte offset in the memory in bytes
+    - size: byte size to copy
+
+    Outputs
+    ----
+    - None
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    375 + 375 * topic_count + 8 * size + memory_expansion_cost
+
+    Source: [evm.codes/#A0](https://www.evm.codes/#A0)
+    """
+
+    LOG1 = Opcode(0xA1, popped_stack_items=3)
+    """
+    LOG1(offset, size, topic1)
+    ----
+
+    Description
+    ----
+    Append log record with one topics
+
+    Inputs
+    ----
+    - offset: byte offset in the memory in bytes
+    - size: byte size to copy
+    - topic1: 32-byte value
+
+    Outputs
+    ----
+    - None
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    375 + 375 * topic_count + 8 * size + memory_expansion_cost
+
+    Source: [evm.codes/#A1](https://www.evm.codes/#A1)
+    """
+
+    LOG2 = Opcode(0xA2, popped_stack_items=4)
+    """
+    LOG2(offset, size, topic1, topic2)
+    ----
+
+    Description
+    ----
+    Append log record with two topics
+
+    Inputs
+    ----
+    - offset: byte offset in the memory in bytes
+    - size: byte size to copy
+    - topic1: 32-byte value
+    - topic2: 32-byte value
+
+    Outputs
+    ----
+    - None
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    375 + 375 * topic_count + 8 * size + memory_expansion_cost
+
+    Source: [evm.codes/#A2](https://www.evm.codes/#A2)
+    """
+
+    LOG3 = Opcode(0xA3, popped_stack_items=5)
+    """
+    LOG3(offset, size, topic1, topic2, topic3)
+    ----
+
+    Description
+    ----
+    Append log record with three topics
+
+    Inputs
+    ----
+    - offset: byte offset in the memory in bytes
+    - size: byte size to copy
+    - topic1: 32-byte value
+    - topic2: 32-byte value
+    - topic3: 32-byte value
+
+    Outputs
+    ----
+    - None
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    375 + 375 * topic_count + 8 * size + memory_expansion_cost
+
+    Source: [evm.codes/#A3](https://www.evm.codes/#A3)
+    """
+
+    LOG4 = Opcode(0xA4, popped_stack_items=6)
+    """
+    LOG4(offset, size, topic1, topic2, topic3, topic4)
+    ----
+
+    Description
+    ----
+    Append log record with four topics
+
+    Inputs
+    ----
+    - offset: byte offset in the memory in bytes
+    - size: byte size to copy
+    - topic1: 32-byte value
+    - topic2: 32-byte value
+    - topic3: 32-byte value
+    - topic4: 32-byte value
+
+    Outputs
+    ----
+    - None
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    375 + 375 * topic_count + 8 * size + memory_expansion_cost
+
+    Source: [evm.codes/#A4](https://www.evm.codes/#A4)
+    """
+
+    RJUMP = Opcode(0xE0, data_portion_length=2)
+    """
+    RJUMP(destination)
+    ----
+
+    Description
+    ----
+    Jump to a relative position in code.
+
+    Inputs
+    ----
+    - destination: The relative position to jump to.
+
+    Fork
+    ----
+    Revolution
+    """
+
+    RJUMPI = Opcode(0xE1, popped_stack_items=1, data_portion_length=2)
+    """
+    RJUMPI()
+    ----
+
+    Description
+    ----
+
+
+    Inputs
+    ----
+
+
+    Outputs
+    ----
+
+
+    Fork
+    ----
+
+    Gas
+    ----
+
+
+    Source:
+
+    """
+
+    RJUMPV = Opcode(0xE2)
+    """
+    RJUMPV
+    ----
+
+    Description
+    ----
+
+
+    Inputs
+    ----
+    -
+
+    Outputs
+    ----
+    -
+
+    Fork
+    ----
+
+
+    Gas
+    ----
+
+
+    Source:
+    """
+
+    CREATE = Opcode(0xF0, popped_stack_items=3, pushed_stack_items=1)
+    """
+    CREATE(value, offset, length) = contract_address
+    ----
+
+    Description
+    ----
+    Create a new contract with the given code.
+
+    Inputs
+    ----
+    - value: value in wei to send to the new account
+    - offset: byte offset in the memory in bytes, the initialisation code for the new account
+    - size: byte size to copy (size of the initialisation code)
+
+    Outputs
+    ----
+    - contract_address: The address of the newly created contract.
+
+    Fork
+    ----
+    Homestead
+
+    Gas
+    ----
+    32000 + init_code_cost + memory_expansion_cost + deployment_code_execution_cost +
+    code_deposit_cost
+
+    Source: [evm.codes/#F0](https://www.evm.codes/#F0)
+    """
+
+    CALL = Opcode(0xF1, popped_stack_items=7, pushed_stack_items=1)
+    """
+    CALL(gas, address, value, argsOffset, argsSize, retOffset, retSize) = success
+    ----
+
+    Description
+    ----
+    Message-call into an account
+
+    Inputs
+    ----
+    - gas: amount of gas to send to the sub context to execute. The gas that is not used by the sub
+      context is returned to this one
+    - address: the account which context to execute
+    - value: value in wei to send to the account
+    - argsOffset: byte offset in the memory in bytes, the calldata of the sub context
+    - argsSize: byte size to copy (size of the calldata)
+    - retOffset: byte offset in the memory in bytes, where to store the return data of the sub
+      context
+    - retSize: byte size to copy (size of the return data)
+
+    Outputs
+    ----
+    - success: return 0 if the sub context reverted, 1 otherwise
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    memory_expansion_cost + code_execution_cost + address_access_cost + positive_value_cost +
+    value_to_empty_account_cost
+
+    Source: [evm.codes/#F1](https://www.evm.codes/#F1)
+    """
+
+    CALLCODE = Opcode(0xF2, popped_stack_items=7, pushed_stack_items=1)
+    """
+    CALLCODE(gas, address, value, argsOffset, argsSize, retOffset, retSize) = success
+    ----
+
+    Description
+    ----
+    Message-call into this account with an alternative account's code. Executes code starting at
+    the address to which the call is made.
+
+    Inputs
+    ----
+    - gas: amount of gas to send to the sub context to execute. The gas that is not used by the sub
+      context is returned to this one.
+    - address: the account which code to execute
+    - value: value in wei to send to the account
+    - argsOffset: byte offset in the memory in bytes, the calldata of the sub context
+    - argsSize: byte size to copy (size of the calldata)
+    - retOffset: byte offset in the memory in bytes, where to store the return data of the sub
+      context
+    - retSize: byte size to copy (size of the return data)
+    Outputs
+    ----
+    - success: return 0 if the sub context reverted, 1 otherwise
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    memory_expansion_cost + code_execution_cost + address_access_cost + positive_value_cost
+
+    Source: [evm.codes/#F2](https://www.evm.codes/#F2)
+    """
+
+    RETURN = Opcode(0xF3, popped_stack_items=2)
+    """
+    RETURN(offset, size)
+    ----
+
+    Description
+    ----
+    Halt execution returning output data.
+
+    Inputs
+    ----
+    - offset: The memory offset to the output data.
+    - size: The size of the output data.
+
+    Outputs
+    ----
+    - None
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    memory_expansion_cost
+
+    Source: [evm.codes/#F3](https://www.evm.codes/#F3)
+    """
+
+    DELEGATECALL = Opcode(0xF4, popped_stack_items=6, pushed_stack_items=1)
+    """
+    DELEGATECALL(gas, address, argsOffset, argsSize, retOffset, retSize) = success
+    ----
+
+    Description
+    ----
+    Message-call into this account with an alternative account’s code, but persisting the current
+    values for sender and value
+
+    Inputs
+    ----
+    - gas: amount of gas to send to the sub context to execute. The gas that is not used by the sub
+      context is returned to this one
+    - address: the account which code to execute
+    - argsOffset: byte offset in the memory in bytes, the calldata of the sub context
+    - argsSize: byte size to copy (size of the calldata)
+    - retOffset: byte offset in the memory in bytes, where to store the return data of the sub
+      context.
+    - retSize: byte size to copy (size of the return data)
+
+    Outputs
+    ----
+    - success: return 0 if the sub context reverted, 1 otherwise
+
+    Fork
+    ----
+    Byzantium
+
+    Gas
+    ----
+    memory_expansion_cost + code_execution_cost + address_access_cost
+
+    Source: [evm.codes/#F4](https://www.evm.codes/#F4)
+    """
+
+    CREATE2 = Opcode(0xF5, popped_stack_items=4, pushed_stack_items=1)
+    """
+    CREATE2(value, offset, size, salt) = address
+    ----
+
+    Description
+    ----
+    Creates a new contract.
+
+    Inputs
+    ----
+    - value: value in wei to send to the new account.
+    - offset: byte offset in the memory in bytes, the initialisation code of the new account.
+    - size: byte size to copy (size of the initialisation code).
+    - salt: 32-byte value used to create the new account at a deterministic address
+
+    Outputs
+    ----
+    - address: the address of the deployed contract, 0 if the deployment failed
+
+    Fork
+    ----
+    Constantinople
+
+    Gas
+    ----
+    minimum_word_size = (size + 31) / 32 init_code_cost = 2 * minimum_word_size hash_cost = 6 *
+    minimum_word_size code_deposit_cost = 200 * deployed_code_size
+
+    32000 + init_code_cost + hash_cost + memory_expansion_cost + deployment_code_execution_cost +
+    code_deposit_cost
+
+    Source: [evm.codes/#F5](https://www.evm.codes/#F5)
+    """
+
+    STATICCALL = Opcode(0xFA, popped_stack_items=6, pushed_stack_items=1)
+    """
+    STATICCALL(gas, address, argsOffset, argsSize, retOffset , retSize) = success
+    ----
+
+    Description
+    ----
+    Static message-call into an account
+
+    Inputs
+    ----
+    - gas: amount of gas to send to the sub context to execute. The gas that is not used by the sub
+      context is returned to this one.
+    - address: the account which context to execute.
+    - argsOffset: byte offset in the memory in bytes, the calldata of the sub context.
+    - argsSize: byte size to copy (size of the calldata).
+    - retOffset: byte offset in the memory in bytes, where to store the return data of the sub
+      context.
+    - retSize: byte size to copy (size of the return data)
+
+    Outputs
+    ----
+    - success: return 0 if the sub context reverted, 1 otherwise
+
+    Fork
+    ----
+    Byzantium
+
+    Gas
+    ----
+    memory_expansion_cost + code_execution_cost + address_access_cost
+
+    Source: [evm.codes/#FA](https://www.evm.codes/#FA)
+    """
+
+    REVERT = Opcode(0xFD, popped_stack_items=2)
+    """
+    REVERT(offset, length)
+    ----
+
+    Description
+    ----
+    Stop execution and revert changes.
+
+    Inputs
+    ----
+    - offset: byte offset in the memory in bytes. The return data of the calling context.
+    - size: byte size to copy (size of the return data).
+
+    Fork
+    ----
+    Byzantium
+
+    Gas
+    ----
+    0
+
+    Source: [evm.codes/#FD](https://www.evm.codes/#FD)
+    """
+
+    INVALID = Opcode(0xFE)
+    """
+    INVALID()
+    ----
+
+    Description
+    ----
+    Invalid opcode.
+
+    Inputs
+    ----
+    None
+
+    Outputs
+    ----
+    None
+
+    Fork
+    ----
+    Homestead
+
+    Gas
+    ----
+    All the remaining gas in this context is consumed
+
+    Source: [evm.codes/#FE](https://www.evm.codes/#FE)
+    """
+
+    SELFDESTRUCT = Opcode(0xFF, popped_stack_items=1)
+    """
+    SELFDESTRUCT(to)
+    ----
+
+    Description
+    ----
+    Halt execution and register the account for later deletion.
+
+    Inputs
+    ----
+    - to: The address to which any remaining funds are transferred.
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+    5000
+
+    Source: [evm.codes/#FF](https://www.evm.codes/#FF)
+    """
+
+    SENDALL = Opcode(0xFF, popped_stack_items=1)
+    """
+    SENDALL(to) = success
+    ----
+
+    Description
+    ----
+    Send all ether to the target address.
+
+    Inputs
+    ----
+    - to: Target address
+
+    Outputs
+    ----
+    - None
+
+    Fork
+    ----
+    Frontier
+
+    Gas
+    ----
+
+
+    Source: [eips.ethereum.org/EIPS/eip-4758](https://eips.ethereum.org/EIPS/eip-4758)
+    """

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -263,6 +263,7 @@ TestAddress
 TestContractCreationGasUsage
 TestMultipleWithdrawalsSameAddress
 textwrap
+ThreeHrSleep
 time15k
 timestamp
 todo


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
Added docstrings to most of the opcodes in the Opcodes Enum.
Left `TSTORE`,`TLOAD`,`SENDALL`,`RJUMPI`,`RJUMPV` incomplete due to confusion
## 🔗 Related Issues
#383 

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [X] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](../docs/) directory.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [X] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
