### PR TITLE
feat(transition_tool): Use execution-specs daemon

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,7 +21,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 ### 🔧 EVM Tools
 
-- ✨ Use `execution-specs` evm tool daemon feature to run tests, which provides an fill speed increase of around 57x ([#453](https://github.com/ethereum/execution-spec-tests/pull/453))
+- ✨ Use `execution-specs` evm tool daemon feature to fill tests, which provides a speed increase of around 57x ([#453](https://github.com/ethereum/execution-spec-tests/pull/453))
 
 ### 📋 Misc
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,8 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 ### 🔧 EVM Tools
 
+- ✨ Use `execution-specs` evm tool daemon feature to run tests, which provides an fill speed increase of around 57x ([#453](https://github.com/ethereum/execution-spec-tests/pull/453))
+
 ### 📋 Misc
 
 - 🐞 Fix deprecation warnings due to outdated config in recommended VS Code project settings ([#420](https://github.com/ethereum/execution-spec-tests/pull/420)).

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ install_requires =
     setuptools
     types-setuptools
     requests>=2.31.0
+    parsys-requests-unixsocket==0.3.1
     colorlog>=6.7.0
     pytest==7.3.2
     pytest-xdist>=3.3.1,<4

--- a/src/evm_transition_tool/execution_specs.py
+++ b/src/evm_transition_tool/execution_specs.py
@@ -4,9 +4,14 @@ Ethereum Specs EVM Transition tool interface.
 https://github.com/ethereum/execution-specs
 """
 
+import subprocess
+import time
 from pathlib import Path
 from re import compile
-from typing import Optional
+from tempfile import TemporaryDirectory
+from typing import Any, Dict, List, Optional, Tuple
+
+from requests_unixsocket import Session  # type: ignore
 
 from ethereum_test_forks import Constantinople, ConstantinopleFix, Fork
 
@@ -16,6 +21,8 @@ UNSUPPORTED_FORKS = (
     Constantinople,
     ConstantinopleFix,
 )
+
+DAEMON_STARTUP_TIMEOUT_SECONDS = 5
 
 
 class ExecutionSpecsTransitionTool(GethTransitionTool):
@@ -93,9 +100,98 @@ class ExecutionSpecsTransitionTool(GethTransitionTool):
     statetest_subcommand: Optional[str] = None
     blocktest_subcommand: Optional[str] = None
 
+    process: Optional[subprocess.Popen] = None
+    server_url: str
+    temp_dir: Optional[TemporaryDirectory] = None
+
     def is_fork_supported(self, fork: Fork) -> bool:
         """
         Returns True if the fork is supported by the tool.
         Currently, ethereum-spec-evm provides no way to determine supported forks.
         """
         return fork not in UNSUPPORTED_FORKS
+
+    def start_server(self):
+        """
+        Starts the t8n-server process, extracts the port, and leaves it running for future re-use.
+        """
+        self.temp_dir = TemporaryDirectory()
+        self.server_file_path = Path(self.temp_dir.name) / "t8n.sock"
+        replaced_str = str(self.server_file_path).replace("/", "%2F")
+        self.server_url = f"http+unix://{replaced_str}/"
+        self.process = subprocess.Popen(
+            args=[
+                str(self.binary),
+                "daemon",
+                "--uds",
+                self.server_file_path,
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+        start = time.time()
+        while True:
+            if self.server_file_path.exists():
+                break
+            if time.time() - start > DAEMON_STARTUP_TIMEOUT_SECONDS:
+                raise Exception("Failed starting ethereum-spec-evm subprocess")
+            time.sleep(0)  # yield to other processes
+
+    def shutdown(self):
+        """
+        Stops the t8n-server process if it was started
+        """
+        if self.process:
+            self.process.kill()
+        if self.temp_dir:
+            self.temp_dir.cleanup()
+            self.temp_dir = None
+
+    def evaluate(
+        self,
+        alloc: Any,
+        txs: Any,
+        env: Any,
+        fork_name: str,
+        chain_id: int = 1,
+        reward: int = 0,
+        eips: Optional[List[int]] = None,
+        debug_output_path: str = "",
+    ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        """
+        Executes `evm t8n` with the specified arguments.
+        """
+        if not self.process:
+            self.start_server()
+
+        if eips is not None:
+            fork_name = "+".join([fork_name] + [str(eip) for eip in eips])
+
+        input_json = {
+            "alloc": alloc,
+            "txs": txs,
+            "env": env,
+        }
+        state_json = {
+            "fork": fork_name,
+            "chainid": chain_id,
+            "reward": reward,
+        }
+
+        post_data = {"state": state_json, "input": input_json}
+        response = Session().post(self.server_url, json=post_data, timeout=5)
+        response.raise_for_status()  # exception visible in pytest failure output
+        output = response.json()
+
+        if response.status_code != 200:
+            raise Exception(
+                f"t8n-server returned status code {response.status_code}, "
+                f"response: {response.text}"
+            )
+        if not all([x in output for x in ["alloc", "result", "body"]]):
+            raise Exception(
+                "Malformed t8n output: missing 'alloc', 'result' or 'body', server response: "
+                f"{response.text}"
+            )
+
+        return output["alloc"], output["result"]

--- a/src/evm_transition_tool/execution_specs.py
+++ b/src/evm_transition_tool/execution_specs.py
@@ -126,8 +126,6 @@ class ExecutionSpecsTransitionTool(GethTransitionTool):
                 "--uds",
                 self.server_file_path,
             ],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
         )
         start = time.time()
         while True:
@@ -179,7 +177,7 @@ class ExecutionSpecsTransitionTool(GethTransitionTool):
         }
 
         post_data = {"state": state_json, "input": input_json}
-        response = Session().post(self.server_url, json=post_data, timeout=5)
+        response = Session().post(self.server_url, json=post_data, timeout=10)
         response.raise_for_status()  # exception visible in pytest failure output
         output = response.json()
 

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -281,6 +281,7 @@ u256
 ubuntu
 ukiyo
 uncomment
+unixsocket
 util
 utils
 v0


### PR DESCRIPTION
## 🗒️ Description
Implements usage of the execution-specs evm daemon implemented in this branch: https://github.com/ethereum/execution-specs/tree/evm-daemon

Which makes filling all tests with EELS around 57 times faster.

I've also diff'd the resulting fixtures and the only difference in all of them is the evm version in the `_info`.

To test the deamon with this branch in an existing/installed [execution-spec-tests setup](https://ethereum.github.io/execution-spec-tests/main/getting_started/quick_start/):
```bash
pip uninstall ethereum
pip install ethereum@git+https://github.com/ethereum/execution-specs@evm-daemon
# verify daemon option is available in `ethereum-spec-evm`'s help:
ethereum-spec-evm --help
fill --evm-bin=ethereum-spec-evm
```

## 🔗 Related Issues
None.

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
