### PR TITLE
fix(fw): Fix `FixedSizeBytes` `!=` comparison

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,8 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 ### 🛠️ Framework
 
+- 🐞 Fix incorrect `!=` operator for `FixedSizeBytes` ([#477](https://github.com/ethereum/execution-spec-tests/pull/477)).
+
 ### 🔧 EVM Tools
 
 ### 📋 Misc

--- a/src/ethereum_test_tools/common/base_types.py
+++ b/src/ethereum_test_tools/common/base_types.py
@@ -173,7 +173,7 @@ class FixedSizeBytes(Bytes):
 
     def __eq__(self, other: object) -> bool:
         """
-        Compares two FixedSizeBytes objects.
+        Compares two FixedSizeBytes objects to be equal.
         """
         if not isinstance(other, FixedSizeBytes):
             assert (
@@ -187,17 +187,9 @@ class FixedSizeBytes(Bytes):
 
     def __ne__(self, other: object) -> bool:
         """
-        Compares two FixedSizeBytes objects.
+        Compares two FixedSizeBytes objects to be not equal.
         """
-        if not isinstance(other, FixedSizeBytes):
-            assert (
-                isinstance(other, str)
-                or isinstance(other, int)
-                or isinstance(other, bytes)
-                or isinstance(other, SupportsBytes)
-            )
-            other = self.__class__(other)
-        return super().__ne__(other)
+        return not self.__eq__(other)
 
 
 class Address(FixedSizeBytes[20]):  # type: ignore

--- a/src/ethereum_test_tools/common/base_types.py
+++ b/src/ethereum_test_tools/common/base_types.py
@@ -2,7 +2,6 @@
 Basic type primitives used to define other types.
 """
 
-
 from typing import ClassVar, SupportsBytes, Type, TypeVar
 
 from .conversions import (
@@ -185,6 +184,20 @@ class FixedSizeBytes(Bytes):
             )
             other = self.__class__(other)
         return super().__eq__(other)
+
+    def __ne__(self, other: object) -> bool:
+        """
+        Compares two FixedSizeBytes objects.
+        """
+        if not isinstance(other, FixedSizeBytes):
+            assert (
+                isinstance(other, str)
+                or isinstance(other, int)
+                or isinstance(other, bytes)
+                or isinstance(other, SupportsBytes)
+            )
+            other = self.__class__(other)
+        return super().__ne__(other)
 
 
 class Address(FixedSizeBytes[20]):  # type: ignore

--- a/src/ethereum_test_tools/tests/test_base_types.py
+++ b/src/ethereum_test_tools/tests/test_base_types.py
@@ -1,0 +1,54 @@
+"""
+Test suite for `ethereum_test` module base types.
+"""
+
+from typing import Any
+
+import pytest
+
+from ..common.base_types import Address, Hash
+
+
+@pytest.mark.parametrize(
+    "a, b, equal",
+    [
+        (Address("0x0"), Address("0x0"), True),
+        (Address("0x0"), Address("0x1"), False),
+        (Address("0x1"), Address("0x0"), False),
+        (Address("0x1"), "0x1", True),
+        (Address("0x1"), "0x2", False),
+        (Address("0x1"), 1, True),
+        (Address("0x1"), 2, False),
+        (Address("0x1"), b"\x01", True),
+        (Address("0x1"), b"\x02", False),
+        ("0x1", Address("0x1"), True),
+        ("0x2", Address("0x1"), False),
+        (1, Address("0x1"), True),
+        (2, Address("0x1"), False),
+        (b"\x01", Address("0x1"), True),
+        (b"\x02", Address("0x1"), False),
+        (Hash("0x0"), Hash("0x0"), True),
+        (Hash("0x0"), Hash("0x1"), False),
+        (Hash("0x1"), Hash("0x0"), False),
+        (Hash("0x1"), "0x1", True),
+        (Hash("0x1"), "0x2", False),
+        (Hash("0x1"), 1, True),
+        (Hash("0x1"), 2, False),
+        (Hash("0x1"), b"\x01", True),
+        (Hash("0x1"), b"\x02", False),
+        ("0x1", Hash("0x1"), True),
+        ("0x2", Hash("0x1"), False),
+        (1, Hash("0x1"), True),
+        (2, Hash("0x1"), False),
+    ],
+)
+def test_comparisons(a: Any, b: Any, equal: bool):
+    """
+    Test the comparison methods of the base types.
+    """
+    if equal:
+        assert a == b
+        assert not a != b
+    else:
+        assert a != b
+        assert not a == b


### PR DESCRIPTION
## 🗒️ Description
Before this PR, it was possible that both of these statements returned true:
```python
Address(0x100) == "0x100"
Address(0x100) != "0x100"
```

Reason was that, since `__ne__` was not implemented for `FixedSizeBytes` and the fallback was to use `str` compare.

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
