### PR TITLE
fix(tests): Remove zero pre-alloc from tests

### DIFF
--- a/tests/cancun/eip1153_tstore/test_tstorage.py
+++ b/tests/cancun/eip1153_tstore/test_tstorage.py
@@ -73,7 +73,7 @@ def test_tload_after_tstore(state_test: StateTestFiller):
 
     pre = {
         TestAddress: Account(balance=10_000_000),
-        code_address: Account(code=code, storage={slot: 0 for slot in slots_under_test}),
+        code_address: Account(code=code, storage={slot: 0xFF for slot in slots_under_test}),
     }
 
     tx = Transaction(

--- a/tests/cancun/eip7516_blobgasfee/test_blobgasfee_opcode.py
+++ b/tests/cancun/eip7516_blobgasfee/test_blobgasfee_opcode.py
@@ -3,6 +3,7 @@ abstract: Tests [EIP-7516: BLOBBASEFEE opcode](https://eips.ethereum.org/EIPS/ei
     Test BLOBGASFEE opcode [EIP-7516: BLOBBASEFEE opcode](https://eips.ethereum.org/EIPS/eip-7516)
 
 """  # noqa: E501
+
 from dataclasses import replace
 from itertools import count
 from typing import Dict
@@ -210,7 +211,7 @@ def test_blobbasefee_during_fork(
             ),
         )
         # pre-set storage just to make sure we detect the change
-        code_caller_pre_storage[block_number] = 1 if timestamp < 15_000 else 0
+        code_caller_pre_storage[block_number] = 0xFF
         code_caller_post_storage[block_number] = 0 if timestamp < 15_000 else 1
 
     pre[code_caller_address] = replace(pre[code_caller_address], storage=code_caller_pre_storage)


### PR DESCRIPTION
## 🗒️ Description
Remove zeros from pre-alloc of some of the tests.

Assigning a zero in the `pre` of a test is unnecessary, and can produce a different behavior in some clients (should actually be defined and fixed).

Assigning a zero in `post` is necessary to verify empty keys in storage in some of the tests.

## 🔗 Related Issues
#447

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
