### PR TITLE
[WIP] Verkle changes to test t8n

### DIFF
--- a/docs/consuming_tests/common_types.md
+++ b/docs/consuming_tests/common_types.md
@@ -337,3 +337,45 @@ Fork type is represented as a JSON string that can be set to one of the followin
 - Terminal Total Difficulty: `0x00`
 - Shanghai Time: `0x00`
 - Cancun Time: `0x00`
+
+### `"Prague"`
+
+- Chain ID: `0x01`
+- Homestead Block: `0x00`
+- EIP150 Block: `0x00`
+- EIP155 Block: `0x00`
+- EIP158 Block: `0x00`
+- DAO Fork Block: `0x00`
+- Byzantium Block: `0x00`
+- Constantinople Block: `0x00`
+- Constantinople Fix Block: `0x00`
+- Istanbul Block: `0x00`
+- Muir Glacier Block: `0x00`
+- Berlin Block: `0x00`
+- London Block: `0x00`
+- Arrow Glacier Block: `0x00`
+- Gray Glacier Block: `0x00`
+- Terminal Total Difficulty: `0x00`
+- Shanghai Time: `0x00`
+- Prague Time: `0x00`
+
+### `"ShanghaiToPragueVerkleTransition"`
+
+- Chain ID: `0x01`
+- Homestead Block: `0x00`
+- EIP150 Block: `0x00`
+- EIP155 Block: `0x00`
+- EIP158 Block: `0x00`
+- DAO Fork Block: `0x00`
+- Byzantium Block: `0x00`
+- Constantinople Block: `0x00`
+- Constantinople Fix Block: `0x00`
+- Istanbul Block: `0x00`
+- Muir Glacier Block: `0x00`
+- Berlin Block: `0x00`
+- London Block: `0x00`
+- Arrow Glacier Block: `0x00`
+- Gray Glacier Block: `0x00`
+- Terminal Total Difficulty: `0x00`
+- Shanghai Time: `0x00`
+- Prague Time: `0x01`

--- a/src/ethereum_test_forks/__init__.py
+++ b/src/ethereum_test_forks/__init__.py
@@ -17,6 +17,7 @@ from .forks.forks import (
     London,
     MuirGlacier,
     Paris,
+    Prague,
     Shanghai,
 )
 from .forks.transition import (
@@ -60,6 +61,7 @@ __all__ = [
     "Shanghai",
     "ShanghaiToCancunAtTime15k",
     "Cancun",
+    "Prague",
     "get_transition_forks",
     "forks_from",
     "forks_from_until",

--- a/src/ethereum_test_forks/base_fork.py
+++ b/src/ethereum_test_forks/base_fork.py
@@ -1,6 +1,7 @@
 """
 Abstract base class for Ethereum forks
 """
+
 from abc import ABC, ABCMeta, abstractmethod
 from typing import Any, ClassVar, List, Mapping, Optional, Protocol, Type
 
@@ -186,6 +187,22 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
 
         This method must always call the `fork_to` method when transitioning, because the
         allocation can only be set at genesis, and thus cannot be changed at transition time.
+        """
+        pass
+
+    @classmethod
+    @abstractmethod
+    def environment_verkle_conversion_information_required(
+        cls, block_number: int = 0, timestamp: int = 0
+    ) -> bool:
+        """
+        Returns true if the environment must contain the verkle conversion information, which
+        includes:
+        - Conversion address
+        - Conversion slot hash
+        - Conversion started
+        - Conversion ended
+        - Conversion storage processed
         """
         pass
 

--- a/src/ethereum_test_forks/base_fork.py
+++ b/src/ethereum_test_forks/base_fork.py
@@ -197,17 +197,21 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
 
     @classmethod
     @abstractmethod
-    def environment_verkle_conversion_information_required(
+    def environment_verkle_conversion_starts(
         cls, block_number: int = 0, timestamp: int = 0
     ) -> bool:
         """
-        Returns true if the environment must contain the verkle conversion information, which
-        includes:
-        - Conversion address
-        - Conversion slot hash
-        - Conversion started
-        - Conversion ended
-        - Conversion storage processed
+        Returns true if the fork starts the verkle conversion process.
+        """
+        pass
+
+    @classmethod
+    @abstractmethod
+    def environment_verkle_conversion_completed(
+        cls, block_number: int = 0, timestamp: int = 0
+    ) -> bool:
+        """
+        Returns true if verkle conversion must have been completed by this fork.
         """
         pass
 

--- a/src/ethereum_test_forks/base_fork.py
+++ b/src/ethereum_test_forks/base_fork.py
@@ -74,6 +74,7 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
     _transition_tool_name: ClassVar[Optional[str]] = None
     _blockchain_test_network_name: ClassVar[Optional[str]] = None
     _solc_name: ClassVar[Optional[str]] = None
+    _ignore: ClassVar[bool] = False
 
     def __init_subclass__(
         cls,
@@ -81,6 +82,7 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
         transition_tool_name: Optional[str] = None,
         blockchain_test_network_name: Optional[str] = None,
         solc_name: Optional[str] = None,
+        ignore: bool = False,
     ) -> None:
         """
         Initializes the new fork with values that don't carry over to subclass forks.
@@ -88,6 +90,7 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
         cls._transition_tool_name = transition_tool_name
         cls._blockchain_test_network_name = blockchain_test_network_name
         cls._solc_name = solc_name
+        cls._ignore = ignore
 
     # Header information abstract methods
     @classmethod
@@ -303,6 +306,13 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
         development.
         """
         return True
+
+    @classmethod
+    def ignore(cls) -> bool:
+        """
+        Returns whether the fork should be ignored during test generation.
+        """
+        return cls._ignore
 
 
 # Fork Type

--- a/src/ethereum_test_forks/base_fork.py
+++ b/src/ethereum_test_forks/base_fork.py
@@ -3,7 +3,7 @@ Abstract base class for Ethereum forks
 """
 
 from abc import ABC, ABCMeta, abstractmethod
-from typing import Any, ClassVar, List, Mapping, Optional, Protocol, Type
+from typing import Any, ClassVar, Dict, List, Optional, Protocol, Type
 
 from semver import Version
 
@@ -184,7 +184,9 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
     @classmethod
     @prefer_transition_to_method
     @abstractmethod
-    def pre_allocation(cls, block_number: int = 0, timestamp: int = 0) -> Mapping:
+    def pre_allocation(
+        cls, block_number: int = 0, timestamp: int = 0
+    ) -> Dict[int, Dict[str, str | int | Dict[int, int]]]:
         """
         Returns required pre-allocation of accounts.
 

--- a/src/ethereum_test_forks/forks/constants.py
+++ b/src/ethereum_test_forks/forks/constants.py
@@ -1,0 +1,53 @@
+"""
+Constant values used by the forks.
+"""
+
+from typing import Dict, Generator, Iterator, Tuple
+
+from Crypto.Hash import SHA256
+
+# Verkle conversion MPT constants
+MAX_ACCOUNTS = 1000
+MAX_NONCE = 2**64 - 1
+MAX_BALANCE = 2**256 - 1
+MAX_STORAGE_SLOTS_PER_ACCOUNT = 1000
+MAX_ACCOUNT_CODE_SIZE = 2**14 + 2**13  # EIP-170
+
+
+def seed_generator(seed: int) -> Generator[int, None, None]:
+    seed = int.from_bytes(
+        bytes=SHA256.new(data=seed.to_bytes(length=256, byteorder="big")).digest(), byteorder="big"
+    )
+    while True:
+        yield seed
+        seed = int.from_bytes(
+            bytes=SHA256.new(data=seed.to_bytes(length=256, byteorder="big")).digest(),
+            byteorder="big",
+        )
+
+
+def storage_generator(
+    seed: Iterator[int], max_slots: int
+) -> Generator[Tuple[int, int], None, None]:
+    MAX_KEY_VALUE = 2**256 - 1
+    for _ in range(max_slots):
+        yield next(seed) % MAX_KEY_VALUE, next(seed) % MAX_KEY_VALUE
+
+
+def account_generator(
+    seed: Iterator[int], max_accounts: int
+) -> Generator[Tuple[int, Dict[str, str | int | Dict[int, int]]], None, None]:
+    for _ in range(max_accounts):
+        storage_g = storage_generator(seed, next(seed) % MAX_STORAGE_SLOTS_PER_ACCOUNT)
+        yield next(seed) % 2**160, {
+            "nonce": next(seed) % MAX_NONCE,
+            "balance": next(seed) % MAX_BALANCE,
+            "storage": {k: v for k, v in storage_g},
+            "code": "0x" + "00" * 32,
+        }
+
+
+VERKLE_PRE_ALLOCATION: Dict[int, Dict[str, str | int | Dict[int, int]]] = {
+    addr: account
+    for addr, account in account_generator(seed=seed_generator(0), max_accounts=MAX_ACCOUNTS)
+}

--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -1,6 +1,7 @@
 """
 All Ethereum fork class definitions.
 """
+
 from typing import List, Mapping, Optional
 
 from semver import Version
@@ -157,6 +158,15 @@ class Frontier(BaseFork, solc_name="homestead"):
         Frontier does not require pre-allocated accounts
         """
         return {}
+
+    @classmethod
+    def environment_verkle_conversion_information_required(
+        cls, block_number: int = 0, timestamp: int = 0
+    ) -> bool:
+        """
+        Returns true if the environment must contain verkle conversion information
+        """
+        return False
 
 
 class Homestead(Frontier):
@@ -471,3 +481,12 @@ class Prague(Cancun):
         Returns the minimum version of solc that supports this fork.
         """
         return Version.parse("1.0.0")  # set a high version; currently unknown
+
+    @classmethod
+    def environment_verkle_conversion_information_required(
+        cls, block_number: int = 0, timestamp: int = 0
+    ) -> bool:
+        """
+        Returns true if the environment must contain verkle conversion information
+        """
+        return True

--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -2,7 +2,7 @@
 All Ethereum fork class definitions.
 """
 
-from typing import List, Mapping, Optional
+from typing import Dict, List, Optional
 
 from semver import Version
 
@@ -151,7 +151,9 @@ class Frontier(BaseFork, solc_name="homestead"):
         return []
 
     @classmethod
-    def pre_allocation(cls, block_number: int = 0, timestamp: int = 0) -> Mapping:
+    def pre_allocation(
+        cls, block_number: int = 0, timestamp: int = 0
+    ) -> Dict[int, Dict[str, str | int | Dict[int, int]]]:
         """
         Returns whether the fork expects pre-allocation of accounts
 
@@ -424,11 +426,13 @@ class Cancun(Shanghai):
         return [0xA] + super(Cancun, cls).precompiles(block_number, timestamp)
 
     @classmethod
-    def pre_allocation(cls, block_number: int = 0, timestamp: int = 0) -> Mapping:
+    def pre_allocation(
+        cls, block_number: int = 0, timestamp: int = 0
+    ) -> Dict[int, Dict[str, str | int | Dict[int, int]]]:
         """
         Cancun requires pre-allocation of the beacon root contract for EIP-4788
         """
-        new_allocation = {
+        new_allocation: Dict[int, Dict[str, str | int | Dict[int, int]]] = {
             0x000F3DF6D732807EF1319FB7B8BB8522D0BEAC02: {
                 "nonce": 1,
                 "code": "0x3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5f"

--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -162,11 +162,20 @@ class Frontier(BaseFork, solc_name="homestead"):
         return {}
 
     @classmethod
-    def environment_verkle_conversion_information_required(
+    def environment_verkle_conversion_starts(
         cls, block_number: int = 0, timestamp: int = 0
     ) -> bool:
         """
-        Returns true if the environment must contain verkle conversion information
+        Returns true if the fork starts the verkle conversion process.
+        """
+        return False
+
+    @classmethod
+    def environment_verkle_conversion_completed(
+        cls, block_number: int = 0, timestamp: int = 0
+    ) -> bool:
+        """
+        Returns true if verkle conversion must have been completed by this fork.
         """
         return False
 
@@ -487,10 +496,10 @@ class Prague(Shanghai):
         return Version.parse("1.0.0")  # set a high version; currently unknown
 
     @classmethod
-    def environment_verkle_conversion_information_required(
+    def environment_verkle_conversion_starts(
         cls, block_number: int = 0, timestamp: int = 0
     ) -> bool:
         """
-        Returns true if the environment must contain verkle conversion information
+        Verkle conversion starts in this fork.
         """
         return True

--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -462,7 +462,7 @@ class Cancun(Shanghai):
         return True
 
 
-class Prague(Cancun):
+class Prague(Shanghai):
     """
     Prague fork
     """

--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -241,7 +241,7 @@ class Istanbul(ConstantinopleFix):
 
 
 # Glacier forks skipped, unless explicitly specified
-class MuirGlacier(Istanbul, solc_name="istanbul"):
+class MuirGlacier(Istanbul, solc_name="istanbul", ignore=True):
     """
     Muir Glacier fork
     """
@@ -283,7 +283,7 @@ class London(Berlin):
 
 
 # Glacier forks skipped, unless explicitly specified
-class ArrowGlacier(London, solc_name="london"):
+class ArrowGlacier(London, solc_name="london", ignore=True):
     """
     Arrow Glacier fork
     """
@@ -291,7 +291,7 @@ class ArrowGlacier(London, solc_name="london"):
     pass
 
 
-class GrayGlacier(ArrowGlacier, solc_name="london"):
+class GrayGlacier(ArrowGlacier, solc_name="london", ignore=True):
     """
     Gray Glacier fork
     """

--- a/src/ethereum_test_forks/forks/transition.py
+++ b/src/ethereum_test_forks/forks/transition.py
@@ -2,7 +2,10 @@
 List of all transition fork definitions.
 """
 
+from typing import Dict
+
 from ..transition_base_fork import transition_fork
+from .constants import VERKLE_PRE_ALLOCATION
 from .forks import Berlin, Cancun, London, Paris, Prague, Shanghai
 
 
@@ -35,9 +38,32 @@ class ShanghaiToCancunAtTime15k(Shanghai):
 
 
 @transition_fork(to_fork=Prague, at_timestamp=32)
-class ShanghaiToPragueAtTime15k(Shanghai):
+class ShanghaiToPragueAtTime32(Shanghai):
     """
     Shanghai to Prague transition at Timestamp 32
     """
 
     pass
+
+
+@transition_fork(to_fork=Prague, at_timestamp=1, always_execute=True)
+class ShanghaiToPragueVerkleTransition(Shanghai):
+    """
+    Shanghai to Prague transition at Timestamp 1
+
+    This is a special case where the transition happens on the first block after genesis, used
+    to test the MPT to Verkle tree conversion.
+
+    We run all tests with this transition fork.
+    """
+
+    @classmethod
+    def pre_allocation(
+        cls, block_number: int = 0, timestamp: int = 0
+    ) -> Dict[int, Dict[str, str | int | Dict[int, int]]]:
+        """
+        Pre-allocates a big state full of accounts and storage to test the MPT to Verkle tree
+        conversion.
+        """
+
+        return VERKLE_PRE_ALLOCATION | super(Shanghai, cls).pre_allocation(block_number, timestamp)

--- a/src/ethereum_test_forks/forks/transition.py
+++ b/src/ethereum_test_forks/forks/transition.py
@@ -1,8 +1,9 @@
 """
 List of all transition fork definitions.
 """
+
 from ..transition_base_fork import transition_fork
-from .forks import Berlin, Cancun, London, Paris, Shanghai
+from .forks import Berlin, Cancun, London, Paris, Prague, Shanghai
 
 
 # Transition Forks
@@ -28,6 +29,15 @@ class ParisToShanghaiAtTime15k(Paris, blockchain_test_network_name="ParisToShang
 class ShanghaiToCancunAtTime15k(Shanghai):
     """
     Shanghai to Cancun transition at Timestamp 15k
+    """
+
+    pass
+
+
+@transition_fork(to_fork=Prague, at_timestamp=32)
+class ShanghaiToPragueAtTime15k(Shanghai):
+    """
+    Shanghai to Prague transition at Timestamp 32
     """
 
     pass

--- a/src/ethereum_test_forks/helpers.py
+++ b/src/ethereum_test_forks/helpers.py
@@ -1,6 +1,7 @@
 """
 Helper methods to resolve forks during test filling
 """
+
 from typing import List, Optional
 
 from semver import Version
@@ -32,6 +33,9 @@ def get_forks() -> List[Fork]:
             continue
         if issubclass(fork, BaseFork) and fork is not BaseFork:
             all_forks.append(fork)
+
+    all_forks += get_transition_forks(always_execute=True)
+
     return all_forks
 
 
@@ -87,7 +91,7 @@ def get_closest_fork_with_solc_support(fork: Fork, solc_version: Version) -> Opt
     )
 
 
-def get_transition_forks() -> List[Fork]:
+def get_transition_forks(always_execute: bool = False) -> List[Fork]:
     """
     Returns all the transition forks
     """
@@ -98,6 +102,8 @@ def get_transition_forks() -> List[Fork]:
         if not isinstance(fork, type):
             continue
         if issubclass(fork, TransitionBaseClass) and issubclass(fork, BaseFork):
+            if always_execute and not fork.always_execute():
+                continue
             transition_forks.append(fork)
 
     return transition_forks

--- a/src/ethereum_test_forks/transition_base_fork.py
+++ b/src/ethereum_test_forks/transition_base_fork.py
@@ -1,6 +1,7 @@
 """
 Base objects used to define transition forks.
 """
+
 from inspect import signature
 from typing import Callable, List, Type
 
@@ -29,6 +30,14 @@ class TransitionBaseClass:
         """
         raise Exception("Not implemented")
 
+    @classmethod
+    def always_execute(cls) -> bool:
+        """
+        Whether the transition fork should be treated as a normal fork and all tests should
+        be filled with it.
+        """
+        raise Exception("Not implemented")
+
 
 def base_fork_abstract_methods() -> List[str]:
     """
@@ -37,7 +46,9 @@ def base_fork_abstract_methods() -> List[str]:
     return list(getattr(BaseFork, "__abstractmethods__"))
 
 
-def transition_fork(to_fork: Fork, at_block: int = 0, at_timestamp: int = 0):
+def transition_fork(
+    to_fork: Fork, at_block: int = 0, at_timestamp: int = 0, always_execute: bool = False
+):
     """
     Decorator to mark a class as a transition fork.
     """
@@ -100,6 +111,7 @@ def transition_fork(to_fork: Fork, at_block: int = 0, at_timestamp: int = 0):
 
         NewTransitionClass.transitions_to = lambda: to_fork  # type: ignore
         NewTransitionClass.transitions_from = lambda: from_fork  # type: ignore
+        NewTransitionClass.always_execute = lambda: always_execute  # type: ignore
         NewTransitionClass.fork_at = lambda block_number=0, timestamp=0: (  # type: ignore
             to_fork if block_number >= at_block and timestamp >= at_timestamp else from_fork
         )

--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -1,6 +1,7 @@
 """
 Useful types for generating Ethereum tests.
 """
+
 from copy import copy, deepcopy
 from dataclasses import dataclass, fields
 from itertools import count
@@ -847,6 +848,41 @@ class Environment:
             cast_type=Hash,
         ),
     )
+    verkle_conversion_address: Optional[FixedSizeBytesConvertible] = field(
+        default=None,
+        json_encoder=JSONEncoder.Field(
+            name="currentConversionAddress",
+            cast_type=Address,
+        ),
+    )
+    verkle_conversion_slot_hash: Optional[FixedSizeBytesConvertible] = field(
+        default=None,
+        json_encoder=JSONEncoder.Field(
+            name="currentConversionSlotHash",
+            cast_type=Hash,
+        ),
+    )
+    verkle_conversion_started: Optional[bool] = field(
+        default=None,
+        json_encoder=JSONEncoder.Field(
+            name="currentConversionStarted",
+            skip_string_convert=True,
+        ),
+    )
+    verkle_conversion_ended: Optional[bool] = field(
+        default=None,
+        json_encoder=JSONEncoder.Field(
+            name="currentConversionEnded",
+            skip_string_convert=True,
+        ),
+    )
+    verkle_conversion_storage_processed: Optional[bool] = field(
+        default=None,
+        json_encoder=JSONEncoder.Field(
+            name="currentConversionStorageProcessed",
+            skip_string_convert=True,
+        ),
+    )
     extra_data: Optional[BytesConvertible] = field(
         default=b"\x00",
         json_encoder=JSONEncoder.Field(
@@ -907,7 +943,37 @@ class Environment:
         if fork.header_beacon_root_required(number, timestamp) and res.beacon_root is None:
             res.beacon_root = 0
 
+        if fork.environment_verkle_conversion_information_required(number, timestamp):
+            if res.verkle_conversion_address is None:
+                res.verkle_conversion_address = 0
+            if res.verkle_conversion_slot_hash is None:
+                res.verkle_conversion_slot_hash = 0
+            if res.verkle_conversion_started is None:
+                res.verkle_conversion_started = False
+            if res.verkle_conversion_ended is None:
+                res.verkle_conversion_ended = False
+            if res.verkle_conversion_storage_processed is None:
+                res.verkle_conversion_storage_processed = False
+
         return res
+
+    def update_from_result(self, transition_tool_result: Dict[str, str]) -> "Environment":
+        """
+        Updates the environment with the result of a transition tool execution.
+        """
+        if "currentConversionAddress" in transition_tool_result:
+            self.verkle_conversion_address = transition_tool_result["currentConversionAddress"]
+        if "currentConversionSlotHash" in transition_tool_result:
+            self.verkle_conversion_slot_hash = transition_tool_result["currentConversionSlotHash"]
+        if "currentConversionStarted" in transition_tool_result:
+            self.verkle_conversion_started = transition_tool_result["currentConversionStarted"]
+        if "currentConversionEnded" in transition_tool_result:
+            self.verkle_conversion_ended = transition_tool_result["currentConversionEnded"]
+        if "currentConversionStorageProcessed" in transition_tool_result:
+            self.verkle_conversion_storage_processed = transition_tool_result[
+                "currentConversionStorageProcessed"
+            ]
+        return self
 
 
 @dataclass(kw_only=True)

--- a/src/ethereum_test_tools/spec/base/base_test.py
+++ b/src/ethereum_test_tools/spec/base/base_test.py
@@ -1,6 +1,7 @@
 """
 Base test class and helper functions for Ethereum state and blockchain tests.
 """
+
 from abc import abstractmethod
 from dataclasses import dataclass, field
 from itertools import count
@@ -43,11 +44,15 @@ def verify_transactions(txs: List[Transaction] | None, result) -> List[int]:
     return list(rejected_txs.keys())
 
 
-def verify_post_alloc(expected_post: Mapping, got_alloc: Mapping):
+def verify_post_alloc(
+    *, expected_post: Mapping, got_alloc: Mapping, got_vkt: Optional[Mapping] = None
+):
     """
     Verify that an allocation matches the expected post in the test.
     Raises exception on unexpected values.
     """
+    # TODO: If VKT is not None, we have an overlay of the VKT on top of the alloc and we need
+    # to verify that
     got_alloc_normalized: Dict[Address, Any] = {
         Address(address): got_alloc[address] for address in got_alloc
     }

--- a/src/ethereum_test_tools/spec/blockchain/blockchain_test.py
+++ b/src/ethereum_test_tools/spec/blockchain/blockchain_test.py
@@ -282,7 +282,7 @@ class BlockchainTest(BaseTest):
             withdrawals=env.withdrawals,
         )
 
-        return header, rlp, txs, next_alloc, env
+        return header, rlp, txs, next_alloc, env.update_from_result(result)
 
     def network_info(self, fork: Fork, eips: Optional[List[int]] = None):
         """

--- a/src/ethereum_test_tools/spec/blockchain/blockchain_test.py
+++ b/src/ethereum_test_tools/spec/blockchain/blockchain_test.py
@@ -245,6 +245,8 @@ class BlockchainTest(BaseTest):
             pprint(result)
             pprint(previous_alloc)
             pprint(next_alloc)
+            if vkt is not None:
+                pprint(vkt)
             raise e
 
         if len(rejected_txs) > 0 and block.exception is None:
@@ -310,12 +312,12 @@ class BlockchainTest(BaseTest):
             else fork.blockchain_test_network_name()
         )
 
-    def verify_post_state(self, t8n, alloc):
+    def verify_post_state(self, *, t8n, alloc, vkt=None):
         """
         Verifies the post alloc after all block/s or payload/s are generated.
         """
         try:
-            verify_post_alloc(self.post, alloc)
+            verify_post_alloc(expected_post=self.post, got_alloc=alloc, got_vkt=vkt)
         except Exception as e:
             print_traces(t8n.get_traces())
             raise e
@@ -387,7 +389,7 @@ class BlockchainTest(BaseTest):
                     ),
                 )
 
-        self.verify_post_state(t8n, alloc)
+        self.verify_post_state(t8n=t8n, alloc=alloc, vkt=vkt)
         return Fixture(
             fork=self.network_info(fork, eips),
             genesis=genesis,
@@ -446,7 +448,7 @@ class BlockchainTest(BaseTest):
         ), "A hive fixture was requested but no forkchoice update is defined. The framework should"
         " never try to execute this test case."
 
-        self.verify_post_state(t8n, alloc)
+        self.verify_post_state(t8n=t8n, alloc=alloc, vkt=vkt)
         return HiveFixture(
             fork=self.network_info(fork, eips),
             genesis=genesis,

--- a/src/ethereum_test_tools/spec/state/state_test.py
+++ b/src/ethereum_test_tools/spec/state/state_test.py
@@ -145,7 +145,7 @@ class StateTest(BaseTest):
             if eips
             else transition_tool_name
         )
-        next_alloc, result = t8n.evaluate(
+        next_alloc, result, vkt = t8n.evaluate(
             alloc=to_json(pre_alloc),
             txs=to_json([tx]),
             env=to_json(env),
@@ -157,7 +157,7 @@ class StateTest(BaseTest):
         )
 
         try:
-            verify_post_alloc(self.post, next_alloc)
+            verify_post_alloc(expected_post=self.post, got_alloc=next_alloc, got_vkt=vkt)
         except Exception as e:
             print_traces(t8n.get_traces())
             raise e

--- a/src/evm_transition_tool/file_utils.py
+++ b/src/evm_transition_tool/file_utils.py
@@ -23,6 +23,8 @@ def dump_files_to_directory(output_path: str, files: Dict[str, Any]) -> None:
     """
     os.makedirs(output_path, exist_ok=True)
     for file_rel_path_flags, file_contents in files.items():
+        if file_contents is None:
+            continue
         file_rel_path, flags = (
             file_rel_path_flags.split("+")
             if "+" in file_rel_path_flags

--- a/src/evm_transition_tool/transition_tool.py
+++ b/src/evm_transition_tool/transition_tool.py
@@ -479,10 +479,12 @@ class TransitionTool:
         if self.t8n_subcommand:
             command.append(self.t8n_subcommand)
 
-        args = command + [
-            "--input.alloc=stdin",
-            "--input.txs=stdin",
-            "--input.env=stdin",
+        args = command + ["--input.alloc=stdin", "--input.txs=stdin", "--input.env=stdin"]
+
+        if t8n_data.mpt_alloc is not None:
+            args.append("--input.allocMPT=stdin")
+
+        args += [
             "--output.result=stdout",
             "--output.alloc=stdout",
             "--output.body=stdout",
@@ -490,9 +492,6 @@ class TransitionTool:
             f"--state.chainid={t8n_data.chain_id}",
             f"--state.reward={t8n_data.reward}",
         ]
-
-        if t8n_data.mpt_alloc is not None:
-            args.append("--input.allocMPT=stdin")
 
         if self.trace:
             args.append("--trace")

--- a/src/evm_transition_tool/transition_tool.py
+++ b/src/evm_transition_tool/transition_tool.py
@@ -491,6 +491,9 @@ class TransitionTool:
             f"--state.reward={t8n_data.reward}",
         ]
 
+        if t8n_data.mpt_alloc is not None:
+            args.append("--input.allocMPT=stdin")
+
         if self.trace:
             args.append("--trace")
             args.append(f"--output.basedir={temp_dir.name}")

--- a/src/evm_transition_tool/transition_tool.py
+++ b/src/evm_transition_tool/transition_tool.py
@@ -469,6 +469,7 @@ class TransitionTool:
                     "output/alloc.json": output["alloc"],
                     "output/result.json": output["result"],
                     "output/txs.rlp": output["body"],
+                    "output/vkt.json": output.get("vkt", None),
                 },
             )
 
@@ -541,6 +542,7 @@ class TransitionTool:
                 "input/alloc.json": stdin["alloc"],
                 "input/env.json": stdin["env"],
                 "input/txs.json": stdin["txs"],
+                "input/vkt.json": stdin.get("vkt", None),
                 "returncode.txt": result.returncode,
                 "stdin.txt": stdin,
                 "stdout.txt": result.stdout.decode(),

--- a/tests/prague/eip6800_verkle_tree/__init__.py
+++ b/tests/prague/eip6800_verkle_tree/__init__.py
@@ -1,0 +1,3 @@
+"""
+Cross-client EIP-6800 Tests
+"""

--- a/tests/prague/eip6800_verkle_tree/test_verkle_from_mpt_conversion.py
+++ b/tests/prague/eip6800_verkle_tree/test_verkle_from_mpt_conversion.py
@@ -45,7 +45,8 @@ def test_verkle_from_mpt_conversion(
       - Memory clear (copy from a location that is out of bounds)
     """
     nonce = count()
-    block_count = 64
+    # block_count = 64 # TODO: Revert, since it takes too long for debugging purposes
+    block_count = 4
     tx_count = 64
     blocks: List[Block] = []
     code_storage = Storage()

--- a/tests/prague/eip6800_verkle_tree/test_verkle_from_mpt_conversion.py
+++ b/tests/prague/eip6800_verkle_tree/test_verkle_from_mpt_conversion.py
@@ -1,0 +1,78 @@
+"""
+abstract: Tests [EIP-6800: Ethereum state using a unified verkle tree](https://eips.ethereum.org/EIPS/eip-6800)
+    Test state tree conversion from MPT [EIP-6800: Ethereum state using a unified verkle tree](https://eips.ethereum.org/EIPS/eip-6800)
+
+"""  # noqa: E501
+
+from itertools import count
+from typing import List, Mapping
+
+import pytest
+
+from ethereum_test_tools import Account, Address, Block, BlockchainTestFiller, Environment, Hash
+from ethereum_test_tools import Opcodes as Op
+from ethereum_test_tools import Storage, TestAddress, Transaction
+
+code_address = Address(0x100)
+
+REFERENCE_SPEC_GIT_PATH = "EIPS/eip-6800.md"
+REFERENCE_SPEC_VERSION = "2f8299df31bb8173618901a03a8366a3183479b0"
+
+
+@pytest.fixture
+def pre() -> Mapping:  # noqa: D103
+    return {
+        TestAddress: Account(balance=10**40),
+        code_address: Account(
+            nonce=1,
+            balance=1,
+            code=Op.SSTORE(Op.CALLDATALOAD(0), Op.CALLDATALOAD(32)),
+        ),
+    }
+
+
+@pytest.mark.valid_at_transition_to("Prague")
+def test_verkle_from_mpt_conversion(
+    blockchain_test: BlockchainTestFiller,
+    pre: Mapping[str, Account],
+):
+    """
+    Perform MCOPY operations using different offsets and lengths:
+      - Zero inputs
+      - Memory rewrites (copy from and to the same location)
+      - Memory overwrites (copy from and to different locations)
+      - Memory extensions (copy to a location that is out of bounds)
+      - Memory clear (copy from a location that is out of bounds)
+    """
+    nonce = count()
+    block_count = 64
+    tx_count = 64
+    blocks: List[Block] = []
+    code_storage = Storage()
+    for _ in range(block_count):
+        txs: List[Transaction] = []
+        for t in range(tx_count):
+            storage_value = 2**256 - t - 1
+            storage_key = code_storage.store_next(storage_value)
+            txs.append(
+                Transaction(
+                    nonce=next(nonce),
+                    to=code_address,
+                    data=Hash(storage_key) + Hash(storage_value),
+                    gas_limit=100_000,
+                )
+            )
+        blocks.append(Block(txs=txs))
+    blockchain_test(
+        genesis_environment=Environment(),
+        pre=pre,
+        post={
+            code_address: Account(
+                nonce=1,
+                balance=1,
+                code=Op.SSTORE(Op.CALLDATALOAD(0), Op.CALLDATALOAD(32)),
+                storage=code_storage,
+            ),
+        },
+        blocks=blocks,
+    )

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -287,6 +287,7 @@ v0
 v1
 validator
 venv
+verkle
 visualstudio
 vkt
 vm

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -288,6 +288,7 @@ v1
 validator
 venv
 visualstudio
+vkt
 vm
 vscode
 vv


### PR DESCRIPTION
## 🗒️ Description
Adds changes to the forks structure to be able to test Prague on top of Shanghai until refactor of verkle geth branch.

**Usage**
Use the following geth branch: `gballet/t8n-merge-from-shanghai-to-prague`

**Remaining Todos**
Use the evm t8n verkle sub command to get the expected key from the tree, in order to verify the appropriate values.

## 🔗 Related Issues
None

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
