### PR TITLE
new(tests): EOF - EIP-3540: Migrate validation tests: EIP3540/validInvalidFiller.yml

### DIFF
--- a/converted-ethereum-tests.txt
+++ b/converted-ethereum-tests.txt
@@ -2,6 +2,9 @@
 GeneralStateTests/stCreate2/call_outsize_then_create2_successful_then_returndatasize.json
 GeneralStateTests/stCreate2/call_then_create2_successful_then_returndatasize.json
 
+([#598](https://github.com/ethereum/execution-spec-tests/pull/598))
+EOFTests/EIP3540/validInvalid.json
+
 EOFTests/efValidation/EOF1_eofcreate_valid_.json
 EOFTests/efValidation/EOF1_truncated_section_.json
 

--- a/src/ethereum_test_types/eof/v1/__init__.py
+++ b/src/ethereum_test_types/eof/v1/__init__.py
@@ -485,6 +485,15 @@ class Container(CopyValidateModel):
         """
         return len(self.bytecode)
 
+    def __str__(self) -> str:
+        """
+        Returns the name of the container if available, otherwise the bytecode of the container
+        as a string.
+        """
+        if self.name:
+            return self.name
+        return str(self.bytecode)
+
 
 @dataclass(kw_only=True)
 class Initcode(Bytecode):

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_migrated_valid_invalid.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_migrated_valid_invalid.py
@@ -293,6 +293,64 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
             EOFException.MISSING_TERMINATOR,
             id="EOF1I3540_0049",
         ),
+        # TODO: Duplicated tests
+        # The following test cases are duplicates but added to confirm test coverage is retained.
+        pytest.param(
+            Container(
+                name="EOF1I3540_0001 (Invalid) No magic",
+                raw_bytes="ef",
+            ),
+            EOFException.INVALID_MAGIC,
+        ),
+        pytest.param(
+            Container(
+                name="EOF1I3540_0002 (Invalid) Invalid magic",
+                raw_bytes="ef010101000402000100010400000000000000fe",
+            ),
+            EOFException.INVALID_MAGIC,
+        ),
+        pytest.param(
+            Container(
+                name="EOF1I3540_0003",
+                raw_bytes="ef020101000402000100010400000000000000fe",
+            ),
+            EOFException.INVALID_MAGIC,
+        ),
+        pytest.param(
+            Container(
+                name="EOF1I3540_0004",
+                raw_bytes="efff0101000402000100010400000000000000fe",
+            ),
+            EOFException.INVALID_MAGIC,
+        ),
+        pytest.param(
+            Container(
+                name="EOF1I3540_0005 (Invalid) No version",
+                raw_bytes="ef00",
+            ),
+            EOFException.INVALID_VERSION,
+        ),
+        pytest.param(
+            Container(
+                name="EOF1I3540_0006 (Invalid) Invalid version",
+                raw_bytes="ef000001000402000100010400000000000000fe",
+            ),
+            EOFException.INVALID_VERSION,
+        ),
+        pytest.param(
+            Container(
+                name="EOF1I3540_0007",
+                raw_bytes="ef000201000402000100010400000000000000fe",
+            ),
+            EOFException.INVALID_VERSION,
+        ),
+        pytest.param(
+            Container(
+                name="EOF1I3540_0008",
+                raw_bytes="ef00ff01000402000100010400000000000000fe",
+            ),
+            EOFException.INVALID_VERSION,
+        ),
     ],
 )
 def test_migrated_valid_invalid(

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_migrated_valid_invalid.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_migrated_valid_invalid.py
@@ -75,7 +75,10 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
         ),
         pytest.param(
             # Empty code section with non-empty data section
-            bytes.fromhex("ef000101000402000100000400020000000000aabb"),
+            Container(
+                sections=[Section.Code(code_outputs=0), Section.Data("aabb")],
+                expected_bytecode="ef000101000402000100000400020000000000aabb",
+            ),
             EOFException.ZERO_SECTION_SIZE,
             id="EOF1I3540_0012",
         ),

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_migrated_valid_invalid.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_migrated_valid_invalid.py
@@ -1,0 +1,287 @@
+"""
+EOF validation tests for EIP-3540 migrated from
+ethereum/tests/src/EOFTestsFiller/EIP3540/validInvalidFiller.yml
+"""
+
+import pytest
+
+from ethereum_test_tools import EOFTestFiller
+from ethereum_test_tools import Opcodes as Op
+from ethereum_test_tools.eof.v1 import Container, EOFException, Section
+
+from .. import EOF_FORK_NAME
+
+REFERENCE_SPEC_GIT_PATH = "EIPS/eip-3540.md"
+REFERENCE_SPEC_VERSION = "8dcb0a8c1c0102c87224308028632cc986a61183"
+
+pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
+
+
+@pytest.mark.parametrize(
+    "eof_code,exception",
+    [
+        pytest.param(
+            # Deployed code without data section
+            Container(
+                name="EOF1V3540_0001",
+                sections=[
+                    Section.Code(code=Op.PUSH1[0] + Op.POP + Op.STOP, max_stack_height=1),
+                ],
+            ),
+            None,
+            id="EOF1V3540_0001",
+        ),
+        pytest.param(
+            # Deployed code with data section
+            Container(
+                name="EOF1V3540_0002",
+                sections=[
+                    Section.Code(code=Op.PUSH1[0] + Op.POP + Op.STOP, max_stack_height=1),
+                    Section.Data("aabbccdd"),
+                ],
+            ),
+            None,
+            id="EOF1V3540_0002",
+        ),
+        pytest.param(
+            # No data section contents (valid according to relaxed validation)
+            Container(
+                name="EOF1V3540_0003",
+                sections=[
+                    Section.Code(code=Op.INVALID),
+                    Section.Data(custom_size=2),
+                ],
+            ),
+            None,
+            id="EOF1V3540_0003",
+        ),
+        pytest.param(
+            # Data section contents incomplete (valid according to relaxed validation)
+            Container(
+                name="EOF1V3540_0004",
+                sections=[
+                    Section.Code(code=Op.INVALID),
+                    Section.Data("aa", custom_size=2),
+                ],
+            ),
+            None,
+            id="EOF1V3540_0004",
+        ),
+        pytest.param(
+            # Type section size incomplete
+            bytes.fromhex("ef00010100"),
+            EOFException.INCOMPLETE_SECTION_SIZE,
+            id="EOF1I3540_0011",
+        ),
+        pytest.param(
+            # Empty code section with non-empty data section
+            bytes.fromhex("ef000101000402000100000400020000000000aabb"),
+            EOFException.ZERO_SECTION_SIZE,
+            id="EOF1I3540_0012",
+        ),
+        pytest.param(
+            # No data section after code section size
+            bytes.fromhex("ef00010100040200010001"),
+            EOFException.MISSING_HEADERS_TERMINATOR,
+            id="EOF1I3540_0017",
+        ),
+        pytest.param(
+            # No data size
+            bytes.fromhex("ef0001010004020001000104"),
+            EOFException.MISSING_HEADERS_TERMINATOR,
+            id="EOF1I3540_0018",
+        ),
+        pytest.param(
+            # Data size incomplete
+            bytes.fromhex("ef000101000402000100010400"),
+            EOFException.INCOMPLETE_SECTION_SIZE,
+            id="EOF1I3540_0019",
+        ),
+        pytest.param(
+            # No section terminator after data section size
+            bytes.fromhex("ef00010100040200010001040002"),
+            EOFException.MISSING_HEADERS_TERMINATOR,
+            id="EOF1I3540_0020",
+        ),
+        pytest.param(
+            # No type section contents
+            bytes.fromhex("ef0001010004020001000104000200"),
+            EOFException.INVALID_SECTION_BODIES_SIZE,
+            id="EOF1I3540_0021",
+        ),
+        pytest.param(
+            # Type section contents (no outputs and max stack)
+            bytes.fromhex("ef000101000402000100010400020000"),
+            EOFException.INVALID_SECTION_BODIES_SIZE,
+            id="EOF1I3540_0022",
+        ),
+        pytest.param(
+            # Type section contents (no max stack)
+            bytes.fromhex("ef00010100040200010001040002000000"),
+            EOFException.INVALID_SECTION_BODIES_SIZE,
+            id="EOF1I3540_0023",
+        ),
+        pytest.param(
+            # Type section contents (max stack incomplete)
+            bytes.fromhex("ef0001010004020001000104000200000000"),
+            EOFException.INVALID_SECTION_BODIES_SIZE,
+            id="EOF1I3540_0024",
+        ),
+        pytest.param(
+            # No code section contents
+            bytes.fromhex("ef000101000402000100010400020000000000"),
+            EOFException.INVALID_SECTION_BODIES_SIZE,
+            id="EOF1I3540_0025",
+        ),
+        pytest.param(
+            # Code section contents incomplete
+            bytes.fromhex("ef0001010004020001002904000000000000027f"),
+            EOFException.INVALID_SECTION_BODIES_SIZE,
+            id="EOF1I3540_0026",
+        ),
+        pytest.param(
+            # Trailing bytes after code section
+            bytes.fromhex("ef000101000402000100010400000000000000feaabbcc"),
+            EOFException.INVALID_SECTION_BODIES_SIZE,
+            id="EOF1I3540_0027",
+        ),
+        pytest.param(
+            # Empty code section
+            bytes.fromhex("ef000101000402000100000400000000000000"),
+            EOFException.ZERO_SECTION_SIZE,
+            id="EOF1I3540_0028",
+        ),
+        pytest.param(
+            # Code section preceding type section
+            bytes.fromhex("ef000102000100010100040400020000000000feaabb"),
+            EOFException.MISSING_TYPE_HEADER,
+            id="EOF1I3540_0030",
+        ),
+        pytest.param(
+            # Data section preceding type section
+            bytes.fromhex("ef000104000201000402000100010000000000feaabb"),
+            EOFException.MISSING_TYPE_HEADER,
+            id="EOF1I3540_0031",
+        ),
+        pytest.param(
+            # Data section preceding code section
+            bytes.fromhex("ef000101000404000202000100010000000000feaabb"),
+            EOFException.MISSING_CODE_HEADER,
+            id="EOF1I3540_0032",
+        ),
+        pytest.param(
+            # Data section without code section
+            bytes.fromhex("ef00010100040400020000000000aabb"),
+            EOFException.MISSING_CODE_HEADER,
+            id="EOF1I3540_0033",
+        ),
+        pytest.param(
+            # No data section
+            bytes.fromhex("ef000101000402000100010000000000fe"),
+            EOFException.MISSING_DATA_SECTION,
+            id="EOF1I3540_0034",
+        ),
+        pytest.param(
+            # Trailing bytes after data section
+            bytes.fromhex("ef000101000402000100010400020000000000feaabbccdd"),
+            EOFException.INVALID_SECTION_BODIES_SIZE,
+            id="EOF1I3540_0035",
+        ),
+        pytest.param(
+            # Multiple data sections
+            bytes.fromhex("ef000101000402000100010400020400020000000000feaabbaabb"),
+            EOFException.MISSING_TERMINATOR,
+            id="EOF1I3540_0036",
+        ),
+        pytest.param(
+            # Multiple code and data sections
+            bytes.fromhex("ef000101000802000200010001040002040002000000000000000000fefeaabbaabb"),
+            EOFException.MISSING_TERMINATOR,
+            id="EOF1I3540_0037",
+        ),
+        pytest.param(
+            # Unknown section ID (at the beginning)
+            bytes.fromhex("ef000105000101000402000100010400000000000000fe"),
+            EOFException.MISSING_TYPE_HEADER,
+            id="EOF1I3540_0038",
+        ),
+        pytest.param(
+            # Unknown section ID (at the beginning)
+            bytes.fromhex("ef000106000101000402000100010400000000000000fe"),
+            EOFException.MISSING_TYPE_HEADER,
+            id="EOF1I3540_0039",
+        ),
+        pytest.param(
+            # Unknown section ID (at the beginning)
+            bytes.fromhex("ef0001ff000101000402000100010400000000000000fe"),
+            EOFException.MISSING_TYPE_HEADER,
+            id="EOF1I3540_0040",
+        ),
+        pytest.param(
+            # Unknown section ID (after types section)
+            bytes.fromhex("ef000101000405000102000100010400000000000000fe"),
+            EOFException.MISSING_CODE_HEADER,
+            id="EOF1I3540_0041",
+        ),
+        pytest.param(
+            # Unknown section ID (after types section)
+            bytes.fromhex("ef000101000406000102000100010400000000000000fe"),
+            EOFException.MISSING_CODE_HEADER,
+            id="EOF1I3540_0042",
+        ),
+        pytest.param(
+            # Unknown section ID (after types section)
+            bytes.fromhex("ef0001010004ff000102000100010400000000000000fe"),
+            EOFException.MISSING_CODE_HEADER,
+            id="EOF1I3540_0043",
+        ),
+        pytest.param(
+            # Unknown section ID (after code section)
+            bytes.fromhex("ef000101000402000100010500010400000000000000fe"),
+            EOFException.MISSING_DATA_SECTION,
+            id="EOF1I3540_0044",
+        ),
+        pytest.param(
+            # Unknown section ID (after code section)
+            bytes.fromhex("ef000101000402000100010600010400000000000000fe"),
+            EOFException.MISSING_DATA_SECTION,
+            id="EOF1I3540_0045",
+        ),
+        pytest.param(
+            # Unknown section ID (after code section)
+            bytes.fromhex("ef00010100040200010001ff00010400000000000000fe"),
+            EOFException.MISSING_DATA_SECTION,
+            id="EOF1I3540_0046",
+        ),
+        pytest.param(
+            # Unknown section ID (after data section)
+            bytes.fromhex("ef000101000402000100010400000500010000000000fe"),
+            EOFException.MISSING_TERMINATOR,
+            id="EOF1I3540_0047",
+        ),
+        pytest.param(
+            # Unknown section ID (after data section)
+            bytes.fromhex("ef000101000402000100010400000600010000000000fe"),
+            EOFException.MISSING_TERMINATOR,
+            id="EOF1I3540_0048",
+        ),
+        pytest.param(
+            # Unknown section ID (after data section)
+            bytes.fromhex("ef00010100040200010001040000ff00010000000000fe"),
+            EOFException.MISSING_TERMINATOR,
+            id="EOF1I3540_0049",
+        ),
+    ],
+)
+def test_migrated_valid_invalid(
+    eof_test: EOFTestFiller,
+    eof_code: Container | bytes,
+    exception: EOFException | None,
+):
+    """
+    Verify EOF container construction and exception
+    """
+    eof_test(
+        data=eof_code,
+        expect_exception=exception,
+    )

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_migrated_valid_invalid.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_migrated_valid_invalid.py
@@ -83,6 +83,20 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
             id="EOF1I3540_0012",
         ),
         pytest.param(
+            Container(
+                name="EOF1I3540_0014 (Invalid) Total of code sections incomplete",
+                raw_bytes="ef00010100040200",
+            ),
+            EOFException.INCOMPLETE_SECTION_NUMBER,
+        ),
+        pytest.param(
+            Container(
+                name="EOF1I3540_0016 (Invalid) Code section size incomplete",
+                raw_bytes="0xef000101000402000100",
+            ),
+            EOFException.INCOMPLETE_SECTION_SIZE,
+        ),
+        pytest.param(
             # No data section after code section size
             bytes.fromhex("ef00010100040200010001"),
             EOFException.MISSING_HEADERS_TERMINATOR,

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_migrated_valid_invalid.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_migrated_valid_invalid.py
@@ -146,6 +146,12 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
             id="EOF1I3540_0027",
         ),
         pytest.param(
+            # Trailing bytes after code section with wrong first section type
+            bytes.fromhex("ef0001 010004 0200010001 040000 00 00000000 fe aabbcc"),
+            EOFException.INVALID_FIRST_SECTION_TYPE,
+            id="EOF1I3540_0027_orig",
+        ),
+        pytest.param(
             # Empty code section
             bytes.fromhex("ef000101000402000100000400000000000000"),
             EOFException.ZERO_SECTION_SIZE,
@@ -186,6 +192,12 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
             bytes.fromhex("ef0001 010004 0200010001 040002 00 00800000 fe aabbccdd"),
             EOFException.INVALID_SECTION_BODIES_SIZE,
             id="EOF1I3540_0035",
+        ),
+        pytest.param(
+            # Trailing bytes after data section with wrong first section type
+            bytes.fromhex("ef0001 010004 0200010001 040002 00 00000000 fe aabbccdd"),
+            EOFException.INVALID_FIRST_SECTION_TYPE,
+            id="EOF1I3540_0035_orig",
         ),
         pytest.param(
             # Multiple data sections

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_migrated_valid_invalid.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_migrated_valid_invalid.py
@@ -189,7 +189,14 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
         ),
         pytest.param(
             # Trailing bytes after data section
-            bytes.fromhex("ef0001 010004 0200010001 040002 00 00800000 fe aabbccdd"),
+            Container(
+                sections=[
+                    Section.Code(Op.INVALID),
+                    Section.Data("aabb"),
+                ],
+                extra="ccdd",
+                expected_bytecode="ef0001 010004 0200010001 040002 00 00800000 fe aabbccdd",
+            ),
             EOFException.INVALID_SECTION_BODIES_SIZE,
             id="EOF1I3540_0035",
         ),

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_migrated_valid_invalid.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_migrated_valid_invalid.py
@@ -5,9 +5,9 @@ ethereum/tests/src/EOFTestsFiller/EIP3540/validInvalidFiller.yml
 
 import pytest
 
-from ethereum_test_tools import EOFTestFiller
+from ethereum_test_tools import EOFException, EOFTestFiller
 from ethereum_test_tools import Opcodes as Op
-from ethereum_test_tools.eof.v1 import Container, EOFException, Section
+from ethereum_test_tools.eof.v1 import Container, Section
 
 from .. import EOF_FORK_NAME
 
@@ -25,7 +25,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
             Container(
                 name="EOF1V3540_0001",
                 sections=[
-                    Section.Code(code=Op.PUSH1[0] + Op.POP + Op.STOP, max_stack_height=1),
+                    Section.Code(code=Op.PUSH1[0] + Op.POP + Op.STOP),
                 ],
             ),
             None,
@@ -36,7 +36,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
             Container(
                 name="EOF1V3540_0002",
                 sections=[
-                    Section.Code(code=Op.PUSH1[0] + Op.POP + Op.STOP, max_stack_height=1),
+                    Section.Code(code=Op.PUSH1[0] + Op.POP + Op.STOP),
                     Section.Data("aabbccdd"),
                 ],
             ),
@@ -44,7 +44,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
             id="EOF1V3540_0002",
         ),
         pytest.param(
-            # No data section contents (valid according to relaxed validation)
+            # No data section contents
             Container(
                 name="EOF1V3540_0003",
                 sections=[
@@ -52,11 +52,11 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                     Section.Data(custom_size=2),
                 ],
             ),
-            None,
+            EOFException.TOPLEVEL_CONTAINER_TRUNCATED,
             id="EOF1V3540_0003",
         ),
         pytest.param(
-            # Data section contents incomplete (valid according to relaxed validation)
+            # Data section contents incomplete
             Container(
                 name="EOF1V3540_0004",
                 sections=[
@@ -64,7 +64,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                     Section.Data("aa", custom_size=2),
                 ],
             ),
-            None,
+            EOFException.TOPLEVEL_CONTAINER_TRUNCATED,
             id="EOF1V3540_0004",
         ),
         pytest.param(
@@ -141,7 +141,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
         ),
         pytest.param(
             # Trailing bytes after code section
-            bytes.fromhex("ef000101000402000100010400000000000000feaabbcc"),
+            bytes.fromhex("ef0001 010004 0200010001 040000 00 00800000 fe aabbcc"),
             EOFException.INVALID_SECTION_BODIES_SIZE,
             id="EOF1I3540_0027",
         ),
@@ -183,7 +183,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
         ),
         pytest.param(
             # Trailing bytes after data section
-            bytes.fromhex("ef000101000402000100010400020000000000feaabbccdd"),
+            bytes.fromhex("ef0001 010004 0200010001 040002 00 00800000 fe aabbccdd"),
             EOFException.INVALID_SECTION_BODIES_SIZE,
             id="EOF1I3540_0035",
         ),

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_migrated_valid_invalid.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_migrated_valid_invalid.py
@@ -29,7 +29,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                 ],
             ),
             None,
-            id="EOF1V3540_0001",
+            id="EOF1V3540_0001_deployed_code_without_data_section",
         ),
         pytest.param(
             # Deployed code with data section
@@ -41,7 +41,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                 ],
             ),
             None,
-            id="EOF1V3540_0002",
+            id="EOF1V3540_0002_deployed_code_with_data_section",
         ),
         pytest.param(
             # No data section contents
@@ -53,7 +53,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                 ],
             ),
             EOFException.TOPLEVEL_CONTAINER_TRUNCATED,
-            id="EOF1V3540_0003",
+            id="EOF1V3540_0003_no_data_section_contents",
         ),
         pytest.param(
             # Data section contents incomplete
@@ -65,13 +65,13 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                 ],
             ),
             EOFException.TOPLEVEL_CONTAINER_TRUNCATED,
-            id="EOF1V3540_0004",
+            id="EOF1V3540_0004_data_section_contents_incomplete",
         ),
         pytest.param(
             # Type section size incomplete
             bytes.fromhex("ef00010100"),
             EOFException.INCOMPLETE_SECTION_SIZE,
-            id="EOF1I3540_0011",
+            id="EOF1I3540_0011_type_section_size_incomplete",
         ),
         pytest.param(
             # Empty code section with non-empty data section
@@ -80,7 +80,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                 expected_bytecode="ef000101000402000100000400020000000000aabb",
             ),
             EOFException.ZERO_SECTION_SIZE,
-            id="EOF1I3540_0012",
+            id="EOF1I3540_0012_empty_code_section_with_non_empty_data_section",
         ),
         pytest.param(
             Container(
@@ -88,6 +88,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                 raw_bytes="ef00010100040200",
             ),
             EOFException.INCOMPLETE_SECTION_NUMBER,
+            id="EOF1I3540_0014_total_of_code_sections_incomplete",
         ),
         pytest.param(
             Container(
@@ -95,114 +96,115 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                 raw_bytes="0xef000101000402000100",
             ),
             EOFException.INCOMPLETE_SECTION_SIZE,
+            id="EOF1I3540_0016_code_section_size_incomplete",
         ),
         pytest.param(
             # No data section after code section size
             bytes.fromhex("ef00010100040200010001"),
             EOFException.MISSING_HEADERS_TERMINATOR,
-            id="EOF1I3540_0017",
+            id="EOF1I3540_0017_no_data_section_after_code_section_size",
         ),
         pytest.param(
             # No data size
             bytes.fromhex("ef0001010004020001000104"),
             EOFException.MISSING_HEADERS_TERMINATOR,
-            id="EOF1I3540_0018",
+            id="EOF1I3540_0018_no_data_size",
         ),
         pytest.param(
             # Data size incomplete
             bytes.fromhex("ef000101000402000100010400"),
             EOFException.INCOMPLETE_SECTION_SIZE,
-            id="EOF1I3540_0019",
+            id="EOF1I3540_0019_data_size_incomplete",
         ),
         pytest.param(
             # No section terminator after data section size
             bytes.fromhex("ef00010100040200010001040002"),
             EOFException.MISSING_HEADERS_TERMINATOR,
-            id="EOF1I3540_0020",
+            id="EOF1I3540_0020_no_section_terminator_after_data_section_size",
         ),
         pytest.param(
             # No type section contents
             bytes.fromhex("ef0001010004020001000104000200"),
             EOFException.INVALID_SECTION_BODIES_SIZE,
-            id="EOF1I3540_0021",
+            id="EOF1I3540_0021_no_type_section_contents",
         ),
         pytest.param(
             # Type section contents (no outputs and max stack)
             bytes.fromhex("ef000101000402000100010400020000"),
             EOFException.INVALID_SECTION_BODIES_SIZE,
-            id="EOF1I3540_0022",
+            id="EOF1I3540_0022_invalid_type_section_no_outputs_and_max_stack",
         ),
         pytest.param(
             # Type section contents (no max stack)
             bytes.fromhex("ef00010100040200010001040002000000"),
             EOFException.INVALID_SECTION_BODIES_SIZE,
-            id="EOF1I3540_0023",
+            id="EOF1I3540_0023_invalid_type_section_no_max_stack",
         ),
         pytest.param(
             # Type section contents (max stack incomplete)
             bytes.fromhex("ef0001010004020001000104000200000000"),
             EOFException.INVALID_SECTION_BODIES_SIZE,
-            id="EOF1I3540_0024",
+            id="EOF1I3540_0024_invalid_type_section_max_stack_incomplete",
         ),
         pytest.param(
             # No code section contents
             bytes.fromhex("ef000101000402000100010400020000000000"),
             EOFException.INVALID_SECTION_BODIES_SIZE,
-            id="EOF1I3540_0025",
+            id="EOF1I3540_0025_no_code_section_contents",
         ),
         pytest.param(
             # Code section contents incomplete
             bytes.fromhex("ef0001010004020001002904000000000000027f"),
             EOFException.INVALID_SECTION_BODIES_SIZE,
-            id="EOF1I3540_0026",
+            id="EOF1I3540_0026_code_section_contents_incomplete",
         ),
         pytest.param(
             # Trailing bytes after code section
             bytes.fromhex("ef0001 010004 0200010001 040000 00 00800000 fe aabbcc"),
             EOFException.INVALID_SECTION_BODIES_SIZE,
-            id="EOF1I3540_0027",
+            id="EOF1I3540_0027_trailing_bytes_after_code_section",
         ),
         pytest.param(
             # Trailing bytes after code section with wrong first section type
             bytes.fromhex("ef0001 010004 0200010001 040000 00 00000000 fe aabbcc"),
             EOFException.INVALID_FIRST_SECTION_TYPE,
-            id="EOF1I3540_0027_orig",
+            id="EOF1I3540_0027_trailing_bytes_after_code_section_with_wrong_first_section_type",
         ),
         pytest.param(
             # Empty code section
             bytes.fromhex("ef000101000402000100000400000000000000"),
             EOFException.ZERO_SECTION_SIZE,
-            id="EOF1I3540_0028",
+            id="EOF1I3540_0028_empty_code_section",
         ),
         pytest.param(
             # Code section preceding type section
             bytes.fromhex("ef000102000100010100040400020000000000feaabb"),
             EOFException.MISSING_TYPE_HEADER,
-            id="EOF1I3540_0030",
+            id="EOF1I3540_0030_code_section_preceding_type_section",
         ),
         pytest.param(
             # Data section preceding type section
             bytes.fromhex("ef000104000201000402000100010000000000feaabb"),
             EOFException.MISSING_TYPE_HEADER,
-            id="EOF1I3540_0031",
+            id="EOF1I3540_0031_data_section_preceding_type_section",
         ),
         pytest.param(
             # Data section preceding code section
             bytes.fromhex("ef000101000404000202000100010000000000feaabb"),
             EOFException.MISSING_CODE_HEADER,
-            id="EOF1I3540_0032",
+            id="EOF1I3540_0032_data_section_preceding_code_section",
         ),
         pytest.param(
             # Data section without code section
             bytes.fromhex("ef00010100040400020000000000aabb"),
             EOFException.MISSING_CODE_HEADER,
-            id="EOF1I3540_0033",
+            id="EOF1I3540_0033_data_section_without_code_section",
         ),
         pytest.param(
             # No data section
             bytes.fromhex("ef000101000402000100010000000000fe"),
             EOFException.MISSING_DATA_SECTION,
-            id="EOF1I3540_0034",
+            id="EOF1I3540_0034_no_data_section",
         ),
         pytest.param(
             # Trailing bytes after data section
@@ -215,97 +217,97 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                 expected_bytecode="ef0001 010004 0200010001 040002 00 00800000 fe aabbccdd",
             ),
             EOFException.INVALID_SECTION_BODIES_SIZE,
-            id="EOF1I3540_0035",
+            id="EOF1I3540_0035_trailing_bytes_after_data_section",
         ),
         pytest.param(
             # Trailing bytes after data section with wrong first section type
             bytes.fromhex("ef0001 010004 0200010001 040002 00 00000000 fe aabbccdd"),
             EOFException.INVALID_FIRST_SECTION_TYPE,
-            id="EOF1I3540_0035_orig",
+            id="EOF1I3540_0035_trailing_bytes_after_data_section_with_wrong_first_section_type",
         ),
         pytest.param(
             # Multiple data sections
             bytes.fromhex("ef000101000402000100010400020400020000000000feaabbaabb"),
             EOFException.MISSING_TERMINATOR,
-            id="EOF1I3540_0036",
+            id="EOF1I3540_0036_multiple_data_sections",
         ),
         pytest.param(
             # Multiple code and data sections
             bytes.fromhex("ef000101000802000200010001040002040002000000000000000000fefeaabbaabb"),
             EOFException.MISSING_TERMINATOR,
-            id="EOF1I3540_0037",
+            id="EOF1I3540_0037_multiple_code_and_data_sections",
         ),
         pytest.param(
             # Unknown section ID (at the beginning)
             bytes.fromhex("ef000105000101000402000100010400000000000000fe"),
             EOFException.MISSING_TYPE_HEADER,
-            id="EOF1I3540_0038",
+            id="EOF1I3540_0038_unknown_section_id_at_the_beginning_05",
         ),
         pytest.param(
             # Unknown section ID (at the beginning)
             bytes.fromhex("ef000106000101000402000100010400000000000000fe"),
             EOFException.MISSING_TYPE_HEADER,
-            id="EOF1I3540_0039",
+            id="EOF1I3540_0039_unknown_section_id_at_the_beginning_06",
         ),
         pytest.param(
             # Unknown section ID (at the beginning)
             bytes.fromhex("ef0001ff000101000402000100010400000000000000fe"),
             EOFException.MISSING_TYPE_HEADER,
-            id="EOF1I3540_0040",
+            id="EOF1I3540_0040_unknown_section_id_at_the_beginning_ff",
         ),
         pytest.param(
             # Unknown section ID (after types section)
             bytes.fromhex("ef000101000405000102000100010400000000000000fe"),
             EOFException.MISSING_CODE_HEADER,
-            id="EOF1I3540_0041",
+            id="EOF1I3540_0041_unknown_section_id_after_types_section_05",
         ),
         pytest.param(
             # Unknown section ID (after types section)
             bytes.fromhex("ef000101000406000102000100010400000000000000fe"),
             EOFException.MISSING_CODE_HEADER,
-            id="EOF1I3540_0042",
+            id="EOF1I3540_0042_unknown_section_id_after_types_section_06",
         ),
         pytest.param(
             # Unknown section ID (after types section)
             bytes.fromhex("ef0001010004ff000102000100010400000000000000fe"),
             EOFException.MISSING_CODE_HEADER,
-            id="EOF1I3540_0043",
+            id="EOF1I3540_0043_unknown_section_id_after_types_section_ff",
         ),
         pytest.param(
             # Unknown section ID (after code section)
             bytes.fromhex("ef000101000402000100010500010400000000000000fe"),
             EOFException.MISSING_DATA_SECTION,
-            id="EOF1I3540_0044",
+            id="EOF1I3540_0044_unknown_section_id_after_code_section_05",
         ),
         pytest.param(
             # Unknown section ID (after code section)
             bytes.fromhex("ef000101000402000100010600010400000000000000fe"),
             EOFException.MISSING_DATA_SECTION,
-            id="EOF1I3540_0045",
+            id="EOF1I3540_0045_unknown_section_id_after_code_section_06",
         ),
         pytest.param(
             # Unknown section ID (after code section)
             bytes.fromhex("ef00010100040200010001ff00010400000000000000fe"),
             EOFException.MISSING_DATA_SECTION,
-            id="EOF1I3540_0046",
+            id="EOF1I3540_0046_unknown_section_id_after_code_section_ff",
         ),
         pytest.param(
             # Unknown section ID (after data section)
             bytes.fromhex("ef000101000402000100010400000500010000000000fe"),
             EOFException.MISSING_TERMINATOR,
-            id="EOF1I3540_0047",
+            id="EOF1I3540_0047_unknown_section_id_after_data_section_05",
         ),
         pytest.param(
             # Unknown section ID (after data section)
             bytes.fromhex("ef000101000402000100010400000600010000000000fe"),
             EOFException.MISSING_TERMINATOR,
-            id="EOF1I3540_0048",
+            id="EOF1I3540_0048_unknown_section_id_after_data_section_06",
         ),
         pytest.param(
             # Unknown section ID (after data section)
             bytes.fromhex("ef00010100040200010001040000ff00010000000000fe"),
             EOFException.MISSING_TERMINATOR,
-            id="EOF1I3540_0049",
+            id="EOF1I3540_0049_unknown_section_id_after_data_section_ff",
         ),
         # TODO: Duplicated tests
         # The following test cases are duplicates but added to confirm test coverage is retained.
@@ -315,6 +317,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                 raw_bytes="ef",
             ),
             EOFException.INVALID_MAGIC,
+            id="EOF1I3540_0001_invalid_no_magic",
         ),
         pytest.param(
             Container(
@@ -322,6 +325,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                 raw_bytes="ef010101000402000100010400000000000000fe",
             ),
             EOFException.INVALID_MAGIC,
+            id="EOF1I3540_0002_invalid_incorrect_magic_01",
         ),
         pytest.param(
             Container(
@@ -329,6 +333,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                 raw_bytes="ef020101000402000100010400000000000000fe",
             ),
             EOFException.INVALID_MAGIC,
+            id="EOF1I3540_0003_invalid_incorrect_magic_02",
         ),
         pytest.param(
             Container(
@@ -336,6 +341,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                 raw_bytes="efff0101000402000100010400000000000000fe",
             ),
             EOFException.INVALID_MAGIC,
+            id="EOF1I3540_0004_invalid_incorrect_magic_ff",
         ),
         pytest.param(
             Container(
@@ -343,6 +349,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                 raw_bytes="ef00",
             ),
             EOFException.INVALID_VERSION,
+            id="EOF1I3540_0005_invalid_no_version",
         ),
         pytest.param(
             Container(
@@ -350,6 +357,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                 raw_bytes="ef000001000402000100010400000000000000fe",
             ),
             EOFException.INVALID_VERSION,
+            id="EOF1I3540_0006_invalid_incorrect_version_00",
         ),
         pytest.param(
             Container(
@@ -357,6 +365,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                 raw_bytes="ef000201000402000100010400000000000000fe",
             ),
             EOFException.INVALID_VERSION,
+            id="EOF1I3540_0007_invalid_incorrect_version_02",
         ),
         pytest.param(
             Container(
@@ -364,6 +373,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                 raw_bytes="ef00ff01000402000100010400000000000000fe",
             ),
             EOFException.INVALID_VERSION,
+            id="EOF1I3540_0008_invalid_incorrect_version_ff",
         ),
     ],
 )


### PR DESCRIPTION
## 🗒️ Description

Migrate https://github.com/ethereum/tests/blob/develop/src/EOFTestsFiller/EIP3540/validInvalidFiller.yml.

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
