### PR TITLE
all: Mark Cancun fork as deployed

### DIFF
--- a/.github/workflows/fixtures.yaml
+++ b/.github/workflows/fixtures.yaml
@@ -21,7 +21,7 @@ jobs:
             python: '3.11'
           - name: 'fixtures_develop'
             evm-type: 'develop'
-            fill-params: '--until=Cancun'
+            fill-params: '--until=Prague'
             solc: '0.8.21'
             python: '3.11'
     steps:

--- a/.vscode/launch.recommended.json
+++ b/.vscode/launch.recommended.json
@@ -42,22 +42,6 @@
       "cwd": "${workspaceFolder}"
     },
     {
-      "name": "Launch fill --until Shanghai",
-      "type": "python",
-      "request": "launch",
-      "module": "pytest",
-      "args": [
-        "-c",
-        "pytest.ini",
-        "--until",
-        "Shanghai",
-        "--evm-bin",
-        "${input:evmBinary}",
-        "-v"
-      ],
-      "cwd": "${workspaceFolder}"
-    },
-    {
       "name": "Launch fill --until Cancun",
       "type": "python",
       "request": "launch",
@@ -67,6 +51,22 @@
         "pytest.ini",
         "--until",
         "Cancun",
+        "--evm-bin",
+        "${input:evmBinary}",
+        "-v"
+      ],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "name": "Launch fill --until Prague",
+      "type": "python",
+      "request": "launch",
+      "module": "pytest",
+      "args": [
+        "-c",
+        "pytest.ini",
+        "--until",
+        "Prague",
         "--evm-bin",
         "${input:evmBinary}",
         "-v"
@@ -132,8 +132,9 @@
         "Paris",
         "Shanghai",
         "Cancun",
+        "Prague",
       ],
-      "default": "Shanghai"
+      "default": "Cancun"
     },
     {
       "type": "promptString",

--- a/.vscode/settings.recommended.json
+++ b/.vscode/settings.recommended.json
@@ -23,7 +23,7 @@
     "python.testing.pytestEnabled": true,
     "python.testing.pytestArgs": [
         // To discover tests for an upcoming fork, use the `--until` argument as following.
-        // "--until=Cancun",
+        // "--until=Prague",
         // Hopefully vscode-python will support multiple test framework environments sooon, see
         // https://github.com/microsoft/vscode-python/issues/12075
         // For now, to toggle between running "framework tests" and "filling tests" comment/

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,10 @@ Test fixtures for use by clients are available for each release on the [Github r
   - State test field `transaction` now uses the proper zero-padded hex number format for fields `maxPriorityFeePerGas`, `maxFeePerGas`, and `maxFeePerBlobGas`
   - Fixtures' hashes (in the `_info` field) are now calculated by removing the "_info" field entirely instead of it being set to an empty dict.
 
+### 💥 Breaking Change
+
+- Cancun is now the latest deployed fork, and the development fork is now Prague ([#489](https://github.com/ethereum/execution-spec-tests/pull/489)).
+
 ## 🔜 [v2.1.1](https://github.com/ethereum/execution-spec-tests/releases/tag/v2.1.1) - 2024-03-09
 
 ### 🧪 Test Cases

--- a/docs/consuming_tests/index.md
+++ b/docs/consuming_tests/index.md
@@ -45,7 +45,7 @@ Artifacts can be downloaded directly from [the release page](https://github.com/
 # The following two artifacts are intended for consumption by clients:
 # - fixtures.tar.gz: Generated up to the last deployed fork.
 # - fixtures_develop.tar.gz: Generated up to and including the latest dev fork.
-# As of Oct 2023, dev is Cancun, deployed is Shanghai.
+# As of March 2024, dev is Prague, deployed is Cancun.
 
 ARTIFACT="fixtures_develop.tar.gz"  
 

--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -367,14 +367,6 @@ class Cancun(Shanghai):
     """
 
     @classmethod
-    def is_deployed(cls):
-        """
-        Flags that Cancun has not been deployed to mainnet; it is under active
-        development.
-        """
-        return False
-
-    @classmethod
     def solc_min_version(cls) -> Version:
         """
         Returns the minimum version of solc that supports this fork.

--- a/src/ethereum_test_forks/tests/test_forks.py
+++ b/src/ethereum_test_forks/tests/test_forks.py
@@ -23,9 +23,9 @@ from ..helpers import (
 from ..transition_base_fork import transition_fork
 
 FIRST_DEPLOYED = Frontier
-LAST_DEPLOYED = Shanghai
+LAST_DEPLOYED = Cancun
 LAST_DEVELOPMENT = Prague
-DEVELOPMENT_FORKS = [Cancun, Prague]
+DEVELOPMENT_FORKS = [Prague]
 
 
 def test_transition_forks():
@@ -67,9 +67,12 @@ def test_transition_forks():
 
 
 def test_forks_from():  # noqa: D103
-    assert forks_from(Paris) == [Paris, LAST_DEPLOYED]
-    assert forks_from(Paris, deployed_only=True) == [Paris, LAST_DEPLOYED]
-    assert forks_from(Paris, deployed_only=False) == [Paris, LAST_DEPLOYED] + DEVELOPMENT_FORKS
+    assert forks_from(Paris)[0] == Paris
+    assert forks_from(Paris)[-1] == LAST_DEPLOYED
+    assert forks_from(Paris, deployed_only=True)[0] == Paris
+    assert forks_from(Paris, deployed_only=True)[-1] == LAST_DEPLOYED
+    assert forks_from(Paris, deployed_only=False)[0] == Paris
+    assert forks_from(Paris, deployed_only=False)[-1] == LAST_DEVELOPMENT
 
 
 def test_forks():

--- a/src/ethereum_test_tools/code/__init__.py
+++ b/src/ethereum_test_tools/code/__init__.py
@@ -3,7 +3,7 @@ Code related utilities and classes.
 """
 from .code import Code
 from .generators import CalldataCase, Case, CodeGasMeasure, Conditional, Initcode, Switch
-from .yul import Yul, YulCompiler
+from .yul import Solc, Yul, YulCompiler
 
 __all__ = (
     "Case",
@@ -12,6 +12,7 @@ __all__ = (
     "CodeGasMeasure",
     "Conditional",
     "Initcode",
+    "Solc",
     "Switch",
     "Yul",
     "YulCompiler",

--- a/src/ethereum_test_tools/code/yul.py
+++ b/src/ethereum_test_tools/code/yul.py
@@ -4,55 +4,32 @@ Yul frontend
 
 import re
 import warnings
+from functools import cached_property
 from pathlib import Path
 from shutil import which
-from subprocess import PIPE, run
-from typing import Optional, Sized, SupportsBytes, Tuple, Type, Union
+from subprocess import CompletedProcess, run
+from typing import Optional, Sized, SupportsBytes, Tuple, Type
 
 from semver import Version
 
-from ethereum_test_forks import Fork
+from ethereum_test_forks import Fork, get_closest_fork_with_solc_support
 
 from ..common.conversions import to_bytes
 from .code import Code
 
 DEFAULT_SOLC_ARGS = ("--assemble", "-")
+VERSION_PATTERN = re.compile(r"Version: (.*)")
 
 
-def get_evm_version_from_fork(fork: Fork | None):
-    """
-    Get the solc evm version corresponding to `fork`.
+class Solc:
+    """Solc compiler."""
 
-    Args
-    ----
-        fork (Fork): The fork to retrieve the corresponding evm version for.
-
-    Returns
-    -------
-        str: The name of evm version as required by solc's --evm-version.
-    """
-    if not fork:
-        return None
-    return fork.solc_name()
-
-
-class Yul(SupportsBytes, Sized):
-    """
-    Yul compiler.
-    Compiles Yul source code into bytecode.
-    """
-
-    source: str
-    compiled: Optional[bytes] = None
+    binary: Path
 
     def __init__(
         self,
-        source: str,
-        fork: Optional[Fork] = None,
         binary: Optional[Path | str] = None,
     ):
-        self.source = source
-        self.evm_version = get_evm_version_from_fork(fork)
         if binary is None:
             which_path = which("solc")
             if which_path is not None:
@@ -65,38 +42,69 @@ class Yul(SupportsBytes, Sized):
             )
         self.binary = Path(binary)
 
+    def run(self, *args: str, input: str | None = None) -> CompletedProcess:
+        """Run solc with the given arguments"""
+        return run(
+            [self.binary, *args],
+            capture_output=True,
+            text=True,
+            input=input,
+        )
+
+    @cached_property
+    def version(self) -> Version:
+        """Return solc's version"""
+        for line in self.run("--version").stdout.splitlines():
+            if match := VERSION_PATTERN.search(line):
+                # Sanitize
+                solc_version_string = match.group(1).replace("g++", "gpp")
+                return Version.parse(solc_version_string)
+        warnings.warn("Unable to determine solc version.")
+        return Version(0)
+
+
+class Yul(Solc, SupportsBytes, Sized):
+    """
+    Yul compiler.
+    Compiles Yul source code into bytecode.
+    """
+
+    source: str
+    evm_version: str | None
+
+    def __init__(
+        self,
+        source: str,
+        fork: Optional[Fork] = None,
+        binary: Optional[Path | str] = None,
+    ):
+        super().__init__(binary)
+        self.source = source
+        if fork and (fork := get_closest_fork_with_solc_support(fork, self.version)):
+            self.evm_version = fork.solc_name()
+
+    @cached_property
+    def compiled(self) -> bytes:
+        """Returns the compiled Yul source code."""
+        solc_args = ("--evm-version", self.evm_version) if self.evm_version else ()
+        
+        result = self.run(*solc_args, *DEFAULT_SOLC_ARGS, input=self.source)
+
+        if result.returncode:
+            stderr_lines = result.stderr.splitlines()
+            stderr_message = "\n".join(line.strip() for line in stderr_lines)
+            raise Exception(f"failed to compile yul source:\n{stderr_message[7:]}")
+
+        lines = result.stdout.splitlines()
+
+        hex_str = lines[lines.index("Binary representation:") + 1]
+
+        return bytes.fromhex(hex_str)
+
     def __bytes__(self) -> bytes:
         """
         Assembles using `solc --assemble`.
         """
-        if not self.compiled:
-            solc_args: Tuple[Union[Path, str], ...] = ()
-            if self.evm_version:
-                solc_args = (
-                    self.binary,
-                    "--evm-version",
-                    self.evm_version,
-                    *DEFAULT_SOLC_ARGS,
-                )
-            else:
-                solc_args = (self.binary, *DEFAULT_SOLC_ARGS)
-            result = run(
-                solc_args,
-                input=str.encode(self.source),
-                stdout=PIPE,
-                stderr=PIPE,
-            )
-
-            if result.returncode != 0:
-                stderr_lines = result.stderr.decode().split("\n")
-                stderr_message = "\n".join(line.strip() for line in stderr_lines)
-                raise Exception(f"failed to compile yul source:\n{stderr_message[7:]}")
-
-            lines = result.stdout.decode().split("\n")
-
-            hex_str = lines[lines.index("Binary representation:") + 1]
-
-            self.compiled = bytes.fromhex(hex_str)
         return self.compiled
 
     def __len__(self) -> int:
@@ -116,29 +124,6 @@ class Yul(SupportsBytes, Sized):
         Adds two code objects together, by converting both to bytes first.
         """
         return Code(to_bytes(other) + bytes(self))
-
-    def version(self) -> Version:
-        """
-        Return solc's version string
-        """
-        result = run(
-            [self.binary, "--version"],
-            stdout=PIPE,
-            stderr=PIPE,
-        )
-        solc_output = result.stdout.decode().split("\n")
-        version_pattern = r"Version: (.*)"
-        solc_version_string = ""
-        for line in solc_output:
-            if match := re.search(version_pattern, line):
-                solc_version_string = match.group(1)
-                break
-        if not solc_version_string:
-            warnings.warn("Unable to determine solc version.")
-            return Version(0)
-        # Sanitize
-        solc_version_string = solc_version_string.replace("g++", "gpp")
-        return Version.parse(solc_version_string)
 
 
 YulCompiler = Type[Yul]

--- a/src/ethereum_test_tools/code/yul.py
+++ b/src/ethereum_test_tools/code/yul.py
@@ -8,7 +8,7 @@ from functools import cached_property
 from pathlib import Path
 from shutil import which
 from subprocess import CompletedProcess, run
-from typing import Optional, Sized, SupportsBytes, Tuple, Type
+from typing import Optional, Sized, SupportsBytes, Type
 
 from semver import Version
 
@@ -87,7 +87,7 @@ class Yul(Solc, SupportsBytes, Sized):
     def compiled(self) -> bytes:
         """Returns the compiled Yul source code."""
         solc_args = ("--evm-version", self.evm_version) if self.evm_version else ()
-        
+
         result = self.run(*solc_args, *DEFAULT_SOLC_ARGS, input=self.source)
 
         if result.returncode:

--- a/src/ethereum_test_tools/code/yul.py
+++ b/src/ethereum_test_tools/code/yul.py
@@ -12,7 +12,7 @@ from typing import Optional, Sized, SupportsBytes, Type
 
 from semver import Version
 
-from ethereum_test_forks import Fork, get_closest_fork_with_solc_support
+from ethereum_test_forks import Fork
 
 from ..common.conversions import to_bytes
 from .code import Code
@@ -80,8 +80,7 @@ class Yul(Solc, SupportsBytes, Sized):
     ):
         super().__init__(binary)
         self.source = source
-        if fork and (fork := get_closest_fork_with_solc_support(fork, self.version)):
-            self.evm_version = fork.solc_name()
+        self.evm_version = fork.solc_name() if fork else None
 
     @cached_property
     def compiled(self) -> bytes:

--- a/src/ethereum_test_tools/tests/conftest.py
+++ b/src/ethereum_test_tools/tests/conftest.py
@@ -15,7 +15,7 @@ SOLC_PADDING_VERSION = Version.parse("0.8.21")
 @pytest.fixture(scope="session")
 def solc_version() -> Version:
     """Return the version of solc being used for tests."""
-    solc_version = Yul("").version().finalize_version()
+    solc_version = Yul("").version.finalize_version()
     if solc_version < Frontier.solc_min_version():
         raise Exception("Unsupported solc version: {}".format(solc_version))
     return solc_version

--- a/src/ethereum_test_tools/tests/test_code.py
+++ b/src/ethereum_test_tools/tests/test_code.py
@@ -8,7 +8,7 @@ from typing import Mapping, SupportsBytes
 import pytest
 from semver import Version
 
-from ethereum_test_forks import Fork, Homestead, Shanghai, get_deployed_forks
+from ethereum_test_forks import Cancun, Fork, Homestead, Shanghai, get_deployed_forks
 from evm_transition_tool import FixtureFormats, GethTransitionTool
 
 from ..code import CalldataCase, Case, Code, Conditional, Initcode, Switch, Yul
@@ -83,7 +83,7 @@ def expected_bytes(request: pytest.FixtureRequest, solc_version: Version, fork: 
             solc_padding = "00"
         return bytes.fromhex(expected_bytes.substitute(solc_padding=solc_padding))
     if isinstance(expected_bytes, bytes):
-        if fork == Shanghai:
+        if fork >= Shanghai:
             expected_bytes = b"\x5f" + expected_bytes[2:]
         if solc_version < SOLC_PADDING_VERSION or fork <= Homestead:
             return expected_bytes
@@ -650,7 +650,7 @@ def test_switch(tx_data: bytes, switch_bytecode: bytes, expected_storage: Mappin
     )
     state_test.generate(
         t8n=GethTransitionTool(),
-        fork=Shanghai,
+        fork=Cancun,
         fixture_format=FixtureFormats.BLOCKCHAIN_TEST,
         eips=None,
     )

--- a/src/ethereum_test_tools/tests/test_code.py
+++ b/src/ethereum_test_tools/tests/test_code.py
@@ -8,10 +8,17 @@ from typing import Mapping, SupportsBytes
 import pytest
 from semver import Version
 
-from ethereum_test_forks import Cancun, Fork, Homestead, Shanghai, get_deployed_forks
+from ethereum_test_forks import (
+    Cancun,
+    Fork,
+    Homestead,
+    Shanghai,
+    get_closest_fork_with_solc_support,
+    get_deployed_forks,
+)
 from evm_transition_tool import FixtureFormats, GethTransitionTool
 
-from ..code import CalldataCase, Case, Code, Conditional, Initcode, Switch, Yul
+from ..code import CalldataCase, Case, Code, Conditional, Initcode, Solc, Switch, Yul
 from ..common import Account, Environment, Hash, TestAddress, Transaction
 from ..spec import StateTest
 from ..vm.opcode import Opcodes as Op
@@ -66,7 +73,9 @@ def yul_code(request: pytest.FixtureRequest, fork: Fork, padding_before: str, pa
     else:
         compiled_yul_code = Code("")
     for yul_code in yul_code_snippets:
-        compiled_yul_code += Yul(yul_code, fork=fork)
+        compiled_yul_code += Yul(
+            yul_code, fork=get_closest_fork_with_solc_support(fork, Solc().version)
+        )
     if padding_after is not None:
         compiled_yul_code += Code(padding_after)
     return compiled_yul_code

--- a/src/pytest_plugins/test_filler/test_filler.py
+++ b/src/pytest_plugins/test_filler/test_filler.py
@@ -168,7 +168,7 @@ def pytest_configure(config):
             "The Besu t8n tool does not work well with the xdist plugin; use -n=0.",
             returncode=pytest.ExitCode.USAGE_ERROR,
         )
-    config.solc_version = Yul("", binary=config.getoption("solc_bin")).version()
+    config.solc_version = Yul("", binary=config.getoption("solc_bin")).version
     if config.solc_version < Frontier.solc_min_version():
         pytest.exit(
             f"Unsupported solc version: {config.solc_version}. Minimum required version is "

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ env_list =
     docs
 
 [main]
-development_fork = Cancun
+development_fork = Prague
 
 [testenv]
 package = wheel


### PR DESCRIPTION
## 🗒️ Description
- Updates:
  - ethereum_test_forks
  - ethereum_test_tools, including a yul compiler code cleanup
  - ethereum_test_tools tests
  - github workflows
  - tox update to use Prague as development
  - vscode recommended files
  - minor changes to the docs

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
