### PR TITLE
Call evmone eofparse during fill refactor

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ install_requires =
     ethereum@git+https://github.com/ethereum/execution-specs.git
     setuptools
     types-setuptools
+    bidict>=0.23,<1
     requests>=2.31.0,<3
     colorlog>=6.7.0,<7
     pytest>7.3.2,<8

--- a/src/ethereum_test_tools/exceptions/__init__.py
+++ b/src/ethereum_test_tools/exceptions/__init__.py
@@ -2,7 +2,7 @@
 Exceptions for invalid execution.
 """
 
-from .evmone_exceptions import EvmoneExceptionParser
+from .evmone_exceptions import EvmoneExceptionMapper
 from .exceptions import (
     BlockException,
     BlockExceptionInstanceOrList,
@@ -19,5 +19,5 @@ __all__ = [
     "ExceptionInstanceOrList",
     "TransactionException",
     "TransactionExceptionInstanceOrList",
-    "EvmoneExceptionParser",
+    "EvmoneExceptionMapper",
 ]

--- a/src/ethereum_test_tools/exceptions/evmone_exceptions.py
+++ b/src/ethereum_test_tools/exceptions/evmone_exceptions.py
@@ -16,7 +16,7 @@ class ExceptionMessage:
     message: str
 
 
-class EvmoneExceptionParser:
+class EvmoneExceptionMapper:
     """
     Translate between EEST exceptions and error strings returned by evmone.
     """
@@ -53,21 +53,21 @@ class EvmoneExceptionParser:
         assert len(set(entry.message for entry in self._mapping_data)) == len(
             self._mapping_data
         ), "Duplicate message in _mapping_data"
-        self.exception_to_message: frozenbidict = frozenbidict(
+        self.exception_to_message_map: frozenbidict = frozenbidict(
             {entry.exception: entry.message for entry in self._mapping_data}
         )
 
-    def parse_exception(self, exception: EOFException) -> str:
+    def exception_to_message(self, exception: EOFException) -> str:
         """Takes an EOFException and returns a formatted string."""
-        message = self.exception_to_message.get(
+        message = self.exception_to_message_map.get(
             exception,
-            f"Missing string for {exception}; please add it to {self.__class__.__name__}",
+            f"No message defined for {exception}; please add it to {self.__class__.__name__}",
         )
         return message
 
-    def rev_parse_exception(self, exception_string: str) -> EOFException:
-        """Takes a string and tires to find matching exception"""
-        exception = self.exception_to_message.inverse.get(
+    def message_to_exception(self, exception_string: str) -> EOFException:
+        """Takes a string and tries to find matching exception"""
+        exception = self.exception_to_message_map.inverse.get(
             exception_string, EOFException.UNDEFINED_EXCEPTION
         )
         return exception

--- a/src/ethereum_test_tools/exceptions/evmone_exceptions.py
+++ b/src/ethereum_test_tools/exceptions/evmone_exceptions.py
@@ -1,51 +1,72 @@
 """
 Evmone eof exceptions ENUM -> str mapper
 """
+from dataclasses import dataclass
+
+from bidict import frozenbidict
 
 from .exceptions import EOFException
 
 
+@dataclass
+class ExceptionMessage:
+    """Defines a mapping between an exception and a message."""
+
+    exception: EOFException
+    message: str
+
+
 class EvmoneExceptionParser:
     """
-    Translate known exceptions into error strings returned by evmone
+    Translate between EEST exceptions and error strings returned by evmone.
     """
 
-    # MUST remain 1:1  both key and values unique for reverse search
-    message_map = {
-        # TODO EVMONE need to differentiate when the section is missing in the header or body
-        EOFException.MISSING_STOP_OPCODE: "err: no_terminating_instruction",
-        EOFException.MISSING_CODE_HEADER: "err: code_section_missing",
-        EOFException.MISSING_TYPE_HEADER: "err: type_section_missing",
-        # TODO EVMONE this exceptions are too similar, this leeds to ambiguity
-        EOFException.MISSING_TERMINATOR: "err: header_terminator_missing",
-        EOFException.MISSING_HEADERS_TERMINATOR: "err: section_headers_not_terminated",
-        EOFException.INVALID_VERSION: "err: eof_version_unknown",
-        EOFException.INVALID_MAGIC: "err: invalid_prefix",
-        EOFException.INVALID_FIRST_SECTION_TYPE: "err: invalid_first_section_type",
-        EOFException.INVALID_SECTION_BODIES_SIZE: "err: invalid_section_bodies_size",
-        EOFException.INVALID_TYPE_SIZE: "err: invalid_type_section_size",
-        EOFException.INCOMPLETE_SECTION_SIZE: "err: incomplete_section_size",
-        EOFException.INCOMPLETE_SECTION_NUMBER: "err: incomplete_section_number",
-        EOFException.TOO_MANY_CODE_SECTIONS: "err: too_many_code_sections",
-        EOFException.ZERO_SECTION_SIZE: "err: zero_section_size",
-    }
+    _mapping_data = (
+        # TODO EVMONE needs to differentiate when the section is missing in the header or body
+        ExceptionMessage(EOFException.MISSING_STOP_OPCODE, "err: no_terminating_instruction"),
+        ExceptionMessage(EOFException.MISSING_CODE_HEADER, "err: code_section_missing"),
+        ExceptionMessage(EOFException.MISSING_TYPE_HEADER, "err: type_section_missing"),
+        # TODO EVMONE these exceptions are too similar, this leeds to ambiguity
+        ExceptionMessage(EOFException.MISSING_TERMINATOR, "err: header_terminator_missing"),
+        ExceptionMessage(
+            EOFException.MISSING_HEADERS_TERMINATOR, "err: section_headers_not_terminated"
+        ),
+        ExceptionMessage(EOFException.INVALID_VERSION, "err: eof_version_unknown"),
+        ExceptionMessage(EOFException.INVALID_MAGIC, "err: invalid_prefix"),
+        ExceptionMessage(
+            EOFException.INVALID_FIRST_SECTION_TYPE, "err: invalid_first_section_type"
+        ),
+        ExceptionMessage(
+            EOFException.INVALID_SECTION_BODIES_SIZE, "err: invalid_section_bodies_size"
+        ),
+        ExceptionMessage(EOFException.INVALID_TYPE_SIZE, "err: invalid_type_section_size"),
+        ExceptionMessage(EOFException.INCOMPLETE_SECTION_SIZE, "err: incomplete_section_size"),
+        ExceptionMessage(EOFException.INCOMPLETE_SECTION_NUMBER, "err: incomplete_section_number"),
+        ExceptionMessage(EOFException.TOO_MANY_CODE_SECTIONS, "err: too_many_code_sections"),
+        ExceptionMessage(EOFException.ZERO_SECTION_SIZE, "err: zero_section_size"),
+    )
 
-    # Reverse the message_map to create a new dictionary where values become keys
-    reverse_message_map = {v: k for k, v in message_map.items()}
-
-    def __init__(self):
-        pass
+    def __init__(self) -> None:
+        assert len(set(entry.exception for entry in self._mapping_data)) == len(
+            self._mapping_data
+        ), "Duplicate exception in _mapping_data"
+        assert len(set(entry.message for entry in self._mapping_data)) == len(
+            self._mapping_data
+        ), "Duplicate message in _mapping_data"
+        self.exception_to_message: frozenbidict = frozenbidict(
+            {entry.exception: entry.message for entry in self._mapping_data}
+        )
 
     def parse_exception(self, exception: EOFException) -> str:
         """Takes an EOFException and returns a formatted string."""
-        message = self.message_map.get(
+        message = self.exception_to_message.get(
             exception, f"EvmoneExceptionParser: Missing string for {exception}"
         )
         return message
 
     def rev_parse_exception(self, exception_string: str) -> EOFException:
         """Takes a string and tires to find matching exception"""
-        exception = self.reverse_message_map.get(
+        exception = self.exception_to_message.inverse.get(
             exception_string, EOFException.UNDEFINED_EXCEPTION
         )
         return exception

--- a/src/ethereum_test_tools/exceptions/evmone_exceptions.py
+++ b/src/ethereum_test_tools/exceptions/evmone_exceptions.py
@@ -67,6 +67,7 @@ class EvmoneExceptionMapper:
 
     def message_to_exception(self, exception_string: str) -> EOFException:
         """Takes a string and tries to find matching exception"""
+        # TODO inform tester where to add the missing exception if get uses default
         exception = self.exception_to_message_map.inverse.get(
             exception_string, EOFException.UNDEFINED_EXCEPTION
         )

--- a/src/ethereum_test_tools/exceptions/evmone_exceptions.py
+++ b/src/ethereum_test_tools/exceptions/evmone_exceptions.py
@@ -60,7 +60,8 @@ class EvmoneExceptionParser:
     def parse_exception(self, exception: EOFException) -> str:
         """Takes an EOFException and returns a formatted string."""
         message = self.exception_to_message.get(
-            exception, f"EvmoneExceptionParser: Missing string for {exception}"
+            exception,
+            f"Missing string for {exception}; please add it to {self.__class__.__name__}",
         )
         return message
 

--- a/src/ethereum_test_tools/spec/eof/eof_test.py
+++ b/src/ethereum_test_tools/spec/eof/eof_test.py
@@ -17,6 +17,72 @@ from ..base.base_test import BaseFixture, BaseTest
 from .types import Fixture, Result
 
 
+class EOFBaseException(Exception):
+    """
+    Base exception class for exceptions raised when verifying EOF code.
+    """
+
+    def __init__(self, message):
+        super().__init__(message)
+
+    @staticmethod
+    def format_code(code: Bytes, max_length=60) -> str:
+        """
+        Avoid printing long bytecode strings in the terminal upon test failure.
+        """
+        if len(code) > max_length:
+            half_length = max_length // 2 - 5  # Floor; adjust for ellipsis
+            return f"{code[:half_length].hex()}...{code[-half_length:].hex()}"
+        return code.hex()
+
+
+class UnexpectedEOFException(EOFBaseException):
+    """
+    Exception used when valid EOF code unexpectedly raises an exception in
+    eofparse.
+    """
+
+    def __init__(self, *, code: Bytes, got: str):
+        message = (
+            "Expected EOF code to be valid, but an exception occurred:\n"
+            f"   Code: {self.format_code(code)}\n"
+            "Expected: No Exception\n"
+            f"    Got: {got}"
+        )
+        super().__init__(message)
+
+
+class ExpectedEOFException(EOFBaseException):
+    """
+    Exception used when EOF code is expected to raise an exception, but
+    eofparse did not raise an exception.
+    """
+
+    def __init__(self, *, code: Bytes, expected: str):
+        message = (
+            "Expected EOF code to be invalid, but no exception was raised:\n"
+            f"    Code: {self.format_code(code)}\n"
+            f"Expected: {expected}\n"
+            "      Got: No Exception"
+        )
+        super().__init__(message)
+
+
+class EOFExceptionMismatch(EOFBaseException):
+    """
+    Exception used when the actual EOF exception differs from the expected one.
+    """
+
+    def __init__(self, code: Bytes, expected: str, got: str):
+        message = (
+            "EOF code raised a different exception than expected:\n"
+            f"    Code: {self.format_code(code)}\n"
+            f"Expected: {expected}\n"
+            f"     Got: {got}"
+        )
+        super().__init__(message)
+
+
 class EOFParse:
     """evmone-eofparse binary."""
 
@@ -104,44 +170,34 @@ class EOFTest(BaseTest):
 
     def verify_result(self, result: CompletedProcess, expected_result: Result, code: Bytes):
         """
-        Checks that the actual reported exception string matches our expected error ENUM
+        Checks that the reported exception string matches the expected error.
         """
         parser = EvmoneExceptionParser()
-        res_error = result.stdout.replace("\n", "")
-        if expected_result.exception is None:
-            if "OK" not in result.stdout:
-                msg = "Expected eof code to be valid, but got an exception:"
-                formatted_message = (
-                    f"{msg} \n"
-                    f"{code} \n"
-                    f"Expected: No Exception \n"
-                    f"     Got: {parser.rev_parse_exception(res_error)} ({res_error})"
-                )
-                raise Exception(formatted_message)
-        else:
-            if "OK" in res_error:
-                expRes = expected_result.exception
-                msg = "Expected eof code to be invalid, but got no exception from eof tool:"
-                formatted_message = (
-                    f"{msg} \n"
-                    f"{code} \n"
-                    f"Expected: {expRes} ({parser.parse_exception(expRes)}) \n"
-                    f"     Got: No Exception"
-                )
-                raise Exception(formatted_message)
-            else:
-                expRes = expected_result.exception
-                if expRes == parser.rev_parse_exception(res_error):
-                    return
+        actual_message = result.stdout.strip()
+        actual_exception = parser.rev_parse_exception(actual_message)
 
-                msg = "EOF code expected to fail with a different exception, than reported:"
-                formatted_message = (
-                    f"{msg} \n"
-                    f"{code} \n"
-                    f"Expected: {expRes} ({parser.parse_exception(expRes)}) \n"
-                    f"     Got: {parser.rev_parse_exception(res_error)} ({res_error})"
+        if expected_result.exception is None:
+            if "OK" in actual_message:
+                return
+            else:
+                raise UnexpectedEOFException(
+                    code=code, got=f"{actual_exception} ({actual_message})"
                 )
-                raise Exception(formatted_message)
+
+        expected_exception = expected_result.exception
+        expected_message = parser.parse_exception(expected_exception)
+
+        if "OK" in actual_message:
+            raise ExpectedEOFException(
+                code=code, expected=f"{expected_exception} ({expected_message})"
+            )
+
+        if expected_exception != actual_exception:
+            raise EOFExceptionMismatch(
+                code=code,
+                expected=f"{expected_exception} ({expected_message})",
+                got=f"{actual_exception} ({actual_message})",
+            )
 
     def generate(
         self,

--- a/src/ethereum_test_tools/spec/eof/eof_test.py
+++ b/src/ethereum_test_tools/spec/eof/eof_test.py
@@ -2,10 +2,11 @@
 Ethereum EOF test spec definition and filler.
 """
 
+import subprocess
 import warnings
 from pathlib import Path
 from shutil import which
-from subprocess import CompletedProcess, run
+from subprocess import CompletedProcess
 from typing import Callable, ClassVar, Generator, List, Optional, Type
 
 from ethereum_test_forks import Fork
@@ -110,7 +111,7 @@ class EOFParse:
 
     def run(self, *args: str, input: str | None = None) -> CompletedProcess:
         """Run evmone with the given arguments"""
-        return run(
+        return subprocess.run(
             [self.binary, *args],
             capture_output=True,
             text=True,

--- a/src/ethereum_test_tools/spec/eof/eof_test.py
+++ b/src/ethereum_test_tools/spec/eof/eof_test.py
@@ -111,12 +111,17 @@ class EOFParse:
 
     def run(self, *args: str, input: str | None = None) -> CompletedProcess:
         """Run evmone with the given arguments"""
-        return subprocess.run(
+        result = subprocess.run(
             [self.binary, *args],
             capture_output=True,
             text=True,
             input=input,
         )
+        if result.returncode not in [0, 1]:
+            raise Exception(
+                f"`{self.binary.name}` call failed with return code {result.returncode}."
+            )
+        return result
 
 
 class EOFTest(BaseTest):

--- a/src/ethereum_test_tools/spec/eof/eof_test.py
+++ b/src/ethereum_test_tools/spec/eof/eof_test.py
@@ -13,7 +13,7 @@ from ethereum_test_forks import Fork
 from evm_transition_tool import FixtureFormats
 
 from ...common.base_types import Bytes
-from ...exceptions import EOFException, EvmoneExceptionParser
+from ...exceptions import EOFException, EvmoneExceptionMapper
 from ..base.base_test import BaseFixture, BaseTest
 from .types import Fixture, Result
 
@@ -178,9 +178,9 @@ class EOFTest(BaseTest):
         """
         Checks that the reported exception string matches the expected error.
         """
-        parser = EvmoneExceptionParser()
+        parser = EvmoneExceptionMapper()
         actual_message = result.stdout.strip()
-        actual_exception = parser.rev_parse_exception(actual_message)
+        actual_exception = parser.message_to_exception(actual_message)
 
         if expected_result.exception is None:
             if "OK" in actual_message:
@@ -191,7 +191,7 @@ class EOFTest(BaseTest):
                 )
 
         expected_exception = expected_result.exception
-        expected_message = parser.parse_exception(expected_exception)
+        expected_message = parser.exception_to_message(expected_exception)
 
         if "OK" in actual_message:
             raise ExpectedEOFException(

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -14,6 +14,7 @@ basefee
 basename
 bb
 besu
+bidict
 big0
 big1
 blobgasfee
@@ -122,6 +123,7 @@ fcu
 formatOnSave
 formatter
 fromhex
+frozenbidict
 func
 gaslimit
 gasprice


### PR DESCRIPTION
## 🗒️ Description
A bit of refactoring of #519.

## 🔗 Related Issues
#519.

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
