### PR TITLE
add EOFException.INVALID_DATALOADN_INDEX

### DIFF
--- a/src/ethereum_test_tools/exceptions/evmone_exceptions.py
+++ b/src/ethereum_test_tools/exceptions/evmone_exceptions.py
@@ -49,6 +49,7 @@ class EvmoneExceptionMapper:
         ExceptionMessage(EOFException.UNREACHABLE_INSTRUCTIONS, "err: unreachable_instructions"),
         ExceptionMessage(EOFException.INVALID_RJUMP_DESTINATION, "err: invalid_rjump_destination"),
         ExceptionMessage(EOFException.UNREACHABLE_CODE_SECTIONS, "err: unreachable_code_sections"),
+        ExceptionMessage(EOFException.INVALID_DATALOADN_INDEX, "err: invalid_dataloadn_index"),
     )
 
     def __init__(self) -> None:

--- a/src/ethereum_test_tools/exceptions/exceptions.py
+++ b/src/ethereum_test_tools/exceptions/exceptions.py
@@ -303,6 +303,10 @@ class EOFException(ExceptionBase):
     """
     EOF container's body have code sections that are unreachable
     """
+    INVALID_DATALOADN_INDEX = auto()
+    """
+    A DATALOADN instruction has out-of-bounds index for the data section
+    """
 
 
 """

--- a/tests/prague/eip7692_eof_v1/eip7480_data_section/test_code_validation.py
+++ b/tests/prague/eip7692_eof_v1/eip7480_data_section/test_code_validation.py
@@ -128,7 +128,7 @@ INVALID: List[Container] = [
                 max_stack_height=1,
             ),
         ],
-        validity_error=EOFException.DEFAULT_EXCEPTION,
+        validity_error=EOFException.INVALID_DATALOADN_INDEX,
     ),
     Container(
         name="DATALOADN_max_small_data",
@@ -141,7 +141,7 @@ INVALID: List[Container] = [
             ),
             Section.Data(data="1122334455667788" * 16),
         ],
-        validity_error=EOFException.DEFAULT_EXCEPTION,
+        validity_error=EOFException.INVALID_DATALOADN_INDEX,
     ),
     Container(
         name="DATALOADN_max_half_data",
@@ -154,7 +154,7 @@ INVALID: List[Container] = [
             ),
             Section.Data(data=("1122334455667788" * 4 * 1024)[2:]),
         ],
-        validity_error=EOFException.DEFAULT_EXCEPTION,
+        validity_error=EOFException.INVALID_DATALOADN_INDEX,
     ),
 ]
 


### PR DESCRIPTION
## 🗒️ Description

Recognize new error code of eofparse: `invalid_dataloadn_index`.

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
