### PR TITLE
test(fw): add empty account tests

### DIFF
--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -243,7 +243,7 @@ class Storage(RootModel[Dict[StorageKeyValueType, StorageKeyValueType]]):
 
     def __bool__(self) -> bool:
         """Returns True if the storage is not empty"""
-        return any(v != 0 for _, v in self.root.items())
+        return any(v for v in self.root.values())
 
     def keys(self) -> set[StorageKeyValueType]:
         """Returns the keys of the storage"""

--- a/src/ethereum_test_tools/tests/test_types.py
+++ b/src/ethereum_test_tools/tests/test_types.py
@@ -100,6 +100,57 @@ def test_storage():
 
 
 @pytest.mark.parametrize(
+    ["account"],
+    [
+        pytest.param(
+            Account(),
+            id="no_fields",
+        ),
+        pytest.param(
+            Account(
+                nonce=0,
+            ),
+            id="zero_nonce",
+        ),
+        pytest.param(
+            Account(
+                balance=0,
+            ),
+            id="zero_balance",
+        ),
+        pytest.param(
+            Account(
+                code="",
+            ),
+            id="empty_code",
+        ),
+        pytest.param(
+            Account(
+                storage={},
+            ),
+            id="empty_storage",
+        ),
+        pytest.param(
+            Account(
+                nonce=0,
+                balance=0,
+                code="",
+                storage={
+                    1: 0,
+                },
+            ),
+            id="only_zero_storage_values",
+        ),
+    ],
+)
+def test_empty_accounts(account: Account):
+    """
+    Test `ethereum_test.types.account` parsing.
+    """
+    assert not bool(account)
+
+
+@pytest.mark.parametrize(
     ["account", "alloc_dict", "should_pass"],
     [
         # All None: Pass


### PR DESCRIPTION
## 🗒️ Description
Fixes empty accounts not being recognized as such because an explicit zero was set as the value to a key.

Edit(dan): The original intent of this PR was also fixed in #486 and this PR now only adds additional tests for empty accounts and one small refactor.

## 🔗 Related Issues
Fixes https://github.com/ethereum/execution-spec-tests/issues/475

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
