### PR TITLE
fix(rlp): fix indexing in block rlp filenames

### DIFF
--- a/tests_consume/test_via_rlp.py
+++ b/tests_consume/test_via_rlp.py
@@ -136,7 +136,7 @@ def client_files(
     - Keys are the target file paths in the client's docker container, and,
     - Values are in-memory buffered file objects.
     """
-    files = {f"/blocks/{i:04d}.rlp": block_rlp for i, block_rlp in enumerate(buffered_blocks_rlp)}
+    files = {f"/blocks/{i + 1:04d}.rlp": rlp for i, rlp in enumerate(buffered_blocks_rlp)}
     files["/genesis.json"] = buffered_genesis
     return files
 


### PR DESCRIPTION
## 🗒️ Description
This PR fixes the indices used in the block RLP filenames (`000n.rlp`) that get created in the client container. `n` should start from 1 (block 1), not 0 (genesis).

This was an oversight in the initial rlp implementation and brings the `*.rlp` file naming inline with the Hive consensus simulator:
![image](https://github.com/ethereum/execution-spec-tests/assets/91727015/0656b8e7-06ac-4d7e-9820-1eb27eb19c5d)

## 🔗 Related Issues
None.

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).  **SKIP**
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
