### PR TITLE
fix(tests): Pytest warning on EIP-2537 tests

### DIFF
--- a/tests/prague/eip2537_bls_12_381_precompiles/helpers.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/helpers.py
@@ -16,7 +16,7 @@ def current_python_script_directory(*args: str) -> str:
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), *args)
 
 
-class TestVector(BaseModel):
+class Vector(BaseModel):
     """
     Test vector for the BLS12-381 precompiles.
     """
@@ -35,7 +35,7 @@ class TestVector(BaseModel):
         return pytest.param(self.input, self.expected, id=self.name)
 
 
-class FailTestVector(BaseModel):
+class FailVector(BaseModel):
     """
     Test vector for the BLS12-381 precompiles.
     """
@@ -53,15 +53,15 @@ class FailTestVector(BaseModel):
         return pytest.param(self.input, id=self.name)
 
 
-class TestVectorList(RootModel):
+class VectorList(RootModel):
     """
     List of test vectors for the BLS12-381 precompiles.
     """
 
-    root: List[TestVector | FailTestVector]
+    root: List[Vector | FailVector]
 
 
-TestVectorListAdapter = TypeAdapter(TestVectorList)
+VectorListAdapter = TypeAdapter(VectorList)
 
 
 def vectors_from_file(filename: str) -> List:
@@ -75,4 +75,4 @@ def vectors_from_file(filename: str) -> List:
         ),
         "rb",
     ) as f:
-        return [v.to_pytest_param() for v in TestVectorListAdapter.validate_json(f.read()).root]
+        return [v.to_pytest_param() for v in VectorListAdapter.validate_json(f.read()).root]


### PR DESCRIPTION
## 🗒️ Description
Fix a warning while generating tests because some of the classes for EIP-2537 tests were named `class Test*` but were not pytests.

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
