### PR TITLE
refactor: update addresses used in tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 ### 🧪 Test Cases
 
+- 🔀 Change addresses used in tests to not use 0x100 ([#553](https://github.com/ethereum/execution-spec-tests/pull/553)).
 - ✨ Add `test_double_kill` and `test_recreate` which test resurrection of accounts killed with `SELFDESTRUCT` ([#488](https://github.com/ethereum/execution-spec-tests/pull/488)).
 - ✨ Add eof example valid invalid tests from ori, fetch EOF Container implementation ([#535](https://github.com/ethereum/execution-spec-tests/pull/535)).
 
@@ -33,7 +34,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Port entry point scripts to use [click](https://click.palletsprojects.com) and add tests ([#483](https://github.com/ethereum/execution-spec-tests/pull/483)).
 - 💥 As part of the pydantic conversion, the fixtures have the following (possibly breaking) changes ([#486](https://github.com/ethereum/execution-spec-tests/pull/486)):
   - State test field `transaction` now uses the proper zero-padded hex number format for fields `maxPriorityFeePerGas`, `maxFeePerGas`, and `maxFeePerBlobGas`
-  - Fixtures' hashes (in the `_info` field) are now calculated by removing the "_info" field entirely instead of it being set to an empty dict.
+  - Fixtures' hashes (in the `_info` field) are now calculated by removing the "\_info" field entirely instead of it being set to an empty dict.
 - 🐞 Relax minor and patch dependency requirements to avoid conflicting package dependencies ([#510](https://github.com/ethereum/execution-spec-tests/pull/510)).
 - 🔀 Update all CI actions to use their respective Node.js 20 versions, ahead of their Node.js 16 version deprecations ([#527](https://github.com/ethereum/execution-spec-tests/pull/527)).
 
@@ -53,8 +54,8 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 - ✨ Adds two `consume` commands [#339](https://github.com/ethereum/execution-spec-tests/pull/339):
 
-   1. `consume direct` - Execute a test fixture directly against a client using a `blocktest`-like command (currently only geth supported).
-   2. `consume rlp` - Execute a test fixture in a hive simulator against a client that imports the test's genesis config and blocks as RLP upon startup. This is a re-write of the [ethereum/consensus](https://github.com/ethereum/hive/tree/master/simulators/ethereum/consensus) Golang simulator.
+  1.  `consume direct` - Execute a test fixture directly against a client using a `blocktest`-like command (currently only geth supported).
+  2.  `consume rlp` - Execute a test fixture in a hive simulator against a client that imports the test's genesis config and blocks as RLP upon startup. This is a re-write of the [ethereum/consensus](https://github.com/ethereum/hive/tree/master/simulators/ethereum/consensus) Golang simulator.
 
 - ✨ Add Prague to forks ([#419](https://github.com/ethereum/execution-spec-tests/pull/419)).
 - ✨ Improve handling of the argument passed to `solc --evm-version` when compiling Yul code ([#418](https://github.com/ethereum/execution-spec-tests/pull/418)).
@@ -196,9 +197,9 @@ The fixture renaming provides a more consistent naming scheme between the pytest
    1. Previous fixture file name: `fixtures/frontier/opcodes/dup/dup.json` (`BlockChainTest` format).
    2. New fixture file names (all present within the release tarball):
 
-     - `fixtures/state_tests/frontier/opcodes/dup/dup.json` (`StateTest` format).
-     - `fixtures/blockchain_tests/frontier/opcodes/dup/dup.json` (`BlockChainTest` format).
-     - `fixtures/blockchain_tests_hive/frontier/opcodes/dup/dup.json` (a blockchain test in `HiveFixture` format).
+   - `fixtures/state_tests/frontier/opcodes/dup/dup.json` (`StateTest` format).
+   - `fixtures/blockchain_tests/frontier/opcodes/dup/dup.json` (`BlockChainTest` format).
+   - `fixtures/blockchain_tests_hive/frontier/opcodes/dup/dup.json` (a blockchain test in `HiveFixture` format).
 
 ## [v1.0.6](https://github.com/ethereum/execution-spec-tests/releases/tag/v1.0.6) - 2023-10-19: 🐍🏖️ Cancun Devnet 10
 

--- a/src/ethereum_test_tools/tests/test_code.py
+++ b/src/ethereum_test_tools/tests/test_code.py
@@ -644,7 +644,7 @@ def test_switch(tx_data: bytes, switch_bytecode: bytes, expected_storage: Mappin
     """
     Test that the switch opcode macro gets executed as using the t8n tool.
     """
-    code_address = 0x100
+    code_address = 0xC0DE
     pre = {
         TestAddress: Account(balance=10_000_000, nonce=0),
         code_address: Account(code=switch_bytecode),

--- a/src/ethereum_test_tools/tests/test_types.py
+++ b/src/ethereum_test_tools/tests/test_types.py
@@ -1638,7 +1638,7 @@ def test_transaction_post_init_defaults(tx_args, expected_attributes_and_values)
                 Withdrawal(
                     index=0,
                     validator_index=0,
-                    address=0x100,
+                    address=0x1000,
                     amount=0,
                 ),
                 Withdrawal(

--- a/stubs/trie/hexary.pyi
+++ b/stubs/trie/hexary.pyi
@@ -1,6 +1,5 @@
 from typing import Dict
 
-
 class HexaryTrie:
     db: Dict
     root_hash: bytes

--- a/tests/byzantium/eip198_modexp_precompile/test_modexp.py
+++ b/tests/byzantium/eip198_modexp_precompile/test_modexp.py
@@ -213,7 +213,7 @@ def test_modexp(state_test: StateTestFiller, input: ModExpInput, output: Expecte
     env = Environment()
     pre = {TestAddress: Account(balance=1000000000000000000000)}
 
-    account = Address(0x100)
+    account = Address(0x1000)
 
     pre[account] = Account(
         code=(

--- a/tests/cancun/eip1153_tstore/test_tstorage.py
+++ b/tests/cancun/eip1153_tstore/test_tstorage.py
@@ -21,7 +21,7 @@ REFERENCE_SPEC_VERSION = ref_spec_1153.version
 
 pytestmark = [pytest.mark.valid_from("Cancun")]
 
-code_address = 0x100
+code_address = 0xC0DE
 
 
 def test_transient_storage_unset_values(state_test: StateTestFiller):

--- a/tests/cancun/eip1153_tstore/test_tstorage_create_contexts.py
+++ b/tests/cancun/eip1153_tstore/test_tstorage_create_contexts.py
@@ -27,7 +27,7 @@ REFERENCE_SPEC_VERSION = ref_spec_1153.version
 pytestmark = [pytest.mark.valid_from("Cancun")]
 
 # the address that creates the contract with create/create2
-creator_address = 0x100
+creator_address = 0x1000
 
 
 @unique

--- a/tests/cancun/eip1153_tstore/test_tstorage_execution_contexts.py
+++ b/tests/cancun/eip1153_tstore/test_tstorage_execution_contexts.py
@@ -24,7 +24,7 @@ pytestmark = [pytest.mark.valid_from("Cancun")]
 caller_address = 0x1000
 
 # Address of the callee contract
-callee_address = 0x200
+callee_address = 0x2000
 
 PUSH_OPCODE_COST = 3
 

--- a/tests/cancun/eip1153_tstore/test_tstorage_execution_contexts.py
+++ b/tests/cancun/eip1153_tstore/test_tstorage_execution_contexts.py
@@ -21,7 +21,7 @@ REFERENCE_SPEC_VERSION = ref_spec_1153.version
 pytestmark = [pytest.mark.valid_from("Cancun")]
 
 # Address used to call the test bytecode on every test case.
-caller_address = 0x100
+caller_address = 0x1000
 
 # Address of the callee contract
 callee_address = 0x200

--- a/tests/cancun/eip1153_tstore/test_tstorage_reentrancy_contexts.py
+++ b/tests/cancun/eip1153_tstore/test_tstorage_reentrancy_contexts.py
@@ -20,7 +20,7 @@ REFERENCE_SPEC_VERSION = ref_spec_1153.version
 pytestmark = [pytest.mark.valid_from("Cancun")]
 
 # Address of the callee contract
-callee_address = 0x200
+callee_address = 0x2000
 
 SETUP_CONDITION: bytes = Op.EQ(Op.CALLDATALOAD(0), 0x01)
 REENTRANT_CALL: bytes = Op.MSTORE(0, 2) + Op.SSTORE(

--- a/tests/cancun/eip1153_tstore/test_tstorage_selfdestruct.py
+++ b/tests/cancun/eip1153_tstore/test_tstorage_selfdestruct.py
@@ -28,7 +28,7 @@ REFERENCE_SPEC_VERSION = ref_spec_1153.version
 pytestmark = [pytest.mark.valid_from("Cancun")]
 
 # Addresses
-caller_address = 0x100
+caller_address = 0x1000
 copy_from_initcode_address = 0x200
 callee_address = compute_create_address(caller_address, 1)
 

--- a/tests/cancun/eip1153_tstore/test_tstorage_selfdestruct.py
+++ b/tests/cancun/eip1153_tstore/test_tstorage_selfdestruct.py
@@ -29,7 +29,7 @@ pytestmark = [pytest.mark.valid_from("Cancun")]
 
 # Addresses
 caller_address = 0x1000
-copy_from_initcode_address = 0x200
+copy_from_initcode_address = 0x2000
 callee_address = compute_create_address(caller_address, 1)
 
 CREATE_CODE = Op.EXTCODECOPY(

--- a/tests/cancun/eip4788_beacon_root/conftest.py
+++ b/tests/cancun/eip4788_beacon_root/conftest.py
@@ -88,7 +88,7 @@ def call_gas() -> int:  # noqa: D103
 
 @pytest.fixture
 def caller_address() -> Address:  # noqa: D103
-    return Address(0x100)
+    return Address(0x1000)
 
 
 @pytest.fixture

--- a/tests/cancun/eip4788_beacon_root/test_beacon_root_contract.py
+++ b/tests/cancun/eip4788_beacon_root/test_beacon_root_contract.py
@@ -379,7 +379,7 @@ def test_multi_block_beacon_root_timestamp_calls(
 
         current_call_account_code = bytes()
         current_call_account_expected_storage = Storage()
-        current_call_account_address = Address(0x100 + i)
+        current_call_account_address = Address(0x1000 + i)
 
         # We are going to call the beacon roots contract once for every timestamp of the current
         # and all previous blocks, and check that the returned beacon root is still correct only
@@ -421,7 +421,7 @@ def test_multi_block_beacon_root_timestamp_calls(
                 txs=[
                     tx.copy(
                         nonce=i,
-                        to=Address(0x100 + i),
+                        to=Address(0x1000 + i),
                         data=Hash(timestamp),
                     )
                 ],
@@ -503,7 +503,7 @@ def test_beacon_root_transition(
 
         current_call_account_code = bytes()
         current_call_account_expected_storage = Storage()
-        current_call_account_address = Address(0x100 + i)
+        current_call_account_address = Address(0x1000 + i)
 
         # We are going to call the beacon roots contract once for every timestamp of the current
         # and all previous blocks, and check that the returned beacon root is correct only
@@ -546,7 +546,7 @@ def test_beacon_root_transition(
                 txs=[
                     tx.copy(
                         nonce=i,
-                        to=Address(0x100 + i),
+                        to=Address(0x1000 + i),
                         data=Hash(timestamp),
                     )
                 ],

--- a/tests/cancun/eip4844_blobs/common.py
+++ b/tests/cancun/eip4844_blobs/common.py
@@ -1,6 +1,7 @@
 """
 Common constants, classes & functions local to EIP-4844 tests.
 """
+
 from dataclasses import dataclass
 from typing import List, Literal, Tuple, Union
 
@@ -101,13 +102,13 @@ class BlobhashContext:
     yul_compiler: Union[YulCompiler, None] = None
     addresses = {
         "blobhash_sstore": Address(0x1000),
-        "blobhash_return": Address(0x600),
-        "call": Address(0x200),
-        "delegatecall": Address(0x300),
-        "callcode": Address(0x800),
-        "staticcall": Address(0x700),
-        "create": Address(0x400),
-        "create2": Address(0x500),
+        "blobhash_return": Address(0x6000),
+        "call": Address(0x2000),
+        "delegatecall": Address(0x3000),
+        "callcode": Address(0x8000),
+        "staticcall": Address(0x7000),
+        "create": Address(0x4000),
+        "create2": Address(0x5000),
     }
 
     @staticmethod

--- a/tests/cancun/eip4844_blobs/common.py
+++ b/tests/cancun/eip4844_blobs/common.py
@@ -100,7 +100,7 @@ class BlobhashContext:
 
     yul_compiler: Union[YulCompiler, None] = None
     addresses = {
-        "blobhash_sstore": Address(0x100),
+        "blobhash_sstore": Address(0x1000),
         "blobhash_return": Address(0x600),
         "call": Address(0x200),
         "delegatecall": Address(0x300),
@@ -173,7 +173,7 @@ class BlobhashContext:
                 """
                 {
                     calldatacopy(0, 0, calldatasize())
-                    pop(call(gas(), 0x100, 0, 0, calldatasize(), 0, 0))
+                    pop(call(gas(), 0x1000, 0, 0, calldatasize(), 0, 0))
                 }
                 """  # noqa: E272, E201, E202
             ),
@@ -181,7 +181,7 @@ class BlobhashContext:
                 """
                 {
                     calldatacopy(0, 0, calldatasize())
-                    pop(delegatecall(gas(), 0x100, 0, calldatasize(), 0, 0))
+                    pop(delegatecall(gas(), 0x1000, 0, calldatasize(), 0, 0))
                 }
                 """  # noqa: E272, E201, E202
             ),

--- a/tests/cancun/eip4844_blobs/conftest.py
+++ b/tests/cancun/eip4844_blobs/conftest.py
@@ -1,6 +1,7 @@
 """
 Pytest (plugin) definitions local to EIP-4844 tests.
 """
+
 import pytest
 
 from ethereum_test_tools import Address, Block, Hash, TestPrivateKey2, Transaction, add_kzg_version
@@ -41,7 +42,7 @@ def non_zero_blob_gas_used_genesis_block(
             Transaction(
                 ty=Spec.BLOB_TX_TYPE,
                 nonce=0,
-                to=Address(0x200),
+                to=Address(0x2000),
                 value=1,
                 gas_limit=21000,
                 max_fee_per_gas=tx_max_fee_per_gas,

--- a/tests/cancun/eip4844_blobs/test_blob_txs.py
+++ b/tests/cancun/eip4844_blobs/test_blob_txs.py
@@ -58,7 +58,7 @@ TestPreFundingAddress = "0x97a7cb1de3cc7d556d0aa32433b035067709e1fc"
 @pytest.fixture
 def destination_account() -> Address:
     """Default destination account for the blob transactions."""
-    return Address(0x100)
+    return Address(0x1000)
 
 
 @pytest.fixture

--- a/tests/cancun/eip4844_blobs/test_blob_txs_full.py
+++ b/tests/cancun/eip4844_blobs/test_blob_txs_full.py
@@ -3,6 +3,7 @@ abstract: Tests full blob type transactions for [EIP-4844: Shard Blob Transactio
     Test full blob type transactions for [EIP-4844: Shard Blob Transactions](https://eips.ethereum.org/EIPS/eip-4844).
 
 """  # noqa: E501
+
 from typing import Dict, List, Optional
 
 import pytest
@@ -30,7 +31,7 @@ REFERENCE_SPEC_VERSION = ref_spec_4844.version
 @pytest.fixture
 def destination_account() -> Address:
     """Default destination account for the blob transactions."""
-    return Address(0x100)
+    return Address(0x1000)
 
 
 @pytest.fixture

--- a/tests/cancun/eip4844_blobs/test_blobhash_opcode.py
+++ b/tests/cancun/eip4844_blobs/test_blobhash_opcode.py
@@ -287,26 +287,26 @@ def test_blobhash_multiple_txs_in_block(
         **pre,
         **{
             Address(address): Account(code=blobhash_bytecode)
-            for address in range(0x100, 0x500, 0x100)
+            for address in range(0x1000, 0x5000, 0x1000)
         },
     }
     blocks = [
         Block(
             txs=[
-                blob_tx(address=Address(0x100), type=3, nonce=0),
-                blob_tx(address=Address(0x100), type=2, nonce=1),
+                blob_tx(address=Address(0x1000), type=3, nonce=0),
+                blob_tx(address=Address(0x1000), type=2, nonce=1),
             ]
         ),
         Block(
             txs=[
-                blob_tx(address=Address(0x200), type=2, nonce=2),
-                blob_tx(address=Address(0x200), type=3, nonce=3),
+                blob_tx(address=Address(0x2000), type=2, nonce=2),
+                blob_tx(address=Address(0x2000), type=3, nonce=3),
             ]
         ),
         Block(
             txs=[
-                blob_tx(address=Address(0x300), type=2, nonce=4),
-                blob_tx(address=Address(0x400), type=3, nonce=5),
+                blob_tx(address=Address(0x3000), type=2, nonce=4),
+                blob_tx(address=Address(0x4000), type=3, nonce=5),
             ],
         ),
     ]
@@ -314,9 +314,9 @@ def test_blobhash_multiple_txs_in_block(
         Address(address): Account(
             storage={i: random_blob_hashes[i] for i in range(SpecHelpers.max_blobs_per_block())}
         )
-        if address in (0x200, 0x400)
+        if address in (0x2000, 0x4000)
         else Account(storage={i: 0 for i in range(SpecHelpers.max_blobs_per_block())})
-        for address in range(0x100, 0x500, 0x100)
+        for address in range(0x1000, 0x5000, 0x1000)
     }
     blockchain_test(
         pre=pre,

--- a/tests/cancun/eip4844_blobs/test_blobhash_opcode.py
+++ b/tests/cancun/eip4844_blobs/test_blobhash_opcode.py
@@ -118,7 +118,7 @@ def test_blobhash_gas_cost(
         for i in blobhash_index_values
     ]
     for i, gas_code in enumerate(gas_measures_code):
-        address = Address(0x100 + i * 0x100)
+        address = Address(0x1000 + i * 0x1000)
         pre[address] = Account(code=gas_code)
         blocks.append(
             Block(
@@ -177,7 +177,7 @@ def test_blobhash_scenarios(
     b_hashes_list = BlobhashScenario.create_blob_hashes_list(length=TOTAL_BLOCKS)
     blobhash_calls = BlobhashScenario.generate_blobhash_bytecode(scenario)
     for i in range(TOTAL_BLOCKS):
-        address = Address(0x100 + i * 0x100)
+        address = Address(0x1000 + i * 0x1000)
         pre[address] = Account(code=blobhash_calls)
         blocks.append(
             Block(
@@ -234,7 +234,7 @@ def test_blobhash_invalid_blob_index(
     TOTAL_BLOCKS = 5
     blobhash_calls = BlobhashScenario.generate_blobhash_bytecode(scenario)
     for i in range(TOTAL_BLOCKS):
-        address = Address(0x100 + i * 0x100)
+        address = Address(0x1000 + i * 0x1000)
         pre[address] = Account(code=blobhash_calls)
         blob_per_block = (i % SpecHelpers.max_blobs_per_block()) + 1
         blobs = [random_blob_hashes[blob] for blob in range(blob_per_block)]

--- a/tests/cancun/eip4844_blobs/test_excess_blob_gas.py
+++ b/tests/cancun/eip4844_blobs/test_excess_blob_gas.py
@@ -175,7 +175,7 @@ def destination_account_bytecode() -> bytes:  # noqa: D103
 
 @pytest.fixture
 def destination_account() -> Address:  # noqa: D103
-    return Address(0x100)
+    return Address(0x1000)
 
 
 @pytest.fixture

--- a/tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py
+++ b/tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py
@@ -75,7 +75,7 @@ def blob_count_per_block() -> int:
 
 @pytest.fixture
 def destination_account() -> Address:  # noqa: D103
-    return Address(0x100)
+    return Address(0x1000)
 
 
 @pytest.fixture

--- a/tests/cancun/eip4844_blobs/test_point_evaluation_precompile.py
+++ b/tests/cancun/eip4844_blobs/test_point_evaluation_precompile.py
@@ -26,6 +26,7 @@ note: Adding a new test
     cases.
 
 """  # noqa: E501
+
 import glob
 import json
 import os
@@ -157,7 +158,7 @@ def precompile_caller_address() -> Address:
     """
     Address of the precompile caller account.
     """
-    return Address(0x100)
+    return Address(0x1000)
 
 
 @pytest.fixture
@@ -589,7 +590,7 @@ def test_point_evaluation_precompile_before_fork(
             0,
         ),
     )
-    precompile_caller_address = Address(0x100)
+    precompile_caller_address = Address(0x1000)
 
     pre = {
         TestAddress: Account(
@@ -648,7 +649,7 @@ def test_point_evaluation_precompile_during_fork(
             0,
         ),
     )
-    precompile_caller_address = Address(0x100)
+    precompile_caller_address = Address(0x1000)
 
     pre = {
         TestAddress: Account(

--- a/tests/cancun/eip4844_blobs/test_point_evaluation_precompile_gas.py
+++ b/tests/cancun/eip4844_blobs/test_point_evaluation_precompile_gas.py
@@ -3,6 +3,7 @@ abstract: Tests gas usage on point evaluation precompile for [EIP-4844: Shard Bl
     Test gas usage on point evaluation precompile for [EIP-4844: Shard Blob Transactions](https://eips.ethereum.org/EIPS/eip-4844).
 
 """  # noqa: E501
+
 from typing import Dict, Literal
 
 import pytest
@@ -128,7 +129,7 @@ def precompile_caller_address() -> Address:
     """
     Address of the precompile caller account.
     """
-    return Address(0x100)
+    return Address(0x1000)
 
 
 @pytest.fixture

--- a/tests/cancun/eip5656_mcopy/test_mcopy.py
+++ b/tests/cancun/eip5656_mcopy/test_mcopy.py
@@ -3,6 +3,7 @@ abstract: Tests [EIP-5656: MCOPY - Memory copying instruction](https://eips.ethe
     Test copy operations of [EIP-5656: MCOPY - Memory copying instruction](https://eips.ethereum.org/EIPS/eip-5656)
 
 """  # noqa: E501
+
 from typing import Mapping, Tuple
 
 import pytest
@@ -21,7 +22,7 @@ from ethereum_test_tools import (
 from .common import REFERENCE_SPEC_GIT_PATH, REFERENCE_SPEC_VERSION, mcopy
 
 # Code address used to call the test bytecode on every test case.
-code_address = 0x100
+code_address = 0xC0DE
 
 REFERENCE_SPEC_GIT_PATH = REFERENCE_SPEC_GIT_PATH
 REFERENCE_SPEC_VERSION = REFERENCE_SPEC_VERSION

--- a/tests/cancun/eip5656_mcopy/test_mcopy_contexts.py
+++ b/tests/cancun/eip5656_mcopy/test_mcopy_contexts.py
@@ -3,6 +3,7 @@ abstract: Tests [EIP-5656: MCOPY - Memory copying instruction](https://eips.ethe
     Test memory copy under different call contexts [EIP-5656: MCOPY - Memory copying instruction](https://eips.ethereum.org/EIPS/eip-5656)
 
 """  # noqa: E501
+
 from itertools import cycle, islice
 from typing import List, Mapping, Tuple
 
@@ -21,7 +22,7 @@ from ethereum_test_tools import (
 from .common import REFERENCE_SPEC_GIT_PATH, REFERENCE_SPEC_VERSION
 
 # Code address used to call the test bytecode on every test case.
-code_address = 0x100
+code_address = 0xC0DE
 
 # Code address of the callee contract
 callee_address = 0x200

--- a/tests/cancun/eip5656_mcopy/test_mcopy_contexts.py
+++ b/tests/cancun/eip5656_mcopy/test_mcopy_contexts.py
@@ -25,7 +25,7 @@ from .common import REFERENCE_SPEC_GIT_PATH, REFERENCE_SPEC_VERSION
 code_address = 0xC0DE
 
 # Code address of the callee contract
-callee_address = 0x200
+callee_address = 0x2000
 
 
 REFERENCE_SPEC_GIT_PATH = REFERENCE_SPEC_GIT_PATH

--- a/tests/cancun/eip5656_mcopy/test_mcopy_memory_expansion.py
+++ b/tests/cancun/eip5656_mcopy/test_mcopy_memory_expansion.py
@@ -4,6 +4,7 @@ abstract: Tests [EIP-5656: MCOPY - Memory copying instruction](https://eips.ethe
     that produce a memory expansion, and potentially an out-of-gas error.
 
 """  # noqa: E501
+
 from typing import Mapping, Tuple
 
 import pytest
@@ -21,7 +22,7 @@ from ethereum_test_tools import (
 from .common import REFERENCE_SPEC_GIT_PATH, REFERENCE_SPEC_VERSION
 
 # Code address used to call the test bytecode on every test case.
-caller_address = 0x100
+caller_address = 0x1000
 
 # Code address used to perform the memory expansion.
 memory_expansion_address = 0x200

--- a/tests/cancun/eip5656_mcopy/test_mcopy_memory_expansion.py
+++ b/tests/cancun/eip5656_mcopy/test_mcopy_memory_expansion.py
@@ -25,7 +25,7 @@ from .common import REFERENCE_SPEC_GIT_PATH, REFERENCE_SPEC_VERSION
 caller_address = 0x1000
 
 # Code address used to perform the memory expansion.
-memory_expansion_address = 0x200
+memory_expansion_address = 0x2000
 
 REFERENCE_SPEC_GIT_PATH = REFERENCE_SPEC_GIT_PATH
 REFERENCE_SPEC_VERSION = REFERENCE_SPEC_VERSION

--- a/tests/cancun/eip7516_blobgasfee/test_blobgasfee_opcode.py
+++ b/tests/cancun/eip7516_blobgasfee/test_blobgasfee_opcode.py
@@ -16,7 +16,7 @@ REFERENCE_SPEC_GIT_PATH = "EIPS/eip-7516.md"
 REFERENCE_SPEC_VERSION = "2ade0452efe8124378f35284676ddfd16dd56ecd"
 
 # Code address used to call the test bytecode on every test case.
-code_caller_address = Address(0x100)
+code_caller_address = Address(0x1000)
 code_callee_address = Address(0x200)
 
 BLOBBASEFEE_GAS = 2

--- a/tests/cancun/eip7516_blobgasfee/test_blobgasfee_opcode.py
+++ b/tests/cancun/eip7516_blobgasfee/test_blobgasfee_opcode.py
@@ -17,7 +17,7 @@ REFERENCE_SPEC_VERSION = "2ade0452efe8124378f35284676ddfd16dd56ecd"
 
 # Code address used to call the test bytecode on every test case.
 code_caller_address = Address(0x1000)
-code_callee_address = Address(0x200)
+code_callee_address = Address(0x2000)
 
 BLOBBASEFEE_GAS = 2
 

--- a/tests/constantinople/create2/test_recreate.py
+++ b/tests/constantinople/create2/test_recreate.py
@@ -22,7 +22,7 @@ def test_recreate(
     """
     env = Environment()
 
-    creator_address = 0x100
+    creator_address = 0x1000
     creator_contract_code = Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE) + Op.CREATE2(
         0, 0, Op.CALLDATASIZE, 0
     )

--- a/tests/frontier/opcodes/test_dup.py
+++ b/tests/frontier/opcodes/test_dup.py
@@ -3,6 +3,7 @@ abstract: Test DUP
     Test the DUP opcodes.
 
 """
+
 import pytest
 
 from ethereum_test_forks import Frontier, Homestead
@@ -50,7 +51,7 @@ def test_dup(
     pre = {TestAddress: Account(balance=1000000000000000000000)}
     post = {}
 
-    account = Address(0x100)
+    account = Address(0x1000)
 
     # Push 0x00 - 0x10 onto the stack
     account_code = b"".join([Op.PUSH1(i) for i in range(0x11)])

--- a/tests/istanbul/eip1344_chainid/test_chainid.py
+++ b/tests/istanbul/eip1344_chainid/test_chainid.py
@@ -33,7 +33,7 @@ def test_chainid(state_test: StateTestFiller):
     )
 
     pre = {
-        Address(0x100): Account(code=Op.SSTORE(1, Op.CHAINID) + Op.STOP),
+        Address(0x1000): Account(code=Op.SSTORE(1, Op.CHAINID) + Op.STOP),
         TestAddress: Account(balance=1000000000000000000000),
     }
 
@@ -41,13 +41,13 @@ def test_chainid(state_test: StateTestFiller):
         ty=0x0,
         chain_id=0x01,
         nonce=0,
-        to=Address(0x100),
+        to=Address(0x1000),
         gas_limit=100000000,
         gas_price=10,
     )
 
     post = {
-        Address(0x100): Account(code="0x4660015500", storage={"0x01": "0x01"}),
+        Address(0x1000): Account(code="0x4660015500", storage={"0x01": "0x01"}),
     }
 
     state_test(env=env, pre=pre, post=post, tx=tx)

--- a/tests/prague/eip3540_eof_v1/test_code_validation.py
+++ b/tests/prague/eip3540_eof_v1/test_code_validation.py
@@ -55,7 +55,7 @@ def create3_init_container(container: Container) -> Initcode:  # noqa: D103
 
 @pytest.fixture
 def create3_opcode_contract_address() -> Address:  # noqa: D103
-    return Address(0x300)
+    return Address(0x3000)
 
 
 @pytest.fixture
@@ -178,7 +178,7 @@ def test_legacy_initcode_invalid_eof_v1_contract(_):
     initcode, a contract creating transaction,
     and the CREATE opcode.
     tx_created_contract_address = compute_create_address(TestAddress, 0)
-    create_opcode_created_contract_address = compute_create_address(0x100, 0)
+    create_opcode_created_contract_address = compute_create_address(0x1000, 0)
 
     env = Environment()
 
@@ -190,7 +190,7 @@ def test_legacy_initcode_invalid_eof_v1_contract(_):
         Address(0x1000): Account(
             code=create_initcode_from_calldata,
         ),
-        Address(0x200): Account(
+        Address(0x2000): Account(
             code=create2_initcode_from_calldata,
         ),
     }
@@ -221,7 +221,7 @@ def test_legacy_initcode_invalid_eof_v1_contract(_):
     )
     tx_create2_opcode = Transaction(
         nonce=2,
-        to=Address(0x200),
+        to=Address(0x2000),
         gas_limit=100000000,
         gas_price=10,
         protected=False,
@@ -239,7 +239,7 @@ def test_legacy_initcode_invalid_eof_v1_contract(_):
         tx_create_opcode.data = legacy_initcode
         tx_create2_opcode.data = legacy_initcode
         create2_opcode_created_contract_address = compute_create2_address(
-            0x200, 0, bytes(legacy_initcode)
+            0x2000, 0, bytes(legacy_initcode)
         )
         post[create2_opcode_created_contract_address] = Account.NONEXISTENT
         yield StateTest(

--- a/tests/prague/eip3540_eof_v1/test_code_validation.py
+++ b/tests/prague/eip3540_eof_v1/test_code_validation.py
@@ -187,7 +187,7 @@ def test_legacy_initcode_invalid_eof_v1_contract(_):
             balance=1000000000000000000000,
             nonce=0,
         ),
-        Address(0x100): Account(
+        Address(0x1000): Account(
             code=create_initcode_from_calldata,
         ),
         Address(0x200): Account(
@@ -196,7 +196,7 @@ def test_legacy_initcode_invalid_eof_v1_contract(_):
     }
 
     post = {
-        Address(0x100): Account(
+        Address(0x1000): Account(
             storage={
                 0: 1,
             }
@@ -214,7 +214,7 @@ def test_legacy_initcode_invalid_eof_v1_contract(_):
     )
     tx_create_opcode = Transaction(
         nonce=1,
-        to=Address(0x100),
+        to=Address(0x1000),
         gas_limit=100000000,
         gas_price=10,
         protected=False,

--- a/tests/prague/eip3540_eof_v1/test_execution_function.py
+++ b/tests/prague/eip3540_eof_v1/test_execution_function.py
@@ -365,7 +365,7 @@ def test_eof_functions_contract_call_succeed(
             balance=1000000000000000000000,
             nonce=1,
         ),
-        Address(0x100): Account(
+        Address(0x1000): Account(
             code=caller_contract,
             nonce=1,
         ),
@@ -377,14 +377,14 @@ def test_eof_functions_contract_call_succeed(
 
     tx = Transaction(
         nonce=1,
-        to=Address(0x100),
+        to=Address(0x1000),
         gas_limit=50000000,
         gas_price=10,
         protected=False,
         data="",
     )
 
-    post = {Address(0x100): Account(storage={0: 1})}
+    post = {Address(0x1000): Account(storage={0: 1})}
 
     state_test(
         env=env,
@@ -411,7 +411,7 @@ def test_eof_functions_contract_call_fail(
             balance=1000000000000000000000,
             nonce=1,
         ),
-        Address(0x100): Account(
+        Address(0x1000): Account(
             code=caller_contract,
             nonce=1,
         ),
@@ -423,14 +423,14 @@ def test_eof_functions_contract_call_fail(
 
     tx = Transaction(
         nonce=1,
-        to=Address(0x100),
+        to=Address(0x1000),
         gas_limit=50000000,
         gas_price=10,
         protected=False,
         data="",
     )
 
-    post = {Address(0x100): Account(storage={0: 1})}
+    post = {Address(0x1000): Account(storage={0: 1})}
 
     state_test(
         env=env,
@@ -456,7 +456,7 @@ def test_eof_functions_contract_call_within_deep_nested(
             balance=1000000000000000000000,
             nonce=1,
         ),
-        Address(0x100): Account(
+        Address(0x1000): Account(
             code=contract_call_within_deep_nested_callf,
         ),
         Address(0x200): Account(
@@ -465,14 +465,14 @@ def test_eof_functions_contract_call_within_deep_nested(
     }
     tx = Transaction(
         nonce=1,
-        to=Address(0x100),
+        to=Address(0x1000),
         gas_limit=50000000,
         gas_price=10,
         protected=False,
         data="",
     )
     post = {
-        Address(0x100): Account(storage={i: 1 for i in range(MAX_CODE_SECTIONS)}),
+        Address(0x1000): Account(storage={i: 1 for i in range(MAX_CODE_SECTIONS)}),
         Address(0x200): Account(
             storage={
                 0: 1,

--- a/tests/prague/eip3540_eof_v1/test_execution_function.py
+++ b/tests/prague/eip3540_eof_v1/test_execution_function.py
@@ -369,7 +369,7 @@ def test_eof_functions_contract_call_succeed(
             code=caller_contract,
             nonce=1,
         ),
-        Address(0x200): Account(
+        Address(0x2000): Account(
             code=container,
             nonce=1,
         ),
@@ -415,7 +415,7 @@ def test_eof_functions_contract_call_fail(
             code=caller_contract,
             nonce=1,
         ),
-        Address(0x200): Account(
+        Address(0x2000): Account(
             code=container,
             nonce=1,
         ),
@@ -459,7 +459,7 @@ def test_eof_functions_contract_call_within_deep_nested(
         Address(0x1000): Account(
             code=contract_call_within_deep_nested_callf,
         ),
-        Address(0x200): Account(
+        Address(0x2000): Account(
             code=Op.SSTORE(0, 1) + Op.STOP(),
         ),
     }
@@ -473,7 +473,7 @@ def test_eof_functions_contract_call_within_deep_nested(
     )
     post = {
         Address(0x1000): Account(storage={i: 1 for i in range(MAX_CODE_SECTIONS)}),
-        Address(0x200): Account(
+        Address(0x2000): Account(
             storage={
                 0: 1,
             }

--- a/tests/prague/eip7480_data_section/test_data_opcodes.py
+++ b/tests/prague/eip7480_data_section/test_data_opcodes.py
@@ -176,7 +176,7 @@ def test_data_section_succeed(
             balance=1000000000000000000000,
             nonce=1,
         ),
-        Address(0x100): Account(
+        Address(0x1000): Account(
             code=caller_contract,
             nonce=1,
         ),
@@ -188,14 +188,14 @@ def test_data_section_succeed(
 
     tx = Transaction(
         nonce=1,
-        to=Address(0x100),
+        to=Address(0x1000),
         gas_limit=50000000,
         gas_price=10,
         protected=False,
         data="",
     )
 
-    post = {Address(0x100): Account(storage=expected_storage)}
+    post = {Address(0x1000): Account(storage=expected_storage)}
 
     state_test(
         env=env,

--- a/tests/prague/eip7480_data_section/test_data_opcodes.py
+++ b/tests/prague/eip7480_data_section/test_data_opcodes.py
@@ -180,7 +180,7 @@ def test_data_section_succeed(
             code=caller_contract,
             nonce=1,
         ),
-        Address(0x200): Account(
+        Address(0x2000): Account(
             code=container,
             nonce=1,
         ),

--- a/tests/shanghai/eip3651_warm_coinbase/test_warm_coinbase.py
+++ b/tests/shanghai/eip3651_warm_coinbase/test_warm_coinbase.py
@@ -88,7 +88,7 @@ def test_warm_coinbase_call_out_of_gas(
         timestamp=1000,
     )
     caller_address = "0xcccccccccccccccccccccccccccccccccccccccc"
-    contract_under_test_address = 0x100
+    contract_under_test_address = 0x1000
 
     if not use_sufficient_gas:
         call_gas_exact -= 1
@@ -236,7 +236,7 @@ def test_warm_coinbase_gas_usage(state_test, fork, opcode, code_gas_measure):
         timestamp=1000,
     )
 
-    measure_address = Address(0x100)
+    measure_address = Address(0x1000)
     pre = {
         TestAddress: Account(balance=1000000000000000000000),
         measure_address: Account(code=code_gas_measure, balance=1000000000000000000000),

--- a/tests/shanghai/eip3855_push0/test_push0.py
+++ b/tests/shanghai/eip3855_push0/test_push0.py
@@ -143,10 +143,10 @@ def test_push0_during_staticcall(
     """
     Test PUSH0 during STATICCALL.
     """
-    addr_2 = Address(0x200)
+    addr_2 = Address(0x2000)
 
     code_1 = (
-        Op.SSTORE(0, Op.STATICCALL(100000, 0x200, 0, 0, 0, 0))
+        Op.SSTORE(0, Op.STATICCALL(100000, 0x2000, 0, 0, 0, 0))
         + Op.SSTORE(0, 1)
         + Op.RETURNDATACOPY(0x1F, 0, 1)
         + Op.SSTORE(1, Op.MLOAD(0))

--- a/tests/shanghai/eip3855_push0/test_push0.py
+++ b/tests/shanghai/eip3855_push0/test_push0.py
@@ -42,7 +42,7 @@ def post():  # noqa: D103
 
 @pytest.fixture
 def addr_1():  # noqa: D103
-    return Address(0x100)
+    return Address(0x1000)
 
 
 @pytest.fixture

--- a/tests/shanghai/eip3860_initcode/test_initcode.py
+++ b/tests/shanghai/eip3860_initcode/test_initcode.py
@@ -496,12 +496,12 @@ class TestCreateInitcode:
     def created_contract_address(self, initcode: Initcode, opcode: Op):  # noqa: D102
         if opcode == Op.CREATE:
             return compute_create_address(
-                address=0x100,
+                address=0x1000,
                 nonce=1,
             )
         if opcode == Op.CREATE2:
             return compute_create2_address(
-                address=0x100,
+                address=0x1000,
                 salt=0xDEADBEEF,
                 initcode=initcode,
             )
@@ -524,17 +524,17 @@ class TestCreateInitcode:
 
         call_code = Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE)
         call_code += Op.SSTORE(
-            Op.CALL(5000000, 0x100, 0, 0, Op.CALLDATASIZE, 0, 0),
+            Op.CALL(5000000, 0x1000, 0, 0, Op.CALLDATASIZE, 0, 0),
             1,
         )
 
         pre = {
             TestAddress: Account(balance=1000000000000000000000),
-            Address(0x100): Account(
+            Address(0x1000): Account(
                 code=create_code,
                 nonce=1,
             ),
-            Address(0x200): Account(
+            Address(0x2000): Account(
                 code=call_code,
                 nonce=1,
             ),
@@ -544,7 +544,7 @@ class TestCreateInitcode:
 
         tx = Transaction(
             nonce=0,
-            to=Address(0x200),
+            to=Address(0x2000),
             data=initcode,
             gas_limit=10000000,
             gas_price=10,
@@ -563,7 +563,7 @@ class TestCreateInitcode:
 
         if len(initcode) > MAX_INITCODE_SIZE and eip_3860_active:
             # Call returns 0 as out of gas s[0]==1
-            post[Address(0x200)] = Account(
+            post[Address(0x2000)] = Account(
                 nonce=1,
                 storage={
                     0: 1,
@@ -572,7 +572,7 @@ class TestCreateInitcode:
             )
 
             post[created_contract_address] = Account.NONEXISTENT
-            post[Address(0x100)] = Account(
+            post[Address(0x1000)] = Account(
                 nonce=1,
                 storage={
                     0: 0,
@@ -597,7 +597,7 @@ class TestCreateInitcode:
                 expected_gas_usage += calculate_initcode_word_cost(len(initcode))
 
             # Call returns 1 as valid initcode length s[0]==1 && s[1]==1
-            post[Address(0x200)] = Account(
+            post[Address(0x2000)] = Account(
                 nonce=1,
                 storage={
                     0: 0,
@@ -606,7 +606,7 @@ class TestCreateInitcode:
             )
 
             post[created_contract_address] = Account(code=initcode.deploy_code)
-            post[Address(0x100)] = Account(
+            post[Address(0x1000)] = Account(
                 nonce=2,
                 storage={
                     0: created_contract_address,

--- a/tests/shanghai/eip4895_withdrawals/test_withdrawals.py
+++ b/tests/shanghai/eip4895_withdrawals/test_withdrawals.py
@@ -56,7 +56,7 @@ class TestUseValueInTx:
             nonce=0,
             gas_price=ONE_GWEI,
             gas_limit=21000,
-            to=Address(0x100),
+            to=Address(0x1000),
             data="0x",
         )
 
@@ -128,7 +128,7 @@ def test_use_value_in_contract(blockchain_test: BlockchainTestFiller):
 
     pre = {
         TestAddress: Account(balance=1000000000000000000000, nonce=0),
-        Address(0x100): Account(balance=0, code=SEND_ONE_GWEI),
+        Address(0x1000): Account(balance=0, code=SEND_ONE_GWEI),
         Address(0x200): Account(balance=1),
     }
     tx = Transaction(
@@ -137,13 +137,13 @@ def test_use_value_in_contract(blockchain_test: BlockchainTestFiller):
         value=0,
         gas_price=10,
         gas_limit=100000,
-        to=Address(0x100),
+        to=Address(0x1000),
         data="0x",
     )
     withdrawal = Withdrawal(
         index=0,
         validator_index=0,
-        address=Address(0x100),
+        address=Address(0x1000),
         amount=1,
     )
 
@@ -157,7 +157,7 @@ def test_use_value_in_contract(blockchain_test: BlockchainTestFiller):
         ),
     ]
     post = {
-        Address(0x100): Account(
+        Address(0x1000): Account(
             storage={
                 0x1: 0x0,  # Call fails on the first attempt
                 0x2: 0x1,  # Succeeds on the second attempt
@@ -182,7 +182,7 @@ def test_balance_within_block(blockchain_test: BlockchainTestFiller):
     )
     pre = {
         TestAddress: Account(balance=1000000000000000000000, nonce=0),
-        Address(0x100): Account(
+        Address(0x1000): Account(
             code=SAVE_BALANCE_ON_BLOCK_NUMBER,
         ),
         Address(0x200): Account(
@@ -195,7 +195,7 @@ def test_balance_within_block(blockchain_test: BlockchainTestFiller):
                 Transaction(
                     nonce=0,
                     gas_limit=100000,
-                    to=Address(0x100),
+                    to=Address(0x1000),
                     data=Hash(0x200),
                 )
             ],
@@ -213,7 +213,7 @@ def test_balance_within_block(blockchain_test: BlockchainTestFiller):
                 Transaction(
                     nonce=1,
                     gas_limit=100000,
-                    to=Address(0x100),
+                    to=Address(0x1000),
                     data=Hash(0x200),
                 )
             ]
@@ -221,7 +221,7 @@ def test_balance_within_block(blockchain_test: BlockchainTestFiller):
     ]
 
     post = {
-        Address(0x100): Account(
+        Address(0x1000): Account(
             storage={
                 1: ONE_GWEI,
                 2: 2 * ONE_GWEI,
@@ -366,13 +366,13 @@ def test_many_withdrawals(blockchain_test: BlockchainTestFiller):
 def test_self_destructing_account(blockchain_test: BlockchainTestFiller, fork: Fork):
     """
     Test withdrawals can be done to self-destructed accounts.
-    Account `0x100` self-destructs and sends all its balance to `0x200`.
-    Then, a withdrawal is received at `0x100` with 99 wei.
+    Account `0x1000` self-destructs and sends all its balance to `0x200`.
+    Then, a withdrawal is received at `0x1000` with 99 wei.
     """
     self_destruct_code = Op.SELFDESTRUCT(Op.CALLDATALOAD(0))
     pre = {
         TestAddress: Account(balance=1000000000000000000000, nonce=0),
-        Address(0x100): Account(
+        Address(0x1000): Account(
             code=self_destruct_code,
             balance=(100 * ONE_GWEI),
         ),
@@ -387,14 +387,14 @@ def test_self_destructing_account(blockchain_test: BlockchainTestFiller, fork: F
         nonce=0,
         gas_price=10,
         gas_limit=100000,
-        to=Address(0x100),
+        to=Address(0x1000),
         data=Hash(0x200),
     )
 
     withdrawal = Withdrawal(
         index=0,
         validator_index=0,
-        address=Address(0x100),
+        address=Address(0x1000),
         amount=(99),
     )
 
@@ -404,7 +404,7 @@ def test_self_destructing_account(blockchain_test: BlockchainTestFiller, fork: F
     )
 
     post = {
-        Address(0x100): Account(
+        Address(0x1000): Account(
             code=self_destruct_code if fork >= Cancun else b"",
             balance=(99 * ONE_GWEI),
         ),
@@ -482,7 +482,7 @@ def test_no_evm_execution(blockchain_test: BlockchainTestFiller):
     """
     pre = {
         TestAddress: Account(balance=1000000000000000000000, nonce=0),
-        Address(0x100): Account(
+        Address(0x1000): Account(
             code=Op.SSTORE(Op.NUMBER, 1),
         ),
         Address(0x200): Account(
@@ -513,7 +513,7 @@ def test_no_evm_execution(blockchain_test: BlockchainTestFiller):
                 Withdrawal(
                     index=0,
                     validator_index=0,
-                    address=Address(0x100),
+                    address=Address(0x1000),
                     amount=1,
                 ),
                 Withdrawal(
@@ -529,7 +529,7 @@ def test_no_evm_execution(blockchain_test: BlockchainTestFiller):
                 Transaction(
                     nonce=2,
                     gas_limit=100000,
-                    to=Address(0x100),
+                    to=Address(0x1000),
                 ),
                 Transaction(
                     nonce=3,
@@ -555,7 +555,7 @@ def test_no_evm_execution(blockchain_test: BlockchainTestFiller):
     ]
 
     post = {
-        Address(0x100): Account(storage={2: 1}),
+        Address(0x1000): Account(storage={2: 1}),
         Address(0x200): Account(storage={2: 1}),
         Address(0x300): Account(storage={1: 1}),
         Address(0x400): Account(storage={1: 1}),
@@ -606,7 +606,7 @@ def test_zero_amount(
         Withdrawal(
             index=0,
             validator_index=0,
-            address=Address(0x100),
+            address=Address(0x1000),
             amount=0,
         ),
         # No value, touched account
@@ -632,7 +632,7 @@ def test_zero_amount(
         ),
     ]
     all_post = {
-        Address(0x100): Account.NONEXISTENT,
+        Address(0x1000): Account.NONEXISTENT,
         Address(0x200): Account(code="0x00", balance=0),
         Address(0x300): Account(balance=ONE_GWEI),
         Address(0x400): Account(balance=(2**64 - 1) * ONE_GWEI),
@@ -645,7 +645,7 @@ def test_zero_amount(
         post = {
             account: all_post[account]
             for account in post
-            if account in [Address(0x100), Address(0x200)]
+            if account in [Address(0x1000), Address(0x200)]
         }
     elif test_case == ZeroAmountTestCases.THREE_ONE_WITH_VALUE:
         withdrawals = all_withdrawals[0:3]
@@ -654,7 +654,7 @@ def test_zero_amount(
             for account in post
             if account
             in [
-                Address(0x100),
+                Address(0x1000),
                 Address(0x200),
                 Address(0x300),
             ]
@@ -729,7 +729,10 @@ def test_large_amount(blockchain_test: BlockchainTestFiller):
 @pytest.mark.parametrize("amount", [0, 1])
 @pytest.mark.with_all_precompiles
 def test_withdrawing_to_precompiles(
-    blockchain_test: BlockchainTestFiller, precompile: int, amount: int, t8n: TransitionTool
+    blockchain_test: BlockchainTestFiller,
+    precompile: int,
+    amount: int,
+    t8n: TransitionTool,
 ):
     """
     Test withdrawing to all precompiles for a given fork.

--- a/tests/shanghai/eip4895_withdrawals/test_withdrawals.py
+++ b/tests/shanghai/eip4895_withdrawals/test_withdrawals.py
@@ -123,13 +123,13 @@ def test_use_value_in_contract(blockchain_test: BlockchainTestFiller):
     """
     SEND_ONE_GWEI = Op.SSTORE(
         Op.NUMBER,
-        Op.CALL(Op.GAS, 0x200, 1000000000, 0, 0, 0, 0),
+        Op.CALL(Op.GAS, 0x2000, 1000000000, 0, 0, 0, 0),
     )
 
     pre = {
         TestAddress: Account(balance=1000000000000000000000, nonce=0),
         Address(0x1000): Account(balance=0, code=SEND_ONE_GWEI),
-        Address(0x200): Account(balance=1),
+        Address(0x2000): Account(balance=1),
     }
     tx = Transaction(
         # Transaction sent from the `TestAddress`, which has 0 balance at start
@@ -163,7 +163,7 @@ def test_use_value_in_contract(blockchain_test: BlockchainTestFiller):
                 0x2: 0x1,  # Succeeds on the second attempt
             }
         ),
-        Address(0x200): Account(
+        Address(0x2000): Account(
             balance=ONE_GWEI + 1,
         ),
     }
@@ -185,7 +185,7 @@ def test_balance_within_block(blockchain_test: BlockchainTestFiller):
         Address(0x1000): Account(
             code=SAVE_BALANCE_ON_BLOCK_NUMBER,
         ),
-        Address(0x200): Account(
+        Address(0x2000): Account(
             balance=ONE_GWEI,
         ),
     }
@@ -196,14 +196,14 @@ def test_balance_within_block(blockchain_test: BlockchainTestFiller):
                     nonce=0,
                     gas_limit=100000,
                     to=Address(0x1000),
-                    data=Hash(0x200),
+                    data=Hash(0x2000),
                 )
             ],
             withdrawals=[
                 Withdrawal(
                     index=0,
                     validator_index=0,
-                    address=Address(0x200),
+                    address=Address(0x2000),
                     amount=1,
                 )
             ],
@@ -214,7 +214,7 @@ def test_balance_within_block(blockchain_test: BlockchainTestFiller):
                     nonce=1,
                     gas_limit=100000,
                     to=Address(0x1000),
-                    data=Hash(0x200),
+                    data=Hash(0x2000),
                 )
             ]
         ),
@@ -335,7 +335,7 @@ def test_many_withdrawals(blockchain_test: BlockchainTestFiller):
     withdrawals = []
     post = {}
     for i in range(N):
-        addr = Address(0x100 * i)
+        addr = Address(0x1000 * i)
         amount = i * 1
         pre[addr] = Account(
             code=Op.SSTORE(Op.NUMBER, 1),
@@ -366,7 +366,7 @@ def test_many_withdrawals(blockchain_test: BlockchainTestFiller):
 def test_self_destructing_account(blockchain_test: BlockchainTestFiller, fork: Fork):
     """
     Test withdrawals can be done to self-destructed accounts.
-    Account `0x1000` self-destructs and sends all its balance to `0x200`.
+    Account `0x1000` self-destructs and sends all its balance to `0x2000`.
     Then, a withdrawal is received at `0x1000` with 99 wei.
     """
     self_destruct_code = Op.SELFDESTRUCT(Op.CALLDATALOAD(0))
@@ -376,7 +376,7 @@ def test_self_destructing_account(blockchain_test: BlockchainTestFiller, fork: F
             code=self_destruct_code,
             balance=(100 * ONE_GWEI),
         ),
-        Address(0x200): Account(
+        Address(0x2000): Account(
             balance=1,
         ),
     }
@@ -388,7 +388,7 @@ def test_self_destructing_account(blockchain_test: BlockchainTestFiller, fork: F
         gas_price=10,
         gas_limit=100000,
         to=Address(0x1000),
-        data=Hash(0x200),
+        data=Hash(0x2000),
     )
 
     withdrawal = Withdrawal(
@@ -408,7 +408,7 @@ def test_self_destructing_account(blockchain_test: BlockchainTestFiller, fork: F
             code=self_destruct_code if fork >= Cancun else b"",
             balance=(99 * ONE_GWEI),
         ),
-        Address(0x200): Account(
+        Address(0x2000): Account(
             code=b"",
             balance=(100 * ONE_GWEI) + 1,
         ),
@@ -485,13 +485,13 @@ def test_no_evm_execution(blockchain_test: BlockchainTestFiller):
         Address(0x1000): Account(
             code=Op.SSTORE(Op.NUMBER, 1),
         ),
-        Address(0x200): Account(
+        Address(0x2000): Account(
             code=Op.SSTORE(Op.NUMBER, 1),
         ),
-        Address(0x300): Account(
+        Address(0x3000): Account(
             code=Op.SSTORE(Op.NUMBER, 1),
         ),
-        Address(0x400): Account(
+        Address(0x4000): Account(
             code=Op.SSTORE(Op.NUMBER, 1),
         ),
     }
@@ -501,12 +501,12 @@ def test_no_evm_execution(blockchain_test: BlockchainTestFiller):
                 Transaction(
                     nonce=0,
                     gas_limit=100000,
-                    to=Address(0x300),
+                    to=Address(0x3000),
                 ),
                 Transaction(
                     nonce=1,
                     gas_limit=100000,
-                    to=Address(0x400),
+                    to=Address(0x4000),
                 ),
             ],
             withdrawals=[
@@ -519,7 +519,7 @@ def test_no_evm_execution(blockchain_test: BlockchainTestFiller):
                 Withdrawal(
                     index=1,
                     validator_index=1,
-                    address=Address(0x200),
+                    address=Address(0x2000),
                     amount=1,
                 ),
             ],
@@ -534,20 +534,20 @@ def test_no_evm_execution(blockchain_test: BlockchainTestFiller):
                 Transaction(
                     nonce=3,
                     gas_limit=100000,
-                    to=Address(0x200),
+                    to=Address(0x2000),
                 ),
             ],
             withdrawals=[
                 Withdrawal(
                     index=0,
                     validator_index=0,
-                    address=Address(0x300),
+                    address=Address(0x3000),
                     amount=1,
                 ),
                 Withdrawal(
                     index=1,
                     validator_index=1,
-                    address=Address(0x400),
+                    address=Address(0x4000),
                     amount=1,
                 ),
             ],
@@ -556,9 +556,9 @@ def test_no_evm_execution(blockchain_test: BlockchainTestFiller):
 
     post = {
         Address(0x1000): Account(storage={2: 1}),
-        Address(0x200): Account(storage={2: 1}),
-        Address(0x300): Account(storage={1: 1}),
-        Address(0x400): Account(storage={1: 1}),
+        Address(0x2000): Account(storage={2: 1}),
+        Address(0x3000): Account(storage={1: 1}),
+        Address(0x4000): Account(storage={1: 1}),
     }
 
     blockchain_test(pre=pre, post=post, blocks=blocks)
@@ -595,7 +595,7 @@ def test_zero_amount(
     """
     pre = {
         TestAddress: Account(balance=1000000000000000000000, nonce=0),
-        Address(0x200): Account(
+        Address(0x2000): Account(
             code="0x00",
             balance=0,
         ),
@@ -613,29 +613,29 @@ def test_zero_amount(
         Withdrawal(
             index=0,
             validator_index=0,
-            address=Address(0x200),
+            address=Address(0x2000),
             amount=0,
         ),
         # Withdrawal with value
         Withdrawal(
             index=1,
             validator_index=0,
-            address=Address(0x300),
+            address=Address(0x3000),
             amount=1,
         ),
         # Withdrawal with maximum amount
         Withdrawal(
             index=2,
             validator_index=0,
-            address=Address(0x400),
+            address=Address(0x4000),
             amount=2**64 - 1,
         ),
     ]
     all_post = {
         Address(0x1000): Account.NONEXISTENT,
-        Address(0x200): Account(code="0x00", balance=0),
-        Address(0x300): Account(balance=ONE_GWEI),
-        Address(0x400): Account(balance=(2**64 - 1) * ONE_GWEI),
+        Address(0x2000): Account(code="0x00", balance=0),
+        Address(0x3000): Account(balance=ONE_GWEI),
+        Address(0x4000): Account(balance=(2**64 - 1) * ONE_GWEI),
     }
 
     withdrawals: List[Withdrawal] = []
@@ -645,7 +645,7 @@ def test_zero_amount(
         post = {
             account: all_post[account]
             for account in post
-            if account in [Address(0x1000), Address(0x200)]
+            if account in [Address(0x1000), Address(0x2000)]
         }
     elif test_case == ZeroAmountTestCases.THREE_ONE_WITH_VALUE:
         withdrawals = all_withdrawals[0:3]
@@ -655,8 +655,8 @@ def test_zero_amount(
             if account
             in [
                 Address(0x1000),
-                Address(0x200),
-                Address(0x300),
+                Address(0x2000),
+                Address(0x3000),
             ]
         }
     elif test_case == ZeroAmountTestCases.FOUR_ONE_WITH_MAX:
@@ -707,7 +707,7 @@ def test_large_amount(blockchain_test: BlockchainTestFiller):
     post = {}
 
     for i, amount in enumerate(amounts):
-        addr = Address(0x100 * (i + 1))
+        addr = Address(0x1000 * (i + 1))
         withdrawals.append(
             Withdrawal(
                 index=i,


### PR DESCRIPTION
## 🗒️ Description
RIP precompiles will use addresses starting from 0x100. As such, and to make the ethereum execution spec tests re-usable by EVM rollups teams, I propose to bump the addresses `0x100` used in tests to something else - in this case, `0x1000`. This allows rollup teams to benefit from the test coverage of ethereum, while innovating on new features.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->
Fixes #552

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
