### PR TITLE
feat(tests): extend Op with Op.OOG macro opcode

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - 🔀 Locally calculate state root for the genesis blocks in the blockchain tests instead of calling t8n ([#450](https://github.com/ethereum/execution-spec-tests/pull/450)).
 - 🐞 Fix bug that causes an exception during test collection because the fork parameter contains `None` ([#452](https://github.com/ethereum/execution-spec-tests/pull/452)).
 - ✨ The `_info` field in the test fixtures now contains a `hash` field, which is the hash of the test fixture, and a `hasher` script has been added which prints and performs calculations on top of the hashes of all fixtures (see `hasher -h`) ([#454](https://github.com/ethereum/execution-spec-tests/pull/454)).
+- ✨ Adds an optional `verify_sync` field to hive blockchain tests (EngineAPI). When set to true a second client attempts to sync to the first client that executed the tests.([#431](https://github.com/ethereum/execution-spec-tests/pull/431)).
 
 ### 🔧 EVM Tools
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - 🐞 Fix bug that causes an exception during test collection because the fork parameter contains `None` ([#452](https://github.com/ethereum/execution-spec-tests/pull/452)).
 - ✨ The `_info` field in the test fixtures now contains a `hash` field, which is the hash of the test fixture, and a `hasher` script has been added which prints and performs calculations on top of the hashes of all fixtures (see `hasher -h`) ([#454](https://github.com/ethereum/execution-spec-tests/pull/454)).
 - ✨ Adds an optional `verify_sync` field to hive blockchain tests (EngineAPI). When set to true a second client attempts to sync to the first client that executed the tests.([#431](https://github.com/ethereum/execution-spec-tests/pull/431)).
+- 🐞 Fix manually setting the gas limit in the genesis test env for post genesis blocks in blockchain tests. ([#472](https://github.com/ethereum/execution-spec-tests/pull/472)).
 
 ### 🔧 EVM Tools
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 ### 🛠️ Framework
 
 - 🐞 Fix incorrect `!=` operator for `FixedSizeBytes` ([#477](https://github.com/ethereum/execution-spec-tests/pull/477)).
+- ✨ Add Macro enum that represents byte sequence of Op instructions ([#457](https://github.com/ethereum/execution-spec-tests/pull/457))
 
 ### 🔧 EVM Tools
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,16 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 ### 🧪 Test Cases
 
+### 🛠️ Framework
+
+### 🔧 EVM Tools
+
+### 📋 Misc
+
+## 🔜 [v2.1.1](https://github.com/ethereum/execution-spec-tests/releases/tag/v2.1.1) - 2024-03-09
+
+### 🧪 Test Cases
+
 - 🐞 Dynamic create2 collision from different transactions same block ([#430](https://github.com/ethereum/execution-spec-tests/pull/430)).
 - 🐞 Fix beacon root contract deployment tests so the account in the pre-alloc is not empty ([#425](https://github.com/ethereum/execution-spec-tests/pull/425)).
 - 🔀 All beacon root contract tests are now contained in tests/cancun/eip4788_beacon_root/test_beacon_root_contract.py, and all state tests have been converted back to blockchain tests format ([#449](https://github.com/ethereum/execution-spec-tests/pull/449))
@@ -22,8 +32,8 @@ Test fixtures for use by clients are available for each release on the [Github r
 - 🔀 Locally calculate state root for the genesis blocks in the blockchain tests instead of calling t8n ([#450](https://github.com/ethereum/execution-spec-tests/pull/450)).
 - 🐞 Fix bug that causes an exception during test collection because the fork parameter contains `None` ([#452](https://github.com/ethereum/execution-spec-tests/pull/452)).
 - ✨ The `_info` field in the test fixtures now contains a `hash` field, which is the hash of the test fixture, and a `hasher` script has been added which prints and performs calculations on top of the hashes of all fixtures (see `hasher -h`) ([#454](https://github.com/ethereum/execution-spec-tests/pull/454)).
-- ✨ Adds an optional `verify_sync` field to hive blockchain tests (EngineAPI). When set to true a second client attempts to sync to the first client that executed the tests.([#431](https://github.com/ethereum/execution-spec-tests/pull/431)).
-- 🐞 Fix manually setting the gas limit in the genesis test env for post genesis blocks in blockchain tests. ([#472](https://github.com/ethereum/execution-spec-tests/pull/472)).
+- ✨ Adds an optional `verify_sync` field to hive blockchain tests (EngineAPI). When set to true a second client attempts to sync to the first client that executed the tests ([#431](https://github.com/ethereum/execution-spec-tests/pull/431)).
+- 🐞 Fix manually setting the gas limit in the genesis test env for post genesis blocks in blockchain tests ([#472](https://github.com/ethereum/execution-spec-tests/pull/472)).
 
 ### 🔧 EVM Tools
 

--- a/src/ethereum_test_tools/__init__.py
+++ b/src/ethereum_test_tools/__init__.py
@@ -55,7 +55,7 @@ from .spec import (
     TestInfo,
 )
 from .spec.blockchain.types import Block, Header
-from .vm import Opcode, OpcodeCallArg, Opcodes
+from .vm import Macro, Opcode, OpcodeCallArg, Opcodes
 
 __all__ = (
     "SPEC_TYPES",
@@ -84,6 +84,7 @@ __all__ = (
     "Initcode",
     "JSONEncoder",
     "Opcode",
+    "Macro",
     "OpcodeCallArg",
     "Opcodes",
     "ReferenceSpec",

--- a/src/ethereum_test_tools/spec/blockchain/blockchain_test.py
+++ b/src/ethereum_test_tools/spec/blockchain/blockchain_test.py
@@ -101,6 +101,7 @@ class BlockchainTest(BaseTest):
     post: Mapping
     blocks: List[Block]
     genesis_environment: Environment = field(default_factory=Environment)
+    verify_sync: Optional[bool] = None
     tag: str = ""
     chain_id: int = 1
 
@@ -393,6 +394,7 @@ class BlockchainTest(BaseTest):
         pre, _, genesis = self.make_genesis(t8n, fork)
         alloc = to_json(pre)
         env = environment_from_parent_header(genesis)
+        head_hash = genesis.hash
 
         for block in self.blocks:
             header, _, txs, new_alloc, new_env = self.generate_block_data(
@@ -412,6 +414,7 @@ class BlockchainTest(BaseTest):
                 if block.exception is None:
                     alloc = new_alloc
                     env = apply_new_parent(env, header)
+                    head_hash = header.hash
         fcu_version = fork.engine_forkchoice_updated_version(header.number, header.timestamp)
         assert (
             fcu_version is not None
@@ -419,6 +422,34 @@ class BlockchainTest(BaseTest):
         " never try to execute this test case."
 
         self.verify_post_state(t8n, alloc)
+
+        sync_payload: Optional[FixtureEngineNewPayload] = None
+        if self.verify_sync:
+            # Test is marked for syncing verification.
+            assert (
+                genesis.hash != head_hash
+            ), "Invalid payload tests negative test via sync is not supported yet."
+
+            # Most clients require the header to start the sync process, so we create an empty
+            # block on top of the last block of the test to send it as new payload and trigger the
+            # sync process.
+            sync_header, _, _, _, _ = self.generate_block_data(
+                t8n=t8n,
+                fork=fork,
+                block=Block(),
+                previous_env=env,
+                previous_alloc=alloc,
+                eips=eips,
+            )
+            sync_payload = FixtureEngineNewPayload.from_fixture_header(
+                fork=fork,
+                header=sync_header,
+                transactions=[],
+                withdrawals=[],
+                validation_error=None,
+                error_code=None,
+            )
+
         return HiveFixture(
             fork=self.network_info(fork, eips),
             genesis=genesis,
@@ -426,6 +457,7 @@ class BlockchainTest(BaseTest):
             fcu_version=fcu_version,
             pre_state=pre,
             post_state=alloc_to_accounts(alloc),
+            sync_payload=sync_payload,
             name=self.tag,
         )
 

--- a/src/ethereum_test_tools/spec/blockchain/types.py
+++ b/src/ethereum_test_tools/spec/blockchain/types.py
@@ -548,9 +548,7 @@ class Block(Header):
         new_env.coinbase = (
             self.coinbase if self.coinbase is not None else environment_default.coinbase
         )
-        new_env.gas_limit = (
-            self.gas_limit if self.gas_limit is not None else environment_default.gas_limit
-        )
+        new_env.gas_limit = self.gas_limit or env.parent_gas_limit or environment_default.gas_limit
         if not isinstance(self.base_fee, Removable):
             new_env.base_fee = self.base_fee
         new_env.withdrawals = self.withdrawals

--- a/src/ethereum_test_tools/spec/blockchain/types.py
+++ b/src/ethereum_test_tools/spec/blockchain/types.py
@@ -1122,6 +1122,13 @@ class HiveFixture(FixtureCommon):
             name="engineFcuVersion",
         ),
     )
+    sync_payload: Optional[FixtureEngineNewPayload] = field(
+        default=None,
+        json_encoder=JSONEncoder.Field(
+            name="syncPayload",
+            to_json=True,
+        ),
+    )
     pre_state: Mapping[str, Account] = field(
         json_encoder=JSONEncoder.Field(
             name="pre",

--- a/src/ethereum_test_tools/tests/test_vm.py
+++ b/src/ethereum_test_tools/tests/test_vm.py
@@ -142,6 +142,10 @@ from ..vm.opcode import Opcodes as Op
             b"\x60\x08\x60\x07\x60\x06\x60\x05\x60\x04\x73\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
             + b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0c\x60\x01\xf0",
         ),
+        (
+            Om.OOG(),
+            bytes([0x64, 0x17, 0x48, 0x76, 0xE8, 0x00, 0x60, 0x00, 0x20]),
+        ),
     ],
 )
 def test_opcodes(opcodes: bytes, expected: bytes):
@@ -157,6 +161,7 @@ def test_opcodes_repr():
     """
     assert f"{Op.CALL}" == "CALL"
     assert f"{Op.DELEGATECALL}" == "DELEGATECALL"
+    assert f"{Om.OOG}" == "OOG"
     assert str(Op.ADD) == "ADD"
 
 
@@ -165,3 +170,5 @@ def test_macros():
     Test opcode and macros interaction
     """
     assert (Op.PUSH1(1) + Om.OOG) == (Op.PUSH1(1) + Op.SHA3(0, 100000000000))
+    for opcode in Op:
+        assert opcode != Om.OOG

--- a/src/ethereum_test_tools/tests/test_vm.py
+++ b/src/ethereum_test_tools/tests/test_vm.py
@@ -5,6 +5,7 @@ Test suite for `ethereum_test_tools.vm` module.
 import pytest
 
 from ..common.base_types import Address
+from ..vm.opcode import Macros as Om
 from ..vm.opcode import Opcodes as Op
 
 
@@ -163,4 +164,4 @@ def test_macros():
     """
     Test opcode and macros interaction
     """
-    assert (Op.PUSH1(1) + Op.OOG) == (Op.PUSH1(1) + Op.SHA3(0, 100000000000))
+    assert (Op.PUSH1(1) + Om.OOG) == (Op.PUSH1(1) + Op.SHA3(0, 100000000000))

--- a/src/ethereum_test_tools/vm/__init__.py
+++ b/src/ethereum_test_tools/vm/__init__.py
@@ -1,10 +1,12 @@
 """
 Ethereum Virtual Machine related definitions and utilities.
 """
-from .opcode import Opcode, OpcodeCallArg, Opcodes
+
+from .opcode import Macro, Opcode, OpcodeCallArg, Opcodes
 
 __all__ = (
     "Opcode",
+    "Macro",
     "OpcodeCallArg",
     "Opcodes",
 )

--- a/src/ethereum_test_tools/vm/opcode.py
+++ b/src/ethereum_test_tools/vm/opcode.py
@@ -4932,7 +4932,7 @@ class Macros(Macro, Enum):
     OOG(args)
     ----
 
-    Halt execution by consuming all available gas
+    Halt execution by consuming all available gas.
 
     Inputs
     ----
@@ -4946,9 +4946,9 @@ class Macros(Macro, Enum):
     ----
     This operation will result in gasprice = 19073514453125027
     Add a little more and geth report gasprice = 30 with oog exception
-    Make it 0 - 1 and geth report gasprice > u64 error
+    Make it 0 - 1 and geth report gasprice > u64 error.
 
-    Source
+    Bytecode
     ----
     SHA3(0, 100000000000)
     """

--- a/src/ethereum_test_tools/vm/opcode.py
+++ b/src/ethereum_test_tools/vm/opcode.py
@@ -48,14 +48,13 @@ class OpcodeMacroBase(bytes):
         """
         return super().__new__(cls, *args)
 
-    def __call__(self, *args_t: Union[int, bytes, str, "Opcode", FixedSizeBytes]) -> bytes:
+    def __call__(self, *_: Union[int, bytes, str, "Opcode", FixedSizeBytes]) -> bytes:
         """
         Make OpcodeMacroBase callable, so that arguments can directly be
         provided to an Opcode in order to more conveniently generate
         bytecode (implemented in the subclass).
         """
         # ignore opcode arguments
-        args_t.count
         return bytes(self)
 
     def __str__(self) -> str:

--- a/src/ethereum_test_tools/vm/opcode.py
+++ b/src/ethereum_test_tools/vm/opcode.py
@@ -62,7 +62,7 @@ class Opcode(bytes):
         """
         Creates a new opcode instance.
         """
-        if type(opcode_or_byte) is Opcode:
+        if type(opcode_or_byte) is Opcode or type(opcode_or_byte) is Macro:
             # Required because Enum class calls the base class with the instantiated object as
             # parameter.
             return opcode_or_byte
@@ -73,7 +73,7 @@ class Opcode(bytes):
             obj.min_stack_height = min_stack_height
             obj.data_portion_length = data_portion_length
             return obj
-        assert False
+        raise TypeError("Opcode constructor '__new__' didn't return an instance!")
 
     def __call__(self, *args_t: Union[int, bytes, str, "Opcode", FixedSizeBytes]) -> bytes:
         """
@@ -4582,8 +4582,8 @@ class Opcodes(Opcode, Enum):
     Inputs
     ----
     - value: value in wei to send to the new account
-    - offset: byte offset in the memory in bytes, the initialisation code for the new account
-    - size: byte size to copy (size of the initialisation code)
+    - offset: byte offset in the memory in bytes, the initialization code for the new account
+    - size: byte size to copy (size of the initialization code)
 
     Outputs
     ----
@@ -4769,8 +4769,8 @@ class Opcodes(Opcode, Enum):
     Inputs
     ----
     - value: value in wei to send to the new account
-    - offset: byte offset in the memory in bytes, the initialisation code of the new account
-    - size: byte size to copy (size of the initialisation code)
+    - offset: byte offset in the memory in bytes, the initialization code of the new account
+    - size: byte size to copy (size of the initialization code)
     - salt: 32-byte value used to create the new account at a deterministic address
 
     Outputs
@@ -4913,7 +4913,7 @@ class Opcodes(Opcode, Enum):
 
     OOG = Macro(SHA3(0, 100000000000))
     """
-    OOG(args)
+    OOG(args) [Macro]
     ----
 
     Halt execution by consuming all available gas
@@ -4928,6 +4928,11 @@ class Opcodes(Opcode, Enum):
 
     Gas
     ----
-    
-    Source: SHA3(0, 100000000000)
+    This operation will result in gasprice = 19073514453125027
+    Add a little more and geth report gasprice = 30 with oog exception
+    Make it 0 - 1 and geth report gasprice > u64 error
+
+    Bytecode
+    ----
+    SHA3(0, 100000000000)
     """

--- a/src/ethereum_test_tools/vm/opcode.py
+++ b/src/ethereum_test_tools/vm/opcode.py
@@ -70,7 +70,7 @@ class OpcodeMacroBase(bytes):
         """
         if isinstance(other, OpcodeMacroBase):
             return self._name_ == other._name_
-        return NotImplemented
+        return False
 
 
 class Opcode(OpcodeMacroBase):

--- a/src/ethereum_test_tools/vm/opcode.py
+++ b/src/ethereum_test_tools/vm/opcode.py
@@ -65,8 +65,11 @@ class OpcodeMacroBase(bytes):
 
     def __eq__(self, other):
         """
-        Required to differentiate between SELFDESTRUCT and SENDALL type of cases
-        And to compare with the Macro opcodes
+        Allows comparison between OpcodeMacroBase instances and bytes objects.
+
+        Raises:
+        - NotImplementedError: if the comparison is not between an OpcodeMacroBase
+            or a bytes object.
         """
         if isinstance(other, OpcodeMacroBase):
             return self._name_ == other._name_

--- a/src/ethereum_test_tools/vm/opcode.py
+++ b/src/ethereum_test_tools/vm/opcode.py
@@ -4944,9 +4944,13 @@ class Macros(Macro, Enum):
 
     Gas
     ----
-    This operation will result in gasprice = 19073514453125027
-    Add a little more and geth report gasprice = 30 with oog exception
-    Make it 0 - 1 and geth report gasprice > u64 error.
+    `SHA3(0, 100000000000)` results in 19073514453125027 gas used and an OOG
+    exception.
+
+    Note:
+    If a value > `100000000000` is used as second argument, the resulting geth
+     trace reports gas `30` and an OOG exception.
+    `SHA3(0, SUB(0, 1))` causes a gas > u64 exception and an OOG exception.
 
     Bytecode
     ----

--- a/src/ethereum_test_tools/vm/opcode.py
+++ b/src/ethereum_test_tools/vm/opcode.py
@@ -66,11 +66,13 @@ class OpcodeMacroBase(bytes):
     def __eq__(self, other):
         """
         Required to differentiate between SELFDESTRUCT and SENDALL type of cases
-        And to register the Macro opcodes which are defined from same bytes
+        And to compare with the Macro opcodes
         """
         if isinstance(other, OpcodeMacroBase):
             return self._name_ == other._name_
-        return False
+        if isinstance(other, bytes):
+            return bytes(self) == other
+        raise NotImplementedError(f"Unsupported type for comparison f{type(other)}")
 
 
 class Opcode(OpcodeMacroBase):

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -81,6 +81,7 @@ eip
 eips
 EIPs
 endianness
+EngineAPI
 enum
 env
 eof

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -339,6 +339,7 @@ makepyfile
 metafunc
 modifyitems
 nodeid
+oog
 optparser
 originalname
 parametrized


### PR DESCRIPTION
## 🗒️ Description
I think it would be handy to have test purpose Op that will trigger OOG if called
This will simplify parametrisations and code in tests when paramtrising over subcall return types
Such as RETURN, REVERT

Op.OOG(x, y)  is replaced with Op..SHA3(0, 100000000000)
alowing to use
```
@pytest.mark.parametrize("call_return", [Op.RETURN, Op.REVERT, Op.OOG])
...
contract_code = Op.MSTORE(0, Op.TLOAD(0)) + call_return(0, 32)
```

Example: 
https://github.com/ethereum/execution-spec-tests/pull/440/

## 🔗 Related Issues
https://github.com/ethereum/execution-spec-tests/issues/455

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
