### PR TITLE
feat(tests): dynamic create2 collision from different transactions same block

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,8 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 ### 🧪 Test Cases
 
+- 🐞 Dynamic create2 collision from different transactions same block ([#430](https://github.com/ethereum/execution-spec-tests/pull/430)).
+
 - 🐞 Fix beacon root contract deployment tests so the account in the pre-alloc is not empty ([#425](https://github.com/ethereum/execution-spec-tests/pull/425)).
 
 ### 🛠️ Framework

--- a/tests/cancun/eip6780_selfdestruct/test_dynamic_create2_selfdestruct_collision.py
+++ b/tests/cancun/eip6780_selfdestruct/test_dynamic_create2_selfdestruct_collision.py
@@ -65,7 +65,7 @@ def test_dynamic_create2_selfdestruct_collision(
     Perform a CREATE2, make sure that the initcode sets at least a couple of storage keys,
     then on a different call, in the same tx, perform a self-destruct.
     Then:
-        a) on the same tx, attempt to recreate the contract   <=== Covered int this test
+        a) on the same tx, attempt to recreate the contract   <=== Covered in this test
             1) and create2 contract already in the state
             2) and create2 contract is not in the state
         b) on a different tx, attempt to recreate the contract
@@ -107,11 +107,11 @@ def test_dynamic_create2_selfdestruct_collision(
     call_address_in_the_end = create2_address if call_create2_contract_at_the_end else address_zero
 
     # Values
-    first_create2_value = 3
-    first_call_value = 5
-    second_create2_value = 7
-    second_call_value = 11
-    pre_existing_create2_balance = 13
+    pre_existing_create2_balance = 1
+    first_create2_value = 10
+    first_call_value = 100
+    second_create2_value = 1000
+    second_call_value = 10000
 
     pre = {
         address_to: Account(
@@ -125,6 +125,8 @@ def test_dynamic_create2_selfdestruct_collision(
                 first_create2_result,
                 Op.MLOAD(0),
             )
+            # In case the create2 didn't work, flush account balance
+            + Op.CALL(100000, address_code, 0, 0, 0, 0, 0)
             # Call to the created account to trigger selfdestruct
             + Op.CALL(100000, call_address_in_between, first_call_value, 0, 0, 0, 0)
             # Make a subcall that do CREATE2 collision and returns its address as the result
@@ -224,6 +226,245 @@ def test_dynamic_create2_selfdestruct_collision(
     )
 
     state_test(env=env, pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.valid_from("Paris")
+@pytest.mark.parametrize(
+    "create2_dest_already_in_state",
+    (True, False),
+)
+@pytest.mark.parametrize(
+    "call_create2_contract_at_the_end",
+    [
+        (True, False),
+    ],
+)
+def test_dynamic_create2_selfdestruct_collision_two_different_transactions(
+    env: Environment,
+    fork: Fork,
+    create2_dest_already_in_state: bool,
+    call_create2_contract_at_the_end: bool,
+    blockchain_test: BlockchainTestFiller,
+):
+    """Dynamic Create2->Suicide->Create2 collision scenario:
+
+    Perform a CREATE2, make sure that the initcode sets at least a couple of storage keys,
+    then on a different call, in the same tx, perform a self-destruct.
+    Then:
+        a) on the same tx, attempt to recreate the contract
+            1) and create2 contract already in the state
+            2) and create2 contract is not in the state
+        b) on a different tx, attempt to recreate the contract <=== Covered in this test
+    Perform a CREATE2, make sure that the initcode sets at least a couple of storage keys,
+    then in a different tx, perform a self-destruct.
+    Then:
+        a) on the same tx, attempt to recreate the contract
+        b) on a different tx, attempt to recreate the contract
+    Verify that the test case described
+    in https://wiki.hyperledger.org/pages/viewpage.action?pageId=117440824 is covered
+    """
+    # assert call_create2_contract_at_the_end, "invalid test"
+
+    # Storage locations
+    create2_constructor_worked = 1
+    first_create2_result = 2
+    second_create2_result = 3
+    code_worked = 4
+
+    # Pre-Existing Addresses
+    address_zero = Address(0x00)
+    address_to = Address(0x0600)
+    address_to_second = Address(0x0700)
+    address_code = Address(0x0601)
+    address_create2_storage = Address(0x0512)
+    sendall_destination = Address(0x03E8)
+
+    # CREATE2 Initcode
+    create2_salt = 1
+    deploy_code = Op.SELFDESTRUCT(sendall_destination)
+    initcode = Initcode(
+        deploy_code=deploy_code,
+        initcode_prefix=Op.SSTORE(create2_constructor_worked, 1)
+        + Op.CALL(Op.GAS(), address_create2_storage, 0, 0, 0, 0, 0),
+    )
+
+    # Created addresses
+    create2_address = compute_create2_address(address_code, create2_salt, initcode)
+    call_address_in_the_end = create2_address if call_create2_contract_at_the_end else address_zero
+
+    # Values
+    pre_existing_create2_balance = 1
+    first_create2_value = 10
+    first_call_value = 100
+    second_create2_value = 1000
+    second_call_value = 10000
+
+    pre = {
+        address_to: Account(
+            balance=100000000,
+            nonce=0,
+            code=Op.JUMPDEST()
+            # Make a subcall that do CREATE2 and returns its the result
+            + Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE())
+            + Op.CALL(100000, address_code, first_create2_value, 0, Op.CALLDATASIZE(), 0, 32)
+            + Op.SSTORE(
+                first_create2_result,
+                Op.MLOAD(0),
+            )
+            # In case the create2 didn't work, flush account balance
+            + Op.CALL(100000, address_code, 0, 0, 0, 0, 0)
+            # Call to the created account to trigger selfdestruct
+            + Op.CALL(100000, create2_address, first_call_value, 0, 0, 0, 0)
+            + Op.SSTORE(code_worked, 1),
+            storage={first_create2_result: 0xFF},
+        ),
+        address_to_second: Account(
+            balance=100000000,
+            nonce=0,
+            code=Op.JUMPDEST()
+            # Make a subcall that do CREATE2 collision and returns its address as the result
+            + Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE())
+            + Op.CALL(100000, address_code, second_create2_value, 0, Op.CALLDATASIZE(), 0, 32)
+            + Op.SSTORE(
+                second_create2_result,
+                Op.MLOAD(0),
+            )
+            # Call to the created account to trigger selfdestruct
+            + Op.CALL(200000, call_address_in_the_end, second_call_value, 0, 0, 0, 0)
+            + Op.SSTORE(code_worked, 1),
+            storage={second_create2_result: 0xFF},
+        ),
+        address_code: Account(
+            balance=0,
+            nonce=0,
+            code=Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE())
+            + Op.MSTORE(
+                0,
+                Op.CREATE2(Op.SELFBALANCE(), 0, Op.CALLDATASIZE(), create2_salt),
+            )
+            + Op.RETURN(0, 32),
+            storage={},
+        ),
+        address_create2_storage: Account(
+            balance=7000000000000000000,
+            nonce=0,
+            code=Op.SSTORE(1, 1),
+            storage={},
+        ),
+        TestAddress: Account(
+            balance=7000000000000000000,
+            nonce=0,
+            code="0x",
+            storage={},
+        ),
+    }
+
+    if create2_dest_already_in_state:
+        # Create2 address already in the state, e.g. deployed in a previous block
+        pre[create2_address] = Account(
+            balance=pre_existing_create2_balance,
+            nonce=1,
+            code=deploy_code,
+            storage={},
+        )
+
+    post: Dict[Address, Union[Account, object]] = {}
+
+    # Create2 address only exists if it was pre-existing and after cancun
+    post[create2_address] = (
+        Account(balance=0, nonce=1, code=deploy_code, storage={create2_constructor_worked: 0x00})
+        if create2_dest_already_in_state and fork >= Cancun
+        else Account.NONEXISTENT
+    )
+
+    # after Cancun Create2 initcode is only executed if the contract did not already exist
+    # and before it will always be executed as the first tx deletes the account
+    post[address_create2_storage] = Account(
+        storage={
+            create2_constructor_worked: int(fork < Cancun or not create2_dest_already_in_state)
+        }
+    )
+
+    # Entry code that makes the calls to the create2 contract creator
+    post[address_to] = Account(
+        storage={
+            code_worked: 0x01,
+            # First create2 only works if the contract was not preexisting
+            first_create2_result: 0x00 if create2_dest_already_in_state else create2_address,
+        }
+    )
+    post[address_to_second] = Account(
+        storage={
+            code_worked: 0x01,
+            # Second create2 will not collide before Cancun as the first tx calls selfdestruct
+            # After cancun it will collide only if create2_dest_already_in_state otherwise the
+            # first tx creates and deletes it
+            second_create2_result: (
+                (0x00 if create2_dest_already_in_state else create2_address)
+                if fork >= Cancun
+                else create2_address
+            ),
+        }
+    )
+
+    # Calculate the destination account expected balance for the selfdestruct/sendall calls
+    sendall_destination_balance = 0
+
+    if create2_dest_already_in_state:
+        sendall_destination_balance += pre_existing_create2_balance
+        if fork >= Cancun:
+            # first create2 fails, but first calls ok. the account is not removed on cancun
+            # therefor with the second create2 it is not successful
+            sendall_destination_balance += first_call_value
+        else:
+            # first create2 fails, first calls totally removes the account
+            # in the second transaction second create2 is successful
+            sendall_destination_balance += first_call_value + second_create2_value
+    else:
+        # if no account in the state, first create2 successful, first call successful and removes
+        # because it is removed in the next transaction second create2 successful
+        sendall_destination_balance = first_create2_value + first_call_value + second_create2_value
+
+    if call_create2_contract_at_the_end:
+        sendall_destination_balance += second_call_value
+
+    post[sendall_destination] = Account(balance=sendall_destination_balance)
+
+    nonce = count()
+
+    blockchain_test(
+        genesis_environment=Environment(),
+        pre=pre,
+        post=post,
+        blocks=[
+            Block(
+                txs=[
+                    Transaction(
+                        ty=0x0,
+                        chain_id=0x0,
+                        nonce=next(nonce),
+                        to=address_to,
+                        gas_price=10,
+                        protected=False,
+                        data=initcode.bytecode if initcode.bytecode is not None else bytes(),
+                        gas_limit=5000000,
+                        value=0,
+                    ),
+                    Transaction(
+                        ty=0x0,
+                        chain_id=0x0,
+                        nonce=next(nonce),
+                        to=address_to_second,
+                        gas_price=10,
+                        protected=False,
+                        data=initcode.bytecode if initcode.bytecode is not None else bytes(),
+                        gas_limit=5000000,
+                        value=0,
+                    ),
+                ]
+            )
+        ],
+    )
 
 
 @pytest.mark.valid_from("Paris")
@@ -392,9 +633,11 @@ def test_dynamic_create2_selfdestruct_collision_multi_tx(
     post[create2_address] = (
         Account(balance=0, nonce=1, code=deploy_code, storage={create2_constructor_worked: 0x01})
         if account_will_exist_with_code
-        else Account(balance=second_call_value, nonce=0)
-        if account_will_exist_with_balance
-        else Account.NONEXISTENT
+        else (
+            Account(balance=second_call_value, nonce=0)
+            if account_will_exist_with_balance
+            else Account.NONEXISTENT
+        )
     )
 
     # Create2 initcode saves storage unconditionally
@@ -408,9 +651,9 @@ def test_dynamic_create2_selfdestruct_collision_multi_tx(
             # First create2 always works
             first_create2_result: create2_address,
             # Second create2 only works if we successfully self-destructed on the first tx
-            second_create2_result: create2_address
-            if selfdestruct_on_first_tx and not recreate_on_first_tx
-            else 0x00,
+            second_create2_result: (
+                create2_address if selfdestruct_on_first_tx and not recreate_on_first_tx else 0x00
+            ),
         }
     )
 


### PR DESCRIPTION
## 🗒️ Description
dynamic create2 collision from different transactions same block

## 🔗 Related Issues
https://github.com/ethereum/execution-spec-tests/issues/381

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](../docs/) directory.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or evm version 1.13.11-unstable-765f2904-20240124
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
