### PR TITLE
feat(fw): add optional `verify_sync` flag to hive blockchain tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - 🔀 Locally calculate state root for the genesis blocks in the blockchain tests instead of calling t8n ([#450](https://github.com/ethereum/execution-spec-tests/pull/450)).
 - 🐞 Fix bug that causes an exception during test collection because the fork parameter contains `None` ([#452](https://github.com/ethereum/execution-spec-tests/pull/452)).
 - ✨ The `_info` field in the test fixtures now contains a `hash` field, which is the hash of the test fixture, and a `hasher` script has been added which prints and performs calculations on top of the hashes of all fixtures (see `hasher -h`) ([#454](https://github.com/ethereum/execution-spec-tests/pull/454)).
+- ✨ Adds an optional `verify_sync` field to hive blockchain tests (EngineAPI). When set to true a second client attempts to sync to the first client that executed the tests.([#431](https://github.com/ethereum/execution-spec-tests/pull/431)).
 
 ### 🔧 EVM Tools
 

--- a/src/ethereum_test_tools/spec/blockchain/types.py
+++ b/src/ethereum_test_tools/spec/blockchain/types.py
@@ -1122,6 +1122,12 @@ class HiveFixture(FixtureCommon):
             name="engineFcuVersion",
         ),
     )
+    verify_sync: Optional[bool] = field(
+        default=None,
+        json_encoder=JSONEncoder.Field(
+            name="verifySync",
+        ),
+    )
     pre_state: Mapping[str, Account] = field(
         json_encoder=JSONEncoder.Field(
             name="pre",

--- a/src/ethereum_test_tools/spec/blockchain/types.py
+++ b/src/ethereum_test_tools/spec/blockchain/types.py
@@ -1122,11 +1122,11 @@ class HiveFixture(FixtureCommon):
             name="engineFcuVersion",
         ),
     )
-    verify_sync: Optional[bool] = field(
+    sync_payload: Optional[FixtureEngineNewPayload] = field(
         default=None,
         json_encoder=JSONEncoder.Field(
-            name="verifySync",
-            skip_string_convert=True,
+            name="syncPayload",
+            to_json=True,
         ),
     )
     pre_state: Mapping[str, Account] = field(

--- a/src/ethereum_test_tools/spec/blockchain/types.py
+++ b/src/ethereum_test_tools/spec/blockchain/types.py
@@ -1126,6 +1126,7 @@ class HiveFixture(FixtureCommon):
         default=None,
         json_encoder=JSONEncoder.Field(
             name="verifySync",
+            skip_string_convert=True,
         ),
     )
     pre_state: Mapping[str, Account] = field(

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -81,6 +81,7 @@ eip
 eips
 EIPs
 endianness
+EngineAPI
 enum
 env
 eof


### PR DESCRIPTION
## 🗒️ Description
Adds an optional `verify_sync` flag for hive (or blockchain Engine API tests) to pick up and test a second client syncing to the first client.

Syncing is tricky to some clients and we actually need to send a full header via `engine_newPayloadVN` for some of them to start the sync process.

So this change also appends an empty block on top of the latest head of the test to use as syncing head.

## 🔗 Related Issues
None.

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](../docs/) directory.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
