### PR TITLE
feat(pytest): use --tb=short as default for fill test reports

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Added EOF fixture format ([#512](https://github.com/ethereum/execution-spec-tests/pull/512)).
 - ✨ Verify filled EOF fixtures using `evmone-eofparse` during `fill` execution ([#519](https://github.com/ethereum/execution-spec-tests/pull/519)).
 - ✨ Added `--traces` support when running with Hyperledger Besu ([#511](https://github.com/ethereum/execution-spec-tests/pull/511)).
+- ✨ Use pytest's "short" traceback style (`--tb=short`) for failure summaries in the test report for more compact terminal output ([#542](https://github.com/ethereum/execution-spec-tests/pull/542)).
 
 ### 🔧 EVM Tools
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,5 +9,6 @@ addopts =
     -p pytest_plugins.spec_version_checker.spec_version_checker
     -p pytest_plugins.test_help.test_help
     -m "not eip_version_check"
+    --tb short
     --dist loadscope
     --ignore tests/cancun/eip4844_blobs/point_evaluation_vectors/

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -300,6 +300,7 @@ todo
 toml
 tox
 Tox
+traceback
 TransactionException
 trie
 tstorage


### PR DESCRIPTION
## 🗒️ Description
Set `--tb=short` in fill's pytest.ini for more compact test reports.

## 🔗 Related Issues
Comparison of different failure reports can be found #541.

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
