### PR TITLE
feat(all): Add EOF (EVM object format) spec and fixtures types

### DIFF
--- a/src/ethereum_test_tools/__init__.py
+++ b/src/ethereum_test_tools/__init__.py
@@ -39,7 +39,7 @@ from .common import (
     cost_memory_bytes,
     eip_2028_transaction_data_cost,
 )
-from .exceptions import BlockException, TransactionException
+from .exceptions import BlockException, EOFException, TransactionException
 from .reference_spec import ReferenceSpec, ReferenceSpecTypes
 from .spec import (
     SPEC_TYPES,
@@ -47,6 +47,8 @@ from .spec import (
     BaseTest,
     BlockchainTest,
     BlockchainTestFiller,
+    EOFTest,
+    EOFTestFiller,
     FixtureCollector,
     StateTest,
     StateTestFiller,
@@ -74,12 +76,15 @@ __all__ = (
     "Conditional",
     "EngineAPIError",
     "Environment",
+    "EOFException",
+    "EOFTest",
+    "EOFTestFiller",
     "FixtureCollector",
     "Hash",
     "Header",
     "Initcode",
-    "Opcode",
     "Macro",
+    "Opcode",
     "OpcodeCallArg",
     "Opcodes",
     "ReferenceSpec",

--- a/src/ethereum_test_tools/exceptions/__init__.py
+++ b/src/ethereum_test_tools/exceptions/__init__.py
@@ -5,6 +5,7 @@ Exceptions for invalid execution.
 from .exceptions import (
     BlockException,
     BlockExceptionList,
+    EOFException,
     ExceptionList,
     TransactionException,
     TransactionExceptionList,
@@ -13,6 +14,7 @@ from .exceptions import (
 __all__ = [
     "BlockException",
     "BlockExceptionList",
+    "EOFException",
     "ExceptionList",
     "TransactionException",
     "TransactionExceptionList",

--- a/src/ethereum_test_tools/exceptions/exceptions.py
+++ b/src/ethereum_test_tools/exceptions/exceptions.py
@@ -163,6 +163,18 @@ class BlockException(ExceptionBase):
     """
 
 
+@unique
+class EOFException(ExceptionBase):
+    """
+    Exception raised when an EOF container is invalid
+    """
+
+    UNKNOWN_VERSION = auto()
+    """
+    EOF container has an unknown version
+    """
+
+
 """
 Pydantic Annotated Types
 """

--- a/src/ethereum_test_tools/spec/__init__.py
+++ b/src/ethereum_test_tools/spec/__init__.py
@@ -6,10 +6,11 @@ from typing import List, Type
 
 from .base.base_test import BaseFixture, BaseTest, TestSpec
 from .blockchain.blockchain_test import BlockchainTest, BlockchainTestFiller, BlockchainTestSpec
+from .eof.eof_test import EOFTest, EOFTestFiller, EOFTestSpec
 from .fixture_collector import FixtureCollector, TestInfo
 from .state.state_test import StateTest, StateTestFiller, StateTestOnly, StateTestSpec
 
-SPEC_TYPES: List[Type[BaseTest]] = [BlockchainTest, StateTest, StateTestOnly]
+SPEC_TYPES: List[Type[BaseTest]] = [BlockchainTest, StateTest, StateTestOnly, EOFTest]
 
 __all__ = (
     "SPEC_TYPES",
@@ -18,6 +19,9 @@ __all__ = (
     "BlockchainTest",
     "BlockchainTestFiller",
     "BlockchainTestSpec",
+    "EOFTest",
+    "EOFTestFiller",
+    "EOFTestSpec",
     "FixtureCollector",
     "StateTest",
     "StateTestFiller",

--- a/src/ethereum_test_tools/spec/base/base_test.py
+++ b/src/ethereum_test_tools/spec/base/base_test.py
@@ -158,6 +158,8 @@ class BaseTest(BaseModel):
 
         By default, it returns the underscore separated name of the class.
         """
+        if cls.__name__ == "EOFTest":
+            return "eof_test"
         return reduce(lambda x, y: x + ("_" if y.isupper() else "") + y, cls.__name__).lower()
 
     def get_next_transition_tool_output_path(self) -> str:

--- a/src/ethereum_test_tools/spec/eof/__init__.py
+++ b/src/ethereum_test_tools/spec/eof/__init__.py
@@ -1,0 +1,3 @@
+"""
+EOFTest type definitions and logic
+"""

--- a/src/ethereum_test_tools/spec/eof/eof_test.py
+++ b/src/ethereum_test_tools/spec/eof/eof_test.py
@@ -1,0 +1,70 @@
+"""
+Ethereum EOF test spec definition and filler.
+"""
+
+from typing import Callable, ClassVar, Generator, List, Optional, Type
+
+from ethereum_test_forks import Fork
+from evm_transition_tool import FixtureFormats
+
+from ...common.base_types import Bytes
+from ...exceptions import EOFException
+from ..base.base_test import BaseFixture, BaseTest
+from .types import Fixture
+
+
+class EOFTest(BaseTest):
+    """
+    Filler type that tests EOF containers.
+    """
+
+    data: Bytes
+    expect_exception: EOFException | None = None
+
+    supported_fixture_formats: ClassVar[List[FixtureFormats]] = [
+        # TODO: Potentially generate a state test and blockchain test too.
+        FixtureFormats.EOF_TEST,
+    ]
+
+    def make_eof_test_fixture(
+        self,
+        *,
+        fork: Fork,
+        eips: Optional[List[int]],
+    ) -> Fixture:
+        """
+        Generate the EOF test fixture.
+        """
+        return Fixture(
+            vectors={
+                "0": {
+                    "code": self.data,
+                    "results": {
+                        fork.blockchain_test_network_name(): {
+                            "exception": self.expect_exception,
+                            "valid": self.expect_exception is None,
+                        }
+                    },
+                }
+            }
+        )
+
+    def generate(
+        self,
+        *,
+        fork: Fork,
+        eips: Optional[List[int]] = None,
+        fixture_format: FixtureFormats,
+        **_,
+    ) -> BaseFixture:
+        """
+        Generate the BlockchainTest fixture.
+        """
+        if fixture_format == FixtureFormats.EOF_TEST:
+            return self.make_eof_test_fixture(fork=fork, eips=eips)
+
+        raise Exception(f"Unknown fixture format: {fixture_format}")
+
+
+EOFTestSpec = Callable[[str], Generator[EOFTest, None, None]]
+EOFTestFiller = Type[EOFTest]

--- a/src/ethereum_test_tools/spec/eof/types.py
+++ b/src/ethereum_test_tools/spec/eof/types.py
@@ -1,0 +1,54 @@
+"""
+EOFTest Type Definitions
+"""
+
+
+from typing import Any, ClassVar, Mapping
+
+from pydantic import Field
+
+from evm_transition_tool import FixtureFormats
+
+from ...common.base_types import Bytes
+from ...common.types import CamelModel
+from ...exceptions import EOFException
+from ..base.base_test import BaseFixture
+
+
+class Result(CamelModel):
+    """
+    Result for a single fork in a fixture.
+    """
+
+    exception: EOFException | None = None
+    valid: bool = Field(..., alias="result")
+
+    def model_post_init(self, __context: Any) -> None:
+        """
+        Simple cross-field validation that a test cannot have an empty exception if
+        the valid is False.
+        """
+        if not self.valid and self.exception is None:
+            raise ValueError("Invalid test: invalid but exception is not set")
+        elif self.valid and self.exception is not None:
+            raise ValueError("Invalid test: valid but exception is set")
+        super().model_post_init(__context)
+
+
+class Vector(CamelModel):
+    """
+    Single test vector in a fixture.
+    """
+
+    code: Bytes
+    results: Mapping[str, Result]
+
+
+class Fixture(BaseFixture):
+    """
+    Fixture for a single EOFTest.
+    """
+
+    vectors: Mapping[str, Vector]
+
+    format: ClassVar[FixtureFormats] = FixtureFormats.EOF_TEST

--- a/src/evm_transition_tool/transition_tool.py
+++ b/src/evm_transition_tool/transition_tool.py
@@ -45,6 +45,7 @@ class FixtureFormats(Enum):
     STATE_TEST = "state_test"
     BLOCKCHAIN_TEST = "blockchain_test"
     BLOCKCHAIN_TEST_HIVE = "blockchain_test_hive"
+    EOF_TEST = "eof_test"
 
     @classmethod
     def is_state_test(cls, format):  # noqa: D102
@@ -81,6 +82,8 @@ class FixtureFormats(Enum):
             return "Tests that generate a blockchain test fixture."
         elif format == cls.BLOCKCHAIN_TEST_HIVE:
             return "Tests that generate a blockchain test fixture in hive format."
+        elif format == cls.EOF_TEST:
+            return "Tests that generate an EOF test fixture."
         raise Exception(f"Unknown fixture format: {format}.")
 
     @property

--- a/tests/prague/eip3540_evm_object_format_v1/__init__.py
+++ b/tests/prague/eip3540_evm_object_format_v1/__init__.py
@@ -1,0 +1,4 @@
+"""
+abstract: Tests [EIP-3540: EOF - EVM Object Format v1](https://eips.ethereum.org/EIPS/eip-3540)
+    Tests for [EIP-3540: EOF - EVM Object Format v1](https://eips.ethereum.org/EIPS/eip-3540).
+"""

--- a/tests/prague/eip3540_evm_object_format_v1/test_eof.py
+++ b/tests/prague/eip3540_evm_object_format_v1/test_eof.py
@@ -1,0 +1,40 @@
+"""
+abstract: Tests [EIP-3540: EOF - EVM Object Format v1](https://eips.ethereum.org/EIPS/eip-3540)
+    Tests for [EIP-3540: EOF - EVM Object Format v1](https://eips.ethereum.org/EIPS/eip-3540).
+"""
+
+from typing import Any
+
+import pytest
+
+from ethereum_test_forks import Shanghai
+from ethereum_test_tools import EOFException, EOFTestFiller
+
+EOF_FORK = Shanghai
+
+REFERENCE_SPEC_GIT_PATH = "EIPS/eip-3540.md"
+REFERENCE_SPEC_VERSION = "e27f0bce83584d38748e33ef5095dd4593cc721a"
+
+
+@pytest.mark.parametrize(
+    "code,expect_exception",
+    [
+        pytest.param(
+            "0xef00010100040200010004040000000080000160005000",
+            None,
+            id="valid_code_1",
+        ),
+    ],
+    ids=["empty_code"],
+)
+@pytest.mark.valid_from(str(EOF_FORK))
+def test_basic_eof_test_generation(
+    eof_test: EOFTestFiller, code: Any, expect_exception: EOFException | None
+) -> None:
+    """
+    Test basic EOF test generation.
+    """
+    eof_test(
+        data=code,
+        expect_exception=expect_exception,
+    )


### PR DESCRIPTION
## 🗒️ Description
Basic implementation of EOF fixture generation, with a simple example.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
