### PR TITLE
feat(rlp): add helpful assert message upon client initialization error in simulator

### DIFF
--- a/tests_consume/test_via_rlp.py
+++ b/tests_consume/test_via_rlp.py
@@ -174,7 +174,11 @@ def client(
         client_type=client_type, environment=environment, files=client_files
     )
     timing_data.start_client = time.perf_counter() - t_start
-    assert client is not None
+    error_message = (
+        f"Unable to connect to the client container ({client_type.name}) via Hive during test "
+        "setup. Check the client or Hive server logs for more information."
+    )
+    assert client is not None, error_message
     yield client
     t_start = time.perf_counter()
     client.stop()


### PR DESCRIPTION
## 🗒️ Description

This PR adds a more helpful message in the case that the simulator fails to connect to the client container. Currently, in the UI, we have the somewhat unhelpful:
![image](https://github.com/ethereum/execution-spec-tests/assets/91727015/1bfc5258-1bde-4eb7-b809-d6a8cf47d472)

## 🔗 Related Issues
This was initially hidden by the bug fixed in #569.

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md) **SKIP**.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
