### PR TITLE
fix(cli): update gentest to use pydantic models

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ The `fill` command now generates HTML test reports with links to the JSON fixtures and debug information ([#537](https://github.com/ethereum/execution-spec-tests/pull/537)).
 - ✨ Add an Ethereum RPC client class for use with consume commands ([#556](https://github.com/ethereum/execution-spec-tests/pull/556)).
 - ✨ Add a "slow" pytest marker, in order to be able to limit the filled tests until release ([#562](https://github.com/ethereum/execution-spec-tests/pull/562)).
+- ✨ Add a CLI tool that generates blockchain tests as Python from a transaction hash ([#470](https://github.com/ethereum/execution-spec-tests/pull/470), [#576](https://github.com/ethereum/execution-spec-tests/pull/576)).
 
 ### 🔧 EVM Tools
 

--- a/src/cli/gentest.py
+++ b/src/cli/gentest.py
@@ -293,6 +293,7 @@ class RequestManager:
         error_str = "An error occurred while making remote request: "
         try:
             response = requests.post(self.node_url, headers=self.headers, data=json.dumps(data))
+            response.raise_for_status()
             if response.status_code >= 200 and response.status_code < 300:
                 return response
             else:

--- a/src/cli/gentest.py
+++ b/src/cli/gentest.py
@@ -317,6 +317,10 @@ class RequestManager:
         response = self._make_request(data)
         res = response.json().get("result", None)
 
+        assert (
+            res["type"] == "0x0"
+        ), f"Transaction has type {res['type']}: Currently only type 0 transactions are supported."
+
         return RequestManager.RemoteTransaction(
             block_number=res["blockNumber"],
             tr_hash=res["hash"],

--- a/src/cli/gentest.py
+++ b/src/cli/gentest.py
@@ -115,7 +115,7 @@ class TestConstructor:
                 state_str += pad + "storage={\n"
 
                 if account_obj.storage is not None:
-                    for record, value in account_obj.storage.items():
+                    for record, value in account_obj.storage.root.items():
                         pad_record = common.ZeroPaddedHexNumber(record)
                         pad_value = common.ZeroPaddedHexNumber(value)
                         state_str += f'{pad}    "{pad_record}" : "{pad_value}",\n'
@@ -141,7 +141,7 @@ class TestConstructor:
             "gas_limit",
             "value",
         ]
-        for field, value in asdict(tr.transaction).items():
+        for field, value in iter(tr.transaction):
             if value is None:
                 continue
 

--- a/src/cli/gentest.py
+++ b/src/cli/gentest.py
@@ -1,5 +1,54 @@
 """
-Define an entry point wrapper for test generator.
+Generate a Python blockchain test from a transaction hash.
+
+This script can be used to generate Python source for a blockchain test case
+that replays a mainnet or testnet transaction from its transaction hash.
+
+Note:
+
+Requirements:
+
+1. Access to a archive node for the network where the transaction
+    originates.
+2. A config file with the remote node data in JSON format
+
+    ```json
+    {
+        "remote_nodes" : [
+            {
+                "name" : "mainnet_archive",
+                "node_url" : "https://example.arhive.node.url/v1
+                "client_id" : "",
+                "secret" : ""
+            }
+        ]
+    }
+    ```
+
+    `client_id` and `secret` may be left empty if the node does not require
+    them.
+3. The transaction hash of a type 0 transaction (currently only legacy
+    transactions are supported).
+
+Example Usage:
+
+1. Generate a test for a transaction with hash
+
+    ```console
+    gentest -c config.json \
+    0xa41f343be7a150b740e5c939fa4d89f3a2850dbe21715df96b612fc20d1906be \
+    tests/paris/test_0xa41f.py
+    ```
+
+2. Fill the test:
+
+    ```console
+    fill --fork=Paris tests/paris/test_0xa41f.py
+    ```
+
+Limitations:
+
+1. Only legacy transaction types (type 0) are currently supported.
 """
 
 import json

--- a/src/cli/gentest.py
+++ b/src/cli/gentest.py
@@ -17,7 +17,7 @@ Requirements:
         "remote_nodes" : [
             {
                 "name" : "mainnet_archive",
-                "node_url" : "https://example.arhive.node.url/v1
+                "node_url" : "https://example.archive.node.url/v1
                 "client_id" : "",
                 "secret" : ""
             }

--- a/src/cli/gentest.py
+++ b/src/cli/gentest.py
@@ -8,8 +8,8 @@ Note:
 
 Requirements:
 
-1. Access to a archive node for the network where the transaction
-    originates.
+1. Access to an archive node for the network where the transaction
+    originates. A provider may be used.
 2. A config file with the remote node data in JSON format
 
     ```json

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -52,6 +52,7 @@ chainid
 changelog
 chfast
 classdict
+cli
 cli2
 codeAddr
 codecopy


### PR DESCRIPTION
## 🗒️ Description
This PR:
- Fixes the `gentest` cli script which got broken by the pydantic refactor (original gentest pr: #470).
- Adds quick-start documentation to `gentest`'s module docstring.

## 🔗 Related Issues
These problems came to light whilst verifying #568.

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
