### PR TITLE
feat(fixtures): do not export rlp_decoded if there is BlockException.RLP_STRUCTURES_ENCODING

### DIFF
--- a/src/ethereum_test_tools/exceptions/exceptions.py
+++ b/src/ethereum_test_tools/exceptions/exceptions.py
@@ -43,6 +43,12 @@ class ExceptionBase(Enum):
     Base class for exceptions.
     """
 
+    def __contains__(self, exception) -> bool:
+        """
+        Checks if provided exception is equal to this
+        """
+        return self == exception
+
     def __or__(
         self,
         other: Union["TransactionException", "BlockException", ExceptionList],
@@ -146,6 +152,10 @@ class BlockException(ExceptionBase):
     INCORRECT_EXCESS_BLOB_GAS = auto()
     """
     Block's excess blob gas in header is incorrect.
+    """
+    RLP_STRUCTURES_ENCODING = auto()
+    """
+    Block's rlp encoding is valid but ethereum structures in it are invalid
     """
 
 

--- a/src/ethereum_test_tools/spec/blockchain/blockchain_test.py
+++ b/src/ethereum_test_tools/spec/blockchain/blockchain_test.py
@@ -38,6 +38,7 @@ from ..base.base_test import (
 from ..debugging import print_traces
 from .types import (
     Block,
+    BlockException,
     Fixture,
     FixtureBlock,
     FixtureEngineNewPayload,
@@ -353,7 +354,11 @@ class BlockchainTest(BaseTest):
                         InvalidFixtureBlock(
                             rlp=rlp,
                             expected_exception=block.exception,
-                            rlp_decoded=replace(fixture_block, rlp=None),
+                            rlp_decoded=(
+                                None
+                                if BlockException.RLP_STRUCTURES_ENCODING in block.exception
+                                else replace(fixture_block, rlp=None)
+                            ),
                         ),
                     )
             else:

--- a/tests/cancun/eip4844_blobs/test_blob_txs.py
+++ b/tests/cancun/eip4844_blobs/test_blob_txs.py
@@ -1153,7 +1153,8 @@ def test_invalid_blob_tx_contract_creation(
         blocks=[
             Block(
                 txs=txs,
-                exception=TransactionException.TYPE_3_TX_CONTRACT_CREATION,
+                exception=TransactionException.TYPE_3_TX_CONTRACT_CREATION
+                | BlockException.RLP_STRUCTURES_ENCODING,
                 header_verify=header_verify,
             )
         ],

--- a/tests/cancun/eip4844_blobs/test_blob_txs_full.py
+++ b/tests/cancun/eip4844_blobs/test_blob_txs_full.py
@@ -12,6 +12,7 @@ from ethereum_test_tools import (
     Address,
     Block,
     BlockchainTestFiller,
+    BlockException,
     Environment,
     Header,
     TestAddress,
@@ -256,7 +257,9 @@ def blocks(
     if any(txs_wrapped_blobs):
         # This is a block exception because the invalid block is only created in the RLP version,
         # not in the transition tool.
-        block_error = TransactionException.TYPE_3_TX_WITH_FULL_BLOBS
+        block_error = (
+            TransactionException.TYPE_3_TX_WITH_FULL_BLOBS | BlockException.RLP_STRUCTURES_ENCODING
+        )
     if len(txs) > 0:
         header_blob_gas_used = (
             sum(


### PR DESCRIPTION
## 🗒️ Description
Do not export rlp_decoded filled blockchain field if there is BlockException.RLP_STRUCTURES_ENCODING exception

## 🔗 Related Issues
https://github.com/ethereum/execution-spec-tests/issues/415
https://github.com/ethereum/execution-spec-tests/issues/417

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](../docs/) directory.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
