### PR TITLE
feat(fw): calculate genesis state root without calling t8n

### DIFF
--- a/src/ethereum_test_tools/spec/blockchain/blockchain_test.py
+++ b/src/ethereum_test_tools/spec/blockchain/blockchain_test.py
@@ -143,11 +143,7 @@ class BlockchainTest(BaseTest):
         )
         if empty_accounts := pre_alloc.empty_accounts():
             raise Exception(f"Empty accounts in pre state: {empty_accounts}")
-        new_alloc, state_root = t8n.calc_state_root(
-            alloc=to_json(pre_alloc),
-            fork=fork,
-            debug_output_path=self.get_next_transition_tool_output_path(),
-        )
+        state_root = pre_alloc.state_root()
         genesis = FixtureHeader(
             parent_hash=Hash(0),
             ommers_hash=Hash(EmptyOmmersRoot),
@@ -179,7 +175,7 @@ class BlockchainTest(BaseTest):
             withdrawals=env.withdrawals,
         )
 
-        return Alloc(new_alloc), genesis_rlp, genesis
+        return pre_alloc, genesis_rlp, genesis
 
     def generate_block_data(
         self,

--- a/src/ethereum_test_tools/tests/test_types.py
+++ b/src/ethereum_test_tools/tests/test_types.py
@@ -35,18 +35,18 @@ def test_storage():
     """
     s = Storage({"10": "0x10"})
 
-    assert 10 in s.data
-    assert s.data[10] == 16
+    assert 10 in s
+    assert s[10] == 16
 
     s = Storage({"10": "10"})
 
-    assert 10 in s.data
-    assert s.data[10] == 10
+    assert 10 in s
+    assert s[10] == 10
 
     s = Storage({10: 10})
 
-    assert 10 in s.data
-    assert s.data[10] == 10
+    assert 10 in s
+    assert s[10] == 10
 
     iter_s = iter(Storage({10: 20, "11": "21"}))
     assert next(iter_s) == 10
@@ -54,8 +54,8 @@ def test_storage():
 
     s["10"] = "0x10"
     s["0x10"] = "10"
-    assert s.data[10] == 16
-    assert s.data[16] == 10
+    assert s[10] == 16
+    assert s[16] == 10
 
     assert "10" in s
     assert "0xa" in s
@@ -67,8 +67,8 @@ def test_storage():
     assert 10 not in s
 
     s = Storage({-1: -1, -2: -2})
-    assert s.data[-1] == -1
-    assert s.data[-2] == -2
+    assert s[-1] == -1
+    assert s[-2] == -2
     d = to_json(s)
     assert (
         d["0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"]

--- a/src/evm_transition_tool/tests/test_evaluate.py
+++ b/src/evm_transition_tool/tests/test_evaluate.py
@@ -7,6 +7,7 @@ from typing import Dict
 import pytest
 
 from ethereum_test_forks import Berlin, Fork, Istanbul, London
+from ethereum_test_tools.common import Alloc
 from evm_transition_tool import GethTransitionTool, TransitionTool
 
 FIXTURES_ROOT = Path(os.path.join("src", "evm_transition_tool", "tests", "fixtures"))
@@ -76,7 +77,7 @@ def test_calc_state_root(  # noqa: D103
 
     env = TestEnv()
     env.base_fee = base_fee
-    assert t8n.calc_state_root(alloc=alloc, fork=fork)[1].startswith(hash)
+    assert Alloc(alloc).state_root().startswith(hash)
 
 
 @pytest.mark.parametrize("evm_tool", [GethTransitionTool])

--- a/src/evm_transition_tool/transition_tool.py
+++ b/src/evm_transition_tool/transition_tool.py
@@ -1,6 +1,7 @@
 """
 Transition tool abstract class.
 """
+
 import json
 import os
 import shutil
@@ -561,49 +562,6 @@ class TransitionTool:
                 t8n_data=t8n_data,
                 debug_output_path=debug_output_path,
             )
-
-    def calc_state_root(
-        self, *, alloc: Any, fork: Fork, debug_output_path: str = ""
-    ) -> Tuple[Dict, bytes]:
-        """
-        Calculate the state root for the given `alloc`.
-        """
-        env: Dict[str, Any] = {
-            "currentCoinbase": "0x0000000000000000000000000000000000000000",
-            "currentDifficulty": "0x0",
-            "currentGasLimit": "0x0",
-            "currentNumber": "0",
-            "currentTimestamp": "0",
-        }
-
-        if fork.header_base_fee_required(0, 0):
-            env["currentBaseFee"] = "7"
-
-        if fork.header_prev_randao_required(0, 0):
-            env["currentRandom"] = "0"
-
-        if fork.header_withdrawals_required(0, 0):
-            env["withdrawals"] = []
-
-        if fork.header_excess_blob_gas_required(0, 0):
-            env["currentExcessBlobGas"] = "0"
-
-        if fork.header_beacon_root_required(0, 0):
-            env[
-                "parentBeaconBlockRoot"
-            ] = "0x0000000000000000000000000000000000000000000000000000000000000000"
-
-        new_alloc, result = self.evaluate(
-            alloc=alloc,
-            txs=[],
-            env=env,
-            fork_name=fork.transition_tool_name(block_number=0, timestamp=0),
-            debug_output_path=debug_output_path,
-        )
-        state_root = result.get("stateRoot")
-        if state_root is None or not isinstance(state_root, str):
-            raise Exception("Unable to calculate state root")
-        return new_alloc, bytes.fromhex(state_root[2:])
 
     def verify_fixture(
         self, fixture_format: FixtureFormats, fixture_path: Path, debug_output_path: Optional[Path]


### PR DESCRIPTION
## 🗒️ Description
Removes the call to t8n to calculate the state root of the genesis block for blockchain tests, and in its place it uses the `execution-specs` routine to fill the state and calculate the root.

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
