### PR TITLE
feat(fw/consume): write the test class & function docstrings to `_info["description"]` for use in hive reports

### DIFF
--- a/src/ethereum_test_tools/spec/base/base_test.py
+++ b/src/ethereum_test_tools/spec/base/base_test.py
@@ -100,6 +100,7 @@ class BaseFixture(CamelModel):
     def fill_info(
         self,
         t8n: TransitionTool,
+        fixture_description: str,
         ref_spec: ReferenceSpec | None,
     ):
         """
@@ -108,6 +109,7 @@ class BaseFixture(CamelModel):
         if "comment" not in self.info:
             self.info["comment"] = "`execution-spec-tests` generated test"
         self.info["filling-transition-tool"] = t8n.version()
+        self.info["description"] = fixture_description
         if ref_spec is not None:
             ref_spec.write_info(self.info)
 

--- a/src/pytest_plugins/consume/simulator_common.py
+++ b/src/pytest_plugins/consume/simulator_common.py
@@ -36,3 +36,13 @@ def fixture(fixture_source: JsonSource, test_case: TestCase) -> Fixture:
         fixtures = BlockchainFixtures.from_file(Path(fixture_source) / test_case.json_path)
         fixture = fixtures[test_case.id]
     return fixture
+
+
+@pytest.fixture(scope="function")
+def fixture_description(fixture: Fixture) -> str:
+    """
+    Return the description of the current test case.
+    """
+    if "description" not in fixture.info:
+        return "No description field provided in the fixture's 'info' section."
+    return fixture.info["description"]

--- a/src/pytest_plugins/pytest_hive/pytest_hive.py
+++ b/src/pytest_plugins/pytest_hive/pytest_hive.py
@@ -107,11 +107,17 @@ def hive_test(request, test_suite: HiveTestSuite):
     """
     Propagate the pytest test case and its result to the hive server.
     """
+    try:
+        fixture_description = request.getfixturevalue("fixture_description")
+    except pytest.FixtureLookupError:
+        pytest.exit(
+            "Error: The 'fixture_description' fixture has not been defined by the simulator "
+            "or pytest plugin using this plugin!"
+        )
     test_parameter_string = request.node.nodeid.split("[")[-1].rstrip("]")  # test fixture name
     test: HiveTest = test_suite.start_test(
-        # TODO: pass test case documentation when available
         name=test_parameter_string,
-        description="TODO: This should come from the '_info' field.",
+        description=fixture_description,
     )
     yield test
     try:

--- a/src/pytest_plugins/test_filler/test_filler.py
+++ b/src/pytest_plugins/test_filler/test_filler.py
@@ -559,6 +559,24 @@ def node_to_test_info(node) -> TestInfo:
     )
 
 
+@pytest.fixture(scope="function")
+def fixture_description(request):
+    """Fixture to extract and combine docstrings from the test class and the test function."""
+    description_unavailable = (
+        "No description available - add a docstring to the python test class or function."
+    )
+    test_class_doc = f"Test class documentation:\n{request.cls.__doc__}" if request.cls else ""
+    test_function_doc = (
+        f"Test function documentation:\n{request.function.__doc__}"
+        if request.function.__doc__
+        else ""
+    )
+    if not test_class_doc and not test_function_doc:
+        return description_unavailable
+    combined_docstring = f"{test_class_doc}\n\n{test_function_doc}".strip()
+    return combined_docstring
+
+
 def base_test_parametrizer(cls: Type[BaseTest]):
     """
     Generates a pytest.fixture for a given BaseTest subclass.
@@ -579,6 +597,7 @@ def base_test_parametrizer(cls: Type[BaseTest]):
         eips,
         dump_dir_parameter_level,
         fixture_collector,
+        fixture_description,
     ):
         """
         Fixture used to instantiate an auto-fillable BaseTest object from within
@@ -603,7 +622,7 @@ def base_test_parametrizer(cls: Type[BaseTest]):
                     fixture_format=fixture_format,
                     eips=eips,
                 )
-                fixture.fill_info(t8n, reference_spec)
+                fixture.fill_info(t8n, fixture_description, ref_spec=reference_spec)
 
                 fixture_path = fixture_collector.add_fixture(
                     node_to_test_info(request.node),


### PR DESCRIPTION
## 🗒️ Description

This PR: 
- Adds a new field "`description`" in the `_info` section that contains the current test class and test function docstrings concatenated. 
- Uses this new field and sends it to the Hive Server when creating a new `HiveTest` in the `pytest_hive` plugin. This makes a test description available in HiveView.

Example:

```json
        "_info": {
            "hash": "0xd7409ee1b8337363780056f9703c8a11122191196155f1e1837b4bce19d1c884",
            "comment": "`execution-spec-tests` generated test",
            "filling-transition-tool": "evm version 1.14.1-unstable-d6e91e2e-20240507",
            "description": "Test class documentation:\n\n    Test contract creation via the CREATE/CREATE2 opcodes that have an initcode\n    that is on/over the max allowed limit.\n    \n\nTest function documentation:\n\n        Test contract creation via the CREATE/CREATE2 opcodes that have an\n        initcode that is on/over the max allowed limit.",
            "reference-spec": "https://github.com/ethereum/EIPs/blob/master/EIPS/eip-3860.md",
            "reference-spec-version": "5f8151e19ad1c99da4bafd514ce0e8ab89783c8f"
        }
```

### TODO

- [ ] Clean-up duplicate info contained in class and function docstrings (as in the current example above) in the scope of this PR (they're aren't many test classes).
- [ ] Test in `hiveview`

## 🔗 Related Issues
None

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
