### PR TITLE
chore: soften package requirements for compatibility with other dependences

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - 💥 As part of the pydantic conversion, the fixtures have the following (possibly breaking) changes ([#486](https://github.com/ethereum/execution-spec-tests/pull/486)):
   - State test field `transaction` now uses the proper zero-padded hex number format for fields `maxPriorityFeePerGas`, `maxFeePerGas`, and `maxFeePerBlobGas`
   - Fixtures' hashes (in the `_info` field) are now calculated by removing the "_info" field entirely instead of it being set to an empty dict.
+- 🐞 Relax minor and patch dependency requirements to avoid conflicting package dependencies ([#510](https://github.com/ethereum/execution-spec-tests/pull/510)).
 
 ### 💥 Breaking Change
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     pytest==7.3.2
     pytest-xdist>=3.3.1,<4
     coincurve>=18.0.0,<19
-    trie==2.1.1
+    trie>=2.0.0,<3
     semver==3.0.1
     click>=8.0.0,<9
     pydantic>=2.6.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,15 +26,15 @@ install_requires =
     ethereum@git+https://github.com/ethereum/execution-specs.git
     setuptools
     types-setuptools
-    requests>=2.31.0
-    colorlog>=6.7.0
-    pytest==7.3.2
+    requests>=2.31.0,<3
+    colorlog>=6.7.0,<7
+    pytest>7.3.2,<8
     pytest-xdist>=3.3.1,<4
     coincurve>=18.0.0,<19
-    trie>=2.0.0,<3
-    semver==3.0.1
+    trie>=2.0.2,<3
+    semver>=3.0.1,<4
     click>=8.0.0,<9
-    pydantic>=2.6.3
+    pydantic>=2.6.3,<3
     rich>=13.7.0,<14
 
 [options.package_data]


### PR DESCRIPTION
## 🗒️ Description

This PR:
- Softens minor and patch package dependency version requirements to try to avoid dependency conflicts with other dependencies (as we're currently experiencing, this is described in more details below).
- Sharpens major package requirements to avoid potential incompatibilities if one of our dependencies releases a new major version. 

[ethereum/execution-specs](https://github.com/ethereum/execution-specs) just bumped their consensus-specs dependency which in turn now requires [py-trie](https://github.com/ethereum/py-trie) v2.0.2. We currently require trie v2.1.1:
https://github.com/ethereum/execution-spec-tests/blob/4e66cef8e51716c437376d344c65f88b11308174/setup.cfg#L25-L34

This leads to a version conflict and installing ethereum-execution-specs fails with:
```
  INFO: pip is looking at multiple versions of eth2spec to determine which version is compatible with other requirements. This could take a while.

The conflict is caused by:
    The user requested trie==2.1.1
    eth2spec 1.4.0b7 depends on trie==2.0.2

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict
...
ERROR: Cannot install ethereum and trie==2.1.1 because these package versions have conflicting dependencies.
ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
...
tests: FAIL ✖ in 19.8 seconds
```

https://github.com/ethereum/execution-specs/commit/caa1b1be15421dd57c9b3e3d2f57f9ac5c4588a1

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
