### PR TITLE
feat(consume): enable loading of `ethereum/tests/BlockchainTests`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,6 +37,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Add more Transaction and Block exceptions from existing ethereum/tests repo ([#572](https://github.com/ethereum/execution-spec-tests/pull/572)).
 - ✨ Add "description" and "url" fields containing test case documentation and a source code permalink to fixtures during `fill` and use them in `consume`-generated Hive test reports ([#579](https://github.com/ethereum/execution-spec-tests/pull/579)).
 - ✨ Add git workflow evmone coverage script for any new lines mentioned in converted_ethereum_tests.txt ([#503](https://github.com/ethereum/execution-spec-tests/pull/503)).
+- ✨ Enable loading of [ethereum/tests/BlockchainTests](https://github.com/ethereum/tests/tree/develop/BlockchainTests) ([#596](https://github.com/ethereum/execution-spec-tests/pull/596)).
 
 ### 🔧 EVM Tools
 

--- a/src/cli/gen_index.py
+++ b/src/cli/gen_index.py
@@ -25,6 +25,17 @@ from evm_transition_tool import FixtureFormats
 
 from .hasher import HashableItem
 
+fixtures_to_skip = set(
+    [
+        # These fixtures have invalid fields that we can't load into our pydantic models (bigint).
+        "BlockchainTests/GeneralStateTests/stTransactionTest/ValueOverflowParis.json",
+        "BlockchainTests/InvalidBlocks/bc4895-withdrawals/withdrawalsAmountBounds.json",
+        "BlockchainTests/InvalidBlocks/bc4895-withdrawals/withdrawalsIndexBounds.json",
+        "BlockchainTests/InvalidBlocks/bc4895-withdrawals/withdrawalsValidatorIndexBounds.json",
+        "BlockchainTests/InvalidBlocks/bc4895-withdrawals/withdrawalsAddressBounds.json",
+    ]
+)
+
 
 def count_json_files_exclude_index(start_path: Path) -> int:
     """
@@ -166,6 +177,9 @@ def generate_fixtures_index(
             if file.name == "index.json":
                 continue
             if "blockchain_tests_hive" in file.parts:
+                continue
+            if any(fixture in str(file) for fixture in fixtures_to_skip):
+                rich.print(f"Skipping '{file}'")
                 continue
 
             try:

--- a/src/cli/gen_index.py
+++ b/src/cli/gen_index.py
@@ -25,6 +25,7 @@ from evm_transition_tool import FixtureFormats
 
 from .hasher import HashableItem
 
+# TODO: remove when these tests are ported or fixed within ethereum/tests.
 fixtures_to_skip = set(
     [
         # These fixtures have invalid fields that we can't load into our pydantic models (bigint).

--- a/src/cli/gen_index.py
+++ b/src/cli/gen_index.py
@@ -58,6 +58,8 @@ def infer_fixture_format_from_path(file: Path) -> FixtureFormats:
         return FixtureFormats.BLOCKCHAIN_TEST_HIVE
     if "blockchain_tests" in file.parts:
         return FixtureFormats.BLOCKCHAIN_TEST
+    if "BlockchainTests" in file.parts:  # ethereum/tests
+        return FixtureFormats.BLOCKCHAIN_TEST
     if "state_tests" in file.parts:
         return FixtureFormats.STATE_TEST
     return FixtureFormats.UNSET_TEST_FORMAT

--- a/src/cli/hasher.py
+++ b/src/cli/hasher.py
@@ -79,13 +79,16 @@ class HashableItem:
                 raise TypeError(f"Expected dict, got {type(item)} for {key}")
             if "_info" not in item:
                 raise KeyError(f"Expected '_info' in {key}")
-            if "hash" not in item["_info"]:
-                raise KeyError(f"Expected 'hash' in {key}")
-            if not isinstance(item["_info"]["hash"], str):
-                raise TypeError(
-                    f"Expected hash to be a string in {key}, got {type(item['_info']['hash'])}"
-                )
-            item_hash_bytes = bytes.fromhex(item["_info"]["hash"][2:])
+
+            # EEST uses 'hash'; ethereum/tests use 'generatedTestHash'
+            hash_value = item["_info"].get("hash") or item["_info"].get("generatedTestHash")
+            if hash_value is None:
+                raise KeyError(f"Expected 'hash' or 'generatedTestHash' in {key}")
+
+            if not isinstance(hash_value, str):
+                raise TypeError(f"Expected hash to be a string in {key}, got {type(hash_value)}")
+
+            item_hash_bytes = bytes.fromhex(hash_value[2:])
             items[key] = cls(
                 type=HashableItemType.TEST,
                 root=item_hash_bytes,

--- a/src/ethereum_test_tools/spec/blockchain/types.py
+++ b/src/ethereum_test_tools/spec/blockchain/types.py
@@ -3,7 +3,17 @@ BlockchainTest types
 """
 
 from functools import cached_property
-from typing import Annotated, Any, ClassVar, Dict, List, Literal, get_args, get_type_hints
+from typing import (
+    Annotated,
+    Any,
+    ClassVar,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    get_args,
+    get_type_hints,
+)
 
 from ethereum import rlp as eth_rlp
 from ethereum.base_types import Uint
@@ -636,7 +646,7 @@ class FixtureCommon(BaseFixture):
     fork: str = Field(..., alias="network")
     genesis: FixtureHeader = Field(..., alias="genesisBlockHeader")
     pre: Alloc
-    post_state: Alloc
+    post_state: Optional[Alloc] = Field(None)
 
     def get_fork(self) -> str:
         """

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -18,6 +18,7 @@ basename
 bb
 besu
 bidict
+bigint
 big0
 big1
 blobgasfee


### PR DESCRIPTION
## 🗒️ Description

Enables loading `ethereum/tests/BlockchainTests` (except for 5 json files that define invalid fields via "bigint").

1. Makes `post_state` an optional field in blockchain fixtures.
2. Adds a list of fixtures to skip in `genindex` (the fixtures here all currently use `bigint` to define invalid fields in json).
3. Updates `hasher` to use `_info["generatedTestHash"]` as a synonym for `_info["hash"]` (this allows `genindex` to check whether the `index.json` is up-to-date for `ethereum/tests`; otherwise it must be regenerated every time).

This requires: https://github.com/ethereum/tests/pull/1380.

Test loading of fixtures into EEST pydantic models with:
```console
genindex -i ~/path/to/ethereum/tests/BlockchainTests/
```
Expected output:
```
Skipping '/home/dtopz/code/github/ethereum/tests/BlockchainTests/GeneralStateTests/stTransactionTest/ValueOverflowParis.json'
Skipping '/home/dtopz/code/github/ethereum/tests/BlockchainTests/InvalidBlocks/bc4895-withdrawals/withdrawalsAmountBounds.json'
Skipping '/home/dtopz/code/github/ethereum/tests/BlockchainTests/InvalidBlocks/bc4895-withdrawals/withdrawalsIndexBounds.json'
Skipping '/home/dtopz/code/github/ethereum/tests/BlockchainTests/InvalidBlocks/bc4895-withdrawals/withdrawalsValidatorIndexBounds.json'
Skipping '/home/dtopz/code/github/ethereum/tests/BlockchainTests/InvalidBlocks/bc4895-withdrawals/withdrawalsAddressBounds.json'
Indexing complete 🦄       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:48
```

The resulting `index.json` file contains 22953 tests.

## 🔗 Related Issues
#572 

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
