### PR TITLE
fix(tests): EIP-7620,EIP-3540: Failing EOF tests

### DIFF
--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/container.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/container.py
@@ -401,7 +401,10 @@ INVALID: List[Container] = [
         name="trailing_bytes_after_data_section",
         extra=bytes([0xEE]),
         sections=[
-            Section.Code(code=Op.PUSH1(0) + Op.STOP),
+            Section.Code(
+                code=Op.PUSH1(0) + Op.STOP,
+                code_outputs=NON_RETURNING_SECTION,
+            ),
             Section.Data(data="0xAABBCCDD"),
         ],
         # TODO should be more specific exception about trailing bytes

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_example_valid_invalid.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_example_valid_invalid.py
@@ -423,7 +423,7 @@ def test_example_valid_invalid(
             False,  # but it's code input bytes still listed in container's body
             False,  # but it's code input bytes size still added to types section size
             "ef000101000802000100030400040000800001000000003050003050000bad60A7",
-            EOFException.INVALID_SECTION_BODIES_SIZE,
+            EOFException.INVALID_TYPE_SECTION_SIZE,
         ),
         (
             False,  # second section is mentioned in code header array (0003)

--- a/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_eofcreate_failures.py
+++ b/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_eofcreate_failures.py
@@ -168,7 +168,11 @@ factory_size = 30
         pytest.param(MAX_BYTECODE_SIZE + 1, id="overmax"),
         pytest.param(MAX_INITCODE_SIZE - factory_size, id="initcodemax"),
         pytest.param(MAX_INITCODE_SIZE - factory_size + 1, id="initcodeovermax"),
-        pytest.param(0xFFFF - factory_size, id="64k-1"),
+        pytest.param(
+            0xFFFF - factory_size,
+            id="64k-1",
+            marks=pytest.mark.skip("Oversized container in pre-alloc"),
+        ),
     ],
 )
 def test_eofcreate_deploy_sizes(

--- a/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_eofcreate_failures.py
+++ b/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_eofcreate_failures.py
@@ -167,7 +167,11 @@ factory_size = 30
         pytest.param(MAX_BYTECODE_SIZE, id="max"),
         pytest.param(MAX_BYTECODE_SIZE + 1, id="overmax"),
         pytest.param(MAX_INITCODE_SIZE - factory_size, id="initcodemax"),
-        pytest.param(MAX_INITCODE_SIZE - factory_size + 1, id="initcodeovermax"),
+        pytest.param(
+            MAX_INITCODE_SIZE - factory_size + 1,
+            id="initcodeovermax",
+            marks=pytest.mark.skip("Oversized container in pre-alloc"),
+        ),
         pytest.param(
             0xFFFF - factory_size,
             id="64k-1",
@@ -251,6 +255,29 @@ def test_eofcreate_deploy_sizes(
     }
 
     state_test(env=env, pre=pre, post=post, tx=simple_transaction())
+
+
+@pytest.mark.parametrize(
+    "target_deploy_size",
+    [
+        pytest.param(0x4000, id="large"),
+        pytest.param(MAX_BYTECODE_SIZE, id="max"),
+        pytest.param(MAX_BYTECODE_SIZE + 1, id="overmax"),
+        pytest.param(MAX_INITCODE_SIZE - factory_size, id="initcodemax"),
+        pytest.param(MAX_INITCODE_SIZE - factory_size + 1, id="initcodeovermax"),
+        pytest.param(0xFFFF - factory_size, id="64k-1"),
+    ],
+)
+@pytest.mark.skip("Not implemented")
+def test_eofcreate_deploy_sizes_tx(
+    state_test: StateTestFiller,
+    target_deploy_size: int,
+):
+    """
+    Verifies a mix of runtime contract sizes mixing success and multiple size failure modes
+    where the initcontainer is included in a transaction
+    """
+    raise NotImplementedError("Not implemented")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## 🗒️ Description
Makes the following fixes:
- `test_code_section_header_body_mismatch`: Change expected exception from `EOFException.INVALID_SECTION_BODIES_SIZE` -> `EOFException.INVALID_TYPE_SECTION_SIZE`
- `test_legacy_initcode_invalid_eof_v1_contract::trailing_bytes_after_data_section`: Correct output (`NON_RETURNING_SECTION`) in code section
- `test_eofcreate_deploy_sizes::64k-1` skip test due to oversized container in the pre-alloc.

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
