### PR TITLE
[WIP] feat(fw): verkle t8n post state verification

### DIFF
--- a/src/ethereum_test_tools/spec/base/base_test.py
+++ b/src/ethereum_test_tools/spec/base/base_test.py
@@ -44,15 +44,11 @@ def verify_transactions(txs: List[Transaction] | None, result) -> List[int]:
     return list(rejected_txs.keys())
 
 
-def verify_post_alloc(
-    *, expected_post: Mapping, got_alloc: Mapping, got_vkt: Optional[Mapping] = None
-):
+def verify_post_alloc(*, expected_post: Mapping, got_alloc: Mapping):
     """
-    Verify that an allocation matches the expected post in the test.
+    Verify that the final allocation mapping matches the expected post in the test.
     Raises exception on unexpected values.
     """
-    # TODO: If VKT is not None, we have an overlay of the VKT on top of the alloc and we need
-    # to verify that
     got_alloc_normalized: Dict[Address, Any] = {
         Address(address): got_alloc[address] for address in got_alloc
     }
@@ -67,6 +63,14 @@ def verify_post_alloc(
                     account.check_alloc(address, got_alloc_normalized[address])
                 else:
                     raise Exception(f"expected account not found: {address}")
+
+
+def verify_post_vkt(*, expected_post: Mapping, got_vkt: Mapping):
+    """
+    Verify that the final verkle tree mapping matches the expected post in the test.
+    Raises exception on unexpected values.
+    """
+    # TODO: Add the use the verkle subcommand to get the keys for each value in the tree.
 
 
 def verify_result(result: Mapping, env: Environment):

--- a/src/ethereum_test_tools/spec/blockchain/blockchain_test.py
+++ b/src/ethereum_test_tools/spec/blockchain/blockchain_test.py
@@ -318,8 +318,10 @@ class BlockchainTest(BaseTest):
         Verifies the post state after all block/s or payload/s are generated.
         """
         try:
-            if vkt is not None and alloc is None:
-                verify_post_vkt(transition_tool=t8n, expected_post=self.post, got_vkt=vkt)
+            if vkt is not None:
+                verify_post_vkt(
+                    transition_tool=t8n, expected_post=self.post, got_vkt=vkt, got_alloc=alloc
+                )
             else:
                 verify_post_alloc(expected_post=self.post, got_alloc=alloc)
         except Exception as e:

--- a/src/ethereum_test_tools/spec/blockchain/blockchain_test.py
+++ b/src/ethereum_test_tools/spec/blockchain/blockchain_test.py
@@ -32,6 +32,7 @@ from ..base.base_test import (
     BaseFixture,
     BaseTest,
     verify_post_alloc,
+    verify_post_vkt,
     verify_result,
     verify_transactions,
 )
@@ -314,10 +315,13 @@ class BlockchainTest(BaseTest):
 
     def verify_post_state(self, *, t8n, alloc, vkt=None):
         """
-        Verifies the post alloc after all block/s or payload/s are generated.
+        Verifies the post state after all block/s or payload/s are generated.
         """
         try:
-            verify_post_alloc(expected_post=self.post, got_alloc=alloc, got_vkt=vkt)
+            if vkt is not None and alloc is None:
+                verify_post_vkt(expected_post=self.post, got_vkt=vkt)
+            else:
+                verify_post_alloc(expected_post=self.post, got_alloc=alloc)
         except Exception as e:
             print_traces(t8n.get_traces())
             raise e

--- a/src/ethereum_test_tools/spec/blockchain/blockchain_test.py
+++ b/src/ethereum_test_tools/spec/blockchain/blockchain_test.py
@@ -319,7 +319,7 @@ class BlockchainTest(BaseTest):
         """
         try:
             if vkt is not None and alloc is None:
-                verify_post_vkt(expected_post=self.post, got_vkt=vkt)
+                verify_post_vkt(transition_tool=t8n, expected_post=self.post, got_vkt=vkt)
             else:
                 verify_post_alloc(expected_post=self.post, got_alloc=alloc)
         except Exception as e:

--- a/src/evm_transition_tool/geth.py
+++ b/src/evm_transition_tool/geth.py
@@ -13,6 +13,7 @@ from typing import Optional
 import pytest
 
 from ethereum_test_forks import Fork
+from ethereum_test_tools import Address
 
 from .transition_tool import FixtureFormats, TransitionTool, dump_files_to_directory
 
@@ -27,6 +28,7 @@ class GethTransitionTool(TransitionTool):
     t8n_subcommand: Optional[str] = "t8n"
     statetest_subcommand: Optional[str] = "statetest"
     blocktest_subcommand: Optional[str] = "blocktest"
+    verkle_subcommand: Optional[str] = "verkle"
 
     binary: Path
     cached_version: Optional[str] = None
@@ -125,3 +127,29 @@ class GethTransitionTool(TransitionTool):
                 f"Failed to verify fixture via: '{' '.join(command)}'. "
                 f"Error: '{result.stderr.decode()}'"
             )
+
+        def verkle_tree_key(self, account: Address, storage_slot: Optional[str]) -> str:
+            """
+            Returns the verkle tree key for the input account using the verkle subcommand.
+            Optionally the key for the storage slot if specified.
+            """
+            command: list[str] = [str(self.binary)]
+            command.append(self.verkle_subcommand)
+
+            command.append(str(account))
+            if storage_slot:
+                command.append(storage_slot)
+
+            command = [str(self.binary), self.verkle_subcommand]
+            result = subprocess.run(
+                command,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+            if result.returncode != 0:
+                raise Exception(
+                    f"Failed to run verkle subcommand: '{' '.join(command)}'. "
+                    f"Error: '{result.stderr.decode()}'"
+                )
+            return result.stdout.decode()

--- a/src/evm_transition_tool/geth.py
+++ b/src/evm_transition_tool/geth.py
@@ -8,7 +8,7 @@ import subprocess
 import textwrap
 from pathlib import Path
 from re import compile
-from typing import Optional
+from typing import Any, Dict, Optional
 
 import pytest
 
@@ -153,3 +153,12 @@ class GethTransitionTool(TransitionTool):
                     f"Error: '{result.stderr.decode()}'"
                 )
             return result.stdout.decode()
+
+        def post_alloc_to_vkt(self, post_alloc: Dict[str, Dict[str, str]]) -> Dict[str, Any]:
+            """
+            Converts the expected post alloc to verkle tree representation using the verkle
+            subcommand.
+            """
+            raise Exception(
+                "`create_post_vkt()` function is not supported by this tool. Use geth's evm tool."
+            )

--- a/src/evm_transition_tool/geth.py
+++ b/src/evm_transition_tool/geth.py
@@ -165,26 +165,26 @@ class GethTransitionTool(TransitionTool):
         for address, account in post_alloc.items():
             # Add the account address: value is simply "0x000...000"
             address_key = self.verkle_tree_key(address)
-            vkt[address_key] = Hash(0)
+            vkt[address_key] = Hash(0).hex()
 
             # Add account balance: numbers are little-endian
             balance_key = address_key[:-2] + "01"
-            balance_value = Hash(int(account["balance"], 16).to_bytes(32, "little"))
+            balance_value = Hash(account.balance.to_bytes(32, "little")).hex()
             vkt[balance_key] = balance_value
 
             # Add account nonce: numbers are little-endian
             nonce_key = address_key[:-2] + "02"
-            nonce_value = Hash(int(account["nonce"], 16).to_bytes(32, "little"))
+            nonce_value = Hash(account.nonce.to_bytes(32, "little")).hex()
             vkt[nonce_key] = nonce_value
 
             # Add account code hash: keccak256 hash of the code
             code_hash_key = address_key[:-2] + "03"
-            code_hash_value = Hash(keccak256(bytes.fromhex(account["code"][2:])).hex())
+            code_hash_value = Hash(keccak256(account.code)).hex()
             vkt[code_hash_key] = code_hash_value
 
             # Add account storage: each slot has a unique key
-            for slot, value in account["storage"].items():
-                slot_key = self.verkle_tree_key(address, slot)
-                vkt[slot_key] = Hash(value)
+            for slot, value in account.storage.data.items():
+                slot_key = self.verkle_tree_key(address, Hash(slot).hex())
+                vkt[slot_key] = Hash(value).hex()
 
         return vkt

--- a/src/evm_transition_tool/tests/test_alloc_to_vkt.py
+++ b/src/evm_transition_tool/tests/test_alloc_to_vkt.py
@@ -1,0 +1,48 @@
+"""
+Test the verkle tree subcommand from the geth transition tool.
+"""
+
+import pytest
+
+from evm_transition_tool import GethTransitionTool
+
+
+@pytest.mark.parametrize(
+    "post_alloc, expected_vkt",
+    [
+        (
+            {
+                "0x0000000000000000000000000000000000000100": {
+                    "nonce": "0x01",
+                    "balance": "0x01",
+                    "code": "0x60203560003555",
+                    "storage": {"0x0a": "0x0b"},
+                },
+            },
+            {
+                "0x31b64bbd0b09c1d09afea606bebb70bce80a2909189e513c924a0871bbd36300": "0x0000000000000000000000000000000000000000000000000000000000000000",  # noqa: E501
+                "0x31b64bbd0b09c1d09afea606bebb70bce80a2909189e513c924a0871bbd36301": "0x0100000000000000000000000000000000000000000000000000000000000000",  # noqa: E501
+                "0x31b64bbd0b09c1d09afea606bebb70bce80a2909189e513c924a0871bbd36302": "0x0100000000000000000000000000000000000000000000000000000000000000",  # noqa: E501
+                "0x31b64bbd0b09c1d09afea606bebb70bce80a2909189e513c924a0871bbd36303": "0x159c5cfa7fab15702c72a4141ef31b26c42827bd74ffc5671d95033227e662e7",  # noqa: E501
+                "0x31b64bbd0b09c1d09afea606bebb70bce80a2909189e513c924a0871bbd3634a": "0x000000000000000000000000000000000000000000000000000000000000000b",  # noqa: E501
+            },
+        ),
+    ],
+)
+def test_post_alloc_to_vkt(post_alloc, expected_vkt):
+    """
+    Verifies that the `post_alloc_to_vkt` method of the `GethTransitionTool` class.
+    """
+    t8n = GethTransitionTool()
+    result_vkt = t8n.post_alloc_to_vkt(post_alloc)
+
+    assert set(result_vkt.keys()) == set(
+        expected_vkt.keys()
+    ), "Keys in created verkle tree do not match the expected keys."
+
+    for key, expected_value in expected_vkt.items():
+        assert key in result_vkt, f"Key {key} is missing in created verkle tree."
+        assert result_vkt[key] == expected_value, (
+            f"Value for {key} in the created verkle tree does not match expected. "
+            f"Expected {expected_value}, got {result_vkt[key]}."
+        )

--- a/src/evm_transition_tool/tests/test_alloc_to_vkt.py
+++ b/src/evm_transition_tool/tests/test_alloc_to_vkt.py
@@ -7,6 +7,7 @@ import pytest
 from evm_transition_tool import GethTransitionTool
 
 
+# TODO: Update to use correct types.
 @pytest.mark.parametrize(
     "post_alloc, expected_vkt",
     [

--- a/src/evm_transition_tool/transition_tool.py
+++ b/src/evm_transition_tool/transition_tool.py
@@ -102,6 +102,7 @@ class TransitionTool:
     blocktest_subcommand: Optional[str] = None
     cached_version: Optional[str] = None
     t8n_use_stream: bool = True
+    verkle_subcommand: Optional[str] = None
 
     # Abstract methods that each tool must implement
 

--- a/src/evm_transition_tool/transition_tool.py
+++ b/src/evm_transition_tool/transition_tool.py
@@ -14,7 +14,7 @@ from enum import Enum
 from itertools import groupby
 from pathlib import Path
 from re import Pattern
-from typing import Any, Dict, List, Optional, Tuple, Type
+from typing import Any, Dict, List, Mapping, Optional, Tuple, Type
 
 from ethereum_test_forks import Fork
 
@@ -646,4 +646,14 @@ class TransitionTool:
         """
         raise Exception(
             "The `verify_fixture()` function is not supported by this tool. Use geth's evm tool."
+        )
+
+    def post_alloc_to_vkt(self, post_alloc: Mapping) -> Mapping:
+        """
+        Converts the expected post alloc to verkle tree representation using the verkle subcommand.
+
+        Currently only implemented by geth's evm.
+        """
+        raise Exception(
+            "The `create_post_vkt()` function is not supported by this tool. Use geth's evm tool."
         )


### PR DESCRIPTION
## 🗒️ Description
Creating a draft PR here for visibility and discussion.

This implements a method for checking the post state of the verkle tree after t8n execution.

Currently it calls an additonal subcommand: `evm t8n verkle`, responsible for generating the verkle tree keys for account addresses and storage slots. These can be used for each account to generate an expected verkle post state using our existing post alloc, and compared against the actual vkt from t8n execution.

---
For example, once we have the account address key:
```
evm t8n verkle 0x0000000000000000000000000000000000000100
> 0x31b6...6300   # address
```
We can create the account balance, nonce and code hash keys, by adding 0x01, 0x02 and 0x03 respectively to get their keys for the vkt:
```
> 0x31b6...6301  # balance
> 0x31b6...6302  # nonce
> 0x31b6...6303  # code hash
```
For account storage keys we simply add the storage slot to the sub-command:
```
evm t8n verkle 0x0000000000000000000000000000000000000100 0x01
> 0x31b6...6341   # storage slot 1
```
Using these keys we can create our own vkt representation, adding there appropriate values from the post alloc. Note the address value is `Hash32(0)`. Numerical values are in little endian (balance/nonce). The code hash value is the keccak256 of the account code bytes.

---

Currently this method is not ideal - but it does work. As we call the subcommand around 260 times it takes around 120s to fill a single test. One proposed solution is update the subcommand, passing the entire post alloc to the subcommand - expecting an entire vkt conversion back. More comments are below.

## Usage

Use the following geth branch: gballet/t8n-merge-from-shanghai-to-prague

Run with:
```
fill --from Prague --until Prague --t8n-dump-dir=./tmp -k test_verkle_from_mpt_conversion[fork_ShanghaiToPragueVerkleTransition-blockchain_test]
```
Check the output folders with `vkt.json` for any debugging.

**Note it takes around 2 mins to fill the test.** 

## 🔗 Related Issues
N/A

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
