### PR TITLE
[WIP] feat: `ethereum/tests` filler reader

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,8 @@ install_requires =
     trie==2.1.1
     semver==3.0.1
     pydantic>=2.6.3
+    PyYAML>=6.0.1
+
 
 [options.package_data]
 ethereum_test_tools =
@@ -53,6 +55,7 @@ console_scripts =
     create_whitelist_for_flake8_spelling = entry_points.create_whitelist_for_flake8_spelling:main
     evm_bytes_to_python = entry_points.evm_bytes_to_python:main
     hasher = entry_points.hasher:main
+    filler_reader = entry_points.filler_reader:main
 
 [options.extras_require]
 test =
@@ -69,6 +72,7 @@ lint =
     flake8>=6.1.0,<7
     pep8-naming==0.13.3
     fname8>=0.0.3
+    types-PyYAML
 
 docs =
     cairosvg>=2.7.0,<3  # required for social plugin (material)

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ install_requires =
     coincurve>=18.0.0,<19
     trie==2.1.1
     semver==3.0.1
+    pydantic>=2.6.3
 
 [options.package_data]
 ethereum_test_tools =
@@ -60,7 +61,7 @@ test =
 
 lint =
     isort>=5.8,<6
-    mypy==0.982; implementation_name == "cpython"
+    mypy==0.991; implementation_name == "cpython"
     types-requests
     black==22.3.0; implementation_name == "cpython"
     flake8-spellcheck>=0.24,<0.25

--- a/src/entry_points/filler_reader.py
+++ b/src/entry_points/filler_reader.py
@@ -1,0 +1,284 @@
+"""
+Simple CLI tool that reads filler files in the `ethereum/tests` format.
+"""
+
+import argparse
+import json
+from glob import glob
+from pathlib import Path
+from typing import Dict, List, Literal
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field
+from pydantic.alias_generators import to_camel
+from pydantic.functional_validators import BeforeValidator
+from typing_extensions import Annotated
+
+
+def check_address(s: str | int) -> bytes:
+    """
+    Check if the given string is a valid address.
+    """
+    if isinstance(s, int):
+        return s.to_bytes(20, "big")
+    assert isinstance(s, str)
+    if s.startswith("0x"):
+        s = s[2:]
+    b = bytes.fromhex(s)
+    if len(b) < 20:
+        b = b.rjust(20, b"\x00")
+    return b
+
+
+Address = Annotated[bytes, BeforeValidator(check_address)]
+
+
+def check_hex_number(i: int | str) -> int:
+    """
+    Check if the given string is a valid hex number.
+    """
+    if isinstance(i, int):
+        return i
+    if i.startswith("0x:bigint "):
+        i = i[10:]
+    return int(i, 16)
+
+
+HexNumber = Annotated[int, BeforeValidator(check_hex_number)]
+
+
+def check_hash(s: str | int) -> bytes:
+    """
+    Check if the given string is a valid hash.
+    """
+    if isinstance(s, int):
+        return s.to_bytes(32, "big")
+    if s.startswith("0x"):
+        s = s[2:]
+    b = bytes.fromhex(s)
+    assert len(b) == 32
+    return b
+
+
+Hash = Annotated[bytes, BeforeValidator(check_hash)]
+
+
+def check_code(input: str | int) -> str:
+    """
+    Check if the given string is a valid code.
+    """
+    if isinstance(input, int):
+        return hex(input)
+    return input
+
+
+Code = Annotated[str, BeforeValidator(check_code)]
+
+CAMEL_CASE_CONFIG = ConfigDict(
+    alias_generator=to_camel,
+    populate_by_name=True,
+    from_attributes=True,
+    extra="forbid",
+)
+
+
+class Environment(BaseModel):
+    """
+    Class that represents an environment filler.
+    """
+
+    current_coinbase: Address
+    current_difficulty: HexNumber | None = Field(None)
+    current_gas_limit: HexNumber
+    current_number: HexNumber
+    current_timestamp: HexNumber
+    current_base_fee: HexNumber | None = Field(None)
+    current_random: Hash | None = Field(None)
+    current_excess_blob_gas: HexNumber | None = Field(None)
+
+    model_config = CAMEL_CASE_CONFIG
+
+
+class Info(BaseModel):
+    """
+    Class that represents an info filler.
+    """
+
+    comment: str
+
+
+class RemovedAccount(BaseModel):
+    """
+    Class that represents an empty account filler.
+    """
+
+    should_not_exist: bool = Field(..., alias="shouldnotexist")
+
+    model_config = CAMEL_CASE_CONFIG
+
+
+class Account(BaseModel):
+    """
+    Class that represents an account filler.
+    """
+
+    balance: HexNumber | None = Field(None)
+    code: Code | None = Field(None)
+    nonce: HexNumber | None = Field(None)
+    storage: Dict[HexNumber, Literal["ANY"] | HexNumber] | None = Field(None)
+
+    model_config = CAMEL_CASE_CONFIG
+
+
+class AccessList(BaseModel):
+    """
+    Class that represents an access list.
+    """
+
+    address: Address
+    storage_keys: List[HexNumber]
+
+    model_config = CAMEL_CASE_CONFIG
+
+
+class Data(BaseModel):
+    """
+    Class that represents the data portion of the test.
+    """
+
+    data: str
+    access_list: List[AccessList]
+
+    model_config = CAMEL_CASE_CONFIG
+
+
+class Transaction(BaseModel):
+    """
+    Class that represents a transaction filler.
+    """
+
+    data: List[str | Data]
+    gas_limit: List[HexNumber]
+    gas_price: HexNumber | None = Field(None)
+    max_fee_per_gas: HexNumber | None = Field(None)
+    max_priority_fee_per_gas: HexNumber | None = Field(None)
+    nonce: HexNumber
+    to: Address
+    value: List[HexNumber]
+    secret_key: Hash
+
+    model_config = CAMEL_CASE_CONFIG
+
+
+class Indexes(BaseModel):
+    """
+    Class that represents an index filler.
+    """
+
+    data: int | str | List[int | str] = Field(-1)
+    gas: int | str | List[int | str] = Field(-1)
+    value: int | str | List[int | str] = Field(-1)
+
+    model_config = CAMEL_CASE_CONFIG
+
+
+class Expect(BaseModel):
+    """
+    Class that represents an expect filler.
+    """
+
+    indexes: Indexes = Field(Indexes(data=-1, gas=-1, value=-1))
+    network: List[str]
+    result: Dict[Address, RemovedAccount | Account]
+    expect_exception: Dict[str, str] | None = Field(None)
+
+    model_config = CAMEL_CASE_CONFIG
+
+
+class StateTest(BaseModel):
+    """
+    Class that represents a state test filler.
+    """
+
+    env: Environment
+    info: Info | None = Field(None, alias="_info")
+    pre: Dict[Address, Account]
+    transaction: Transaction
+    expect: List[Expect]
+    exceptions: List[str] | None = Field(None)
+    solidity: str | None = Field(None)
+    verify: Dict | None = Field(None)
+    verify_bc: Dict | None = Field(None, alias="verifyBC")
+
+    model_config = CAMEL_CASE_CONFIG
+
+
+def remove_comments(d: dict) -> dict:
+    """
+    Remove comments from a dictionary.
+    """
+    result = {}
+    for k, v in d.items():
+        if isinstance(k, str) and k.startswith("//"):
+            continue
+        if isinstance(v, dict):
+            v = remove_comments(v)
+        elif isinstance(v, list):
+            v = [remove_comments(i) if isinstance(i, dict) else i for i in v]
+        result[k] = v
+    return result
+
+
+class StateFiller(BaseModel):
+    """
+    Class that represents a state test filler.
+    """
+
+    tests: Dict[str, StateTest]
+
+    @classmethod
+    def from_json(cls, path: Path) -> None:
+        """
+        Read the state filler from a JSON file.
+        """
+        with open(path, "r") as f:
+            o = json.load(f)
+            StateFiller(tests=remove_comments(o))
+
+    @classmethod
+    def from_yml(cls, path: Path) -> None:
+        """
+        Read the state filler from a YML file.
+        """
+        with open(path, "r") as f:
+            o = yaml.load(f, Loader=yaml.FullLoader)
+            StateFiller(tests=remove_comments(o))
+
+
+def main() -> None:
+    """
+    Main function.
+    """
+    parser = argparse.ArgumentParser(description="Filler parser.")
+
+    parser.add_argument(
+        "mode", type=str, help="The type of filler we are trying to parse: blockchain/state."
+    )
+    parser.add_argument("folder_path", type=Path, help="The path to the JSON/YML filler directory")
+
+    args = parser.parse_args()
+
+    files = glob(str(args.folder_path / "**" / "*.json")) + glob(
+        str(args.folder_path / "**" / "*.yml")
+    )
+
+    filler_cls = StateFiller
+    if args.mode == "blockchain":
+        raise NotImplementedError("Blockchain filler not implemented yet.")
+
+    for file in files:
+        print(file)
+        if file.endswith(".json"):
+            filler_cls.from_json(Path(file))
+        elif file.endswith(".yml"):
+            filler_cls.from_yml(Path(file))


### PR DESCRIPTION
## 🗒️ Description
Implements the pydantic models to parse the `ethereum/tests` fillers.

At the moment only the `GeneralStateTestsFiller` is implemented.

Not meant to be merged.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
