### PR TITLE
chore(forks,pytest): Add `BaseFork.ignore` method

### DIFF
--- a/src/ethereum_test_forks/base_fork.py
+++ b/src/ethereum_test_forks/base_fork.py
@@ -73,6 +73,7 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
     _transition_tool_name: ClassVar[Optional[str]] = None
     _blockchain_test_network_name: ClassVar[Optional[str]] = None
     _solc_name: ClassVar[Optional[str]] = None
+    _ignore: ClassVar[bool] = False
 
     def __init_subclass__(
         cls,
@@ -80,6 +81,7 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
         transition_tool_name: Optional[str] = None,
         blockchain_test_network_name: Optional[str] = None,
         solc_name: Optional[str] = None,
+        ignore: bool = False,
     ) -> None:
         """
         Initializes the new fork with values that don't carry over to subclass forks.
@@ -87,6 +89,7 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
         cls._transition_tool_name = transition_tool_name
         cls._blockchain_test_network_name = blockchain_test_network_name
         cls._solc_name = solc_name
+        cls._ignore = ignore
 
     # Header information abstract methods
     @classmethod
@@ -286,6 +289,13 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
         development.
         """
         return True
+
+    @classmethod
+    def ignore(cls) -> bool:
+        """
+        Returns whether the fork should be ignored during test generation.
+        """
+        return cls._ignore
 
 
 # Fork Type

--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -231,7 +231,7 @@ class Istanbul(ConstantinopleFix):
 
 
 # Glacier forks skipped, unless explicitly specified
-class MuirGlacier(Istanbul, solc_name="istanbul"):
+class MuirGlacier(Istanbul, solc_name="istanbul", ignore=True):
     """
     Muir Glacier fork
     """
@@ -273,7 +273,7 @@ class London(Berlin):
 
 
 # Glacier forks skipped, unless explicitly specified
-class ArrowGlacier(London, solc_name="london"):
+class ArrowGlacier(London, solc_name="london", ignore=True):
     """
     Arrow Glacier fork
     """
@@ -281,7 +281,7 @@ class ArrowGlacier(London, solc_name="london"):
     pass
 
 
-class GrayGlacier(ArrowGlacier, solc_name="london"):
+class GrayGlacier(ArrowGlacier, solc_name="london", ignore=True):
     """
     Gray Glacier fork
     """

--- a/src/ethereum_test_forks/transition_base_fork.py
+++ b/src/ethereum_test_forks/transition_base_fork.py
@@ -1,6 +1,7 @@
 """
 Base objects used to define transition forks.
 """
+
 from inspect import signature
 from typing import Callable, List, Type
 
@@ -54,6 +55,7 @@ def transition_fork(to_fork: Fork, at_block: int = 0, at_timestamp: int = 0):
             transition_tool_name=cls._transition_tool_name,
             blockchain_test_network_name=cls._blockchain_test_network_name,
             solc_name=cls._solc_name,
+            ignore=cls._ignore,
         ):
             pass
 

--- a/src/ethereum_test_tools/tests/test_code.py
+++ b/src/ethereum_test_tools/tests/test_code.py
@@ -53,10 +53,6 @@ def test_code_operations(code: Code, expected_bytes: bytes):
 def fork(request: pytest.FixtureRequest):
     """
     Return the target evm-version (fork) for solc compilation.
-
-    Note:
-    - Homestead.
-    - forks_from_until: Used to remove the Glacier forks
     """
     return request.param
 


### PR DESCRIPTION
## 🗒️ Description
Fixes this [line](https://github.com/ethereum/execution-spec-tests/blob/ccf25a322bf37a1c0fd9d6498c5e9edfaeb0d098/src/pytest_plugins/forks/forks.py#L190) by implementing an `ignore` method that returns `True` for forks that need to be ignored during test generation, such as the glacier forks.

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](../docs/) directory.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
