### PR TITLE
fix(tests): EOF - EIP-3540: Remove duplicated validation tests

### DIFF
--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/container.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/container.py
@@ -22,11 +22,11 @@ VALID: List[Container] = [
         name="single_code_single_data_section",
         sections=[
             Section.Code(
-                code=Op.ADDRESS + Op.POP + Op.STOP,
+                code=Op.PUSH0 + Op.POP + Op.STOP,
                 code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=1,
             ),
-            Section.Data(data="0xef"),
+            Section.Data(data="0x00"),
         ],
     ),
     Container(
@@ -169,11 +169,6 @@ INVALID: List[Container] = [
     ),
     Container(
         name="code_section_size_incomplete_4",
-        raw_bytes=bytes([0xEF, 0x00, 0x01, 0x01, 0x00, 0x04, 0x02, 0x00, 0x01]),
-        validity_error=EOFException.MISSING_HEADERS_TERMINATOR,
-    ),
-    Container(
-        name="code_section_size_incomplete_5",
         raw_bytes=bytes([0xEF, 0x00, 0x01, 0x01, 0x00, 0x04, 0x02, 0x00, 0x01, 0x00]),
         validity_error=EOFException.INCOMPLETE_SECTION_SIZE,
     ),
@@ -417,21 +412,11 @@ INVALID: List[Container] = [
         validity_error=EOFException.MISSING_TERMINATOR,
     ),
     Container(
-        name="multiple_code_and_data_sections_1",
+        name="multiple_code_and_data_sections",
         sections=[
             Section.Code(Op.STOP, code_outputs=NON_RETURNING_SECTION),
             Section.Code(Op.STOP, code_outputs=NON_RETURNING_SECTION),
             Section.Data(data="0xAA"),
-            Section.Data(data="0xAA"),
-        ],
-        validity_error=EOFException.MISSING_TERMINATOR,
-    ),
-    Container(
-        name="multiple_code_and_data_sections_2",
-        sections=[
-            Section.Code(Op.STOP, code_outputs=NON_RETURNING_SECTION),
-            Section.Data(data="0xAA"),
-            Section.Code(Op.STOP, code_outputs=NON_RETURNING_SECTION),
             Section.Data(data="0xAA"),
         ],
         validity_error=EOFException.MISSING_TERMINATOR,
@@ -646,15 +631,6 @@ INVALID += [
     ),
     Container(
         name="single_code_section_incomplete_type",
-        sections=[
-            Section(kind=Kind.TYPE, data="0x00"),
-            Section.Code(Op.STOP, code_outputs=NON_RETURNING_SECTION),
-        ],
-        auto_type_section=AutoSection.NONE,
-        validity_error=EOFException.INVALID_TYPE_SECTION_SIZE,
-    ),
-    Container(
-        name="single_code_section_incomplete_type_2",
         sections=[
             Section(kind=Kind.TYPE, data="0x00", custom_size=2),
             Section.Code(Op.STOP, code_outputs=NON_RETURNING_SECTION),


### PR DESCRIPTION
## 🗒️ Description

I added an instrumentation to `eof_test()` to collect all EOF bytecodes and report duplicates.
These are some duplicated test cases removed.

I don't think we have to clean it all right now, but this is handy tool for migrating tests from other places.

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
