### PR TITLE
fix(consume): correctly forward test setup error to hive server

### DIFF
--- a/src/pytest_plugins/pytest_hive/pytest_hive.py
+++ b/src/pytest_plugins/pytest_hive/pytest_hive.py
@@ -124,7 +124,12 @@ def hive_test(request, test_suite: HiveTestSuite):
             test_result_details = request.node.result_call.longreprtext
         elif hasattr(request.node, "result_setup") and not request.node.result_setup.passed:
             test_passed = False
-            test_result_details = "Test setup failed.\n" + request.node.result_call.longreprtext
+            test_result_details = "Test setup failed.\n" + request.node.result_setup.longreprtext
+        elif hasattr(request.node, "result_teardown") and not request.node.result_teardown.passed:
+            test_passed = False
+            test_result_details = (
+                "Test teardown failed.\n" + request.node.result_teardown.longreprtext
+            )
         else:
             test_passed = False
             test_result_details = "Test failed for unknown reason (setup or call status unknown)."


### PR DESCRIPTION
## 🗒️ Description
- Correctly forward an error encountered during test setup (in fixtures, for example) to the hive server (this fixes the error observed in the screenshot from hiveview below).
- Additionally forwards a failure to the hive server if an error occurs during test teardown.

![hive_test_error](https://github.com/ethereum/execution-spec-tests/assets/91727015/745c6774-a1e4-4c8a-bea5-80a363cddb63)

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md). **Skipping**
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
