### PR TITLE
fix(docs): fix nested lists and content tabs formatting #459

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -106,9 +106,6 @@ markdown_extensions:
   - pymdownx.tasklist:
       custom_checkbox: true
   - pymdownx.tilde
-  # support pad width = 2
-  - mdx_truly_sane_lists
-
 
 extra:
   version:

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,7 +81,6 @@ docs =
     mkdocs-material-extensions>=1.1.1,<2
     mkdocstrings>=0.21.2,<1
     mkdocstrings-python>=1.0.0,<2
-    mdx-truly-sane-lists>=1.3.0,<2
     pillow>=10.0.1,<11  # required for social plugin (material)
     pyspelling>=2.8.2,<3
 


### PR DESCRIPTION
## 🗒️ Description
Removes the `mdx-truly-sane-lists` package introduced in #403. This seemingly fixed nested lists, but actually double-nested lists are still broken, as are context tabs, see #459.

## 🔗 Related Issues
Fixes #459.

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
