### PR TITLE
Revert "chore(ci): disable tox -e tests-develop in github actions"

### DIFF
--- a/.github/workflows/fixtures.yaml
+++ b/.github/workflows/fixtures.yaml
@@ -19,11 +19,11 @@ jobs:
             fill-params: ''
             solc: '0.8.21'
             python: '3.11'
-          # - name: 'fixtures_develop'
-          #   evm-type: 'develop'
-          #   fill-params: '--until=Prague'
-          #   solc: '0.8.21'
-          #   python: '3.11'
+          - name: 'fixtures_develop'
+            evm-type: 'develop'
+            fill-params: '--until=Prague'
+            solc: '0.8.21'
+            python: '3.11'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/fixtures.yaml
+++ b/.github/workflows/fixtures.yaml
@@ -21,7 +21,7 @@ jobs:
             python: '3.11'
           - name: 'fixtures_develop'
             evm-type: 'develop'
-            fill-params: '--until=Prague'
+            fill-params: '--until=Prague --ignore=./tests/prague/eip7692_eof_v1'
             solc: '0.8.21'
             python: '3.11'
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,8 +21,8 @@ jobs:
           - os: ubuntu-latest
             python: '3.11'
             solc: '0.8.21'
-            evm-type: 'main'  # 'develop'
-            tox-cmd: 'tox run-parallel --parallel-no-spinner'  # 'tox -e tests-develop'
+            evm-type: 'develop'
+            tox-cmd: 'tox -e tests-develop'
           - os: macos-latest
             python: '3.11'
             solc: '0.8.22'

--- a/evm-config.yaml
+++ b/evm-config.yaml
@@ -4,5 +4,5 @@ main:
   ref: master
 develop:
   impl: geth
-  repo: ethereum/go-ethereum
-  ref: master
+  repo: lightclient/go-ethereum
+  ref: prague-devnet-0

--- a/tox.ini
+++ b/tox.ini
@@ -64,7 +64,7 @@ extras =
     {[testenv:tests-base]extras}
 
 commands =
-    pytest -n auto --until={[main]development_fork}  -k "not slow"
+    pytest -n auto --until={[main]development_fork}  -k "not slow" --ignore=./tests/prague/eip7692_eof_v1
 
 [testenv:docs]
 description = Run documentation checks


### PR DESCRIPTION
- Reverts ethereum/execution-spec-tests#515
- Use develop only for devnet-0 EIPs, EOF should be filled separately