### PR TITLE
feat(evm_transition_tool): Use geth t8n daemon

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ install_requires =
     click>=8.0.0,<9
     pydantic>=2.6.3,<3
     rich>=13.7.0,<14
+    parsys-requests-unixsocket==0.3.1
 
 [options.package_data]
 ethereum_test_tools =

--- a/src/evm_transition_tool/besu.py
+++ b/src/evm_transition_tool/besu.py
@@ -30,8 +30,6 @@ class BesuTransitionTool(TransitionTool):
     binary: Path
     cached_version: Optional[str] = None
     trace: bool
-    process: Optional[subprocess.Popen] = None
-    server_url: str
     besu_trace_dir: Optional[tempfile.TemporaryDirectory]
 
     def __init__(

--- a/src/pytest_plugins/test_filler/test_filler.py
+++ b/src/pytest_plugins/test_filler/test_filler.py
@@ -87,6 +87,13 @@ def pytest_addoption(parser):
             "Default: The first (geth) 'evm' entry in PATH."
         ),
     )
+    evm_group.addoption(
+        "--evm-server",
+        action="store_true",
+        dest="evm_server",
+        default=False,
+        help=("Whether to run the t8n in server mode if the binary supports it."),
+    )
 
     solc_group = parser.getgroup("solc", "Arguments defining the solc executable")
     solc_group.addoption(
@@ -371,7 +378,9 @@ def t8n(request, evm_bin: Path) -> Generator[TransitionTool, None, None]:
     Returns the configured transition tool.
     """
     t8n = TransitionTool.from_binary_path(
-        binary_path=evm_bin, trace=request.config.getoption("evm_collect_traces")
+        binary_path=evm_bin,
+        trace=request.config.getoption("evm_collect_traces"),
+        server=request.config.getoption("evm_server"),
     )
     yield t8n
     t8n.shutdown()

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -80,6 +80,7 @@ Dencun
 deprecations
 dev
 devnet
+DEVNULL
 difficulty
 dir
 dirs
@@ -162,6 +163,7 @@ iat
 ignoreRevsFile
 img
 incrementing
+INET
 init
 initcode
 instantiation
@@ -323,6 +325,7 @@ u256
 ubuntu
 ukiyo
 uncomment
+unixsocket
 util
 utils
 v0


### PR DESCRIPTION
## 🗒️ Description
Uses evm t8n server in https://github.com/ethereum/go-ethereum/pull/29739 to fill tests.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
