### PR TITLE
fix: fix extending pytest args when adding hive parallelism

### DIFF
--- a/src/cli/pytest_commands.py
+++ b/src/cli/pytest_commands.py
@@ -150,7 +150,7 @@ def get_hive_flags_from_env():
     pytest_args = []
     xdist_workers = os.getenv("HIVE_PARALLELISM")
     if xdist_workers is not None:
-        pytest_args.extend("-n", xdist_workers)
+        pytest_args.extend(["-n", xdist_workers])
     test_pattern = os.getenv("HIVE_TEST_PATTERN")
     if test_pattern is not None:
         # TODO: Check that the regex is a valid pytest -k "test expression"


### PR DESCRIPTION
## 🗒️ Description
Small bugfix in consume cli.

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md). **SKIP**
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
