### PR TITLE
fix: bump go version from 1.20.5 to 1.21.x

### DIFF
--- a/.github/actions/build-geth-evm/action.yaml
+++ b/.github/actions/build-geth-evm/action.yaml
@@ -12,7 +12,7 @@ inputs:
   golang:
     description: 'Golang version to use to build Geth'
     required: false
-    default: '1.20.5'
+    default: '1.21.x'
 runs:
   using: "composite"
   steps:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,8 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 ### 📋 Misc
 
+- 🐞 Fix CI by using Golang 1.21 in Github Actions to build geth ([#484](https://github.com/ethereum/execution-spec-tests/pull/484)).
+
 ## 🔜 [v2.1.1](https://github.com/ethereum/execution-spec-tests/releases/tag/v2.1.1) - 2024-03-09
 
 ### 🧪 Test Cases

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -123,6 +123,7 @@ Github
 glightbox
 globals
 go-ethereum's
+Golang
 gwei
 hardfork
 hash32


### PR DESCRIPTION
## 🗒️ Description
Github Actions are currently failing to build geth; this PR bumps Github Action to build geth with Golang 1.21. 

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
