### PR TITLE
fix: Macro+Opcode integration

### DIFF
--- a/src/entry_points/evm_bytes_to_python.py
+++ b/src/entry_points/evm_bytes_to_python.py
@@ -5,6 +5,7 @@ Define an entry point wrapper for pytest.
 import sys
 from typing import Any, List, Optional
 
+from ethereum_test_tools import Macro
 from ethereum_test_tools import Opcodes as Op
 
 
@@ -21,7 +22,7 @@ def process_evm_bytes(evm_bytes_hex_string: Any) -> str:  # noqa: D103
 
         opcode: Optional[Op] = None
         for op in Op:
-            if op.int() == opcode_byte:
+            if not isinstance(op, Macro) and op.int() == opcode_byte:
                 opcode = op
                 break
 

--- a/src/entry_points/tests/test_evm_bytes_to_python.py
+++ b/src/entry_points/tests/test_evm_bytes_to_python.py
@@ -5,6 +5,7 @@ Test suite for `entry_points.evm_bytes_to_python` module.
 import pytest
 from evm_bytes_to_python import process_evm_bytes
 
+from ethereum_test_tools import Macro
 from ethereum_test_tools import Opcodes as Op
 
 basic_vector = [
@@ -31,7 +32,7 @@ def test_evm_bytes_to_python(evm_bytes, python_opcodes):
     assert process_evm_bytes(evm_bytes) == python_opcodes
 
 
-@pytest.mark.parametrize("opcode", list(Op))
+@pytest.mark.parametrize("opcode", [op for op in Op if not isinstance(op, Macro)])
 def test_individual_opcodes(opcode):
     """Test each opcode individually"""
     if opcode.data_portion_length > 0:

--- a/src/ethereum_test_tools/tests/test_vm.py
+++ b/src/ethereum_test_tools/tests/test_vm.py
@@ -157,3 +157,10 @@ def test_opcodes_repr():
     assert f"{Op.CALL}" == "CALL"
     assert f"{Op.DELEGATECALL}" == "DELEGATECALL"
     assert str(Op.ADD) == "ADD"
+
+
+def test_macros():
+    """
+    Test opcode and macros interaction
+    """
+    assert (Op.PUSH1(1) + Op.OOG) == (Op.PUSH1(1) + Op.SHA3(0, 100000000000))


### PR DESCRIPTION
## 🗒️ Description
Fixes

## 🔗 Related Issues
None

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
