### PR TITLE
skip(tests): Lengthy EIP-2935 test

### DIFF
--- a/tests/prague/eip2935_historical_block_hashes_from_state/test_block_hashes.py
+++ b/tests/prague/eip2935_historical_block_hashes_from_state/test_block_hashes.py
@@ -79,7 +79,7 @@ def generate_block_check_code(
         pytest.param(
             Spec.HISTORY_SERVE_WINDOW + 1,
             id="fork_at_HISTORY_SERVE_WINDOW_plus_1",
-            marks=pytest.mark.slow,
+            marks=pytest.mark.skip("To be re-evaluated when updating the tests for new spec"),
         ),
     ],
 )


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
It takes 1hr and 27 minutes to fill this EIP-2935 test, and given that the spec is changed, this test is probably out-of-date too.

So we will be skipping filling this test until https://github.com/ethereum/execution-spec-tests/issues/570 is implemented.

![image](https://github.com/ethereum/execution-spec-tests/assets/11726710/8d6cc473-10e8-4ec3-a10f-267b60d1c544)


## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
