### PR TITLE
docs(chore): remove extra '|' in table to appease markdownlint-cli2 v0.12.1

### DIFF
--- a/docs/consuming_tests/index.md
+++ b/docs/consuming_tests/index.md
@@ -29,7 +29,7 @@ The @ethereum/execution-spec-tests repository provides [releases](https://github
 
 | Release Artifact               | Consumer | Fork/feature scope |
 | ------------------------------ | -------- | ------------------ |
-| `fixtures.tar.gz`              | Clients  | All tests until the last stable fork | "Must pass" |
+| `fixtures.tar.gz`              | Clients  | All tests until the last stable fork ("must pass") |
 | `fixtures_develop.tar.gz`      | Clients  | All tests until the last development fork |
 
 ## Obtaining the Most Recent Release Artifacts


### PR DESCRIPTION
## 🗒️ Description
Fix:
```console
python -m src.entry_points.markdownlintcli2_soft_fail
markdownlint-cli2 v0.12.1 (markdownlint v0.33.0)
Finding: ./docs/**/*.md ./README.md
Linting: 43 file(s)
Summary: 1 error(s)
docs/consuming_tests/index.md:32:84 MD056/table-column-count Table column count [Expected: 3; Actual: 4; Too many cells, extra data will be missing]
```

## 🔗 Related Issues
None.

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md). **Skipping changelog for this very minor markdown-only change.**
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
