### PR TITLE
all: Refactor post verification

### DIFF
--- a/src/ethereum_test_tools/common/__init__.py
+++ b/src/ethereum_test_tools/common/__init__.py
@@ -1,6 +1,7 @@
 """
 Common definitions and types.
 """
+
 from .base_types import (
     Address,
     Bloom,
@@ -21,6 +22,7 @@ from .constants import (
     TestPrivateKey,
     TestPrivateKey2,
 )
+from .conversions import str_or_none
 from .helpers import (
     TestParameterGroup,
     add_kzg_version,
@@ -45,7 +47,6 @@ from .types import (
     Withdrawal,
     alloc_to_accounts,
     serialize_transactions,
-    str_or_none,
     transaction_list_root,
     withdrawals_root,
 )

--- a/src/ethereum_test_tools/spec/__init__.py
+++ b/src/ethereum_test_tools/spec/__init__.py
@@ -1,9 +1,10 @@
 """
 Test spec definitions and utilities.
 """
+
 from typing import List, Type
 
-from .base.base_test import BaseFixture, BaseTest, TestSpec, verify_post_alloc
+from .base.base_test import BaseFixture, BaseTest, TestSpec
 from .blockchain.blockchain_test import BlockchainTest, BlockchainTestFiller, BlockchainTestSpec
 from .fixture_collector import FixtureCollector, TestInfo
 from .state.state_test import StateTest, StateTestFiller, StateTestOnly, StateTestSpec
@@ -24,5 +25,4 @@ __all__ = (
     "StateTestSpec",
     "TestInfo",
     "TestSpec",
-    "verify_post_alloc",
 )

--- a/src/ethereum_test_tools/spec/base/base_test.py
+++ b/src/ethereum_test_tools/spec/base/base_test.py
@@ -14,7 +14,7 @@ from typing import Any, Callable, Dict, Generator, Iterator, List, Mapping, Opti
 from ethereum_test_forks import Fork
 from evm_transition_tool import FixtureFormats, TransitionTool
 
-from ...common import Account, Address, Environment, Transaction, withdrawals_root
+from ...common import Environment, Transaction, withdrawals_root
 from ...common.conversions import to_hex
 from ...common.json import JSONEncoder
 from ...common.json import field as json_field
@@ -45,27 +45,6 @@ def verify_transactions(txs: List[Transaction] | None, result) -> List[int]:
             # TODO: Also we need a way to check we actually got the
             # correct error
     return list(rejected_txs.keys())
-
-
-def verify_post_alloc(expected_post: Mapping, got_alloc: Mapping):
-    """
-    Verify that an allocation matches the expected post in the test.
-    Raises exception on unexpected values.
-    """
-    got_alloc_normalized: Dict[Address, Any] = {
-        Address(address): got_alloc[address] for address in got_alloc
-    }
-    for address, account in expected_post.items():
-        address = Address(address)
-        if account is not None:
-            if account == Account.NONEXISTENT:
-                if address in got_alloc_normalized:
-                    raise Exception(f"found unexpected account: {address}")
-            else:
-                if address in got_alloc_normalized:
-                    account.check_alloc(address, got_alloc_normalized[address])
-                else:
-                    raise Exception(f"expected account not found: {address}")
 
 
 def verify_result(result: Mapping, env: Environment):

--- a/src/ethereum_test_tools/spec/blockchain/blockchain_test.py
+++ b/src/ethereum_test_tools/spec/blockchain/blockchain_test.py
@@ -28,13 +28,7 @@ from ...common import (
 )
 from ...common.constants import EmptyOmmersRoot
 from ...common.json import to_json
-from ..base.base_test import (
-    BaseFixture,
-    BaseTest,
-    verify_post_alloc,
-    verify_result,
-    verify_transactions,
-)
+from ..base.base_test import BaseFixture, BaseTest, verify_result, verify_transactions
 from ..debugging import print_traces
 from .types import (
     Block,
@@ -296,7 +290,7 @@ class BlockchainTest(BaseTest):
         Verifies the post alloc after all block/s or payload/s are generated.
         """
         try:
-            verify_post_alloc(self.post, alloc)
+            Alloc(alloc).verify_post(expected_post=self.post)
         except Exception as e:
             print_traces(t8n.get_traces())
             raise e

--- a/src/ethereum_test_tools/spec/state/state_test.py
+++ b/src/ethereum_test_tools/spec/state/state_test.py
@@ -12,7 +12,7 @@ from evm_transition_tool import FixtureFormats, TransitionTool
 from ...common import Account, Address, Alloc, Environment, Number, Transaction
 from ...common.constants import EngineAPIError
 from ...common.json import to_json
-from ..base.base_test import BaseFixture, BaseTest, verify_post_alloc
+from ..base.base_test import BaseFixture, BaseTest
 from ..blockchain.blockchain_test import Block, BlockchainTest
 from ..blockchain.types import Header
 from ..debugging import print_traces
@@ -157,7 +157,7 @@ class StateTest(BaseTest):
         )
 
         try:
-            verify_post_alloc(self.post, next_alloc)
+            Alloc(next_alloc).verify_post(expected_post=self.post)  # type: ignore
         except Exception as e:
             print_traces(t8n.get_traces())
             raise e

--- a/src/ethereum_test_tools/tests/test_filling/test_expect.py
+++ b/src/ethereum_test_tools/tests/test_filling/test_expect.py
@@ -1,6 +1,7 @@
 """
 Test fixture post state (expect section) during state fixture generation.
 """
+
 from typing import Any, Mapping
 
 import pytest
@@ -8,7 +9,7 @@ import pytest
 from ethereum_test_forks import Fork, get_deployed_forks
 from evm_transition_tool import FixtureFormats, GethTransitionTool
 
-from ...common import Account, Address, Environment, Transaction
+from ...common import Account, Address, Bytes, Environment, Transaction
 from ...common.types import Storage
 from ...spec import StateTest
 
@@ -164,7 +165,7 @@ def test_post_code_value_mismatch(pre, post, state_test, t8n, fork):
     with pytest.raises(Account.CodeMismatch) as e_info:
         state_test.generate(t8n=t8n, fork=fork)
     assert e_info.value == Account.CodeMismatch(
-        address=ADDRESS_UNDER_TEST, want=post_code, got=pre_code
+        address=ADDRESS_UNDER_TEST, want=Bytes(post_code), got=Bytes(pre_code)
     )
 
 

--- a/src/ethereum_test_tools/tests/test_specs.py
+++ b/src/ethereum_test_tools/tests/test_specs.py
@@ -2,12 +2,11 @@
 Test suite for test spec submodules of the `ethereum_test` module.
 """
 
-from typing import Any, Mapping
+from typing import Mapping
 
 import pytest
 
-from ..common import Account
-from ..spec import verify_post_alloc
+from ..common import Account, Alloc
 
 
 @pytest.mark.parametrize(
@@ -86,11 +85,12 @@ from ..spec import verify_post_alloc
         ),
     ],
 )
-def test_verify_post_alloc(
-    post: Mapping[str, Account], alloc: Mapping[str, Any], should_pass: bool
-):
+def test_verify_post_alloc(post: Mapping[str, Account], alloc: Mapping, should_pass: bool):
+    """
+    Test post alloc verification
+    """
     if should_pass:
-        verify_post_alloc(post, alloc)
+        Alloc(alloc).verify_post(expected_post=post)
     else:
         with pytest.raises(Exception) as _:
-            verify_post_alloc(post, alloc)
+            Alloc(alloc).verify_post(expected_post=post)

--- a/src/ethereum_test_tools/tests/test_types.py
+++ b/src/ethereum_test_tools/tests/test_types.py
@@ -276,12 +276,12 @@ def test_storage():
         ),
     ],
 )
-def test_account_check_alloc(account: Account, alloc: Dict[Any, Any], should_pass: bool):
+def test_account_verify(account: Account, alloc: Dict[Any, Any], should_pass: bool):
     if should_pass:
-        account.check_alloc(Address(1), alloc)
+        account.verify(Address(1), Account.from_dict(alloc))
     else:
         with pytest.raises(Exception) as _:
-            account.check_alloc(Address(1), alloc)
+            account.verify(Address(1), Account.from_dict(alloc))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## 🗒️ Description
This PR performs a refactor of the post-alloc verification in order to pave the way for a verkle-overlay tree verification.

The main difference is that we now convert the result from the t8n tool to an `Alloc` instance, and call the instance's method called `verify_post`.

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
