### PR TITLE
fix(fw): Fix `MissingKey` and `KeyValueMismatch` exceptions `str`

### DIFF
--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -167,7 +167,7 @@ class Storage(RootModel[Dict[StorageKeyValueType, StorageKeyValueType]]):
 
         def __str__(self):
             """Print exception string"""
-            return "key {0} not found in storage".format(Storage.key_value_to_string(self.key))
+            return "key {0} not found in storage".format(Hash(self.key))
 
     @dataclass(kw_only=True)
     class KeyValueMismatch(Exception):
@@ -192,9 +192,9 @@ class Storage(RootModel[Dict[StorageKeyValueType, StorageKeyValueType]]):
             """Print exception string"""
             return (
                 f"incorrect value in address {self.address} for "
-                + f"key {Storage.key_value_to_string(self.key)}:"
-                + f" want {Storage.key_value_to_string(self.want)} (dec:{self.want}),"
-                + f" got {Storage.key_value_to_string(self.got)} (dec:{self.got})"
+                + f"key {Hash(self.key)}:"
+                + f" want {HexNumber(self.want)} (dec:{self.want}),"
+                + f" got {HexNumber(self.got)} (dec:{self.got})"
             )
 
     def __contains__(self, key: StorageKeyValueTypeConvertible | StorageKeyValueType) -> bool:


### PR DESCRIPTION
## 🗒️ Description
Fixes a bug where some exceptions were still using `Storage.key_value_to_string`, which doesn't exist anymore.

## 🔗 Related Issues
#523

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
