### PR TITLE
chore(ci): hotfix github actions by using macos-12

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,7 +23,7 @@ jobs:
             solc: '0.8.21'
             evm-type: 'main'  # 'develop'
             tox-cmd: 'tox run-parallel --parallel-no-spinner'  # 'tox -e tests-develop'
-          - os: macos-latest
+          - os: macos-12
             python: '3.11'
             solc: '0.8.22'
             evm-type: 'main'


### PR DESCRIPTION
## 🗒️ Description

Hotfix for the current issue we have in Github Actions (requires a proper follow-up fix!)

```
docs: freeze> python -m pip freeze --all
2 files would be left unchanged.
ERROR   -  "cairosvg" Python module is installed, but it crashed with:
no library called "cairo-2" was found
no library called "cairo" was found
no library called "libcairo-2" was found
cannot load library 'libcairo.so.2': dlopen(libcairo.so.2, 0x0002): tried: 'libcairo.so.2' (no such file), '/System/Volumes/Preboot/Cryptexes/OSlibcairo.so.2' (no such file), '/usr/lib/libcairo.so.2' (no such file, not in dyld cache), 'libcairo.so.2' (no such file), '/usr/local/lib/libcairo.so.2' (no such file), '/usr/lib/libcairo.so.2' (no such file, not in dyld cache).  Additionally, ctypes.util.find_library() did not manage to locate a library called 'libcairo.so.2'
```
Looks like a Github Actions update within the last 18 hours now points macos-latest  to macos-14 (previously macos-12) which breaks tox -e docs.


## 🔗 Related Issues
None.

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
