### PR TITLE
[WIP] Verkle changes to test t8n

### DIFF
--- a/src/ethereum_test_forks/base_fork.py
+++ b/src/ethereum_test_forks/base_fork.py
@@ -1,6 +1,7 @@
 """
 Abstract base class for Ethereum forks
 """
+
 from abc import ABC, ABCMeta, abstractmethod
 from typing import Any, ClassVar, List, Mapping, Optional, Protocol, Type
 
@@ -186,6 +187,22 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
 
         This method must always call the `fork_to` method when transitioning, because the
         allocation can only be set at genesis, and thus cannot be changed at transition time.
+        """
+        pass
+
+    @classmethod
+    @abstractmethod
+    def environment_verkle_conversion_information_required(
+        cls, block_number: int = 0, timestamp: int = 0
+    ) -> bool:
+        """
+        Returns true if the environment must contain the verkle conversion information, which
+        includes:
+        - Conversion address
+        - Conversion slot hash
+        - Conversion started
+        - Conversion ended
+        - Conversion storage processed
         """
         pass
 

--- a/src/ethereum_test_forks/base_fork.py
+++ b/src/ethereum_test_forks/base_fork.py
@@ -74,6 +74,7 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
     _transition_tool_name: ClassVar[Optional[str]] = None
     _blockchain_test_network_name: ClassVar[Optional[str]] = None
     _solc_name: ClassVar[Optional[str]] = None
+    _ignore: ClassVar[bool] = False
 
     def __init_subclass__(
         cls,
@@ -81,6 +82,7 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
         transition_tool_name: Optional[str] = None,
         blockchain_test_network_name: Optional[str] = None,
         solc_name: Optional[str] = None,
+        ignore: bool = False,
     ) -> None:
         """
         Initializes the new fork with values that don't carry over to subclass forks.
@@ -88,6 +90,7 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
         cls._transition_tool_name = transition_tool_name
         cls._blockchain_test_network_name = blockchain_test_network_name
         cls._solc_name = solc_name
+        cls._ignore = ignore
 
     # Header information abstract methods
     @classmethod
@@ -303,6 +306,13 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
         development.
         """
         return True
+
+    @classmethod
+    def ignore(cls) -> bool:
+        """
+        Returns whether the fork should be ignored during test generation.
+        """
+        return cls._ignore
 
 
 # Fork Type

--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -1,6 +1,7 @@
 """
 All Ethereum fork class definitions.
 """
+
 from typing import List, Mapping, Optional
 
 from semver import Version
@@ -157,6 +158,15 @@ class Frontier(BaseFork, solc_name="homestead"):
         Frontier does not require pre-allocated accounts
         """
         return {}
+
+    @classmethod
+    def environment_verkle_conversion_information_required(
+        cls, block_number: int = 0, timestamp: int = 0
+    ) -> bool:
+        """
+        Returns true if the environment must contain verkle conversion information
+        """
+        return False
 
 
 class Homestead(Frontier):
@@ -471,3 +481,12 @@ class Prague(Cancun):
         Returns the minimum version of solc that supports this fork.
         """
         return Version.parse("1.0.0")  # set a high version; currently unknown
+
+    @classmethod
+    def environment_verkle_conversion_information_required(
+        cls, block_number: int = 0, timestamp: int = 0
+    ) -> bool:
+        """
+        Returns true if the environment must contain verkle conversion information
+        """
+        return True

--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -462,7 +462,7 @@ class Cancun(Shanghai):
         return True
 
 
-class Prague(Cancun):
+class Prague(Shanghai):
     """
     Prague fork
     """

--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -241,7 +241,7 @@ class Istanbul(ConstantinopleFix):
 
 
 # Glacier forks skipped, unless explicitly specified
-class MuirGlacier(Istanbul, solc_name="istanbul"):
+class MuirGlacier(Istanbul, solc_name="istanbul", ignore=True):
     """
     Muir Glacier fork
     """
@@ -283,7 +283,7 @@ class London(Berlin):
 
 
 # Glacier forks skipped, unless explicitly specified
-class ArrowGlacier(London, solc_name="london"):
+class ArrowGlacier(London, solc_name="london", ignore=True):
     """
     Arrow Glacier fork
     """
@@ -291,7 +291,7 @@ class ArrowGlacier(London, solc_name="london"):
     pass
 
 
-class GrayGlacier(ArrowGlacier, solc_name="london"):
+class GrayGlacier(ArrowGlacier, solc_name="london", ignore=True):
     """
     Gray Glacier fork
     """

--- a/src/ethereum_test_forks/forks/transition.py
+++ b/src/ethereum_test_forks/forks/transition.py
@@ -1,8 +1,9 @@
 """
 List of all transition fork definitions.
 """
+
 from ..transition_base_fork import transition_fork
-from .forks import Berlin, Cancun, London, Paris, Shanghai
+from .forks import Berlin, Cancun, London, Paris, Prague, Shanghai
 
 
 # Transition Forks
@@ -28,6 +29,15 @@ class ParisToShanghaiAtTime15k(Paris, blockchain_test_network_name="ParisToShang
 class ShanghaiToCancunAtTime15k(Shanghai):
     """
     Shanghai to Cancun transition at Timestamp 15k
+    """
+
+    pass
+
+
+@transition_fork(to_fork=Prague, at_timestamp=32)
+class ShanghaiToPragueAtTime15k(Shanghai):
+    """
+    Shanghai to Prague transition at Timestamp 32
     """
 
     pass

--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -1,6 +1,7 @@
 """
 Useful types for generating Ethereum tests.
 """
+
 from copy import copy, deepcopy
 from dataclasses import dataclass, fields
 from itertools import count
@@ -847,6 +848,41 @@ class Environment:
             cast_type=Hash,
         ),
     )
+    verkle_conversion_address: Optional[FixedSizeBytesConvertible] = field(
+        default=None,
+        json_encoder=JSONEncoder.Field(
+            name="currentConversionAddress",
+            cast_type=Address,
+        ),
+    )
+    verkle_conversion_slot_hash: Optional[FixedSizeBytesConvertible] = field(
+        default=None,
+        json_encoder=JSONEncoder.Field(
+            name="currentConversionSlotHash",
+            cast_type=Hash,
+        ),
+    )
+    verkle_conversion_started: Optional[bool] = field(
+        default=None,
+        json_encoder=JSONEncoder.Field(
+            name="currentConversionStarted",
+            skip_string_convert=True,
+        ),
+    )
+    verkle_conversion_ended: Optional[bool] = field(
+        default=None,
+        json_encoder=JSONEncoder.Field(
+            name="currentConversionEnded",
+            skip_string_convert=True,
+        ),
+    )
+    verkle_conversion_storage_processed: Optional[bool] = field(
+        default=None,
+        json_encoder=JSONEncoder.Field(
+            name="currentConversionStorageProcessed",
+            skip_string_convert=True,
+        ),
+    )
     extra_data: Optional[BytesConvertible] = field(
         default=b"\x00",
         json_encoder=JSONEncoder.Field(
@@ -907,7 +943,37 @@ class Environment:
         if fork.header_beacon_root_required(number, timestamp) and res.beacon_root is None:
             res.beacon_root = 0
 
+        if fork.environment_verkle_conversion_information_required(number, timestamp):
+            if res.verkle_conversion_address is None:
+                res.verkle_conversion_address = 0
+            if res.verkle_conversion_slot_hash is None:
+                res.verkle_conversion_slot_hash = 0
+            if res.verkle_conversion_started is None:
+                res.verkle_conversion_started = False
+            if res.verkle_conversion_ended is None:
+                res.verkle_conversion_ended = False
+            if res.verkle_conversion_storage_processed is None:
+                res.verkle_conversion_storage_processed = False
+
         return res
+
+    def update_from_result(self, transition_tool_result: Dict[str, str]) -> "Environment":
+        """
+        Updates the environment with the result of a transition tool execution.
+        """
+        if "currentConversionAddress" in transition_tool_result:
+            self.verkle_conversion_address = transition_tool_result["currentConversionAddress"]
+        if "currentConversionSlotHash" in transition_tool_result:
+            self.verkle_conversion_slot_hash = transition_tool_result["currentConversionSlotHash"]
+        if "currentConversionStarted" in transition_tool_result:
+            self.verkle_conversion_started = transition_tool_result["currentConversionStarted"]
+        if "currentConversionEnded" in transition_tool_result:
+            self.verkle_conversion_ended = transition_tool_result["currentConversionEnded"]
+        if "currentConversionStorageProcessed" in transition_tool_result:
+            self.verkle_conversion_storage_processed = transition_tool_result[
+                "currentConversionStorageProcessed"
+            ]
+        return self
 
 
 @dataclass(kw_only=True)

--- a/src/ethereum_test_tools/spec/blockchain/blockchain_test.py
+++ b/src/ethereum_test_tools/spec/blockchain/blockchain_test.py
@@ -282,7 +282,7 @@ class BlockchainTest(BaseTest):
             withdrawals=env.withdrawals,
         )
 
-        return header, rlp, txs, next_alloc, env
+        return header, rlp, txs, next_alloc, env.update_from_result(result)
 
     def network_info(self, fork: Fork, eips: Optional[List[int]] = None):
         """

--- a/tests/prague/eip6800_verkle_tree/__init__.py
+++ b/tests/prague/eip6800_verkle_tree/__init__.py
@@ -1,0 +1,3 @@
+"""
+Cross-client EIP-6800 Tests
+"""

--- a/tests/prague/eip6800_verkle_tree/test_verkle_from_mpt_conversion.py
+++ b/tests/prague/eip6800_verkle_tree/test_verkle_from_mpt_conversion.py
@@ -1,0 +1,78 @@
+"""
+abstract: Tests [EIP-6800: Ethereum state using a unified verkle tree](https://eips.ethereum.org/EIPS/eip-6800)
+    Test state tree conversion from MPT [EIP-6800: Ethereum state using a unified verkle tree](https://eips.ethereum.org/EIPS/eip-6800)
+
+"""  # noqa: E501
+
+from itertools import count
+from typing import List, Mapping
+
+import pytest
+
+from ethereum_test_tools import Account, Address, Block, BlockchainTestFiller, Environment, Hash
+from ethereum_test_tools import Opcodes as Op
+from ethereum_test_tools import Storage, TestAddress, Transaction
+
+code_address = Address(0x100)
+
+REFERENCE_SPEC_GIT_PATH = "EIPS/eip-6800.md"
+REFERENCE_SPEC_VERSION = "2f8299df31bb8173618901a03a8366a3183479b0"
+
+
+@pytest.fixture
+def pre() -> Mapping:  # noqa: D103
+    return {
+        TestAddress: Account(balance=10**40),
+        code_address: Account(
+            nonce=1,
+            balance=1,
+            code=Op.SSTORE(Op.CALLDATALOAD(0), Op.CALLDATALOAD(32)),
+        ),
+    }
+
+
+@pytest.mark.valid_at_transition_to("Prague")
+def test_verkle_from_mpt_conversion(
+    blockchain_test: BlockchainTestFiller,
+    pre: Mapping[str, Account],
+):
+    """
+    Perform MCOPY operations using different offsets and lengths:
+      - Zero inputs
+      - Memory rewrites (copy from and to the same location)
+      - Memory overwrites (copy from and to different locations)
+      - Memory extensions (copy to a location that is out of bounds)
+      - Memory clear (copy from a location that is out of bounds)
+    """
+    nonce = count()
+    block_count = 64
+    tx_count = 64
+    blocks: List[Block] = []
+    code_storage = Storage()
+    for _ in range(block_count):
+        txs: List[Transaction] = []
+        for t in range(tx_count):
+            storage_value = 2**256 - t - 1
+            storage_key = code_storage.store_next(storage_value)
+            txs.append(
+                Transaction(
+                    nonce=next(nonce),
+                    to=code_address,
+                    data=Hash(storage_key) + Hash(storage_value),
+                    gas_limit=100_000,
+                )
+            )
+        blocks.append(Block(txs=txs))
+    blockchain_test(
+        genesis_environment=Environment(),
+        pre=pre,
+        post={
+            code_address: Account(
+                nonce=1,
+                balance=1,
+                code=Op.SSTORE(Op.CALLDATALOAD(0), Op.CALLDATALOAD(32)),
+                storage=code_storage,
+            ),
+        },
+        blocks=blocks,
+    )


### PR DESCRIPTION
## 🗒️ Description
Adds changes to the forks structure to be able to test Prague on top of Shanghai until refactor of verkle geth branch.

## 🔗 Related Issues
None

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](../docs/) directory.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
