### PR TITLE
chore(ci): Revert CI to use macOS and Ubuntu latest releases

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,22 +8,22 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             python: '3.10'
             solc: '0.8.20'
             evm-type: 'main'
             tox-cmd: 'tox run-parallel --parallel-no-spinner'
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             python: '3.12'
             solc: '0.8.23'
             evm-type: 'main'
             tox-cmd: 'tox run-parallel --parallel-no-spinner'
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             python: '3.11'
             solc: '0.8.21'
             evm-type: 'main'  # 'develop'
             tox-cmd: 'tox run-parallel --parallel-no-spinner'  # 'tox -e tests-develop'
-          - os: macos-12
+          - os: macos-latest
             python: '3.11'
             solc: '0.8.22'
             evm-type: 'main'

--- a/tox.ini
+++ b/tox.ini
@@ -75,6 +75,9 @@ extras =
 
 setenv =
     SPEC_TESTS_AUTO_GENERATE_FILES = true
+    # Required for `cairosvg` so tox can find `libcairo-2`.
+    # https://squidfunk.github.io/mkdocs-material/plugins/requirements/image-processing/?h=cairo#cairo-library-was-not-found
+    DYLD_FALLBACK_LIBRARY_PATH = /opt/homebrew/lib
 
 src = setup.py docs/gen_test_case_reference.py
 


### PR DESCRIPTION
## 🗒️ Description

Resolves the github actions CI issues that have occured over the past few days:

- Reverts OS versions back to `macos-latest` and `ubuntu-latest`.
- For macOS only -  sets a fallback environment required for the `cairosvg` package within the tox ini file:
  - This allows tox to find `libcairo-2`, that is installed and linked within homebrew. 
  - It seems to be the only viable solution for now and is highlighted within the `mkdocs-material` [documentation](https://squidfunk.github.io/mkdocs-material/plugins/requirements/image-processing/?h=cairo#cairo-library-was-not-found). 
  - Note this has to be set within tox as it uses an isolated environment. The environment variable set is exclusive to macOS so won't cause issues for other OS's.
  - Please see related issues below for more context.

Past hotfix PRs:
- macOS: #520 
- Ubuntu: #524

## 🔗 Related Issues
- https://github.com/squidfunk/mkdocs-material/issues/5121
- https://github.com/aai-institute/pyDVL/issues/544
- https://github.com/dora-metrics/pelorus/issues/1073

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
