### PR TITLE
fix(pytest-filler): Remove collected items without parametrized fork

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Improve handling of the argument passed to `solc --evm-version` when compiling Yul code ([#418](https://github.com/ethereum/execution-spec-tests/pull/418)).
 - 🐞 Fix `fill -m yul_test` which failed to filter tests that are (dynamically) marked as a yul test ([#418](https://github.com/ethereum/execution-spec-tests/pull/418)).
 - 🔀 Helper methods `to_address`, `to_hash` and `to_hash_bytes` have been deprecated in favor of `Address` and `Hash`, which are automatically detected as opcode parameters and pushed to the stack in the resulting bytecode ([#422](https://github.com/ethereum/execution-spec-tests/pull/422)).
+- 🐞 Fix bug that causes an exception during test collection because the fork parameter contains `None` ([#452](https://github.com/ethereum/execution-spec-tests/pull/452))
 
 ### 🔧 EVM Tools
 

--- a/src/pytest_plugins/test_filler/test_filler.py
+++ b/src/pytest_plugins/test_filler/test_filler.py
@@ -241,7 +241,7 @@ def do_fixture_verification(request, t8n) -> bool:
 @pytest.fixture(autouse=True, scope="session")
 def evm_fixture_verification(
     request, do_fixture_verification: bool, evm_bin: Path, verify_fixtures_bin: Path
-) -> Optional[Generator[TransitionTool, None, None]]:
+) -> Generator[Optional[TransitionTool], None, None]:
     """
     Returns the configured evm binary for executing statetest and blocktest
     commands used to verify generated JSON fixtures.
@@ -492,6 +492,9 @@ def pytest_collection_modifyitems(config, items):
     """
     for item in items[:]:  # use a copy of the list, as we'll be modifying it
         if isinstance(item, EIPSpecTestItem):
+            continue
+        if "fork" not in item.callspec.params or item.callspec.params["fork"] is None:
+            items.remove(item)
             continue
         if item.callspec.params["fork"] < Paris:
             # Even though the `state_test` test spec does not produce a hive STATE_TEST, it does


### PR DESCRIPTION
## 🗒️ Description
There's some instances where a test function in a module ends up being skipped and the parametrized fork contains a `None` value which then triggers an exception in function `pytest_collection_modifyitems` of `test_filler.py`.

This PR modifies behavior so that the item is removed if it reaches the `pytest_collection_modifyitems` without a fork value.

Example fill command:
```bash
fill -vv --fork=Prague tests/cancun/eip7516_blobgasfee/test_blobgasfee_opcode.py
```
fails before this PR.

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
