### PR TITLE
feat(pytest): add a plugin that removes tracebacks from test report failures summaries

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Added EOF fixture format ([#512](https://github.com/ethereum/execution-spec-tests/pull/512)).
 - ✨ Verify filled EOF fixtures using `evmone-eofparse` during `fill` execution ([#519](https://github.com/ethereum/execution-spec-tests/pull/519)).
 - ✨ Added `--traces` support when running with Hyperledger Besu ([#511](https://github.com/ethereum/execution-spec-tests/pull/511)).
+- ✨ More readable "Failures" summary in test reports (traceback information is removed by default) ([#541](https://github.com/ethereum/execution-spec-tests/pull/541)).
 
 ### 🔧 EVM Tools
 

--- a/docs/getting_started/executing_tests_command_line.md
+++ b/docs/getting_started/executing_tests_command_line.md
@@ -169,6 +169,10 @@ Arguments related to running execution-spec-tests:
   --test-help           Only show help options specific to execution-spec-tests
                         and exit.
 
+Arguments modifying terminal output:
+  --disable-exceptions-only
+                        Disable custom terminal output for test failures (use pytest's default format).
+
 Exit: After displaying help.
 
 ```

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,6 +8,7 @@ addopts =
     -p pytest_plugins.forks.forks
     -p pytest_plugins.spec_version_checker.spec_version_checker
     -p pytest_plugins.test_help.test_help
+    -p pytest_plugins.misc.exceptions_only_failure_summary
     -m "not eip_version_check"
     --dist loadscope
     --ignore tests/cancun/eip4844_blobs/point_evaluation_vectors/

--- a/src/pytest_plugins/misc/__init__.py
+++ b/src/pytest_plugins/misc/__init__.py
@@ -1,0 +1,3 @@
+"""
+Various smaller pytest plugins used in execution-spec-tests.
+"""

--- a/src/pytest_plugins/misc/exceptions_only_failure_summary.py
+++ b/src/pytest_plugins/misc/exceptions_only_failure_summary.py
@@ -1,0 +1,55 @@
+"""
+A pytest plugin that modifies the "Failures" terminal summary to only show the
+exception name and message; it removes all traceback information for a clearer
+summary.
+
+The stdout and stderr sections of a failing test will still be displayed.
+
+The user can disable this plugin and achieve default traceback behavior by
+either:
+
+1. Specifying the `--disable-exceptions-only` flag, or,
+2. Specifying the `--tb` flag.
+"""
+import sys
+
+
+def pytest_addoption(parser):
+    """
+    Adds command-line options to pytest.
+    """
+    exceptions_only = parser.getgroup("exceptions_only", "Arguments modifying terminal output")
+    exceptions_only.addoption(
+        "--disable-exceptions-only",
+        dest="disable_exceptions_only",
+        action="store_true",
+        default=False,
+        help="traceback style",
+    )
+
+
+def pytest_configure(config):
+    """
+    Apply configuration after command-line options have been parsed.
+
+    Disable the custom failures summary output if the user has
+    specified the `--tb` flag. This allows the user to easily override
+    this custom behavior using standard pytest flags.
+    """
+    if any(arg.startswith("--tb") for arg in sys.argv):
+        config.option.disable_exceptions_only = True
+
+
+def pytest_exception_interact(node, call, report):
+    """
+    Modify the terminal output to display only the exception message.
+
+    In particular, we remove all traceback information.
+    """
+    if not node.config.getoption("disable_exceptions_only") and report.failed:
+        excinfo = call.excinfo
+        exception_name = excinfo.type.__name__
+        exception_message = str(excinfo.value)
+        formatted_exception = f"{exception_name}: {exception_message}"
+        new_lines_preserved = formatted_exception.replace("\\n", "\n").replace("\\t", "\t")
+        report.longrepr = new_lines_preserved

--- a/src/pytest_plugins/misc/exceptions_only_failure_summary.py
+++ b/src/pytest_plugins/misc/exceptions_only_failure_summary.py
@@ -18,13 +18,15 @@ def pytest_addoption(parser):
     """
     Adds command-line options to pytest.
     """
-    exceptions_only = parser.getgroup("exceptions_only", "Arguments modifying terminal output")
-    exceptions_only.addoption(
+    terminal_output = parser.getgroup(
+        "custom_terminal_output", "Arguments modifying terminal output"
+    )
+    terminal_output.addoption(
         "--disable-exceptions-only",
         dest="disable_exceptions_only",
         action="store_true",
         default=False,
-        help="traceback style",
+        help="Disable custom terminal output for test failures (use pytest's default format).",
     )
 
 

--- a/src/pytest_plugins/test_help/test_help.py
+++ b/src/pytest_plugins/test_help/test_help.py
@@ -44,6 +44,7 @@ def show_test_help(config):
         "fork range",
         "filler location",
         "defining debug",  # the "debug" group in test_filler plugin.
+        "modifying terminal output",
     ]
 
     test_parser = argparse.ArgumentParser()

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -302,6 +302,7 @@ todo
 toml
 tox
 Tox
+traceback
 TransactionException
 trie
 tstorage

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -110,6 +110,7 @@ evaluatable
 evm
 evmone
 Evmone
+excinfo
 executables
 extcodecopy
 extcodehash
@@ -185,6 +186,7 @@ listdir
 lll
 lllc
 london
+longrepr
 macOS
 mainnet
 marioevz

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -112,6 +112,7 @@ evmone
 Evmone
 excinfo
 executables
+exitstatus
 extcodecopy
 extcodehash
 extcodesize
@@ -289,6 +290,7 @@ substring
 sudo
 t8n
 tamasfe
+terminalreporter
 testability
 TestAddress
 TestContractCreationGasUsage


### PR DESCRIPTION
## 🗒️ Description
Adds a pytest plugin that modifies the "Failures" terminal summary to only show the exception name and message; it removes all traceback information for a clearer summary.

Setting `--tb=short` is close, but still contains a short traceback that is rarely helpful to determine a test failure. The traceback is unhelpful in our case as the underlying checks that trigger failures are implemented in EEST's library functions.

The stdout and stderr sections of a failing test will still be displayed in the summary.

The user can disable this plugin and achieve default traceback behavior by either:

1. Specifying the `--disable-exceptions-only` flag, or,
2. Specifying the `--tb` flag.

## Comparison

The examples below are use `-x` (exit upon first failure) - the difference between 2. and 3. is much larger with multiple failures. It's also much clearer in the HTML report (see #537).

### 1. Default behavior without this PR
Doesn't fit on screen; skip screenshot :smile: 
### 2. `--tb=short` (with or without this PR activated)
![image](https://github.com/ethereum/execution-spec-tests/assets/91727015/1ee277fc-7087-4206-9214-9ef92fd90165)
### 3. Default behavior with this PR
![image](https://github.com/ethereum/execution-spec-tests/assets/91727015/854659c9-7611-4715-973a-2e27d5143c40)


## 🔗 Related Issues
#77.

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
