### PR TITLE
fix(pytest): actually check the fork before issuing a fork mismatch warning for yul compilation

### DIFF
--- a/src/pytest_plugins/test_filler/test_filler.py
+++ b/src/pytest_plugins/test_filler/test_filler.py
@@ -5,6 +5,7 @@ Top-level pytest configuration file providing:
 and that modifies pytest hooks in order to fill test specs for all tests and
 writes the generated fixtures to file.
 """
+
 import warnings
 from pathlib import Path
 from typing import Generator, List, Optional, Type
@@ -372,8 +373,8 @@ def yul(fork: Fork, request):
     else:
         solc_target_fork = get_closest_fork_with_solc_support(fork, request.config.solc_version)
         assert solc_target_fork is not None, "No fork supports provided solc version."
-        if request.config.getoption("verbose") >= 1:
-            warnings.warn(f"Compiling Yul for {solc_target_fork}, not {fork}.")
+        if solc_target_fork != fork and request.config.getoption("verbose") >= 1:
+            warnings.warn(f"Compiling Yul for {solc_target_fork.name()}, not {fork.name()}.")
 
     class YulWrapper(Yul):
         def __init__(self, *args, **kwargs):


### PR DESCRIPTION
## 🗒️ Description

This PR fixes an error introduced in #418: `src/pytest_plugins/test_filler/test_filler.py` always issued a warning for an incorrect fork, regardless of whether `get_closest_fork_with_solc_support()` returned the requried fork, or not. For example,
```
fill tests/homestead/yul/test_yul_example.py --fork=Shanghai -v
```
with a solc that supports Shanghai incorrectly warns:
```
============================================= warnings summary ==============================================
tests/homestead/yul/test_yul_example.py::test_yul[fork_Shanghai-blockchain_test]
tests/homestead/yul/test_yul_example.py::test_yul[fork_Shanghai-blockchain_test_hive]
tests/homestead/yul/test_yul_example.py::test_yul[fork_Shanghai-state_test]
  /home/dtopz/code/github/danceratopz/execution-spec-tests/src/pytest_plugins/test_filler/test_filler.py:376:
 UserWarning: Compiling Yul for Shanghai, not Shanghai.
    warnings.warn(f"Compiling Yul for {solc_target_fork}, not {fork}.")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================= 3 passed, 3 warnings in 0.34s =======================================
```

## 🔗 Related Issues
None.

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md). **Unreleased; skipping changelog.**
- [x] All: Considered updating the online docs in the [./docs/](../docs/) directory.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
