### PR TITLE
feat(fw): make NON_RETURNING_SECTION default in Container

### DIFF
--- a/src/ethereum_test_tools/eof/v1/__init__.py
+++ b/src/ethereum_test_tools/eof/v1/__init__.py
@@ -20,6 +20,7 @@ from .constants import (
     HEADER_SECTION_COUNT_BYTE_LENGTH,
     HEADER_SECTION_KIND_BYTE_LENGTH,
     HEADER_SECTION_SIZE_BYTE_LENGTH,
+    NON_RETURNING_SECTION,
     TYPES_INPUTS_BYTE_LENGTH,
     TYPES_OUTPUTS_BYTE_LENGTH,
     TYPES_STACK_BYTE_LENGTH,
@@ -102,7 +103,7 @@ class Section(CopyValidateModel):
     """
     Data stack items consumed by this code section (function)
     """
-    code_outputs: int = 0
+    code_outputs: int = NON_RETURNING_SECTION
     """
     Data stack items produced by or expected at the end of this code section
     (function)

--- a/src/ethereum_test_tools/tests/test_eof_v1.py
+++ b/src/ethereum_test_tools/tests/test_eof_v1.py
@@ -25,7 +25,7 @@ test_cases: List[Tuple[str, Container, str]] = [
                 Section.Code("0x00"),
             ],
         ),
-        "ef0001 01 0004 02 0001 0001 04 0000 00 00000000 00",
+        "ef0001 01 0004 02 0001 0001 04 0000 00 00800000 00",
     ),
     (
         "Single code section, single container section",
@@ -35,7 +35,7 @@ test_cases: List[Tuple[str, Container, str]] = [
                 Section.Container("0x0B"),
             ],
         ),
-        "ef0001 01 0004 02 0001 0001 03 0001 0001 04 0000 00 00000000 0A 0B",
+        "ef0001 01 0004 02 0001 0001 03 0001 0001 04 0000 00 00800000 0A 0B",
     ),
     (
         "Single code section, single container section, single data",
@@ -46,7 +46,7 @@ test_cases: List[Tuple[str, Container, str]] = [
                 Section.Data("0x0C"),
             ],
         ),
-        "ef0001 01 0004 02 0001 0001 03 0001 0001 04 0001 00" "00000000 0A 0B 0C",
+        "ef0001 01 0004 02 0001 0001 03 0001 0001 04 0001 00 00800000 0A 0B 0C",
     ),
     (
         "Single code section, single container section, single data 2",
@@ -57,7 +57,7 @@ test_cases: List[Tuple[str, Container, str]] = [
                 Section.Container("0x0B"),
             ],
         ),
-        "ef0001 01 0004 02 0001 0001 03 0001 0001 04 0001 00" "00000000 0A 0B 0C",
+        "ef0001 01 0004 02 0001 0001 03 0001 0001 04 0001 00 00800000 0A 0B 0C",
     ),
     (
         "Single code section, multiple container section, single data",
@@ -69,7 +69,7 @@ test_cases: List[Tuple[str, Container, str]] = [
                 Section.Container("0x0D"),
             ],
         ),
-        "ef0001 01 0004 02 0001 0001 03 0002 0001 0001 04 0001 00" "00000000 0A 0B 0D 0C",
+        "ef0001 01 0004 02 0001 0001 03 0002 0001 0001 04 0001 00 00800000 0A 0B 0D 0C",
     ),
     (
         "Single code section, multiple container sections",
@@ -80,7 +80,7 @@ test_cases: List[Tuple[str, Container, str]] = [
                 Section.Container("0x00"),
             ],
         ),
-        "ef0001 01 0004 02 0001 0001 03 0002 0002 0001 04 0000 00 00000000 00" "0001 00",
+        "ef0001 01 0004 02 0001 0001 03 0002 0002 0001 04 0000 00 00800000 00 0001 00",
     ),
     (
         "No code section",
@@ -121,7 +121,7 @@ test_cases: List[Tuple[str, Container, str]] = [
                 Section.Data("0x0f"),
             ],
         ),
-        "ef0001 01 0004 02 0001 0001 04 0001 00 00000000 0e 0f",
+        "ef0001 01 0004 02 0001 0001 04 0001 00 00800000 0e 0f",
     ),
     (
         "Multiple type sections",
@@ -139,7 +139,7 @@ test_cases: List[Tuple[str, Container, str]] = [
             ],
             auto_type_section=AutoSection.NONE,
         ),
-        "ef0001 01 0004 01 0004 02 0001 0001 04 0000 00" "00000000 00000000 00",
+        "ef0001 01 0004 01 0004 02 0001 0001 04 0000 00 00000000 00000000 00",
     ),
     (
         "Invalid Magic",
@@ -149,7 +149,7 @@ test_cases: List[Tuple[str, Container, str]] = [
                 Section.Code("0x00"),
             ],
         ),
-        "effe01 01 0004 02 0001 0001 04 0000 00 00000000 00",
+        "effe01 01 0004 02 0001 0001 04 0000 00 00800000 00",
     ),
     (
         "Invalid Version",
@@ -159,7 +159,7 @@ test_cases: List[Tuple[str, Container, str]] = [
                 Section.Code("0x00"),
             ],
         ),
-        "ef0002 01 0004 02 0001 0001 04 0000 00 00000000 00",
+        "ef0002 01 0004 02 0001 0001 04 0000 00 00800000 00",
     ),
     (
         "Section Invalid size Version",
@@ -171,7 +171,7 @@ test_cases: List[Tuple[str, Container, str]] = [
                 ),
             ],
         ),
-        "ef0001 01 0004 02 0001 ffff 04 0000 00 00000000 00",
+        "ef0001 01 0004 02 0001 ffff 04 0000 00 00800000 00",
     ),
     (
         "Nested EOF",
@@ -186,8 +186,8 @@ test_cases: List[Tuple[str, Container, str]] = [
                 ),
             ],
         ),
-        "ef0001 01 0004 02 0001 0001 03 0001 0014 04 0000 00 00000000 00"
-        "ef0001 01 0004 02 0001 0001 04 0000 00 00000000 01",
+        "ef0001 01 0004 02 0001 0001 03 0001 0014 04 0000 00 00800000 00"
+        "ef0001 01 0004 02 0001 0001 04 0000 00 00800000 01",
     ),
     (
         "Nested EOF in Data",
@@ -201,8 +201,8 @@ test_cases: List[Tuple[str, Container, str]] = [
                 ),
             ],
         ),
-        "ef0001 01 0004 02 0001 0001 04 0014 00 00000000 00"
-        "ef0001 01 0004 02 0001 0001 04 0000 00 00000000 01",
+        "ef0001 01 0004 02 0001 0001 04 0014 00 00800000 00"
+        "ef0001 01 0004 02 0001 0001 04 0000 00 00800000 01",
     ),
     (
         "Incomplete code section",
@@ -214,7 +214,7 @@ test_cases: List[Tuple[str, Container, str]] = [
                 ),
             ],
         ),
-        "ef0001 01 0004 02 0001 0002 04 0000 00 00000000",
+        "ef0001 01 0004 02 0001 0002 04 0000 00 00800000",
     ),
     (
         "Trailing bytes after code section",
@@ -224,7 +224,7 @@ test_cases: List[Tuple[str, Container, str]] = [
             ],
             extra=bytes.fromhex("deadbeef"),
         ),
-        "ef0001 01 0004 02 0001 0003 04 0000 00 00000000 600000 deadbeef",
+        "ef0001 01 0004 02 0001 0003 04 0000 00 00800000 600000 deadbeef",
     ),
     (
         "Multiple code sections",
@@ -236,7 +236,7 @@ test_cases: List[Tuple[str, Container, str]] = [
         ),
         """
             ef0001 01 0008 02 0002 0003 0003 04 0000 00
-            00000000 00000000
+            00800000 00800000
             600000
             600000
             """,
@@ -249,7 +249,7 @@ test_cases: List[Tuple[str, Container, str]] = [
             ],
             header_terminator=bytes(),
         ),
-        "ef0001 01 0004 02 0001 0003 04 0000 00000000 600000",
+        "ef0001 01 0004 02 0001 0003 04 0000 00800000 600000",
     ),
     (
         "No auto type section",
@@ -274,7 +274,7 @@ test_cases: List[Tuple[str, Container, str]] = [
         ),
         """
             ef0001 01 0008 02 0001 0001 04 0001 00
-            00000000 00000000
+            00800000 00800000
             00 00
             """,
     ),
@@ -290,7 +290,7 @@ test_cases: List[Tuple[str, Container, str]] = [
         ),
         """
             ef0001 01 0004 02 0001 0001 04 0000 00
-            01000000
+            01800000
             00
             """,
     ),
@@ -306,7 +306,7 @@ test_cases: List[Tuple[str, Container, str]] = [
         ),
         """
             ef0001 01 0004 02 0001 0001 04 0000 00
-            ff000000
+            ff800000
             00
             """,
     ),
@@ -354,7 +354,7 @@ test_cases: List[Tuple[str, Container, str]] = [
         ),
         """
             ef0001 01 0004 02 0001 0001 04 0000 00
-            00000201
+            00800201
             00
             """,
     ),
@@ -370,7 +370,7 @@ test_cases: List[Tuple[str, Container, str]] = [
         ),
         """
             ef0001 01 0004 02 0001 0001 04 0000 00
-            0000FFFF
+            0080FFFF
             00
             """,
     ),
@@ -387,7 +387,7 @@ test_cases: List[Tuple[str, Container, str]] = [
         ),
         """
             ef0001 01 0008 02 0002 0001 0001 04 0000 00
-            0000FFFF 00000000
+            0080FFFF 00800000
             00
             00
             """,

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/container.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/container.py
@@ -373,10 +373,7 @@ INVALID: List[Container] = [
         name="trailing_bytes_after_data_section",
         extra=bytes([0xEE]),
         sections=[
-            Section.Code(
-                code=Op.PUSH1(0) + Op.STOP,
-                code_outputs=NON_RETURNING_SECTION,
-            ),
+            Section.Code(code=Op.PUSH1(0) + Op.STOP),
             Section.Data(data="0xAABBCCDD"),
         ],
         # TODO should be more specific exception about trailing bytes

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/container.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/container.py
@@ -12,7 +12,6 @@ from ethereum_test_tools.eof.v1.constants import (
     MAX_CODE_OUTPUTS,
     MAX_CODE_SECTIONS,
     MAX_OPERAND_STACK_HEIGHT,
-    NON_RETURNING_SECTION,
 )
 from ethereum_test_tools.exceptions import EOFException
 from ethereum_test_tools.vm.opcode import Opcodes as Op
@@ -23,7 +22,6 @@ VALID: List[Container] = [
         sections=[
             Section.Code(
                 code=Op.ADDRESS + Op.POP + Op.STOP,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=1,
             ),
             Section.Data(data="0xef"),
@@ -33,7 +31,7 @@ VALID: List[Container] = [
         # EOF allows truncated data section
         name="no_data_section_contents",
         sections=[
-            Section.Code(Op.STOP, code_outputs=NON_RETURNING_SECTION),
+            Section.Code(Op.STOP),
             Section.Data(data="0x", custom_size=1),
         ],
         code="ef0001 010004 0200010001 040001 00 00800000 00",
@@ -42,27 +40,21 @@ VALID: List[Container] = [
         # EOF allows truncated data section
         name="data_section_contents_incomplete",
         sections=[
-            Section.Code(Op.STOP, code_outputs=NON_RETURNING_SECTION),
+            Section.Code(Op.STOP),
             Section.Data(data="0xAABBCC", custom_size=4),
         ],
     ),
     Container(
         name="max_code_sections",
         sections=[
-            Section.Code(
-                Op.JUMPF[i + 1] if i < (MAX_CODE_SECTIONS - 1) else Op.STOP,
-                code_outputs=NON_RETURNING_SECTION,
-            )
+            Section.Code(Op.JUMPF[i + 1] if i < (MAX_CODE_SECTIONS - 1) else Op.STOP)
             for i in range(MAX_CODE_SECTIONS)
         ],
     ),
     Container(
         name="max_code_sections_plus_data",
         sections=[
-            Section.Code(
-                Op.JUMPF[i + 1] if i < (MAX_CODE_SECTIONS - 1) else Op.STOP,
-                code_outputs=NON_RETURNING_SECTION,
-            )
+            Section.Code(Op.JUMPF[i + 1] if i < (MAX_CODE_SECTIONS - 1) else Op.STOP)
             for i in range(MAX_CODE_SECTIONS)
         ]
         + [Section.Data(data="0x00")],
@@ -70,10 +62,7 @@ VALID: List[Container] = [
     Container(
         name="max_code_sections_plus_container",
         sections=[
-            Section.Code(
-                Op.JUMPF[i + 1] if i < (MAX_CODE_SECTIONS - 1) else Op.STOP,
-                code_outputs=NON_RETURNING_SECTION,
-            )
+            Section.Code(Op.JUMPF[i + 1] if i < (MAX_CODE_SECTIONS - 1) else Op.STOP)
             for i in range(MAX_CODE_SECTIONS)
         ]
         + [
@@ -81,10 +70,7 @@ VALID: List[Container] = [
                 container=Container(
                     name="max_code_sections",
                     sections=[
-                        Section.Code(
-                            Op.JUMPF[i + 1] if i < (MAX_CODE_SECTIONS - 1) else Op.STOP,
-                            code_outputs=NON_RETURNING_SECTION,
-                        )
+                        Section.Code(Op.JUMPF[i + 1] if i < (MAX_CODE_SECTIONS - 1) else Op.STOP)
                         for i in range(MAX_CODE_SECTIONS)
                     ],
                 )
@@ -94,10 +80,7 @@ VALID: List[Container] = [
     Container(
         name="max_code_sections_plus_data_plus_container",
         sections=[
-            Section.Code(
-                Op.JUMPF[i + 1] if i < (MAX_CODE_SECTIONS - 1) else Op.STOP,
-                code_outputs=NON_RETURNING_SECTION,
-            )
+            Section.Code(Op.JUMPF[i + 1] if i < (MAX_CODE_SECTIONS - 1) else Op.STOP)
             for i in range(MAX_CODE_SECTIONS)
         ]
         + [
@@ -105,10 +88,7 @@ VALID: List[Container] = [
                 container=Container(
                     name="max_code_sections",
                     sections=[
-                        Section.Code(
-                            Op.JUMPF[i + 1] if i < (MAX_CODE_SECTIONS - 1) else Op.STOP,
-                            code_outputs=NON_RETURNING_SECTION,
-                        )
+                        Section.Code(Op.JUMPF[i + 1] if i < (MAX_CODE_SECTIONS - 1) else Op.STOP)
                         for i in range(MAX_CODE_SECTIONS)
                     ],
                 )
@@ -123,7 +103,7 @@ INVALID: List[Container] = [
     Container(
         name="single_code_section_no_data_section",
         sections=[
-            Section.Code(Op.STOP, code_outputs=NON_RETURNING_SECTION),
+            Section.Code(Op.STOP),
         ],
         auto_data_section=False,
         validity_error=EOFException.MISSING_DATA_SECTION,
@@ -229,31 +209,31 @@ INVALID: List[Container] = [
     Container(
         name="invalid_magic_01",
         magic=b"\xef\x01",
-        sections=[Section.Code(Op.STOP, code_outputs=NON_RETURNING_SECTION)],
+        sections=[Section.Code(Op.STOP)],
         validity_error=EOFException.INVALID_MAGIC,
     ),
     Container(
         name="invalid_magic_ff",
         magic=b"\xef\xFF",
-        sections=[Section.Code(Op.STOP, code_outputs=NON_RETURNING_SECTION)],
+        sections=[Section.Code(Op.STOP)],
         validity_error=EOFException.INVALID_MAGIC,
     ),
     Container(
         name="invalid_version_zero",
         version=b"\x00",
-        sections=[Section.Code(Op.STOP, code_outputs=NON_RETURNING_SECTION)],
+        sections=[Section.Code(Op.STOP)],
         validity_error=EOFException.INVALID_VERSION,
     ),
     Container(
         name="invalid_version_plus_one",
         version=int.to_bytes(LATEST_EOF_VERSION + 1, length=1, byteorder="big"),
-        sections=[Section.Code(Op.STOP, code_outputs=NON_RETURNING_SECTION)],
+        sections=[Section.Code(Op.STOP)],
         validity_error=EOFException.INVALID_VERSION,
     ),
     Container(
         name="invalid_version_high",
         version=b"\xFF",
-        sections=[Section.Code(Op.STOP, code_outputs=NON_RETURNING_SECTION)],
+        sections=[Section.Code(Op.STOP)],
         validity_error=EOFException.INVALID_VERSION,
     ),
     Container(
@@ -268,10 +248,7 @@ INVALID: List[Container] = [
     Container(
         name="too_many_code_sections",
         sections=[
-            Section.Code(
-                Op.JUMPF[i + 1] if i < MAX_CODE_SECTIONS else Op.STOP,
-                code_outputs=NON_RETURNING_SECTION,
-            )
+            Section.Code(Op.JUMPF[i + 1] if i < MAX_CODE_SECTIONS else Op.STOP)
             for i in range(MAX_CODE_SECTIONS + 1)
         ],
         validity_error=EOFException.TOO_MANY_CODE_SECTIONS,
@@ -308,45 +285,45 @@ INVALID: List[Container] = [
     Container(
         name="no_section_terminator_1",
         header_terminator=bytes(),
-        sections=[Section.Code(code=Op.STOP, custom_size=2, code_outputs=NON_RETURNING_SECTION)],
+        sections=[Section.Code(code=Op.STOP, custom_size=2)],
         # TODO the exception must be about terminator
         validity_error=EOFException.INVALID_SECTION_BODIES_SIZE,
     ),
     Container(
         name="no_section_terminator_2",
         header_terminator=bytes(),
-        sections=[Section.Code(code="0x", custom_size=3, code_outputs=NON_RETURNING_SECTION)],
+        sections=[Section.Code(code="0x", custom_size=3)],
         # TODO the exception must be about terminator
         validity_error=EOFException.INVALID_SECTION_BODIES_SIZE,
     ),
     Container(
         name="no_section_terminator_3",
         header_terminator=bytes(),
-        sections=[Section.Code(code=Op.PUSH1(0) + Op.STOP, code_outputs=NON_RETURNING_SECTION)],
+        sections=[Section.Code(code=Op.PUSH1(0) + Op.STOP)],
         # TODO the exception must be about terminator
         validity_error=EOFException.INVALID_SECTION_BODIES_SIZE,
     ),
     Container(
         name="no_code_section_contents",
-        sections=[Section.Code(code="0x", custom_size=0x01, code_outputs=NON_RETURNING_SECTION)],
+        sections=[Section.Code(code="0x", custom_size=0x01)],
         validity_error=EOFException.INVALID_SECTION_BODIES_SIZE,
     ),
     Container(
         name="incomplete_code_section_contents",
         sections=[
-            Section.Code(code=Op.STOP, custom_size=0x02, code_outputs=NON_RETURNING_SECTION),
+            Section.Code(code=Op.STOP, custom_size=0x02),
         ],
         validity_error=EOFException.INVALID_SECTION_BODIES_SIZE,
     ),
     Container(
         name="trailing_bytes_after_code_section",
-        sections=[Section.Code(code=Op.PUSH1(0) + Op.STOP, code_outputs=NON_RETURNING_SECTION)],
+        sections=[Section.Code(code=Op.PUSH1(0) + Op.STOP)],
         extra=bytes([0xDE, 0xAD, 0xBE, 0xEF]),
         validity_error=EOFException.INVALID_SECTION_BODIES_SIZE,
     ),
     Container(
         name="empty_code_section",
-        sections=[Section.Code(code="0x", code_outputs=NON_RETURNING_SECTION)],
+        sections=[Section.Code(code="0x")],
         # TODO the exception must be about code section EOFException.INVALID_CODE_SECTION,
         validity_error=EOFException.ZERO_SECTION_SIZE,
     ),
@@ -365,7 +342,7 @@ INVALID: List[Container] = [
         auto_sort_sections=AutoSection.NONE,
         sections=[
             Section.Data(data="0xDEADBEEF"),
-            Section.Code(Op.STOP, code_outputs=NON_RETURNING_SECTION),
+            Section.Code(Op.STOP),
         ],
         validity_error=EOFException.MISSING_CODE_HEADER,
     ),
@@ -378,12 +355,7 @@ INVALID: List[Container] = [
     Container(
         name="no_section_terminator_3a",
         header_terminator=bytes(),
-        sections=[
-            Section.Code(
-                code="0x030004",
-                code_outputs=NON_RETURNING_SECTION,
-            )
-        ],
+        sections=[Section.Code(code="0x030004")],
         # TODO the exception must be about terminator
         validity_error=EOFException.INVALID_SECTION_BODIES_SIZE,
     ),
@@ -391,7 +363,7 @@ INVALID: List[Container] = [
         name="no_section_terminator_4a",
         header_terminator=bytes(),
         sections=[
-            Section.Code(Op.STOP, code_outputs=NON_RETURNING_SECTION),
+            Section.Code(Op.STOP),
             Section.Data(data="0xAABBCCDD"),
         ],
         # TODO: The error of this validation can be random.
@@ -422,8 +394,8 @@ INVALID: List[Container] = [
     Container(
         name="multiple_code_and_data_sections_1",
         sections=[
-            Section.Code(Op.STOP, code_outputs=NON_RETURNING_SECTION),
-            Section.Code(Op.STOP, code_outputs=NON_RETURNING_SECTION),
+            Section.Code(Op.STOP),
+            Section.Code(Op.STOP),
             Section.Data(data="0xAA"),
             Section.Data(data="0xAA"),
         ],
@@ -432,9 +404,9 @@ INVALID: List[Container] = [
     Container(
         name="multiple_code_and_data_sections_2",
         sections=[
-            Section.Code(Op.STOP, code_outputs=NON_RETURNING_SECTION),
+            Section.Code(Op.STOP),
             Section.Data(data="0xAA"),
-            Section.Code(Op.STOP, code_outputs=NON_RETURNING_SECTION),
+            Section.Code(Op.STOP),
             Section.Data(data="0xAA"),
         ],
         validity_error=EOFException.MISSING_TERMINATOR,
@@ -442,7 +414,7 @@ INVALID: List[Container] = [
     Container(
         name="unknown_section_1",
         sections=[
-            Section.Code(Op.STOP, code_outputs=NON_RETURNING_SECTION),
+            Section.Code(Op.STOP),
             Section.Data(data="0x"),
             Section(kind=VERSION_MAX_SECTION_KIND + 1, data="0x01"),
         ],
@@ -453,7 +425,7 @@ INVALID: List[Container] = [
         sections=[
             Section(kind=VERSION_MAX_SECTION_KIND + 1, data="0x01"),
             Section.Data(data="0x"),
-            Section.Code(Op.STOP, code_outputs=NON_RETURNING_SECTION),
+            Section.Code(Op.STOP),
         ],
         # TODO the exception should be about unknown section definition
         validity_error=EOFException.MISSING_TERMINATOR,
@@ -461,7 +433,7 @@ INVALID: List[Container] = [
     Container(
         name="unknown_section_empty",
         sections=[
-            Section.Code(Op.STOP, code_outputs=NON_RETURNING_SECTION),
+            Section.Code(Op.STOP),
             Section.Data(data="0x"),
             Section(kind=VERSION_MAX_SECTION_KIND + 1, data="0x"),
         ],
@@ -481,7 +453,7 @@ INVALID: List[Container] = [
         sections=[
             Section(kind=Kind.TYPE, data="0x00000000"),
             Section(kind=Kind.TYPE, data="0x00000000"),
-            Section.Code(Op.STOP, code_outputs=NON_RETURNING_SECTION),
+            Section.Code(Op.STOP),
         ],
         auto_type_section=AutoSection.NONE,
         validity_error=EOFException.MISSING_CODE_HEADER,
@@ -490,7 +462,7 @@ INVALID: List[Container] = [
         name="empty_type_section",
         sections=[
             Section(kind=Kind.TYPE, data="0x"),
-            Section.Code(Op.STOP, code_outputs=NON_RETURNING_SECTION),
+            Section.Code(Op.STOP),
         ],
         auto_type_section=AutoSection.NONE,
         # TODO the exception must be about type section EOFException.INVALID_TYPE_SECTION_SIZE,
@@ -500,7 +472,7 @@ INVALID: List[Container] = [
         name="type_section_too_small_1",
         sections=[
             Section(kind=Kind.TYPE, data="0x00"),
-            Section.Code(Op.STOP, code_outputs=NON_RETURNING_SECTION),
+            Section.Code(Op.STOP),
         ],
         auto_type_section=AutoSection.NONE,
         validity_error=EOFException.INVALID_TYPE_SECTION_SIZE,
@@ -509,7 +481,7 @@ INVALID: List[Container] = [
         name="type_section_too_small_2",
         sections=[
             Section(kind=Kind.TYPE, data="0x000000"),
-            Section.Code(Op.STOP, code_outputs=NON_RETURNING_SECTION),
+            Section.Code(Op.STOP),
         ],
         auto_type_section=AutoSection.NONE,
         validity_error=EOFException.INVALID_TYPE_SECTION_SIZE,
@@ -518,7 +490,7 @@ INVALID: List[Container] = [
         name="type_section_too_big",
         sections=[
             Section(kind=Kind.TYPE, data="0x0000000000"),
-            Section.Code(Op.STOP, code_outputs=NON_RETURNING_SECTION),
+            Section.Code(Op.STOP),
         ],
         auto_type_section=AutoSection.NONE,
         validity_error=EOFException.INVALID_TYPE_SECTION_SIZE,
@@ -539,8 +511,6 @@ VALID += [
                 code=(Op.CALLER * MAX_OPERAND_STACK_HEIGHT)
                 + (Op.POP * MAX_OPERAND_STACK_HEIGHT)
                 + Op.STOP,
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=MAX_OPERAND_STACK_HEIGHT,
             ),
         ],
@@ -550,8 +520,6 @@ VALID += [
         sections=[
             Section.Code(
                 code=((Op.PUSH0 * MAX_CODE_INPUTS) + Op.CALLF[1] + Op.STOP),
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=MAX_CODE_INPUTS,
             ),
             Section.Code(
@@ -567,8 +535,6 @@ VALID += [
         sections=[
             Section.Code(
                 code=(Op.CALLF[1] + Op.STOP),
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=MAX_CODE_OUTPUTS,
             ),
             Section.Code(
@@ -584,7 +550,6 @@ VALID += [
         sections=[
             Section.Code(
                 (Op.PUSH0 * MAX_CODE_OUTPUTS) + Op.CALLF[1] + Op.STOP,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=MAX_CODE_OUTPUTS,
             ),
             Section.Code(
@@ -600,9 +565,7 @@ VALID += [
 INVALID += [
     Container(
         name="single_code_section_non_zero_inputs",
-        sections=[
-            Section.Code(code=Op.POP + Op.RETF, code_inputs=1, code_outputs=NON_RETURNING_SECTION)
-        ],
+        sections=[Section.Code(code=Op.POP + Op.RETF, code_inputs=1)],
         # TODO the exception must be about code or non, cause it looks legit
         validity_error=EOFException.INVALID_FIRST_SECTION_TYPE,
     ),
@@ -615,8 +578,8 @@ INVALID += [
     Container(
         name="multiple_code_section_non_zero_inputs",
         sections=[
-            Section.Code(code=Op.POP + Op.RETF, code_inputs=1, code_outputs=NON_RETURNING_SECTION),
-            Section.Code(Op.STOP, code_outputs=NON_RETURNING_SECTION),
+            Section.Code(code=Op.POP + Op.RETF, code_inputs=1),
+            Section.Code(Op.STOP),
         ],
         # TODO the actual exception should be EOFException.INVALID_TYPE_BODY,
         validity_error=EOFException.INVALID_FIRST_SECTION_TYPE,
@@ -625,7 +588,7 @@ INVALID += [
         name="multiple_code_section_non_zero_outputs",
         sections=[
             Section.Code(code=Op.PUSH0, code_outputs=1),
-            Section.Code(Op.STOP, code_outputs=NON_RETURNING_SECTION),
+            Section.Code(Op.STOP),
         ],
         # TODO the actual exception should be EOFException.INVALID_TYPE_BODY,
         validity_error=EOFException.INVALID_FIRST_SECTION_TYPE,
@@ -634,7 +597,7 @@ INVALID += [
         name="data_section_before_code_with_type",
         sections=[
             Section.Data(data="0xAA"),
-            Section.Code(Op.STOP, code_outputs=NON_RETURNING_SECTION),
+            Section.Code(Op.STOP),
         ],
         auto_sort_sections=AutoSection.NONE,
         validity_error=EOFException.MISSING_CODE_HEADER,
@@ -643,7 +606,7 @@ INVALID += [
         name="data_section_listed_in_type",
         sections=[
             Section.Data(data="0x00", force_type_listing=True),
-            Section.Code(Op.STOP, code_outputs=NON_RETURNING_SECTION),
+            Section.Code(Op.STOP),
         ],
         validity_error=EOFException.INVALID_TYPE_SECTION_SIZE,
     ),
@@ -651,7 +614,7 @@ INVALID += [
         name="single_code_section_incomplete_type",
         sections=[
             Section(kind=Kind.TYPE, data="0x00"),
-            Section.Code(Op.STOP, code_outputs=NON_RETURNING_SECTION),
+            Section.Code(Op.STOP),
         ],
         auto_type_section=AutoSection.NONE,
         validity_error=EOFException.INVALID_TYPE_SECTION_SIZE,
@@ -660,7 +623,7 @@ INVALID += [
         name="single_code_section_incomplete_type_2",
         sections=[
             Section(kind=Kind.TYPE, data="0x00", custom_size=2),
-            Section.Code(Op.STOP, code_outputs=NON_RETURNING_SECTION),
+            Section.Code(Op.STOP),
         ],
         validity_error=EOFException.INVALID_SECTION_BODIES_SIZE,
     ),
@@ -669,8 +632,6 @@ INVALID += [
         sections=[
             Section.Code(
                 code=((Op.PUSH0 * (MAX_CODE_INPUTS + 1)) + Op.CALLF[1] + Op.STOP),
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=(MAX_CODE_INPUTS + 1),
             ),
             Section.Code(
@@ -688,8 +649,6 @@ INVALID += [
         sections=[
             Section.Code(
                 code=(Op.CALLF[1] + Op.STOP),
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=(MAX_CODE_OUTPUTS + 2),
             ),
             Section.Code(
@@ -707,8 +666,6 @@ INVALID += [
         sections=[
             Section.Code(
                 code=Op.CALLER * 1024 + Op.POP * 1024 + Op.STOP,
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=1024,
             ),
         ],

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_eof_example.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_eof_example.py
@@ -13,7 +13,6 @@ from ethereum_test_tools.eof.v1 import (
     EOFException,
     Section,
 )
-from ethereum_test_tools.eof.v1.constants import NON_RETURNING_SECTION
 
 from .. import EOF_FORK_NAME
 
@@ -36,8 +35,6 @@ def test_eof_example(eof_test: EOFTestFiller):
             Section.Code(
                 code=Op.CALLF[1](Op.PUSH0) + Op.STOP,  # bytecode to be deployed in the body
                 # Code: call section 1 with a single zero as input, then stop.
-                code_inputs=0,  # define code header (in body) input bytes
-                code_outputs=NON_RETURNING_SECTION,  # define code header (in body) output bytes
                 max_stack_height=1,  # define code header (in body) stack size
             ),
             # There can be multiple code sections
@@ -51,7 +48,6 @@ def test_eof_example(eof_test: EOFTestFiller):
             Section.Code(
                 # Call section 3 with two inputs (address twice), return
                 code=Op.CALLF[3](Op.DUP1, Op.ADDRESS) + Op.POP + Op.POP + Op.RETF,
-                code_inputs=0,
                 code_outputs=1,
                 max_stack_height=3,
             ),
@@ -102,8 +98,6 @@ def test_eof_example_custom_fields(eof_test: EOFTestFiller):
             Section.Code(
                 code=Op.PUSH1(2)
                 + Op.STOP,  # this is the actual bytecode to be deployed in the body
-                code_inputs=0,  # define code header (in body) input bytes
-                code_outputs=NON_RETURNING_SECTION,  # define code header (in body) output bytes
                 max_stack_height=1,  # define code header (in body) stack size
             ),
             # DATA section
@@ -155,8 +149,6 @@ def test_eof_example_parameters(
         sections=[
             Section.Code(
                 code=code_section_code,
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=1,
             ),
             Section.Data(data_section_bytes),

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_example_valid_invalid.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_example_valid_invalid.py
@@ -7,7 +7,6 @@ import pytest
 from ethereum_test_tools import EOFTestFiller, Opcode
 from ethereum_test_tools import Opcodes as Op
 from ethereum_test_tools.eof.v1 import Bytes, Container, EOFException, Section
-from ethereum_test_tools.eof.v1.constants import NON_RETURNING_SECTION
 
 from .. import EOF_FORK_NAME
 
@@ -27,8 +26,6 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                 sections=[
                     Section.Code(
                         code=Op.ADDRESS + Op.POP + Op.STOP,
-                        code_inputs=0,
-                        code_outputs=NON_RETURNING_SECTION,
                         max_stack_height=1,
                     ),
                     Section.Data("0xef"),
@@ -46,8 +43,6 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                 sections=[
                     Section.Code(
                         code=Op.ADDRESS + Op.POP + Op.STOP,
-                        code_inputs=0,
-                        code_outputs=NON_RETURNING_SECTION,
                         max_stack_height=1,
                     ),
                     Section.Data("0x0bad", custom_size=4),
@@ -64,8 +59,6 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                 sections=[
                     Section.Code(
                         code=Op.ADDRESS + Op.POP + Op.STOP,
-                        code_inputs=0,
-                        code_outputs=NON_RETURNING_SECTION,
                         max_stack_height=1,
                     ),
                     Section.Data("0x0bad60A70BAD", custom_size=4),
@@ -82,8 +75,6 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                 sections=[
                     Section.Code(
                         code=Op.ADDRESS + Op.POP + Op.STOP,
-                        code_inputs=0,
-                        code_outputs=NON_RETURNING_SECTION,
                         max_stack_height=1,
                     ),
                     Section.Data("0x0bad60A7"),
@@ -100,8 +91,6 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                 sections=[
                     Section.Code(
                         code=Op.ADDRESS + Opcode(0xEF) + Op.STOP,
-                        code_inputs=0,
-                        code_outputs=NON_RETURNING_SECTION,
                         max_stack_height=1,
                     ),
                     Section.Data("0x0bad60A7"),
@@ -118,8 +107,6 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                 sections=[
                     Section.Code(
                         code=Op.ADDRESS + Op.POP + Op.INVALID,
-                        code_inputs=0,
-                        code_outputs=NON_RETURNING_SECTION,
                         max_stack_height=1,
                     ),
                     Section.Data("0x0bad60A7"),
@@ -136,8 +123,6 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                 sections=[
                     Section.Code(
                         code=Op.ADDRESS + Op.POP + Op.STOP,
-                        code_inputs=0,
-                        code_outputs=NON_RETURNING_SECTION,
                         max_stack_height=1,
                     ),
                     Section.Data("0xef"),
@@ -160,8 +145,6 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                         + Op.RJUMP[3]
                         + Op.RJUMP[-6]
                         + Op.STOP,
-                        code_inputs=0,
-                        code_outputs=NON_RETURNING_SECTION,
                         max_stack_height=1,
                     ),
                     Section.Data("0x0bad60A7"),
@@ -176,12 +159,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
             Container(
                 name="EOF1I0023",
                 sections=[
-                    Section.Code(
-                        code=Op.RJUMP[1] + Op.NOOP + Op.STOP,
-                        code_inputs=0,
-                        code_outputs=NON_RETURNING_SECTION,
-                        max_stack_height=0,
-                    ),
+                    Section.Code(code=Op.RJUMP[1] + Op.NOOP + Op.STOP),
                     Section.Data("0x0bad60A7"),
                 ],
             ),
@@ -196,8 +174,6 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                 sections=[
                     Section.Code(
                         code=Op.PUSH1(1) + Op.RJUMPI[1] + Op.NOOP + Op.STOP,
-                        code_inputs=0,
-                        code_outputs=NON_RETURNING_SECTION,
                         max_stack_height=1,
                     ),
                     Section.Data("0x0bad60A7"),
@@ -221,33 +197,20 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                         + Op.JUMPF[3]
                         + Op.CALLF[4]
                         + Op.STOP,
-                        code_inputs=0,
-                        code_outputs=NON_RETURNING_SECTION,
                         max_stack_height=1,
                     ),
                     Section.Code(
                         code=Op.PUSH0 + Op.PUSH0 + Op.RETURN,
-                        code_inputs=0,
-                        code_outputs=NON_RETURNING_SECTION,
                         max_stack_height=2,
                     ),
                     Section.Code(
                         code=Op.PUSH0 + Op.PUSH0 + Op.REVERT,
-                        code_inputs=0,
-                        code_outputs=NON_RETURNING_SECTION,
                         max_stack_height=2,
                     ),
-                    Section.Code(
-                        code=Op.INVALID,
-                        code_inputs=0,
-                        code_outputs=NON_RETURNING_SECTION,
-                        max_stack_height=0,
-                    ),
+                    Section.Code(code=Op.INVALID),
                     Section.Code(
                         code=Op.RETF,
-                        code_inputs=0,
                         code_outputs=0,
-                        max_stack_height=0,
                     ),
                     Section.Data("0x0bad60A7"),
                 ],
@@ -270,8 +233,6 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                         + Op.ADDRESS
                         + Op.POP
                         + Op.STOP,
-                        code_inputs=0,
-                        code_outputs=NON_RETURNING_SECTION,
                         max_stack_height=1,
                     ),
                     Section.Data("0x0bad60A7"),
@@ -294,8 +255,6 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                         + Op.ADDRESS
                         + Op.POP
                         + Op.STOP,
-                        code_inputs=0,
-                        code_outputs=NON_RETURNING_SECTION,
                         max_stack_height=1,
                     ),
                     Section.Data("0x0bad60A7"),
@@ -313,8 +272,6 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                 sections=[
                     Section.Code(
                         code=Op.PUSH1(1) + Op.RJUMPI[1] + Op.ADDRESS + Op.NOOP + Op.STOP,
-                        code_inputs=0,
-                        code_outputs=NON_RETURNING_SECTION,
                         max_stack_height=1,
                     ),
                     Section.Data("0x0bad60A7"),
@@ -329,12 +286,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
             Container(
                 name="EOF1I0019",
                 sections=[
-                    Section.Code(
-                        code=Op.RJUMP[3] + Op.RJUMP[2] + Op.RJUMP[-6] + Op.STOP,
-                        code_inputs=0,
-                        code_outputs=NON_RETURNING_SECTION,
-                        max_stack_height=0,
-                    ),
+                    Section.Code(code=Op.RJUMP[3] + Op.RJUMP[2] + Op.RJUMP[-6] + Op.STOP),
                     Section.Data("0x0bad60A7"),
                 ],
             ),
@@ -355,8 +307,6 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                         + Op.RJUMPI[2]
                         + Op.RJUMPI[-6]
                         + Op.STOP,
-                        code_inputs=0,
-                        code_outputs=NON_RETURNING_SECTION,
                         max_stack_height=3,
                     ),
                     Section.Data("0x0bad60A7"),
@@ -373,8 +323,6 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                 sections=[
                     Section.Code(
                         code=Op.PUSH1(3) + Op.JUMP + Op.JUMPDEST + Op.STOP,
-                        code_inputs=0,
-                        code_outputs=NON_RETURNING_SECTION,
                         max_stack_height=1,
                     ),
                     Section.Data("0xef"),
@@ -477,8 +425,6 @@ def test_code_section_header_body_mismatch(
         sections=[
             Section.Code(
                 code=Op.ADDRESS + Op.POP + Op.STOP,
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=1,
             ),
             Section.Code(

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_execution_function.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_execution_function.py
@@ -15,11 +15,7 @@ from ethereum_test_tools import (
     Transaction,
 )
 from ethereum_test_tools.eof.v1 import Container, Section
-from ethereum_test_tools.eof.v1.constants import (
-    MAX_CODE_SECTIONS,
-    MAX_RETURN_STACK_HEIGHT,
-    NON_RETURNING_SECTION,
-)
+from ethereum_test_tools.eof.v1.constants import MAX_CODE_SECTIONS, MAX_RETURN_STACK_HEIGHT
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 from .. import EOF_FORK_NAME
@@ -37,8 +33,6 @@ contract_call_within_deep_nested_callf = Container(
     sections=[
         Section.Code(
             code=Op.CALLF[1] + Op.SSTORE(0, 1) + Op.STOP,
-            code_inputs=0,
-            code_outputs=NON_RETURNING_SECTION,
             max_stack_height=2,
         )
     ]
@@ -81,8 +75,6 @@ recursive_contract_call_within_deep_nested_callf = Container(
         # to their call stack height key
         Section.Code(
             code=Op.CALLF[i + 1] + Op.SSTORE(i, 1) + Op.STOP,
-            code_inputs=0,
-            code_outputs=NON_RETURNING_SECTION,
             max_stack_height=2,
         )
         for i in range(MAX_CODE_SECTIONS - 1)
@@ -116,8 +108,6 @@ CALL_SUCCEED_CONTRACTS: List[Container] = [
         sections=[
             Section.Code(
                 code=(Op.CALLF[1] + Op.STOP),
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=0,
             ),
             Section.Code(
@@ -133,8 +123,6 @@ CALL_SUCCEED_CONTRACTS: List[Container] = [
         sections=[
             Section.Code(
                 code=(Op.PUSH1(1) + Op.CALLF[1] + Op.STOP),
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=1,
             ),
             Section.Code(
@@ -161,8 +149,6 @@ CALL_SUCCEED_CONTRACTS: List[Container] = [
         sections=[
             Section.Code(
                 code=Op.SSTORE(0, 1) + Op.CALLF[1] + Op.STOP,
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=2,
             ),
             Section.Code(
@@ -193,8 +179,6 @@ CALL_SUCCEED_CONTRACTS: List[Container] = [
         sections=[
             Section.Code(
                 code=(Op.PUSH1(1) + Op.PUSH0 + Op.MSTORE + Op.CALLF[1] + Op.STOP),
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=2,
             ),
             Section.Code(
@@ -231,8 +215,6 @@ CALL_FAIL_CONTRACTS: List[Container] = [
         sections=[
             Section.Code(
                 code=(Op.INVALID),
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=0,
             ),
         ],
@@ -242,8 +224,6 @@ CALL_FAIL_CONTRACTS: List[Container] = [
         sections=[
             Section.Code(
                 code=(Op.PUSH1(1) + Op.CALLF[1] + Op.STOP),
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=1,
             ),
             Section.Code(
@@ -270,8 +250,6 @@ CALL_FAIL_CONTRACTS: List[Container] = [
         sections=[
             Section.Code(
                 code=Op.SSTORE(0, 1) + Op.CALLF[1] + Op.STOP,
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=2,
             ),
             Section.Code(
@@ -302,8 +280,6 @@ CALL_FAIL_CONTRACTS: List[Container] = [
         sections=[
             Section.Code(
                 code=Op.MSTORE(0, 1) + Op.CALLF[1] + Op.STOP,
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=2,
             ),
             Section.Code(

--- a/tests/prague/eip7692_eof_v1/eip4200_relative_jumps/test_rjump.py
+++ b/tests/prague/eip7692_eof_v1/eip4200_relative_jumps/test_rjump.py
@@ -6,7 +6,6 @@ import pytest
 
 from ethereum_test_tools import Account, EOFException, EOFStateTestFiller, EOFTestFiller
 from ethereum_test_tools.eof.v1 import Container, Section
-from ethereum_test_tools.eof.v1.constants import NON_RETURNING_SECTION
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 from .. import EOF_FORK_NAME
@@ -32,7 +31,6 @@ def test_rjump_positive_negative(
                     + Op.SSTORE(slot_code_worked, value_code_worked)
                     + Op.STOP
                     + Op.RJUMP[-10],
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=2,
                 )
             ],
@@ -55,7 +53,6 @@ def test_rjump_positive_negative_with_data(
                     + Op.SSTORE(slot_code_worked, value_code_worked)
                     + Op.STOP
                     + Op.RJUMP[-10],
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=2,
                 ),
                 Section.Data(data=b"\xde\xad\xbe\xef"),
@@ -74,7 +71,6 @@ def test_rjump_zero(
             sections=[
                 Section.Code(
                     code=Op.RJUMP[0] + Op.SSTORE(slot_code_worked, value_code_worked) + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=2,
                 )
             ],
@@ -98,7 +94,6 @@ def test_rjump_maxes(
                     + Op.SSTORE(slot_code_worked, value_code_worked)
                     + Op.STOP
                     + Op.RJUMP[0x8000],
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=2,
                 )
             ],
@@ -113,7 +108,7 @@ def test_rjump_truncated_rjump(
     """EOF1I4200_0001 (Invalid) EOF code containing truncated RJUMP"""
     eof_test(
         data=Container(
-            sections=[Section.Code(code=Op.RJUMP, code_outputs=NON_RETURNING_SECTION)],
+            sections=[Section.Code(code=Op.RJUMP)],
         ),
         expect_exception=EOFException.TRUNCATED_INSTRUCTION,
     )
@@ -125,7 +120,7 @@ def test_rjump_truncated_rjump_2(
     """EOF1I4200_0002 (Invalid) EOF code containing truncated RJUMP"""
     eof_test(
         data=Container(
-            sections=[Section.Code(code=Op.RJUMP + Op.STOP, code_outputs=NON_RETURNING_SECTION)],
+            sections=[Section.Code(code=Op.RJUMP + Op.STOP)],
         ),
         expect_exception=EOFException.TRUNCATED_INSTRUCTION,
     )
@@ -141,7 +136,7 @@ def test_rjump_into_header(
     eof_test(
         data=Container(
             sections=[
-                Section.Code(code=Op.RJUMP[-5], code_outputs=NON_RETURNING_SECTION),
+                Section.Code(code=Op.RJUMP[-5]),
             ],
         ),
         expect_exception=EOFException.INVALID_RJUMP_DESTINATION,
@@ -158,10 +153,7 @@ def test_rjump_before_header(
     eof_test(
         data=Container(
             sections=[
-                Section.Code(
-                    code=Op.RJUMP[-23],
-                    code_outputs=NON_RETURNING_SECTION,
-                ),
+                Section.Code(code=Op.RJUMP[-23]),
             ],
         ),
         expect_exception=EOFException.INVALID_RJUMP_DESTINATION,
@@ -178,10 +170,7 @@ def test_rjump_into_data(
     eof_test(
         data=Container(
             sections=[
-                Section.Code(
-                    code=Op.RJUMP[2],
-                    code_outputs=NON_RETURNING_SECTION,
-                ),
+                Section.Code(code=Op.RJUMP[2]),
                 Section.Data(data=b"\xaa\xbb\xcc"),
             ],
         ),
@@ -196,14 +185,8 @@ def test_rjump_outside_other_section_before(
     eof_test(
         data=Container(
             sections=[
-                Section.Code(
-                    code=Op.JUMPF[1],
-                    code_outputs=NON_RETURNING_SECTION,
-                ),
-                Section.Code(
-                    code=Op.RJUMP[-6],
-                    code_outputs=NON_RETURNING_SECTION,
-                ),
+                Section.Code(code=Op.JUMPF[1]),
+                Section.Code(code=Op.RJUMP[-6]),
             ],
         ),
         expect_exception=EOFException.INVALID_RJUMP_DESTINATION,
@@ -217,18 +200,9 @@ def test_rjump_outside_other_section_after(
     eof_test(
         data=Container(
             sections=[
-                Section.Code(
-                    code=Op.JUMPF[1],
-                    code_outputs=NON_RETURNING_SECTION,
-                ),
-                Section.Code(
-                    code=Op.RJUMP[3] + Op.JUMPF[2],
-                    code_outputs=NON_RETURNING_SECTION,
-                ),
-                Section.Code(
-                    code=Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
-                ),
+                Section.Code(code=Op.JUMPF[1]),
+                Section.Code(code=Op.RJUMP[3] + Op.JUMPF[2]),
+                Section.Code(code=Op.STOP),
             ],
         ),
         expect_exception=EOFException.INVALID_RJUMP_DESTINATION,
@@ -245,10 +219,7 @@ def test_rjump_after_container(
     eof_test(
         data=Container(
             sections=[
-                Section.Code(
-                    code=Op.RJUMP[2],
-                    code_outputs=NON_RETURNING_SECTION,
-                ),
+                Section.Code(code=Op.RJUMP[2]),
             ],
         ),
         expect_exception=EOFException.INVALID_RJUMP_DESTINATION,
@@ -265,10 +236,7 @@ def test_rjump_to_code_end(
     eof_test(
         data=Container(
             sections=[
-                Section.Code(
-                    code=Op.RJUMP[1] + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
-                ),
+                Section.Code(code=Op.RJUMP[1] + Op.STOP),
             ],
         ),
         expect_exception=EOFException.INVALID_RJUMP_DESTINATION,
@@ -282,10 +250,7 @@ def test_rjump_into_self(
     eof_test(
         data=Container(
             sections=[
-                Section.Code(
-                    code=Op.RJUMP[-1],
-                    code_outputs=NON_RETURNING_SECTION,
-                ),
+                Section.Code(code=Op.RJUMP[-1]),
             ],
         ),
         expect_exception=EOFException.INVALID_RJUMP_DESTINATION,
@@ -299,10 +264,7 @@ def test_rjump_into_rjump(
     eof_test(
         data=Container(
             sections=[
-                Section.Code(
-                    code=Op.RJUMP[1] + Op.RJUMP[0],
-                    code_outputs=NON_RETURNING_SECTION,
-                ),
+                Section.Code(code=Op.RJUMP[1] + Op.RJUMP[0]),
             ],
         ),
         expect_exception=EOFException.INVALID_RJUMP_DESTINATION,
@@ -318,7 +280,6 @@ def test_rjump_into_rjumpi(
             sections=[
                 Section.Code(
                     code=Op.RJUMP[5] + Op.STOP + Op.PUSH1(1) + Op.RJUMPI[-6] + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 )
             ],
@@ -336,11 +297,7 @@ def test_rjump_into_push_1(eof_test: EOFTestFiller, jump: JumpDirection):
     eof_test(
         data=Container(
             sections=[
-                Section.Code(
-                    code=code,
-                    code_outputs=NON_RETURNING_SECTION,
-                    max_stack_height=1,
-                ),
+                Section.Code(code=code, max_stack_height=1),
             ],
         ),
         expect_exception=EOFException.INVALID_RJUMP_DESTINATION,
@@ -406,11 +363,7 @@ def test_rjump_into_push_n(
     eof_test(
         data=Container(
             sections=[
-                Section.Code(
-                    code=code,
-                    code_outputs=NON_RETURNING_SECTION,
-                    max_stack_height=1,
-                ),
+                Section.Code(code=code, max_stack_height=1),
             ],
         ),
         expect_exception=EOFException.INVALID_RJUMP_DESTINATION,
@@ -440,7 +393,6 @@ def test_rjump_into_rjumpv(
                     + Op.PUSH1(1)
                     + Op.RJUMPV[target_jump_table]
                     + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 )
             ],
@@ -465,7 +417,6 @@ def test_rjump_into_callf(
             sections=[
                 Section.Code(
                     code=Op.RJUMP[invalid_destination] + Op.CALLF[1] + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                 ),
                 Section.Code(
                     code=Op.SSTORE(1, 1) + Op.RETF,
@@ -492,7 +443,6 @@ def test_rjump_into_dupn(
                     + Op.DUPN[1]
                     + Op.SSTORE
                     + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=2,
                 ),
             ],
@@ -515,7 +465,6 @@ def test_rjump_into_swapn(
                     + Op.SWAPN[1]
                     + Op.SSTORE
                     + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=2,
                 ),
             ],
@@ -539,7 +488,6 @@ def test_rjump_into_exchange(
                     + Op.EXCHANGE[0x00]
                     + Op.SSTORE
                     + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=3,
                 ),
             ],
@@ -557,7 +505,6 @@ def test_rjump_into_eofcreate(
             sections=[
                 Section.Code(
                     code=Op.RJUMP[1] + Op.EOFCREATE[0](0, 0, 0, 0) + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=4,
                 ),
                 Section.Container(
@@ -565,16 +512,12 @@ def test_rjump_into_eofcreate(
                         sections=[
                             Section.Code(
                                 code=Op.RETURNCONTRACT[0](0, 0),
-                                code_outputs=NON_RETURNING_SECTION,
                                 max_stack_height=2,
                             ),
                             Section.Container(
                                 container=Container(
                                     sections=[
-                                        Section.Code(
-                                            code=Op.STOP,
-                                            code_outputs=NON_RETURNING_SECTION,
-                                        )
+                                        Section.Code(code=Op.STOP),
                                     ]
                                 )
                             ),
@@ -596,7 +539,6 @@ def test_rjump_into_returncontract(
             sections=[
                 Section.Code(
                     code=Op.EOFCREATE[0](0, 0, 0, 0) + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=4,
                 ),
                 Section.Container(
@@ -604,16 +546,12 @@ def test_rjump_into_returncontract(
                         sections=[
                             Section.Code(
                                 code=Op.RJUMP[5] + Op.RETURNCONTRACT[0](0, 0),
-                                code_outputs=NON_RETURNING_SECTION,
                                 max_stack_height=2,
                             ),
                             Section.Container(
                                 container=Container(
                                     sections=[
-                                        Section.Code(
-                                            code=Op.STOP,
-                                            code_outputs=NON_RETURNING_SECTION,
-                                        )
+                                        Section.Code(code=Op.STOP),
                                     ]
                                 )
                             ),

--- a/tests/prague/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpi.py
+++ b/tests/prague/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpi.py
@@ -15,7 +15,6 @@ from ethereum_test_tools import (
     Transaction,
 )
 from ethereum_test_tools.eof.v1 import Container, Section
-from ethereum_test_tools.eof.v1.constants import NON_RETURNING_SECTION
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 from .. import EOF_FORK_NAME
@@ -62,7 +61,6 @@ def test_rjumpi_condition_forwards(
                         + Op.STOP
                         + Op.SSTORE(slot_conditional_result, value_calldata_true)
                         + Op.STOP,
-                        code_outputs=NON_RETURNING_SECTION,
                         max_stack_height=2,
                     )
                 ]
@@ -112,7 +110,6 @@ def test_rjumpi_condition_backwards(
                         + Op.RJUMPI[-11]
                         + Op.SSTORE(slot_conditional_result, value_calldata_false)
                         + Op.STOP,
-                        code_outputs=NON_RETURNING_SECTION,
                         max_stack_height=2,
                     )
                 ]
@@ -158,7 +155,6 @@ def test_rjumpi_condition_zero(
                         + Op.RJUMPI[0]
                         + Op.SSTORE(slot_code_worked, value_code_worked)
                         + Op.STOP,
-                        code_outputs=NON_RETURNING_SECTION,
                         max_stack_height=2,
                     )
                 ]
@@ -185,7 +181,6 @@ def test_rjumpi_forwards(
                     + Op.STOP
                     + Op.SSTORE(slot_code_worked, value_code_worked)
                     + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=2,
                 )
             ],
@@ -209,7 +204,6 @@ def test_rjumpi_backwards(
                     + Op.PUSH1(1)
                     + Op.RJUMPI[-12]
                     + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=2,
                 )
             ],
@@ -230,7 +224,6 @@ def test_rjumpi_zero(
                     + Op.RJUMPI[0]
                     + Op.SSTORE(slot_code_worked, value_code_worked)
                     + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=2,
                 )
             ],
@@ -252,7 +245,6 @@ def test_rjumpi_max_forward(
                     + Op.NOOP * 32768
                     + Op.SSTORE(slot_code_worked, value_code_worked)
                     + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=2,
                 )
             ],
@@ -277,7 +269,6 @@ def test_rjumpi_max_backward(
                     + Op.PUSH0
                     + Op.RJUMPI[0x8000]
                     + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=2,
                 )
             ],
@@ -295,7 +286,6 @@ def test_rjump_truncated(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(0) + Op.RJUMPI,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 )
             ],
@@ -313,7 +303,6 @@ def test_rjump_truncated_2(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(0) + Op.RJUMPI + b"\0",
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 )
             ],
@@ -334,7 +323,6 @@ def test_rjumpi_into_header(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1) + Op.RJUMPI[-7] + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 )
             ],
@@ -355,7 +343,6 @@ def test_rjumpi_jump_before_header(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1) + Op.RJUMPI[-25] + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 )
             ],
@@ -376,7 +363,6 @@ def test_rjumpi_into_data(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1) + Op.RJUMPI[2] + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 ),
                 Section.Data(data=b"\xaa\xbb\xcc"),
@@ -398,7 +384,6 @@ def test_rjumpi_after_container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1) + Op.RJUMPI[2] + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 )
             ],
@@ -419,7 +404,6 @@ def test_rjumpi_to_code_end(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1) + Op.RJUMPI[1] + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 ),
             ],
@@ -437,7 +421,6 @@ def test_rjumpi_into_self(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1) + Op.RJUMPI[-1] + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 )
             ],
@@ -455,7 +438,6 @@ def test_rjumpi_into_rjump(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1) + Op.RJUMPI[3] + Op.STOP + Op.RJUMP[-9],
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 )
             ],
@@ -478,7 +460,6 @@ def test_rjumpi_into_rjumpi(
                     + Op.PUSH1(1)
                     + Op.RJUMPI[-11]
                     + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 )
             ],
@@ -501,11 +482,7 @@ def test_rjumpi_into_push_1(
     eof_test(
         data=Container(
             sections=[
-                Section.Code(
-                    code=code,
-                    code_outputs=NON_RETURNING_SECTION,
-                    max_stack_height=1,
-                )
+                Section.Code(code=code, max_stack_height=1),
             ],
         ),
         expect_exception=EOFException.INVALID_RJUMP_DESTINATION,
@@ -571,11 +548,7 @@ def test_rjumpi_into_push_n(
     eof_test(
         data=Container(
             sections=[
-                Section.Code(
-                    code=code,
-                    code_outputs=NON_RETURNING_SECTION,
-                    max_stack_height=1,
-                )
+                Section.Code(code=code, max_stack_height=1),
             ],
         ),
         expect_exception=EOFException.INVALID_RJUMP_DESTINATION,
@@ -606,7 +579,6 @@ def test_rjumpi_into_rjumpv(
                     + Op.PUSH1(1)
                     + Op.RJUMPV[target_jump_table]
                     + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 )
             ],
@@ -631,7 +603,6 @@ def test_rjumpi_into_callf(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1) + Op.RJUMPI[invalid_destination] + Op.CALLF[1] + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 ),
                 Section.Code(
@@ -660,7 +631,6 @@ def test_rjumpi_into_dupn(
                     + Op.DUPN[1]
                     + Op.SSTORE
                     + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=3,
                 ),
             ],
@@ -684,7 +654,6 @@ def test_rjumpi_into_swapn(
                     + Op.SWAPN[1]
                     + Op.SSTORE
                     + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=3,
                 ),
             ],
@@ -709,7 +678,6 @@ def test_rjump_into_exchange(
                     + Op.EXCHANGE[0x00]
                     + Op.SSTORE
                     + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=4,
                 ),
             ],
@@ -727,7 +695,6 @@ def test_rjumpi_into_eofcreate(
             sections=[
                 Section.Code(
                     code=Op.PUSH0 + Op.RJUMPI[9] + Op.EOFCREATE[0](0, 0, 0, 0) + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=4,
                 ),
                 Section.Container(
@@ -735,16 +702,12 @@ def test_rjumpi_into_eofcreate(
                         sections=[
                             Section.Code(
                                 code=Op.RETURNCONTRACT[0](0, 0),
-                                code_outputs=NON_RETURNING_SECTION,
                                 max_stack_height=2,
                             ),
                             Section.Container(
                                 container=Container(
                                     sections=[
-                                        Section.Code(
-                                            code=Op.STOP,
-                                            code_outputs=NON_RETURNING_SECTION,
-                                        )
+                                        Section.Code(code=Op.STOP),
                                     ]
                                 )
                             ),
@@ -766,7 +729,6 @@ def test_rjumpi_into_returncontract(
             sections=[
                 Section.Code(
                     code=Op.EOFCREATE[0](0, 0, 0, 0) + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=4,
                 ),
                 Section.Container(
@@ -774,16 +736,12 @@ def test_rjumpi_into_returncontract(
                         sections=[
                             Section.Code(
                                 code=Op.PUSH0 + Op.RJUMPI[5] + Op.RETURNCONTRACT[0](0, 0),
-                                code_outputs=NON_RETURNING_SECTION,
                                 max_stack_height=2,
                             ),
                             Section.Container(
                                 container=Container(
                                     sections=[
-                                        Section.Code(
-                                            code=Op.STOP,
-                                            code_outputs=NON_RETURNING_SECTION,
-                                        )
+                                        Section.Code(code=Op.STOP),
                                     ]
                                 )
                             ),

--- a/tests/prague/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py
+++ b/tests/prague/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py
@@ -6,7 +6,6 @@ import pytest
 
 from ethereum_test_tools import Account, EOFException, EOFStateTestFiller, EOFTestFiller
 from ethereum_test_tools.eof.v1 import Container, Section
-from ethereum_test_tools.eof.v1.constants import NON_RETURNING_SECTION
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 from .. import EOF_FORK_NAME
@@ -63,7 +62,6 @@ def test_rjumpv_condition(
                     + Op.RJUMPV[jump_table]
                     + fall_through_case
                     + jump_targets,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=2,
                 )
             ]
@@ -94,7 +92,6 @@ def test_rjumpv_forwards(
                     + Op.STOP
                     + Op.SSTORE(slot_code_worked, value_code_worked)
                     + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=2,
                 )
             ],
@@ -118,7 +115,6 @@ def test_rjumpv_backwards(
                     + Op.PUSH1(0)
                     + Op.RJUMPV[-13]
                     + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=2,
                 )
             ],
@@ -139,7 +135,6 @@ def test_rjumpv_zero(
                     + Op.RJUMPV[0]
                     + Op.SSTORE(slot_code_worked, value_code_worked)
                     + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=2,
                 )
             ],
@@ -163,7 +158,6 @@ def test_rjumpv_size_3(
                     + Op.STOP
                     + Op.SSTORE(slot_code_worked, value_code_worked)
                     + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=2,
                 )
             ],
@@ -185,7 +179,6 @@ def test_rjumpv_full_table(
                     + Op.NOOP * 256
                     + Op.SSTORE(slot_code_worked, value_code_worked)
                     + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=2,
                 )
             ],
@@ -207,7 +200,6 @@ def test_rjumpv_full_table_mid(
                     + Op.NOOP * 256
                     + Op.SSTORE(slot_code_worked, value_code_worked)
                     + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=2,
                 )
             ],
@@ -229,7 +221,6 @@ def test_rjumpv_full_table_end(
                     + Op.NOOP * 256
                     + Op.SSTORE(slot_code_worked, value_code_worked)
                     + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=2,
                 )
             ],
@@ -251,7 +242,6 @@ def test_rjumpv_full_table_last(
                     + Op.NOOP * 256
                     + Op.SSTORE(slot_code_worked, value_code_worked)
                     + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=2,
                 )
             ],
@@ -273,7 +263,6 @@ def test_rjumpv_max_forwards(
                     + Op.NOOP * 32768
                     + Op.SSTORE(slot_code_worked, value_code_worked)
                     + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=2,
                 )
             ],
@@ -291,7 +280,6 @@ def test_rjumpv_truncated(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1) + Op.RJUMPV + b"\0",
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 )
             ],
@@ -309,7 +297,6 @@ def test_rjumpv_truncated_1(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1) + Op.RJUMPV,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 )
             ],
@@ -328,7 +315,6 @@ def test_rjumpv_truncated_2(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1) + Op.RJUMPV + b"\0\0",
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 )
             ],
@@ -346,7 +332,6 @@ def test_rjumpv_truncated_3(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1) + Op.RJUMPV + b"\0\0",
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 )
             ],
@@ -364,7 +349,6 @@ def test_rjumpv_truncated_4(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1) + Op.RJUMPV + b"\2\0\0\0\0",
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 )
             ],
@@ -398,7 +382,6 @@ def test_rjumpv_into_header(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1) + Op.RJUMPV[jump_table] + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 )
             ],
@@ -432,7 +415,6 @@ def test_rjumpv_before_container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1) + Op.RJUMPV[jump_table] + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 )
             ],
@@ -466,7 +448,6 @@ def test_rjumpv_into_data(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1) + Op.RJUMPV[jump_table] + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 ),
                 Section.Data(data=b"\xaa\xbb\xcc"),
@@ -501,7 +482,6 @@ def test_rjumpv_after_container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1) + Op.RJUMPV[jump_table] + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 )
             ],
@@ -535,7 +515,6 @@ def test_rjumpv_at_end(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1) + Op.RJUMPV[jump_table] + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 )
             ],
@@ -572,7 +551,6 @@ def test_rjumpv_into_self(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1) + Op.RJUMPV[jump_table] + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 )
             ],
@@ -614,7 +592,6 @@ def test_rjumpv_into_rjump(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1) + Op.RJUMPV[jump_table] + Op.STOP + Op.RJUMP[0] + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 )
             ],
@@ -661,7 +638,6 @@ def test_rjumpv_into_rjumpi(
                     + Op.PUSH1(1)
                     + Op.RJUMPI[0]
                     + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 )
             ],
@@ -709,7 +685,6 @@ def test_rjumpv_into_push_1(
             sections=[
                 Section.Code(
                     code=code,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 )
             ],
@@ -803,11 +778,7 @@ def test_rjumpv_into_push_n(
     eof_test(
         data=Container(
             sections=[
-                Section.Code(
-                    code=code,
-                    code_outputs=NON_RETURNING_SECTION,
-                    max_stack_height=1,
-                )
+                Section.Code(code=code, max_stack_height=1),
             ],
         ),
         expect_exception=EOFException.INVALID_RJUMP_DESTINATION,
@@ -850,7 +821,6 @@ def test_rjumpv_into_rjumpv(
                     + Op.PUSH1(1)
                     + Op.RJUMPV[target_jump_table]
                     + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 )
             ],
@@ -887,7 +857,6 @@ def test_rjumpv_into_callf(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(0) + Op.RJUMPV[jump_table] + Op.CALLF[1] + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 ),
                 Section.Code(
@@ -929,7 +898,6 @@ def test_rjumpv_into_dupn(
                     + Op.DUPN[1]
                     + Op.SSTORE
                     + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=3,
                 ),
             ],
@@ -966,7 +934,6 @@ def test_rjumpv_into_swapn(
                     + Op.SWAPN[1]
                     + Op.SSTORE
                     + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=3,
                 ),
             ],
@@ -1004,7 +971,6 @@ def test_rjump_into_exchange(
                     + Op.EXCHANGE[0x00]
                     + Op.SSTORE
                     + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=4,
                 ),
             ],
@@ -1038,7 +1004,6 @@ def test_rjumpv_into_eofcreate(
                     + Op.RJUMPV[jump_table]
                     + Op.EOFCREATE[0](0, 0, 0, 0)
                     + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=4,
                 ),
                 Section.Container(
@@ -1046,16 +1011,12 @@ def test_rjumpv_into_eofcreate(
                         sections=[
                             Section.Code(
                                 code=Op.RETURNCONTRACT[0](0, 0),
-                                code_outputs=NON_RETURNING_SECTION,
                                 max_stack_height=2,
                             ),
                             Section.Container(
                                 container=Container(
                                     sections=[
-                                        Section.Code(
-                                            code=Op.STOP,
-                                            code_outputs=NON_RETURNING_SECTION,
-                                        )
+                                        Section.Code(code=Op.STOP),
                                     ]
                                 )
                             ),
@@ -1090,7 +1051,6 @@ def test_rjumpv_into_returncontract(
             sections=[
                 Section.Code(
                     code=Op.EOFCREATE[0](0, 0, 0, 0) + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=4,
                 ),
                 Section.Container(
@@ -1100,16 +1060,12 @@ def test_rjumpv_into_returncontract(
                                 code=Op.PUSH1(0)
                                 + Op.RJUMPV[jump_table]
                                 + Op.RETURNCONTRACT[0](0, 0),
-                                code_outputs=NON_RETURNING_SECTION,
                                 max_stack_height=2,
                             ),
                             Section.Container(
                                 container=Container(
                                     sections=[
-                                        Section.Code(
-                                            code=Op.STOP,
-                                            code_outputs=NON_RETURNING_SECTION,
-                                        )
+                                        Section.Code(code=Op.STOP),
                                     ]
                                 )
                             ),

--- a/tests/prague/eip7692_eof_v1/eip6206_jumpf/test_jumpf_execution.py
+++ b/tests/prague/eip7692_eof_v1/eip6206_jumpf/test_jumpf_execution.py
@@ -49,14 +49,15 @@ def test_jumpf_backward(
             sections=[
                 Section.Code(
                     code=Op.CALLF[2] + Op.SSTORE(slot_code_worked, value_code_worked) + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=2,
                 ),
                 Section.Code(
                     code=Op.RETF,
+                    code_outputs=0,
                 ),
                 Section.Code(
                     code=Op.JUMPF[1],
+                    code_outputs=0,
                 ),
             ],
         ),
@@ -153,7 +154,7 @@ def test_callf_to_non_returning_section(
                 ),
                 Section.Code(
                     code=Op.STOP,
-                    outputs=NON_RETURNING_SECTION,
+                    code_outputs=0,
                 ),
             ],
             validity_error=EOFException.MISSING_STOP_OPCODE,

--- a/tests/prague/eip7692_eof_v1/eip6206_jumpf/test_jumpf_execution.py
+++ b/tests/prague/eip7692_eof_v1/eip6206_jumpf/test_jumpf_execution.py
@@ -5,7 +5,6 @@ import pytest
 
 from ethereum_test_tools import Account, EOFException, EOFStateTestFiller
 from ethereum_test_tools.eof.v1 import Container, Section
-from ethereum_test_tools.eof.v1.constants import NON_RETURNING_SECTION
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 from .. import EOF_FORK_NAME
@@ -26,11 +25,9 @@ def test_jumpf_forward(
             sections=[
                 Section.Code(
                     code=Op.JUMPF[1],
-                    code_outputs=NON_RETURNING_SECTION,
                 ),
                 Section.Code(
                     Op.SSTORE(slot_code_worked, value_code_worked) + Op.STOP,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=2,
                 ),
             ],
@@ -80,7 +77,6 @@ def test_jumpf_to_self(
                     + Op.STOP
                     + Op.SSTORE(slot_code_worked, value_code_worked)
                     + Op.JUMPF[0],
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=2,
                 )
             ],
@@ -99,7 +95,6 @@ def test_jumpf_too_large(
             sections=[
                 Section.Code(
                     code=Op.JUMPF[1025],
-                    code_outputs=NON_RETURNING_SECTION,
                 )
             ],
             validity_error=EOFException.UNDEFINED_EXCEPTION,
@@ -116,7 +111,6 @@ def test_jumpf_way_too_large(
             sections=[
                 Section.Code(
                     code=Op.JUMPF[0xFFFF],
-                    code_outputs=NON_RETURNING_SECTION,
                 )
             ],
             validity_error=EOFException.UNDEFINED_EXCEPTION,
@@ -133,7 +127,6 @@ def test_jumpf_to_nonexistent_section(
             sections=[
                 Section.Code(
                     code=Op.JUMPF[5],
-                    code_outputs=NON_RETURNING_SECTION,
                 )
             ],
             validity_error=EOFException.UNDEFINED_EXCEPTION,
@@ -150,7 +143,6 @@ def test_callf_to_non_returning_section(
             sections=[
                 Section.Code(
                     code=Op.CALLF[1],
-                    code_outputs=NON_RETURNING_SECTION,
                 ),
                 Section.Code(
                     code=Op.STOP,

--- a/tests/prague/eip7692_eof_v1/eip6206_jumpf/test_jumpf_stack.py
+++ b/tests/prague/eip7692_eof_v1/eip6206_jumpf/test_jumpf_stack.py
@@ -5,7 +5,6 @@ import pytest
 
 from ethereum_test_tools import Account, EOFException, EOFStateTestFiller
 from ethereum_test_tools.eof.v1 import Container, Section
-from ethereum_test_tools.eof.v1.constants import NON_RETURNING_SECTION
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 from .. import EOF_FORK_NAME
@@ -41,11 +40,9 @@ def test_jumpf_stack_non_returning_rules(
         sections=[
             Section.Code(
                 code=Op.JUMPF[1],
-                code_outputs=NON_RETURNING_SECTION,
             ),
             Section.Code(
                 code=Op.PUSH0 * stack_height + Op.JUMPF[2],
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=stack_height,
             ),
             Section.Code(
@@ -53,7 +50,6 @@ def test_jumpf_stack_non_returning_rules(
                 + Op.SSTORE(slot_code_worked, value_code_worked)
                 + Op.STOP,
                 code_inputs=target_inputs,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=max(2, target_inputs),
             ),
         ],
@@ -110,7 +106,6 @@ def test_jumpf_stack_returning_rules(
         sections=[
             Section.Code(
                 code=Op.CALLF[1] + Op.SSTORE(slot_code_worked, value_code_worked) + Op.STOP,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=2 + source_outputs,
             ),
             Section.Code(

--- a/tests/prague/eip7692_eof_v1/eip6206_jumpf/test_jumpf_target.py
+++ b/tests/prague/eip7692_eof_v1/eip6206_jumpf/test_jumpf_target.py
@@ -90,7 +90,6 @@ def test_jumpf_target_rules(
             Section.Code(
                 code=base_code,
                 code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=base_height,
             ),
             source_section,

--- a/tests/prague/eip7692_eof_v1/eip663_dupn_swapn_exchange/test_dupn.py
+++ b/tests/prague/eip7692_eof_v1/eip663_dupn_swapn_exchange/test_dupn.py
@@ -15,7 +15,7 @@ from ethereum_test_tools import (
     Transaction,
 )
 from ethereum_test_tools.eof.v1 import Container, Section
-from ethereum_test_tools.eof.v1.constants import MAX_OPERAND_STACK_HEIGHT, NON_RETURNING_SECTION
+from ethereum_test_tools.eof.v1.constants import MAX_OPERAND_STACK_HEIGHT
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 from .. import EOF_FORK_NAME
@@ -42,8 +42,6 @@ def test_dupn_all_valid_immediates(
                 code=b"".join(Op.PUSH2(v) for v in values)
                 + b"".join(Op.SSTORE(x, Op.DUPN[x]) for x in range(0, n))
                 + Op.STOP,
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=n + 2,
             )
         ],
@@ -90,8 +88,6 @@ def test_dupn_stack_underflow(
                 code=b"".join(Op.PUSH2(v) for v in range(0, stack_height))
                 + Op.DUPN[stack_height]
                 + Op.STOP,
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=max_stack_height,
             )
         ],
@@ -127,8 +123,6 @@ def test_dupn_stack_overflow(
                 code=b"".join(Op.PUSH2(v) for v in range(0, MAX_OPERAND_STACK_HEIGHT))
                 + Op.DUPN[dupn_operand]
                 + Op.STOP,
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=max_stack_height,
             )
         ],

--- a/tests/prague/eip7692_eof_v1/eip663_dupn_swapn_exchange/test_exchange.py
+++ b/tests/prague/eip7692_eof_v1/eip663_dupn_swapn_exchange/test_exchange.py
@@ -15,7 +15,6 @@ from ethereum_test_tools import (
     Transaction,
 )
 from ethereum_test_tools.eof.v1 import Container, Section
-from ethereum_test_tools.eof.v1.constants import NON_RETURNING_SECTION
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 from .. import EOF_FORK_NAME
@@ -44,8 +43,6 @@ def test_exchange_all_valid_immediates(
                 + b"".join(Op.EXCHANGE(x) for x in range(0, n))
                 + b"".join((Op.PUSH1(x) + Op.SSTORE) for x in range(0, s))
                 + Op.STOP,
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=s + 1,
             )
         ],
@@ -105,8 +102,6 @@ def test_exchange_all_invalid_immediates(
                 + Op.EXCHANGE[x, y]
                 + Op.POP * stack_height
                 + Op.STOP,
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=stack_height,
             )
         ],

--- a/tests/prague/eip7692_eof_v1/eip663_dupn_swapn_exchange/test_swapn.py
+++ b/tests/prague/eip7692_eof_v1/eip663_dupn_swapn_exchange/test_swapn.py
@@ -15,7 +15,7 @@ from ethereum_test_tools import (
     Transaction,
 )
 from ethereum_test_tools.eof.v1 import Container, Section
-from ethereum_test_tools.eof.v1.constants import MAX_OPERAND_STACK_HEIGHT, NON_RETURNING_SECTION
+from ethereum_test_tools.eof.v1.constants import MAX_OPERAND_STACK_HEIGHT
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 from .. import EOF_FORK_NAME
@@ -42,8 +42,6 @@ def test_swapn_all_valid_immediates(
                 code=b"".join(Op.PUSH2(v) for v in values)
                 + b"".join(Op.SSTORE(x, Op.SWAPN[0xFF - x]) for x in range(0, n))
                 + Op.STOP,
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=n + 2,
             )
         ],
@@ -86,8 +84,6 @@ def test_swapn_on_max_stack(
                 code=b"".join(Op.PUSH2(v) for v in range(0, MAX_OPERAND_STACK_HEIGHT))
                 + Op.SWAPN[swapn_operand]
                 + Op.STOP,
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=MAX_OPERAND_STACK_HEIGHT,
             )
         ],
@@ -119,8 +115,6 @@ def test_swapn_stack_underflow(
                 code=b"".join(Op.PUSH2(v) for v in range(0, stack_height))
                 + Op.SWAPN[stack_height]
                 + Op.STOP,
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=MAX_OPERAND_STACK_HEIGHT,
             )
         ],

--- a/tests/prague/eip7692_eof_v1/eip7480_data_section/test_code_validation.py
+++ b/tests/prague/eip7692_eof_v1/eip7480_data_section/test_code_validation.py
@@ -8,7 +8,6 @@ import pytest
 
 from ethereum_test_tools import EOFException, EOFTestFiller
 from ethereum_test_tools.eof.v1 import Container, Section
-from ethereum_test_tools.eof.v1.constants import NON_RETURNING_SECTION
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 from .. import EOF_FORK_NAME
@@ -24,8 +23,6 @@ VALID: List[Container] = [
         sections=[
             Section.Code(
                 code=Op.ADDRESS + Op.POP + Op.STOP,
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=1,
             ),
             Section.Data(data=""),
@@ -36,8 +33,6 @@ VALID: List[Container] = [
         sections=[
             Section.Code(
                 code=Op.ADDRESS + Op.POP + Op.STOP,
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=1,
             ),
             Section.Data(data="1122334455667788" * 4),
@@ -48,8 +43,6 @@ VALID: List[Container] = [
         sections=[
             Section.Code(
                 code=Op.ADDRESS + Op.POP + Op.STOP,
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=1,
             ),
             Section.Data(data="1122334455667788" * 3 * 1024),
@@ -60,8 +53,6 @@ VALID: List[Container] = [
         sections=[
             Section.Code(
                 code=Op.ADDRESS + Op.POP + Op.STOP,
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=1,
             ),
             Section.Data(data=("1122334455667788" * 8 * 1024)[2:]),
@@ -72,8 +63,6 @@ VALID: List[Container] = [
         sections=[
             Section.Code(
                 code=Op.DATALOADN[0] + Op.POP + Op.STOP,
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=1,
             ),
             Section.Data(data="1122334455667788" * 16),
@@ -84,8 +73,6 @@ VALID: List[Container] = [
         sections=[
             Section.Code(
                 code=Op.DATALOADN[16] + Op.POP + Op.STOP,
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=1,
             ),
             Section.Data(data="1122334455667788" * 16),
@@ -96,8 +83,6 @@ VALID: List[Container] = [
         sections=[
             Section.Code(
                 code=Op.DATALOADN[128 - 32] + Op.POP + Op.STOP,
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=1,
             ),
             Section.Data(data="1122334455667788" * 16),
@@ -108,8 +93,6 @@ VALID: List[Container] = [
         sections=[
             Section.Code(
                 code=Op.DATALOADN[0xFFFF - 32] + Op.POP + Op.STOP,
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=1,
             ),
             Section.Data(data=("1122334455667788" * 8 * 1024)[2:]),
@@ -123,8 +106,6 @@ INVALID: List[Container] = [
         sections=[
             Section.Code(
                 code=Op.DATALOADN[0xFFFF - 32] + Op.POP + Op.STOP,
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=1,
             ),
         ],
@@ -135,8 +116,6 @@ INVALID: List[Container] = [
         sections=[
             Section.Code(
                 code=Op.DATALOADN[0xFFFF - 32] + Op.POP + Op.STOP,
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=1,
             ),
             Section.Data(data="1122334455667788" * 16),
@@ -148,8 +127,6 @@ INVALID: List[Container] = [
         sections=[
             Section.Code(
                 code=Op.DATALOADN[0xFFFF - 32] + Op.POP + Op.STOP,
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=1,
             ),
             Section.Data(data=("1122334455667788" * 4 * 1024)[2:]),

--- a/tests/prague/eip7692_eof_v1/eip7480_data_section/test_data_opcodes.py
+++ b/tests/prague/eip7692_eof_v1/eip7480_data_section/test_data_opcodes.py
@@ -13,7 +13,7 @@ from ethereum_test_tools import (
     Transaction,
 )
 from ethereum_test_tools.eof.v1 import Container, Section
-from ethereum_test_tools.eof.v1.constants import MAX_CODE_SECTIONS, NON_RETURNING_SECTION
+from ethereum_test_tools.eof.v1.constants import MAX_CODE_SECTIONS
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 from .. import EOF_FORK_NAME
@@ -28,8 +28,6 @@ contract_call_within_deep_nested_callf = Container(
     sections=[
         Section.Code(
             code=(Op.CALLF[1] + Op.SSTORE(0, 1) + Op.STOP),
-            code_inputs=0,
-            code_outputs=NON_RETURNING_SECTION,
             max_stack_height=2,
         )
     ]
@@ -64,8 +62,6 @@ recursive_contract_call_within_deep_nested_callf = Container(
         # to their call stack height key
         Section.Code(
             code=(Op.CALLF[i + 1] + Op.PUSH1(1) + Op.PUSH2(i) + Op.SSTORE + Op.STOP),
-            code_inputs=0,
-            code_outputs=NON_RETURNING_SECTION,
             max_stack_height=2,
         )
         for i in range(MAX_CODE_SECTIONS - 1)
@@ -106,8 +102,6 @@ def create_data_test(offset: int, datasize: int):
                         + Op.SSTORE(0, 1)
                         + Op.STOP
                     ),
-                    code_inputs=0,
-                    code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=2,
                 ),
                 Section.Code(

--- a/tests/prague/eip7692_eof_v1/eip7620_eof_create/helpers.py
+++ b/tests/prague/eip7692_eof_v1/eip7620_eof_create/helpers.py
@@ -7,7 +7,6 @@ from ethereum_test_tools import Address
 from ethereum_test_tools import Opcodes as Op
 from ethereum_test_tools import Transaction
 from ethereum_test_tools.eof.v1 import Container, Section
-from ethereum_test_tools.eof.v1.constants import NON_RETURNING_SECTION
 
 """Storage addresses for common testing fields"""
 _slot = itertools.count()
@@ -31,9 +30,7 @@ value_call_result_success = 0
 smallest_runtime_subcontainer = Container(
     name="Runtime Subcontainer",
     sections=[
-        Section.Code(
-            code=Op.STOP, code_inputs=0, code_outputs=NON_RETURNING_SECTION, max_stack_height=0
-        )
+        Section.Code(code=Op.STOP),
     ],
 )
 
@@ -42,8 +39,6 @@ smallest_initcode_subcontainer = Container(
     sections=[
         Section.Code(
             code=Op.RETURNCONTRACT[0](0, 0),
-            code_inputs=0,
-            code_outputs=NON_RETURNING_SECTION,
             max_stack_height=2,
         ),
         Section.Container(container=smallest_runtime_subcontainer),

--- a/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_eofcreate.py
+++ b/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_eofcreate.py
@@ -12,7 +12,6 @@ from ethereum_test_tools import (
     compute_eofcreate_address,
 )
 from ethereum_test_tools.eof.v1 import Container, Section
-from ethereum_test_tools.eof.v1.constants import NON_RETURNING_SECTION
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 from .. import EOF_FORK_NAME
@@ -54,8 +53,6 @@ def test_simple_eofcreate(
                 sections=[
                     Section.Code(
                         code=Op.SSTORE(0, Op.EOFCREATE[0](0, 0, 0, 0)) + Op.STOP,
-                        code_inputs=0,
-                        code_outputs=NON_RETURNING_SECTION,
                         max_stack_height=4,
                     ),
                     Section.Container(container=smallest_initcode_subcontainer),
@@ -88,8 +85,6 @@ def test_eofcreate_then_call(
         sections=[
             Section.Code(
                 code=Op.SSTORE(slot_code_worked, value_code_worked) + Op.STOP,
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=2,
             ),
         ]
@@ -98,8 +93,6 @@ def test_eofcreate_then_call(
         sections=[
             Section.Code(
                 code=Op.RETURNCONTRACT[0](0, 0),
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=2,
             ),
             Section.Container(container=callable_contract),
@@ -117,8 +110,6 @@ def test_eofcreate_then_call(
                         + Op.EXTCALL(Op.SLOAD(slot_create_address), 0, 0, 0)
                         + Op.SSTORE(slot_code_worked, value_code_worked)
                         + Op.STOP,
-                        code_inputs=0,
-                        code_outputs=NON_RETURNING_SECTION,
                         max_stack_height=4,
                     ),
                     Section.Container(container=callable_contract_initcode),
@@ -162,9 +153,7 @@ def test_auxdata_variations(state_test: StateTestFiller, auxdata_bytes: bytes):
     runtime_subcontainer = Container(
         name="Runtime Subcontainer with truncated data",
         sections=[
-            Section.Code(
-                code=Op.STOP, code_inputs=0, code_outputs=NON_RETURNING_SECTION, max_stack_height=0
-            ),
+            Section.Code(code=Op.STOP),
             Section.Data(data=pre_deploy_data, custom_size=pre_deploy_header_data_size),
         ],
     )
@@ -175,8 +164,6 @@ def test_auxdata_variations(state_test: StateTestFiller, auxdata_bytes: bytes):
             Section.Code(
                 code=Op.MSTORE(0, Op.PUSH32(auxdata_bytes.ljust(32, b"\0")))
                 + Op.RETURNCONTRACT[0](0, auxdata_size),
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=2,
             ),
             Section.Container(container=runtime_subcontainer),
@@ -190,8 +177,6 @@ def test_auxdata_variations(state_test: StateTestFiller, auxdata_bytes: bytes):
                 sections=[
                     Section.Code(
                         code=Op.SSTORE(slot_create_address, Op.EOFCREATE[0](0, 0, 0, 0)) + Op.STOP,
-                        code_inputs=0,
-                        code_outputs=NON_RETURNING_SECTION,
                         max_stack_height=4,
                     ),
                     Section.Container(container=initcode_subcontainer),
@@ -230,8 +215,6 @@ def test_calldata(state_test: StateTestFiller):
                 code=Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE)
                 + Op.SSTORE(slot_calldata, Op.MLOAD(0))
                 + Op.RETURNCONTRACT[0](0, Op.CALLDATASIZE),
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=3,
             ),
             Section.Container(container=smallest_runtime_subcontainer),
@@ -249,8 +232,6 @@ def test_calldata(state_test: StateTestFiller):
                         code=Op.MSTORE(0, Op.PUSH32(calldata))
                         + Op.SSTORE(slot_create_address, Op.EOFCREATE[0](0, 0, 0, calldata_size))
                         + Op.STOP,
-                        code_inputs=0,
-                        code_outputs=NON_RETURNING_SECTION,
                         max_stack_height=4,
                     ),
                     Section.Container(container=initcode_subcontainer),
@@ -290,8 +271,6 @@ def test_eofcreate_in_initcode(
                 code=Op.SSTORE(slot_create_address, Op.EOFCREATE[0](0, 0, 0, 0))
                 + Op.SSTORE(slot_code_worked, value_code_worked)
                 + Op.RETURNCONTRACT[1](0, 0),
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=4,
             ),
             Section.Container(container=smallest_initcode_subcontainer),
@@ -309,8 +288,6 @@ def test_eofcreate_in_initcode(
                         code=Op.SSTORE(slot_create_address, Op.EOFCREATE[0](0, 0, 0, 0))
                         + Op.SSTORE(slot_code_worked, value_code_worked)
                         + Op.STOP,
-                        code_inputs=0,
-                        code_outputs=NON_RETURNING_SECTION,
                         max_stack_height=4,
                     ),
                     Section.Container(container=nested_initcode_subcontainer),
@@ -345,8 +322,6 @@ def test_eofcreate_in_initcode_reverts(
                 code=Op.SSTORE(slot_create_address, Op.EOFCREATE[0](0, 0, 0, 0))
                 + Op.SSTORE(slot_code_worked, value_code_worked)
                 + Op.REVERT(0, 0),
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=4,
             ),
             Section.Container(container=smallest_initcode_subcontainer),
@@ -364,8 +339,6 @@ def test_eofcreate_in_initcode_reverts(
                         code=Op.SSTORE(slot_create_address, Op.EOFCREATE[0](0, 0, 0, 0))
                         + Op.SSTORE(slot_code_worked, value_code_worked)
                         + Op.STOP,
-                        code_inputs=0,
-                        code_outputs=NON_RETURNING_SECTION,
                         max_stack_height=4,
                     ),
                     Section.Container(container=nested_initcode_subcontainer),
@@ -405,8 +378,6 @@ def test_return_data_cleared(
         sections=[
             Section.Code(
                 code=Op.MSTORE(0, value_return_canary) + Op.RETURN(0, value_return_canary_size),
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=2,
             )
         ]
@@ -425,8 +396,6 @@ def test_return_data_cleared(
                         + Op.SSTORE(slot_returndata_size_2, Op.RETURNDATASIZE)
                         + Op.SSTORE(slot_code_worked, value_code_worked)
                         + Op.STOP,
-                        code_inputs=0,
-                        code_outputs=NON_RETURNING_SECTION,
                         max_stack_height=4,
                     ),
                     Section.Container(container=smallest_initcode_subcontainer),
@@ -485,8 +454,6 @@ def test_address_collision(
                         + Op.SSTORE(slot_create_address_3, Op.EOFCREATE[0](0, 1, 0, 0))
                         + Op.SSTORE(slot_code_worked, value_code_worked)
                         + Op.STOP,
-                        code_inputs=0,
-                        code_outputs=NON_RETURNING_SECTION,
                         max_stack_height=4,
                     ),
                     Section.Container(container=smallest_initcode_subcontainer),

--- a/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_eofcreate_failures.py
+++ b/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_eofcreate_failures.py
@@ -12,11 +12,7 @@ from ethereum_test_tools import (
     compute_eofcreate_address,
 )
 from ethereum_test_tools.eof.v1 import Container, Section
-from ethereum_test_tools.eof.v1.constants import (
-    MAX_BYTECODE_SIZE,
-    MAX_INITCODE_SIZE,
-    NON_RETURNING_SECTION,
-)
+from ethereum_test_tools.eof.v1.constants import MAX_BYTECODE_SIZE, MAX_INITCODE_SIZE
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 from .. import EOF_FORK_NAME
@@ -60,8 +56,6 @@ def test_initcode_revert(state_test: StateTestFiller, revert: bytes):
         sections=[
             Section.Code(
                 code=Op.MSTORE(0, Op.PUSH32(revert)) + Op.REVERT(32 - revert_size, revert_size),
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=2,
             ),
         ],
@@ -77,8 +71,6 @@ def test_initcode_revert(state_test: StateTestFiller, revert: bytes):
                 + Op.SSTORE(slot_returndata, Op.MLOAD(0))
                 + Op.SSTORE(slot_code_worked, value_code_worked)
                 + Op.STOP,
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=4,
             ),
             Section.Container(container=initcode_subcontainer),
@@ -120,8 +112,6 @@ def test_initcode_aborts(
                         code=Op.SSTORE(slot_create_address, Op.EOFCREATE[0](0, 0, 0, 0))
                         + Op.SSTORE(slot_code_worked, value_code_worked)
                         + Op.STOP,
-                        code_inputs=0,
-                        code_outputs=NON_RETURNING_SECTION,
                         max_stack_height=4,
                     ),
                     Section.Container(
@@ -129,8 +119,6 @@ def test_initcode_aborts(
                             sections=[
                                 Section.Code(
                                     code=Op.INVALID,
-                                    code_inputs=0,
-                                    code_outputs=NON_RETURNING_SECTION,
                                     max_stack_height=0,
                                 )
                             ]
@@ -193,8 +181,6 @@ def test_eofcreate_deploy_sizes(
             Section.Code(
                 code=Op.JUMPDEST * (target_deploy_size - len(smallest_runtime_subcontainer))
                 + Op.STOP,
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=0,
             ),
         ]
@@ -205,8 +191,6 @@ def test_eofcreate_deploy_sizes(
         sections=[
             Section.Code(
                 code=Op.RETURNCONTRACT[0](0, 0),
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=2,
             ),
             Section.Container(container=runtime_container),
@@ -229,8 +213,6 @@ def test_eofcreate_deploy_sizes(
                         code=Op.SSTORE(slot_create_address, Op.EOFCREATE[0](0, 0, 0, 0))
                         + Op.SSTORE(slot_code_worked, value_code_worked)
                         + Op.STOP,
-                        code_inputs=0,
-                        code_outputs=NON_RETURNING_SECTION,
                         max_stack_height=4,
                     ),
                     Section.Container(container=initcode_subcontainer),
@@ -304,8 +286,6 @@ def test_auxdata_size_failures(state_test: StateTestFiller, auxdata_size: int):
             Section.Code(
                 code=Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE)
                 + Op.RETURNCONTRACT[0](0, Op.CALLDATASIZE),
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=3,
             ),
             Section.Container(container=smallest_runtime_subcontainer),
@@ -322,8 +302,6 @@ def test_auxdata_size_failures(state_test: StateTestFiller, auxdata_size: int):
                         + Op.SSTORE(slot_create_address, Op.EOFCREATE[0](0, 0, 0, Op.CALLDATASIZE))
                         + Op.SSTORE(slot_code_worked, value_code_worked)
                         + Op.STOP,
-                        code_inputs=0,
-                        code_outputs=NON_RETURNING_SECTION,
                         max_stack_height=4,
                     ),
                     Section.Container(container=initcode_subcontainer),
@@ -374,8 +352,6 @@ def test_eofcreate_insufficient_stipend(
                 code=Op.SSTORE(slot_create_address, Op.EOFCREATE[0](value, 0, 0, 0))
                 + Op.SSTORE(slot_code_worked, value_code_worked)
                 + Op.STOP,
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=4,
             ),
             Section.Container(container=smallest_initcode_subcontainer),
@@ -414,8 +390,6 @@ def test_insufficient_initcode_gas(
         sections=[
             Section.Code(
                 code=Op.RETURNCONTRACT[0](0, 0),
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=2,
             ),
             Section.Container(container=smallest_runtime_subcontainer),
@@ -432,8 +406,6 @@ def test_insufficient_initcode_gas(
                         code=Op.SSTORE(slot_create_address, Op.EOFCREATE[0](0, 0, 0, 0))
                         + Op.SSTORE(slot_code_should_fail, value_code_worked)
                         + Op.STOP,
-                        code_inputs=0,
-                        code_outputs=NON_RETURNING_SECTION,
                         max_stack_height=4,
                     ),
                     Section.Container(container=initcode_container),
@@ -477,8 +449,6 @@ def test_insufficient_gas_memory_expansion(
                 code=Op.SSTORE(slot_create_address, Op.EOFCREATE[0](0, 0, 0, auxdata_size))
                 + Op.SSTORE(slot_code_should_fail, slot_code_worked)
                 + Op.STOP,
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=4,
             ),
             Section.Container(container=smallest_initcode_subcontainer),
@@ -533,8 +503,6 @@ def test_insufficient_returncontract_auxdata_gas(
         sections=[
             Section.Code(
                 code=Op.RETURNCONTRACT[0](0, auxdata_size),
-                code_inputs=0,
-                code_outputs=NON_RETURNING_SECTION,
                 max_stack_height=2,
             ),
             Section.Container(container=smallest_runtime_subcontainer),
@@ -550,8 +518,6 @@ def test_insufficient_returncontract_auxdata_gas(
                         code=Op.SSTORE(slot_create_address, Op.EOFCREATE[0](0, 0, 0, 0))
                         + Op.SSTORE(slot_code_should_fail, value_code_worked)
                         + Op.STOP,
-                        code_inputs=0,
-                        code_outputs=NON_RETURNING_SECTION,
                         max_stack_height=4,
                     ),
                     Section.Container(container=initcode_container),


### PR DESCRIPTION
## 🗒️ Description

Having non-returning code sections in EOF is much more common (at least in tests) and because we rely on the default values the `NON_RETURNING_SECTION` is better default.

I only update container.py for visualization and fixed JUMPF failing tests (including one typo). New default can be applied to other tests later.

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
