### PR TITLE
bug(fw): fix block header `gasLimit` value in post genesis blocks for blockchain tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - 🐞 Fix bug that causes an exception during test collection because the fork parameter contains `None` ([#452](https://github.com/ethereum/execution-spec-tests/pull/452)).
 - ✨ The `_info` field in the test fixtures now contains a `hash` field, which is the hash of the test fixture, and a `hasher` script has been added which prints and performs calculations on top of the hashes of all fixtures (see `hasher -h`) ([#454](https://github.com/ethereum/execution-spec-tests/pull/454)).
 - ✨ Adds an optional `verify_sync` field to hive blockchain tests (EngineAPI). When set to true a second client attempts to sync to the first client that executed the tests.([#431](https://github.com/ethereum/execution-spec-tests/pull/431)).
+- 🐞 Fix manually setting the gas limit in the genesis test env for post genesis blocks in blockchain tests. ([#472](https://github.com/ethereum/execution-spec-tests/pull/472)).
 
 ### 🔧 EVM Tools
 

--- a/src/ethereum_test_tools/spec/blockchain/types.py
+++ b/src/ethereum_test_tools/spec/blockchain/types.py
@@ -549,7 +549,9 @@ class Block(Header):
             self.coinbase if self.coinbase is not None else environment_default.coinbase
         )
         new_env.gas_limit = (
-            self.gas_limit if self.gas_limit is not None else environment_default.gas_limit
+            env.parent_gas_limit
+            if env.parent_gas_limit is not None
+            else environment_default.gas_limit
         )
         if not isinstance(self.base_fee, Removable):
             new_env.base_fee = self.base_fee

--- a/src/ethereum_test_tools/spec/blockchain/types.py
+++ b/src/ethereum_test_tools/spec/blockchain/types.py
@@ -548,11 +548,7 @@ class Block(Header):
         new_env.coinbase = (
             self.coinbase if self.coinbase is not None else environment_default.coinbase
         )
-        new_env.gas_limit = (
-            env.parent_gas_limit
-            if env.parent_gas_limit is not None
-            else environment_default.gas_limit
-        )
+        new_env.gas_limit = self.gas_limit or env.parent_gas_limit or environment_default.gas_limit
         if not isinstance(self.base_fee, Removable):
             new_env.base_fee = self.base_fee
         new_env.withdrawals = self.withdrawals


### PR DESCRIPTION
## 🗒️ Description
Sets the `gas_limit` block header value to that optionally specified in the `genesis_env` provided to the blockchain tests constructor, by taking it from the previous env.

## 🔗 Related Issues
Fixes #468.

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
