### PR TITLE
 fix(fw): fix extending pytest args when adding hive parallelism

### DIFF
--- a/src/cli/pytest_commands.py
+++ b/src/cli/pytest_commands.py
@@ -154,7 +154,7 @@ def get_hive_flags_from_env():
     test_pattern = os.getenv("HIVE_TEST_PATTERN")
     if test_pattern is not None:
         # TODO: Check that the regex is a valid pytest -k "test expression"
-        pytest_args.extend("-k", test_pattern)
+        pytest_args.extend(["-k", test_pattern])
     random_seed = os.getenv("HIVE_RANDOM_SEED")
     if random_seed is not None:
         # TODO: implement random seed

--- a/src/cli/pytest_commands.py
+++ b/src/cli/pytest_commands.py
@@ -150,7 +150,7 @@ def get_hive_flags_from_env():
     pytest_args = []
     xdist_workers = os.getenv("HIVE_PARALLELISM")
     if xdist_workers is not None:
-        pytest_args.extend("-n", xdist_workers)
+        pytest_args.extend(["-n", xdist_workers])
     test_pattern = os.getenv("HIVE_TEST_PATTERN")
     if test_pattern is not None:
         # TODO: Check that the regex is a valid pytest -k "test expression"


### PR DESCRIPTION
## 🗒️ Description
Small bugfix in consume cli.

## 🔗 Related Issues
None.

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
