### PR TITLE
refactor(tests): EIP-6780 Self-Destruct Tests Parametrization Change

### DIFF
--- a/tests/cancun/eip6780_selfdestruct/test_selfdestruct.py
+++ b/tests/cancun/eip6780_selfdestruct/test_selfdestruct.py
@@ -238,29 +238,39 @@ def pre(
             id="single_call_self",
         ),
         pytest.param(
-            10,
+            2,
             [Address(0x1000)],
             id="multiple_calls_single_sendall_recipient",
         ),
         pytest.param(
-            10,
+            2,
+            [SELF_ADDRESS],
+            id="multiple_calls_single_self_recipient",
+        ),
+        pytest.param(
+            3,
             [Address(0x1000), Address(0x2000), Address(0x3000)],
             id="multiple_calls_multiple_sendall_recipients",
         ),
         pytest.param(
-            10,
+            3,
             [SELF_ADDRESS, Address(0x2000), Address(0x3000)],
             id="multiple_calls_multiple_sendall_recipients_including_self",
-        ),
-        pytest.param(
-            10,
-            [Address(0x1000), Address(0x2000), SELF_ADDRESS],
-            id="multiple_calls_multiple_sendall_recipients_including_self_different_order",
         ),
         pytest.param(
             3,
             [Address(0x1000), Address(0x2000), SELF_ADDRESS],
             id="multiple_calls_multiple_sendall_recipients_including_self_last",
+        ),
+        pytest.param(
+            6,
+            [SELF_ADDRESS, Address(0x2000), Address(0x3000)],
+            id="multiple_calls_multiple_repeating_sendall_recipients_including_self",
+        ),
+        pytest.param(
+            6,
+            [Address(0x1000), Address(0x2000), SELF_ADDRESS],
+            id="multiple_calls_multiple_repeating_sendall_recipients_including_self_last",
         ),
     ],
 )
@@ -722,32 +732,42 @@ def test_recreate_self_destructed_contract_different_txs(
         pytest.param(
             1,
             [PRE_EXISTING_SELFDESTRUCT_ADDRESS],
-            id="single_call_self_sendall_recipient",
+            id="single_call_self",
         ),
         pytest.param(
-            10,
+            2,
             [Address(0x1000)],
             id="multiple_calls_single_sendall_recipient",
         ),
         pytest.param(
-            10,
+            2,
+            [PRE_EXISTING_SELFDESTRUCT_ADDRESS],
+            id="multiple_calls_single_self_recipient",
+        ),
+        pytest.param(
+            3,
             [Address(0x1000), Address(0x2000), Address(0x3000)],
             id="multiple_calls_multiple_sendall_recipients",
         ),
         pytest.param(
-            10,
+            3,
             [PRE_EXISTING_SELFDESTRUCT_ADDRESS, Address(0x2000), Address(0x3000)],
             id="multiple_calls_multiple_sendall_recipients_including_self",
-        ),
-        pytest.param(
-            10,
-            [Address(0x1000), Address(0x2000), PRE_EXISTING_SELFDESTRUCT_ADDRESS],
-            id="multiple_calls_multiple_sendall_recipients_including_self_different_order",
         ),
         pytest.param(
             3,
             [Address(0x1000), Address(0x2000), PRE_EXISTING_SELFDESTRUCT_ADDRESS],
             id="multiple_calls_multiple_sendall_recipients_including_self_last",
+        ),
+        pytest.param(
+            6,
+            [PRE_EXISTING_SELFDESTRUCT_ADDRESS, Address(0x2000), Address(0x3000)],
+            id="multiple_calls_multiple_repeating_sendall_recipients_including_self",
+        ),
+        pytest.param(
+            6,
+            [Address(0x1000), Address(0x2000), PRE_EXISTING_SELFDESTRUCT_ADDRESS],
+            id="multiple_calls_multiple_repeating_sendall_recipients_including_self_last",
         ),
     ],
 )


### PR DESCRIPTION
## 🗒️ Description
Small parametrization change to make sure we don't always `SELFDESTRUCT(self)` on the last call to self-destruct.

Executed on all clients, no issues.

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](../docs/) directory.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
