### PR TITLE
fix(fw): warnings.warn in get_hive_flags_from_env()

### DIFF
--- a/src/cli/pytest_commands.py
+++ b/src/cli/pytest_commands.py
@@ -158,11 +158,11 @@ def get_hive_flags_from_env():
     random_seed = os.getenv("HIVE_RANDOM_SEED")
     if random_seed is not None:
         # TODO: implement random seed
-        warnings.warning("HIVE_RANDOM_SEED is not yet supported.")
+        warnings.warn("HIVE_RANDOM_SEED is not yet supported.")
     log_level = os.getenv("HIVE_LOGLEVEL")
     if log_level is not None:
         # TODO add logging within simulators and implement log level via cli
-        warnings.warning("HIVE_LOG_LEVEL is not yet supported.")
+        warnings.warn("HIVE_LOG_LEVEL is not yet supported.")
     return pytest_args
 
 


### PR DESCRIPTION
## 🗒️ Description
Fix bad warnings.

## 🔗 Related Issues
None.

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
