### PR TITLE
fix(tests): mcopy: block gas limit for memory expansion tests

### DIFF
--- a/tests/cancun/eip5656_mcopy/test_mcopy_memory_expansion.py
+++ b/tests/cancun/eip5656_mcopy/test_mcopy_memory_expansion.py
@@ -203,6 +203,7 @@ def post(bytecode_storage: Tuple[bytes, Storage.StorageDictType]) -> Mapping:  #
 @pytest.mark.valid_from("Cancun")
 def test_mcopy_memory_expansion(
     state_test: StateTestFiller,
+    env: Environment,
     pre: Mapping[str, Account],
     post: Mapping[str, Account],
     tx: Transaction,
@@ -211,7 +212,7 @@ def test_mcopy_memory_expansion(
     Perform MCOPY operations that expand the memory, and verify the gas it costs to do so.
     """
     state_test(
-        env=Environment(),
+        env=env,
         pre=pre,
         post=post,
         tx=tx,
@@ -263,6 +264,7 @@ def test_mcopy_memory_expansion(
 @pytest.mark.valid_from("Cancun")
 def test_mcopy_huge_memory_expansion(
     state_test: StateTestFiller,
+    env: Environment,
     pre: Mapping[str, Account],
     post: Mapping[str, Account],
     tx: Transaction,
@@ -272,7 +274,7 @@ def test_mcopy_huge_memory_expansion(
     runs out of gas.
     """
     state_test(
-        env=Environment(),
+        env=env,
         pre=pre,
         post=post,
         tx=tx,


### PR DESCRIPTION
## 🗒️ Description
Use unused environment value for the block gas limit in the memory expansion tests of mcopy.

Test still worked because the default block gas limit is much higher than what the test accounted for, so this change is only useful so that the test does not break if we reduce the default value at some point.

## 🔗 Related Issues
https://github.com/ethereum/execution-spec-tests/issues/471

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
