### PR TITLE
refactor(fw): augment & use Fixtures model in fixture collection

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - 🐞 Fix incorrect `!=` operator for `FixedSizeBytes` ([#477](https://github.com/ethereum/execution-spec-tests/pull/477)).
 - ✨ Add Macro enum that represents byte sequence of Op instructions ([#457](https://github.com/ethereum/execution-spec-tests/pull/457))
 - ✨ Number of parameters used to call opcodes (to generate bytecode) is now checked ([#492](https://github.com/ethereum/execution-spec-tests/pull/492)).
-- ✨ Libraries have been refactored to use `pydantic` for type checking in most test types ([#486](https://github.com/ethereum/execution-spec-tests/pull/486), [#501](https://github.com/ethereum/execution-spec-tests/pull/501)).
+- ✨ Libraries have been refactored to use `pydantic` for type checking in most test types ([#486](https://github.com/ethereum/execution-spec-tests/pull/486), [#501](https://github.com/ethereum/execution-spec-tests/pull/501), [#508](https://github.com/ethereum/execution-spec-tests/pull/508)).
 
 ### 🔧 EVM Tools
 

--- a/src/ethereum_test_tools/spec/base/base_test.py
+++ b/src/ethereum_test_tools/spec/base/base_test.py
@@ -9,7 +9,7 @@ from functools import cached_property, reduce
 from itertools import count
 from os import path
 from pathlib import Path
-from typing import Any, Callable, ClassVar, Dict, Generator, Iterator, List, Optional, TextIO
+from typing import Any, Callable, ClassVar, Dict, Generator, Iterator, List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -110,17 +110,6 @@ class BaseFixture(CamelModel):
         self.info["filling-transition-tool"] = t8n.version()
         if ref_spec is not None:
             ref_spec.write_info(self.info)
-
-    @classmethod
-    def collect_into_file(cls, fd: TextIO, fixtures: Dict[str, "BaseFixture"]):
-        """
-        For all formats, we simply join the json fixtures into a single file.
-        """
-        json_fixtures: Dict[str, Dict[str, Any]] = {}
-        for name, fixture in fixtures.items():
-            assert isinstance(fixture, cls), f"Invalid fixture type: {type(fixture)}"
-            json_fixtures[name] = fixture.json_dict_with_info()
-        json.dump(json_fixtures, fd, indent=4)
 
 
 class BaseTest(BaseModel):


### PR DESCRIPTION
## 🗒️ Description
This is a gentle refactor to make use of `Fixtures` during fixture collection and writing:
- Moves `collect_info_file()` from the `BaseFixture` class to `Fixtures`. It now also takes a file instead of an fd for consistency with other `Fixtures` methods.
-  Use `Fixtures` model in the `FixtureCollector` class.

## 🔗 Related Issues
Makes use of #501.

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
