### PR TITLE
chore(fw): Utilize an EthRPC class within consume rlp

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Added `--traces` support when running with Hyperledger Besu ([#511](https://github.com/ethereum/execution-spec-tests/pull/511)).
 - ✨ Use pytest's "short" traceback style (`--tb=short`) for failure summaries in the test report for more compact terminal output ([#542](https://github.com/ethereum/execution-spec-tests/pull/542)).
 - ✨ The `fill` command now generates HTML test reports with links to the JSON fixtures and debug information ([#537](https://github.com/ethereum/execution-spec-tests/pull/537)).
+- ✨ Add an Ethereum RPC client class for use with consume commands ([#556](https://github.com/ethereum/execution-spec-tests/pull/556)).
 
 ### 🔧 EVM Tools
 

--- a/src/ethereum_test_tools/rpc/__init__.py
+++ b/src/ethereum_test_tools/rpc/__init__.py
@@ -1,0 +1,7 @@
+"""
+JSON-RPC methods and helper functions for EEST consume based hive simulators.
+"""
+
+from .rpc import BlockNumberType, EthRPC
+
+__all__ = ["EthRPC", "BlockNumberType"]

--- a/src/ethereum_test_tools/rpc/rpc.py
+++ b/src/ethereum_test_tools/rpc/rpc.py
@@ -1,0 +1,115 @@
+"""
+JSON-RPC methods and helper functions for EEST consume based hive simulators.
+"""
+
+from abc import ABC
+from typing import Any, Dict, List, Literal, Optional, Union
+
+import requests
+from tenacity import retry, stop_after_attempt, wait_exponential
+
+from ethereum_test_tools import Address
+
+BlockNumberType = Union[int, Literal["latest", "earliest", "pending"]]
+
+
+class BaseRPC(ABC):
+    """
+    Represents a base RPC class for every RPC call used within EEST based hive simulators.
+    """
+
+    def __init__(self, client_ip: str, port: int):
+        self.ip = client_ip
+        self.url = f"http://{client_ip}:{port}"
+
+    @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, max=10))
+    def post_request(
+        self, method: str, params: List[Any], extra_headers: Optional[Dict] = None
+    ) -> Dict:
+        """
+        Sends a JSON-RPC POST request to the client RPC server at port defined in the url.
+        """
+        payload = {
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+            "id": 1,
+        }
+        base_header = {
+            "Content-Type": "application/json",
+        }
+        headers = base_header if extra_headers is None else {**base_header, **extra_headers}
+
+        response = requests.post(self.url, json=payload, headers=headers)
+        response.raise_for_status()
+        result = response.json().get("result")
+
+        if result is None or "error" in result:
+            error_info = "result is None; and therefore contains no error info"
+            error_code = None
+            if result is not None:
+                error_info = result["error"]
+                error_code = result["error"]["code"]
+            raise Exception(
+                f"Error calling JSON RPC {method}, code: {error_code}, " f"message: {error_info}"
+            )
+
+        return result
+
+
+class EthRPC(BaseRPC):
+    """
+    Represents an `eth_X` RPC class for every default ethereum RPC method used within EEST based
+    hive simulators.
+    """
+
+    def __init__(self, client_ip):
+        """
+        Initializes the EthRPC class with the http port 8545, which requires no authentication.
+        """
+        super().__init__(client_ip, port=8545)
+
+    BlockNumberType = Union[int, Literal["latest", "earliest", "pending"]]
+
+    def get_block_by_number(self, block_number: BlockNumberType = "latest", full_txs: bool = True):
+        """
+        `eth_getBlockByNumber`: Returns information about a block by block number.
+        """
+        block = hex(block_number) if isinstance(block_number, int) else block_number
+        return self.post_request("eth_getBlockByNumber", [block, full_txs])
+
+    def get_balance(self, address: str, block_number: BlockNumberType = "latest"):
+        """
+        `eth_getBalance`: Returns the balance of the account of given address.
+        """
+        block = hex(block_number) if isinstance(block_number, int) else block_number
+        return self.post_request("eth_getBalance", [address, block])
+
+    def get_transaction_count(self, address: Address, block_number: BlockNumberType = "latest"):
+        """
+        `eth_getTransactionCount`: Returns the number of transactions sent from an address.
+        """
+        block = hex(block_number) if isinstance(block_number, int) else block_number
+        return self.post_request("eth_getTransactionCount", [address, block])
+
+    def get_storage_at(
+        self, address: str, position: str, block_number: BlockNumberType = "latest"
+    ):
+        """
+        `eth_getStorageAt`: Returns the value from a storage position at a given address.
+        """
+        block = hex(block_number) if isinstance(block_number, int) else block_number
+        return self.post_request("eth_getStorageAt", [address, position, block])
+
+    def storage_at_keys(
+        self, account: str, keys: List[str], block_number: BlockNumberType = "latest"
+    ) -> Dict:
+        """
+        Helper to retrieve the storage values for the specified keys at a given address and block
+        number.
+        """
+        results: Dict = {}
+        for key in keys:
+            storage_value = self.get_storage_at(account, key, block_number)
+            results[key] = storage_value
+        return results


### PR DESCRIPTION
## 🗒️ Description

Adds the EthRPC class alongside the BaseRPC class. The latter are used within `tests_consume/test_via_rlp.py`, and will be extended for consume engine.

~~I added this within `src/pytest_plugins/consume/json_rpc.py` but open to moving this somewhere else.~~
Moved to: `src/ethereum_test_tools/rpc/rpc.py`


## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
