### PR TITLE
feat(fw): Call `evmone-eofparse` on EOF tests filling

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Libraries have been refactored to use `pydantic` for type checking in most test types ([#486](https://github.com/ethereum/execution-spec-tests/pull/486), [#501](https://github.com/ethereum/execution-spec-tests/pull/501), [#508](https://github.com/ethereum/execution-spec-tests/pull/508)).
 - ✨ Opcodes are now subscriptable and it's used to define the data portion of the opcode: `Op.PUSH1(1) == Op.PUSH1[1]  == b"\x60\x01"` ([#513](https://github.com/ethereum/execution-spec-tests/pull/513))
 - ✨ Added EOF fixture format ([#512](https://github.com/ethereum/execution-spec-tests/pull/512)).
+- ✨ Verify filled EOF fixtures using `evmone-eofparse` during `fill` execution ([#519](https://github.com/ethereum/execution-spec-tests/pull/519)).
 
 ### 🔧 EVM Tools
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ install_requires =
     ethereum@git+https://github.com/ethereum/execution-specs.git
     setuptools
     types-setuptools
+    bidict>=0.23,<1
     requests>=2.31.0,<3
     colorlog>=6.7.0,<7
     pytest>7.3.2,<8

--- a/src/ethereum_test_tools/exceptions/__init__.py
+++ b/src/ethereum_test_tools/exceptions/__init__.py
@@ -2,7 +2,7 @@
 Exceptions for invalid execution.
 """
 
-from .evmone_exceptions import EvmoneExceptionParser
+from .evmone_exceptions import EvmoneExceptionMapper
 from .exceptions import (
     BlockException,
     BlockExceptionInstanceOrList,
@@ -19,5 +19,5 @@ __all__ = [
     "ExceptionInstanceOrList",
     "TransactionException",
     "TransactionExceptionInstanceOrList",
-    "EvmoneExceptionParser",
+    "EvmoneExceptionMapper",
 ]

--- a/src/ethereum_test_tools/exceptions/__init__.py
+++ b/src/ethereum_test_tools/exceptions/__init__.py
@@ -2,6 +2,7 @@
 Exceptions for invalid execution.
 """
 
+from .evmone_exceptions import EvmoneExceptionParser
 from .exceptions import (
     BlockException,
     BlockExceptionInstanceOrList,
@@ -18,4 +19,5 @@ __all__ = [
     "ExceptionInstanceOrList",
     "TransactionException",
     "TransactionExceptionInstanceOrList",
+    "EvmoneExceptionParser",
 ]

--- a/src/ethereum_test_tools/exceptions/evmone_exceptions.py
+++ b/src/ethereum_test_tools/exceptions/evmone_exceptions.py
@@ -1,51 +1,74 @@
 """
 Evmone eof exceptions ENUM -> str mapper
 """
+from dataclasses import dataclass
+
+from bidict import frozenbidict
 
 from .exceptions import EOFException
 
 
-class EvmoneExceptionParser:
+@dataclass
+class ExceptionMessage:
+    """Defines a mapping between an exception and a message."""
+
+    exception: EOFException
+    message: str
+
+
+class EvmoneExceptionMapper:
     """
-    Translate known exceptions into error strings returned by evmone
+    Translate between EEST exceptions and error strings returned by evmone.
     """
 
-    # MUST remain 1:1  both key and values unique for reverse search
-    message_map = {
-        # TODO EVMONE need to differentiate when the section is missing in the header or body
-        EOFException.MISSING_STOP_OPCODE: "err: no_terminating_instruction",
-        EOFException.MISSING_CODE_HEADER: "err: code_section_missing",
-        EOFException.MISSING_TYPE_HEADER: "err: type_section_missing",
-        # TODO EVMONE this exceptions are too similar, this leeds to ambiguity
-        EOFException.MISSING_TERMINATOR: "err: header_terminator_missing",
-        EOFException.MISSING_HEADERS_TERMINATOR: "err: section_headers_not_terminated",
-        EOFException.INVALID_VERSION: "err: eof_version_unknown",
-        EOFException.INVALID_MAGIC: "err: invalid_prefix",
-        EOFException.INVALID_FIRST_SECTION_TYPE: "err: invalid_first_section_type",
-        EOFException.INVALID_SECTION_BODIES_SIZE: "err: invalid_section_bodies_size",
-        EOFException.INVALID_TYPE_SIZE: "err: invalid_type_section_size",
-        EOFException.INCOMPLETE_SECTION_SIZE: "err: incomplete_section_size",
-        EOFException.INCOMPLETE_SECTION_NUMBER: "err: incomplete_section_number",
-        EOFException.TOO_MANY_CODE_SECTIONS: "err: too_many_code_sections",
-        EOFException.ZERO_SECTION_SIZE: "err: zero_section_size",
-    }
+    _mapping_data = (
+        # TODO EVMONE needs to differentiate when the section is missing in the header or body
+        ExceptionMessage(EOFException.MISSING_STOP_OPCODE, "err: no_terminating_instruction"),
+        ExceptionMessage(EOFException.MISSING_CODE_HEADER, "err: code_section_missing"),
+        ExceptionMessage(EOFException.MISSING_TYPE_HEADER, "err: type_section_missing"),
+        # TODO EVMONE these exceptions are too similar, this leeds to ambiguity
+        ExceptionMessage(EOFException.MISSING_TERMINATOR, "err: header_terminator_missing"),
+        ExceptionMessage(
+            EOFException.MISSING_HEADERS_TERMINATOR, "err: section_headers_not_terminated"
+        ),
+        ExceptionMessage(EOFException.INVALID_VERSION, "err: eof_version_unknown"),
+        ExceptionMessage(EOFException.INVALID_MAGIC, "err: invalid_prefix"),
+        ExceptionMessage(
+            EOFException.INVALID_FIRST_SECTION_TYPE, "err: invalid_first_section_type"
+        ),
+        ExceptionMessage(
+            EOFException.INVALID_SECTION_BODIES_SIZE, "err: invalid_section_bodies_size"
+        ),
+        ExceptionMessage(EOFException.INVALID_TYPE_SIZE, "err: invalid_type_section_size"),
+        ExceptionMessage(EOFException.INCOMPLETE_SECTION_SIZE, "err: incomplete_section_size"),
+        ExceptionMessage(EOFException.INCOMPLETE_SECTION_NUMBER, "err: incomplete_section_number"),
+        ExceptionMessage(EOFException.TOO_MANY_CODE_SECTIONS, "err: too_many_code_sections"),
+        ExceptionMessage(EOFException.ZERO_SECTION_SIZE, "err: zero_section_size"),
+    )
 
-    # Reverse the message_map to create a new dictionary where values become keys
-    reverse_message_map = {v: k for k, v in message_map.items()}
+    def __init__(self) -> None:
+        assert len(set(entry.exception for entry in self._mapping_data)) == len(
+            self._mapping_data
+        ), "Duplicate exception in _mapping_data"
+        assert len(set(entry.message for entry in self._mapping_data)) == len(
+            self._mapping_data
+        ), "Duplicate message in _mapping_data"
+        self.exception_to_message_map: frozenbidict = frozenbidict(
+            {entry.exception: entry.message for entry in self._mapping_data}
+        )
 
-    def __init__(self):
-        pass
-
-    def parse_exception(self, exception: EOFException) -> str:
+    def exception_to_message(self, exception: EOFException) -> str:
         """Takes an EOFException and returns a formatted string."""
-        message = self.message_map.get(
-            exception, f"EvmoneExceptionParser: Missing string for {exception}"
+        message = self.exception_to_message_map.get(
+            exception,
+            f"No message defined for {exception}; please add it to {self.__class__.__name__}",
         )
         return message
 
-    def rev_parse_exception(self, exception_string: str) -> EOFException:
-        """Takes a string and tires to find matching exception"""
-        exception = self.reverse_message_map.get(
+    def message_to_exception(self, exception_string: str) -> EOFException:
+        """Takes a string and tries to find matching exception"""
+        # TODO inform tester where to add the missing exception if get uses default
+        exception = self.exception_to_message_map.inverse.get(
             exception_string, EOFException.UNDEFINED_EXCEPTION
         )
         return exception

--- a/src/ethereum_test_tools/exceptions/evmone_exceptions.py
+++ b/src/ethereum_test_tools/exceptions/evmone_exceptions.py
@@ -1,0 +1,51 @@
+"""
+Evmone eof exceptions ENUM -> str mapper
+"""
+
+from .exceptions import EOFException
+
+
+class EvmoneExceptionParser:
+    """
+    Translate known exceptions into error strings returned by evmone
+    """
+
+    # MUST remain 1:1  both key and values unique for reverse search
+    message_map = {
+        # TODO EVMONE need to differentiate when the section is missing in the header or body
+        EOFException.MISSING_STOP_OPCODE: "err: no_terminating_instruction",
+        EOFException.MISSING_CODE_HEADER: "err: code_section_missing",
+        EOFException.MISSING_TYPE_HEADER: "err: type_section_missing",
+        # TODO EVMONE this exceptions are too similar, this leeds to ambiguity
+        EOFException.MISSING_TERMINATOR: "err: header_terminator_missing",
+        EOFException.MISSING_HEADERS_TERMINATOR: "err: section_headers_not_terminated",
+        EOFException.INVALID_VERSION: "err: eof_version_unknown",
+        EOFException.INVALID_MAGIC: "err: invalid_prefix",
+        EOFException.INVALID_FIRST_SECTION_TYPE: "err: invalid_first_section_type",
+        EOFException.INVALID_SECTION_BODIES_SIZE: "err: invalid_section_bodies_size",
+        EOFException.INVALID_TYPE_SIZE: "err: invalid_type_section_size",
+        EOFException.INCOMPLETE_SECTION_SIZE: "err: incomplete_section_size",
+        EOFException.INCOMPLETE_SECTION_NUMBER: "err: incomplete_section_number",
+        EOFException.TOO_MANY_CODE_SECTIONS: "err: too_many_code_sections",
+        EOFException.ZERO_SECTION_SIZE: "err: zero_section_size",
+    }
+
+    # Reverse the message_map to create a new dictionary where values become keys
+    reverse_message_map = {v: k for k, v in message_map.items()}
+
+    def __init__(self):
+        pass
+
+    def parse_exception(self, exception: EOFException) -> str:
+        """Takes an EOFException and returns a formatted string."""
+        message = self.message_map.get(
+            exception, f"EvmoneExceptionParser: Missing string for {exception}"
+        )
+        return message
+
+    def rev_parse_exception(self, exception_string: str) -> EOFException:
+        """Takes a string and tires to find matching exception"""
+        exception = self.reverse_message_map.get(
+            exception_string, EOFException.UNDEFINED_EXCEPTION
+        )
+        return exception

--- a/src/ethereum_test_tools/exceptions/exceptions.py
+++ b/src/ethereum_test_tools/exceptions/exceptions.py
@@ -193,6 +193,11 @@ class EOFException(ExceptionBase):
     Expect some exception, not yet known
     """
 
+    UNDEFINED_EXCEPTION = auto()
+    """
+    Indicates that exception string is not mapped to an exception enum
+    """
+
     UNKNOWN_VERSION = auto()
     """
     EOF container has an unknown version
@@ -276,6 +281,10 @@ class EOFException(ExceptionBase):
     TOO_MANY_CODE_SECTIONS = auto()
     """
     EOF container header has too many code sections
+    """
+    MISSING_STOP_OPCODE = auto()
+    """
+    EOF container's code missing STOP bytecode at it's end
     """
 
 

--- a/src/ethereum_test_tools/spec/eof/eof_test.py
+++ b/src/ethereum_test_tools/spec/eof/eof_test.py
@@ -2,6 +2,9 @@
 Ethereum EOF test spec definition and filler.
 """
 
+from pathlib import Path
+from shutil import which
+from subprocess import CompletedProcess, run
 from typing import Callable, ClassVar, Generator, List, Optional, Type
 
 from ethereum_test_forks import Fork
@@ -11,6 +14,39 @@ from ...common.base_types import Bytes
 from ...exceptions import EOFException
 from ..base.base_test import BaseFixture, BaseTest
 from .types import Fixture
+
+
+class EOFParse:
+    """evmone-eofparse binary."""
+
+    binary: Path
+
+    def __new__(cls):
+        """Make EOF binary a singleton."""
+        if not hasattr(cls, "instance"):
+            cls.instance = super(EOFParse, cls).__new__(cls)
+        return cls.instance
+
+    def __init__(
+        self,
+        binary: Optional[Path | str] = None,
+    ):
+        if binary is None:
+            which_path = which("evmone-eofparse")
+            if which_path is not None:
+                binary = Path(which_path)
+        if binary is None or not Path(binary).exists():
+            raise Exception("""`evmone-eofparse` binary executable not found""")
+        self.binary = Path(binary)
+
+    def run(self, *args: str, input: str | None = None) -> CompletedProcess:
+        """Run evmone with the given arguments"""
+        return run(
+            [self.binary, *args],
+            capture_output=True,
+            text=True,
+            input=input,
+        )
 
 
 class EOFTest(BaseTest):
@@ -35,7 +71,7 @@ class EOFTest(BaseTest):
         """
         Generate the EOF test fixture.
         """
-        return Fixture(
+        fixture = Fixture(
             vectors={
                 "0": {
                     "code": self.data,
@@ -48,6 +84,11 @@ class EOFTest(BaseTest):
                 }
             }
         )
+        eof_parse = EOFParse()
+        result = eof_parse.run(input=fixture.model_dump_json(exclude_none=True))
+        if result.returncode != 0:
+            raise Exception(result.stderr)
+        return fixture
 
     def generate(
         self,

--- a/src/ethereum_test_tools/spec/eof/eof_test.py
+++ b/src/ethereum_test_tools/spec/eof/eof_test.py
@@ -162,7 +162,7 @@ class EOFTest(BaseTest):
         try:
             eof_parse = EOFParse()
         except FileNotFoundError as e:
-            warnings.warn(f"{e}, skipping EOF fixture verification. Fixtures may be invalid!")
+            warnings.warn(f"{e} Skipping EOF fixture verification. Fixtures may be invalid!")
             return fixture
 
         for _, vector in fixture.vectors.items():

--- a/src/pytest_plugins/test_filler/test_filler.py
+++ b/src/pytest_plugins/test_filler/test_filler.py
@@ -427,7 +427,7 @@ def base_test_parametrizer(cls: Type[BaseTest]):
         (see `pytest_parameter_name` in each implementation of BaseTest) in its function
         arguments.
 
-        When parametrizing, indirect must be used along with the fixture format as value.
+        When parametrize, indirect must be used along with the fixture format as value.
         """
         fixture_format = request.param
         assert isinstance(fixture_format, FixtureFormats)

--- a/tests/prague/eip3540_eof_v1/container.py
+++ b/tests/prague/eip3540_eof_v1/container.py
@@ -46,7 +46,7 @@ INVALID: List[Container] = [
     Container(
         name="incomplete_magic",
         raw_bytes=bytes([0xEF]),
-        validity_error=EOFException.INCOMPLETE_MAGIC,
+        validity_error=EOFException.INVALID_MAGIC,
     ),
     Container(
         name="no_version",

--- a/tests/prague/eip3540_eof_v1/test_eof_example.py
+++ b/tests/prague/eip3540_eof_v1/test_eof_example.py
@@ -6,7 +6,7 @@ import pytest
 
 from ethereum_test_tools import EOFTestFiller
 from ethereum_test_tools import Opcodes as Op
-from ethereum_test_tools.eof.v1 import AutoSection, Container, Section
+from ethereum_test_tools.eof.v1 import AutoSection, BytesConvertible, Container, Section
 from ethereum_test_tools.eof.v1.constants import NON_RETURNING_SECTION
 
 from .spec import EOF_FORK_NAME
@@ -119,6 +119,41 @@ def test_eof_example_custom_fields(eof_test: EOFTestFiller):
         # AutoSection.ONLY_BODY - means the sorting will be done only for the body bytes
         # AutoSection.ONLY_BODY - means the section will be done only for the header bytes
         auto_sort_sections=AutoSection.AUTO,
+    )
+
+    eof_test(
+        data=eof_code,
+        expect_exception=eof_code.validity_error,
+    )
+
+
+@pytest.mark.parametrize(
+    "data_section_bytes",
+    ("0x01", "0xef"),
+)
+@pytest.mark.parametrize(
+    "code_section_code",
+    (Op.PUSH1(10) + Op.STOP, Op.PUSH1(14) + Op.STOP),
+)
+def test_eof_example_parameters(
+    eof_test: EOFTestFiller,
+    data_section_bytes: BytesConvertible,
+    code_section_code: BytesConvertible,
+):
+    """
+    Example of python EOF classes
+    """
+    eof_code = Container(
+        name="parametrized_eof_example",
+        sections=[
+            Section.Code(
+                code=code_section_code,
+                code_inputs=0,
+                code_outputs=NON_RETURNING_SECTION,
+                max_stack_height=1,
+            ),
+            Section.Data(data_section_bytes),
+        ],
     )
 
     eof_test(

--- a/tests/prague/eip3540_eof_v1/test_eof_example.py
+++ b/tests/prague/eip3540_eof_v1/test_eof_example.py
@@ -6,7 +6,13 @@ import pytest
 
 from ethereum_test_tools import EOFTestFiller
 from ethereum_test_tools import Opcodes as Op
-from ethereum_test_tools.eof.v1 import AutoSection, BytesConvertible, Container, Section
+from ethereum_test_tools.eof.v1 import (
+    AutoSection,
+    BytesConvertible,
+    Container,
+    EOFException,
+    Section,
+)
 from ethereum_test_tools.eof.v1.constants import NON_RETURNING_SECTION
 
 from .spec import EOF_FORK_NAME
@@ -132,13 +138,14 @@ def test_eof_example_custom_fields(eof_test: EOFTestFiller):
     ("0x01", "0xef"),
 )
 @pytest.mark.parametrize(
-    "code_section_code",
-    (Op.PUSH1(10) + Op.STOP, Op.PUSH1(14) + Op.STOP),
+    "code_section_code, exception",
+    [(Op.PUSH1(10) + Op.STOP, None), (Op.PUSH1(14), EOFException.MISSING_STOP_OPCODE)],
 )
 def test_eof_example_parameters(
     eof_test: EOFTestFiller,
     data_section_bytes: BytesConvertible,
     code_section_code: BytesConvertible,
+    exception: EOFException,
 ):
     """
     Example of python EOF classes
@@ -154,6 +161,7 @@ def test_eof_example_parameters(
             ),
             Section.Data(data_section_bytes),
         ],
+        validity_error=exception,
     )
 
     eof_test(

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -14,6 +14,7 @@ basefee
 basename
 bb
 besu
+bidict
 big0
 big1
 blobgasfee
@@ -122,6 +123,7 @@ fcu
 formatOnSave
 formatter
 fromhex
+frozenbidict
 func
 gaslimit
 gasprice


### PR DESCRIPTION
## 🗒️ Description
Adds EOF exception checking using evmone-eofparse tool. Prints a nice message now if expected exception does not match returned by evmone or if valid eof test fails on evmone and so on.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
