### PR TITLE
feat(fw|ci): add fixture diff utility within CI and local CLI

### DIFF
--- a/.github/workflows/fixtures.yaml
+++ b/.github/workflows/fixtures.yaml
@@ -44,7 +44,7 @@ jobs:
           wget -O $GITHUB_WORKSPACE/bin/solc https://binaries.soliditylang.org/${PLATFORM}/$RELEASE_NAME
           chmod a+x $GITHUB_WORKSPACE/bin/solc
           echo $GITHUB_WORKSPACE/bin >> $GITHUB_PATH
-      - name: Run fixtures fill
+      - name: Run fixtures fill and create fixtures tree hash file
         shell: bash
         run: |
           pip install --upgrade pip
@@ -52,6 +52,8 @@ jobs:
           source env/bin/activate
           pip install -e .
           fill ${{ matrix.fill-params }}
+          dfx --generate-fixtures-tree-only
+          mv fixtures_tree.json ${{ matrix.name }}_hash_tree.json
       - name: Create fixtures info file
         shell: bash
         run: |
@@ -61,20 +63,32 @@ jobs:
         shell: bash
         run: |
           tar -czvf ${{ matrix.name }}.tar.gz ./fixtures
-      - uses: actions/upload-artifact@v3
+      - name: Upload fixtures tar artifact
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.name }}
-          path: ${{ matrix.name }}.tar.gz
+          path: |
+            ${{ matrix.name }}.tar.gz
+      - name: Upload separate fixtures tree hash artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.name }}_hash_tree
+          path: |
+            ${{ matrix.name }}_hash_tree.json
   release:
     runs-on: ubuntu-latest
     needs: build
     if: startsWith(github.ref, 'refs/tags/')
     steps:
-      - name: Download artifacts
+      - name: Download all artifacts
         uses: actions/download-artifact@v3
         with:
           path: .
-      - name: Draft Release
+      - name: Remove fixtures hash tree files
+        shell: bash
+        run: |
+          rm *_hash_tree.json
+      - name: Draft release with remaining files
         uses: softprops/action-gh-release@v1
         with:
           files: './**'

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__/
 venv/
 /fixtures/
 /out/
+.env
 
 # C extensions
 *.so
@@ -59,4 +60,4 @@ verify_kzg_proof
 _readthedocs
 site
 venv-docs/
-.pyspelling_en.dict
+.pyspelling_en.dic

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,7 @@ evm_transition_tool =
 console_scripts =
     fill = entry_points.fill:main
     tf = entry_points.tf:main
+    dfx = entry_points.diff_fixtures:main
     order_fixtures = entry_points.order_fixtures:main
     pyspelling_soft_fail = entry_points.pyspelling_soft_fail:main
     markdownlintcli2_soft_fail = entry_points.markdownlintcli2_soft_fail:main

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ install_requires =
     coincurve>=18.0.0,<19
     trie==2.1.1
     semver==3.0.1
+    python-dotenv==1.0.1
 
 [options.package_data]
 ethereum_test_tools =

--- a/src/entry_points/diff_fixtures.py
+++ b/src/entry_points/diff_fixtures.py
@@ -1,0 +1,120 @@
+"""
+Functions and CLI interface for identifying differences in fixture content based on SHA256 hashes.
+
+Features include generating SHA256 hash maps for fixture files, excluding the '_info' key for
+consistency, and calculating a cumulative hash across all files for quick detection of any changes.
+
+The CLI interface allows users to detect changes locally during development.
+
+Example CLI Usage:
+    ```
+    python diff_fixtures.py --input ./fixtures --develop
+    # or via CLI entry point after package installation
+    dfx --input ./fixtures
+    ```
+
+CI/CD utilizes the functions to create a json fixture hash map file for the main branch during the
+fixture artifact build process, and within the PR branch that a user is developing on. These are
+then compared within the PR workflow during each commit to flag any changes in the fixture files.
+"""
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+
+def get_fixture_hash_map(fixtures_directory: str) -> dict:
+    """
+    Generates a sha256 hash map of the fixture json files, mapped to the file name.
+    The hash for each fixture is calculated without the `_info` key.
+    """
+    hash_map = {}
+    fixtures_dir_path = Path(fixtures_directory)
+    for fixture_path in fixtures_dir_path.rglob("*.json"):
+        with open(fixture_path, "r") as file:
+            data = json.load(file)
+            data.pop("_info", None)
+            fixture_hash = hashlib.sha256(json.dumps(data, sort_keys=True).encode()).hexdigest()
+        relative_path_parts = fixture_path.relative_to(fixtures_dir_path).parts
+        modified_path = Path(*relative_path_parts[1:]).as_posix()
+        hash_map[modified_path] = [fixture_hash]
+    return hash_map
+
+
+def get_fixture_cumulative_hash(fixtures_hash_map: dict) -> str:
+    """
+    Creates a sha256 hash of the sorted hashes of the fixture json files.
+    """
+    sorted_hashes = sorted(fixtures_hash_map.keys())
+    cumulative_hash = hashlib.sha256("".join(sorted_hashes).encode()).hexdigest()
+    return cumulative_hash
+
+
+def generate_fixture_hash_map_dict(cumulative_hash: str, hash_map: dict) -> dict:
+    """
+    Generates a dict containing both the hash map of fixture files and the cumulative hash.
+    """
+    return {"cumulative_hash": cumulative_hash, "hash_map": hash_map}
+
+
+def generate_fixture_hash_map_json(
+    fixtures_directory: str, fixture_hash_map_json: str = "fixture_hash_map.json"
+) -> None:
+    """
+    Generates a json file containing the hash map of fixture files and the cumulative hash,
+    directly from the input fixtures directory. Used within CI/CD artifact generation.
+    """
+    hash_map = get_fixture_hash_map(fixtures_directory)
+    cumulative_hash = get_fixture_cumulative_hash(hash_map)
+    with open(fixture_hash_map_json, "w") as file:
+        json.dump(generate_fixture_hash_map_dict(cumulative_hash, hash_map), file, indent=4)
+
+
+def main():
+    """
+    CLI interface for comparing fixture differences between the input directory and the main
+    branch fixture artifacts.
+    """
+    parser = argparse.ArgumentParser(
+        description=(
+            "Determines if a diff exists between an input fixtures directory and the most recent "
+            "built fixtures from the main branch git workflow. "
+            "Does not provide detailed file changes. "
+            "If no input directory is provided, `./fixtures` is used as the default. "
+            "Compares only the non-development fixtures by default."
+        )
+    )
+    parser.add_argument(
+        "--input",
+        type=str,
+        default="./fixtures",
+        help="Input path for the fixtures directory",
+    )
+    parser.add_argument(
+        "--develop",
+        action="store_true",
+        default=False,
+        help="Compares all fixtures including the development fixtures.",
+    )
+    parser.add_argument(  # To be implemented
+        "--commit",
+        type=str,
+        default=None,
+        help="The commit hash to compare the input fixtures against.",
+    )
+    args = parser.parse_args()
+
+    input_path = Path(args.input)
+    if not input_path.exists() or not input_path.is_dir():
+        raise FileNotFoundError(
+            f"Error: The input or default fixtures directory does not exist: {args.input}"
+        )
+
+    # Todo - implement the fixture diff comparison locally
+    # Currently using dfx for testing the json generation
+    generate_fixture_hash_map_json(args.input)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/entry_points/diff_fixtures.py
+++ b/src/entry_points/diff_fixtures.py
@@ -18,16 +18,17 @@ fixture artifact build process, and within the PR branch that a user is developi
 then compared within the PR workflow during each commit to flag any changes in the fixture files.
 """
 
-import requests
 import argparse
 import hashlib
 import json
-from pathlib import Path
-from io import BytesIO
-from typing import Dict, List, Tuple
-from dotenv import load_dotenv
 import os
 import zipfile
+from io import BytesIO
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import requests
+from dotenv import load_dotenv
 
 
 def compute_fixture_hash(fixture_path: Path) -> str:
@@ -58,6 +59,7 @@ def generate_fixtures_tree_json(
     cumulative hashes at each folder and file. The tree structure is a nested dictionary used to
     compare fixture differences, using the cumulative hash as a quick comparison metric.
     """
+
     def build_tree(directory: Path, parent_path) -> Tuple[Dict, List[str]]:
         """
         Recursively builds a tree structure for fixture directories and files,
@@ -203,21 +205,16 @@ def main():
 
     if args.generate_fixtures_tree_only:
         generate_fixtures_tree_json(
-            fixtures_directory=input_path,
-            output_file="fixtures_tree.json"
+            fixtures_directory=input_path, output_file="fixtures_tree.json"
         )
         return
 
     # Download the latest fixtures tree hash json artifact from the main branch
-    write_artifact_fixtures_tree_json(
-        commit=args.commit,
-        develop=args.develop
-    )
+    write_artifact_fixtures_tree_json(commit=args.commit, develop=args.develop)
 
     # Generate the fixtures tree hash from the local input directory
     generate_fixtures_tree_json(
-        fixtures_directory=input_path,
-        output_file="fixtures_hash_tree_local.json"
+        fixtures_directory=input_path, output_file="fixtures_hash_tree_local.json"
     )
 
 

--- a/src/entry_points/fill.py
+++ b/src/entry_points/fill.py
@@ -3,11 +3,17 @@ Define an entry point wrapper for pytest.
 """
 
 import sys
+import os
 
 import pytest
 
 
 def main():  # noqa: D103
+
+    # Set FILL_CMD env to be added to fixture info section
+    os.environ["FILL_CMD"] = " ".join([os.path.basename(sys.argv[0])] + sys.argv[1:])
+
+    # Run pytest with relevant args
     pytest.main(sys.argv[1:])
 
 

--- a/src/entry_points/fill.py
+++ b/src/entry_points/fill.py
@@ -2,8 +2,8 @@
 Define an entry point wrapper for pytest.
 """
 
-import sys
 import os
+import sys
 
 import pytest
 

--- a/src/ethereum_test_tools/spec/base/base_test.py
+++ b/src/ethereum_test_tools/spec/base/base_test.py
@@ -1,6 +1,7 @@
 """
 Base test class and helper functions for Ethereum state and blockchain tests.
 """
+
 import os
 from abc import abstractmethod
 from dataclasses import dataclass, field

--- a/src/ethereum_test_tools/spec/base/base_test.py
+++ b/src/ethereum_test_tools/spec/base/base_test.py
@@ -1,6 +1,7 @@
 """
 Base test class and helper functions for Ethereum state and blockchain tests.
 """
+import os
 from abc import abstractmethod
 from dataclasses import dataclass, field
 from itertools import count
@@ -100,6 +101,7 @@ class BaseFixture:
         self.info["filling-transition-tool"] = t8n.version()
         if ref_spec is not None:
             ref_spec.write_info(self.info)
+        self.info["fill-cmd"] = os.getenv("FILL_CMD", "")
 
     @abstractmethod
     def to_json(self) -> Dict[str, Any]:

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -47,6 +47,7 @@ changelog
 chfast
 classdict
 cli2
+cmd
 codeAddr
 codecopy
 codesize
@@ -141,6 +142,7 @@ hyperledger
 ignoreRevsFile
 img
 incrementing
+infolist
 init
 initcode
 instantiation

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -77,7 +77,9 @@ dirname
 discordapp
 docstring
 docstrings
+dotenv
 dup
+EEST
 eip
 eips
 EIPs
@@ -99,6 +101,7 @@ executables
 extcodecopy
 extcodehash
 extcodesize
+extractall
 filesystem
 fn
 fname
@@ -196,7 +199,6 @@ pdb
 petersburg
 png
 Pomerantz
-posix
 ppa
 ppas
 pre
@@ -283,6 +285,7 @@ u256
 ubuntu
 ukiyo
 uncomment
+unlink
 util
 utils
 v0

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -70,6 +70,7 @@ delitem
 Dencun
 dev
 devnet
+dfx
 difficulty
 dir
 dirname
@@ -195,6 +196,7 @@ pdb
 petersburg
 png
 Pomerantz
+posix
 ppa
 ppas
 pre


### PR DESCRIPTION
## 🗒️ Description

I thought I would give this a try. So far I've added an entry point `diff_fixtures.py` (like @danceratopz) suggested. This file will be used for both CI workflows and additionally for the CLI interface for local fixture diff'ing.

### CI Workflows

`diff_fixtures.py` will have functions that the CI/CD workflows can use. My understanding is that we only need to be able to tell what files have changed. So far I am planning on adding additional json files that are created using these functions within the workflows, containing:
1) An **ordered** map of the fixture file name, to its content hashed (minus the `_info` section). Allowing us to check what files have changed specifically.
2) A cumulative hash of each fixture hash. Allowing us to simply check anything fixtures have changed.

Here is an example structure:
```json
{
    "cumulative_hash": "ae79b35b75b95cea2fca707cb0750d08a65950160a63b50e5d9d4bba360e3a7e",
    "hash_map": {
        "cancun/eip4844_blobs/point_evaluation_precompile/point_evaluation_precompile_before_fork.json": [
            "6cb959f9baa5c76d60c5042c2434981bbc5994d065f2122b30f4998c9e075fa6"
        ],
        "cancun/eip4844_blobs/point_evaluation_precompile/point_evaluation_precompile_calls.json": [
            "e4e1affc2687a817d5cc971b3a6a73583b001c16091fefef0500d4f67514dbb5"
        ],
        ...
```
An additional step will be added to the build and release workflow, so that every time a PR is merged into main a new json file is created with the hashes. Similarly, I will add an equivalent file that is generated for each commit within a PR. This will be a separate workflow that will be added as an extenstion to the existing tox verifacations.

At this point we have 2 files that a comparison can be drawn from, using the cumulative hash first, and then the file by file hash afterwards. If we want to be more granular with diffing we can in the future. We can also only diff the files that we expect to change, to speed up the workflow.

Maybe a trigger within the PR will be nice to determine when the fixture diff should occur.

### CLI Interface

The CLI command, I'm calling it `dfx` for now will be able to generate the same file locally and pull in the the json file generated from main, such that a diff can be created.

This will be more granular with more information, where as the workflows will ideally signal if a diff exists.

If we want we can add this to tox, but my gut feeling is that it should be a seperate utility.

## 🔗 Related Issues
https://github.com/ethereum/execution-spec-tests/issues/388


## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](../docs/) directory.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
