### PR TITLE
chore(ci): Update workflow actions to use Node.js 20 versions

### DIFF
--- a/.github/actions/build-geth-evm/action.yaml
+++ b/.github/actions/build-geth-evm/action.yaml
@@ -17,13 +17,13 @@ runs:
   using: "composite"
   steps:
     - name: Checkout go-ethereum
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: ${{ inputs.repo }}
         ref: ${{ inputs.ref }}
         path: go-ethereum
     - name: Setup golang
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ inputs.golang }}
         cache-dependency-path: go-ethereum/go.sum

--- a/.github/workflows/docs_main.yaml
+++ b/.github/workflows/docs_main.yaml
@@ -12,13 +12,13 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3.5.2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
         ssh-key: ${{secrets.GH_ACTIONS_DEPLOY_KEY}}
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.11'
 

--- a/.github/workflows/docs_tags.yaml
+++ b/.github/workflows/docs_tags.yaml
@@ -12,13 +12,13 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3.5.2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
         ssh-key: ${{secrets.GH_ACTIONS_DEPLOY_KEY}}
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.11'
 

--- a/.github/workflows/fixtures.yaml
+++ b/.github/workflows/fixtures.yaml
@@ -25,7 +25,7 @@ jobs:
           #   solc: '0.8.21'
           #   python: '3.11'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - uses: ./.github/actions/build-evm
@@ -33,7 +33,7 @@ jobs:
         with:
           type: ${{ matrix.evm-type }}
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
       - name: Install solc compiler
@@ -61,7 +61,7 @@ jobs:
         shell: bash
         run: |
           tar -czvf ${{ matrix.name }}.tar.gz ./fixtures
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.name }}
           path: ${{ matrix.name }}.tar.gz
@@ -71,11 +71,11 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: .
       - name: Draft Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: './**'
           draft: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,7 +29,7 @@ jobs:
             evm-type: 'main'
             tox-cmd: 'tox run-parallel --parallel-no-spinner'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - uses: ./.github/actions/build-evm
@@ -37,7 +37,7 @@ jobs:
         with:
           type: ${{ matrix.evm-type }}
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
           allow-prereleases: true
@@ -62,7 +62,7 @@ jobs:
         run: pip install tox
       - name: Run Tox (CPython)
         run: ${{ matrix.tox-cmd }}
-      - uses: DavidAnson/markdownlint-cli2-action@v11
+      - uses: DavidAnson/markdownlint-cli2-action@v16
         with:
           globs: |
             README.md


### PR DESCRIPTION
## 🗒️ Description

Almost all of our CI workflows show the following warning message or similar:
>    Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-go@v4, actions/setup-python@v4, DavidAnson/markdownlint-cli2-action@v11. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

The following https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/ states these must be updated by "Spring 2024", as github will drop support for actions that are not using node js 20.

This PR updates the these actions to use there respective node js 20 versions.

### Versions updated alongside there respectice node js 20 release notes or issue
- `actions/checkout@v3` -> `actions/checkout@v4`
  - https://github.com/actions/checkout/releases/tag/v4.0.0
- `actions/setup-python@v4` -> `actions/setup-python@v5`
  - https://github.com/actions/setup-python/releases/tag/v5.0.0
- `DavidAnson/markdownlint-cli2-action@v11` -> `DavidAnson/markdownlint-cli2-action@v16` (newest)
  - Issue: https://github.com/DavidAnson/markdownlint-cli2-action/issues/117#issuecomment-1779637291
  - All releases: https://github.com/DavidAnson/markdownlint-cli2-action/releases
- `actions/upload-artifact@v3` and `actions/download-artifact@v3` -> `...@v4`
  - https://github.com/actions/upload-artifact/issues/444#issuecomment-1856410599
- `softprops/action-gh-release@v1` -> `softprops/action-gh-release@v2`
  - Please see rel. notes: https://github.com/softprops/action-gh-release/releases/tag/v2.0.0 
- `actions/setup-go@v4` -> `actions/setup-go@v5`
  - Please see rel. notes: https://github.com/actions/setup-go/releases/tag/v5.0.0
  
For more precise details please see the related issue below.

## 🔗 Related Issues

Resolves #526.

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
