### PR TITLE
fix(fw,tests): Withdrawal request v1 update execution-apis #549

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Add tests for [EIP-7069: EOF - Revamped CALL instructions](https://eips.ethereum.org/EIPS/eip-7069) ([#595](https://github.com/ethereum/execution-spec-tests/pull/595)).
 - 🐞 Fix typos in self-destruct collision test from erroneous pytest parametrization ([#608](https://github.com/ethereum/execution-spec-tests/pull/608)).
 - ✨ Add tests for [EIP-3540: EOF - EVM Object Format v1](https://eips.ethereum.org/EIPS/eip-3540) ([#634](https://github.com/ethereum/execution-spec-tests/pull/634)).
+- 🔀 Update EIP-7002 tests to match spec changes in [ethereum/execution-apis#549](https://github.com/ethereum/execution-apis/pull/549) ([#600](https://github.com/ethereum/execution-spec-tests/pull/600))
 
 ### 🛠️ Framework
 

--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -1511,7 +1511,7 @@ class WithdrawalRequestGeneric(RequestBase, CamelModel, Generic[NumberBoundTypeV
     """
 
     source_address: Address = Address(0)
-    validator_public_key: BLSPublicKey
+    validator_pubkey: BLSPublicKey
     amount: NumberBoundTypeVar
 
     @classmethod
@@ -1527,7 +1527,7 @@ class WithdrawalRequestGeneric(RequestBase, CamelModel, Generic[NumberBoundTypeV
         """
         return [
             self.source_address,
-            self.validator_public_key,
+            self.validator_pubkey,
             Uint(self.amount),
         ]
 

--- a/tests/prague/eip7002_el_triggerable_withdrawals/helpers.py
+++ b/tests/prague/eip7002_el_triggerable_withdrawals/helpers.py
@@ -54,7 +54,7 @@ class WithdrawalRequest(WithdrawalRequestBase):
         withdrawal.
         """
         return self.calldata_modifier(
-            self.validator_public_key + self.amount.to_bytes(8, byteorder="big")
+            self.validator_pubkey + self.amount.to_bytes(8, byteorder="big")
         )
 
     def with_source_address(self, source_address: Address) -> "WithdrawalRequest":
@@ -274,7 +274,7 @@ def get_n_fee_increment_blocks(n: int) -> List[List[WithdrawalRequestContract]]:
                 WithdrawalRequestContract(
                     requests=[
                         WithdrawalRequest(
-                            validator_public_key=i,
+                            validator_pubkey=i,
                             amount=0,
                             fee=fee,
                         )

--- a/tests/prague/eip7002_el_triggerable_withdrawals/test_withdrawal_requests.py
+++ b/tests/prague/eip7002_el_triggerable_withdrawals/test_withdrawal_requests.py
@@ -45,7 +45,7 @@ pytestmark = pytest.mark.valid_from("Prague")
                     WithdrawalRequestTransaction(
                         requests=[
                             WithdrawalRequest(
-                                validator_public_key=0x01,
+                                validator_pubkey=0x01,
                                 amount=0,
                                 fee=Spec.get_fee(0),
                             )
@@ -61,7 +61,7 @@ pytestmark = pytest.mark.valid_from("Prague")
                     WithdrawalRequestTransaction(
                         requests=[
                             WithdrawalRequest(
-                                validator_public_key=0x01,
+                                validator_pubkey=0x01,
                                 amount=0,
                                 fee=0,
                             )
@@ -77,7 +77,7 @@ pytestmark = pytest.mark.valid_from("Prague")
                     WithdrawalRequestTransaction(
                         requests=[
                             WithdrawalRequest(
-                                validator_public_key=0x01,
+                                validator_pubkey=0x01,
                                 amount=0,
                                 fee=Spec.get_fee(0),
                                 calldata_modifier=lambda x: x[:-1],
@@ -95,7 +95,7 @@ pytestmark = pytest.mark.valid_from("Prague")
                     WithdrawalRequestTransaction(
                         requests=[
                             WithdrawalRequest(
-                                validator_public_key=0x01,
+                                validator_pubkey=0x01,
                                 amount=0,
                                 fee=Spec.get_fee(0),
                                 calldata_modifier=lambda x: x + b"\x00",
@@ -113,12 +113,12 @@ pytestmark = pytest.mark.valid_from("Prague")
                     WithdrawalRequestTransaction(
                         requests=[
                             WithdrawalRequest(
-                                validator_public_key=0x01,
+                                validator_pubkey=0x01,
                                 amount=0,
                                 fee=Spec.get_fee(0),
                             ),
                             WithdrawalRequest(
-                                validator_public_key=0x02,
+                                validator_pubkey=0x02,
                                 amount=Spec.MAX_AMOUNT - 1,
                                 fee=Spec.get_fee(0),
                             ),
@@ -134,7 +134,7 @@ pytestmark = pytest.mark.valid_from("Prague")
                     WithdrawalRequestTransaction(
                         requests=[
                             WithdrawalRequest(
-                                validator_public_key=0x01,
+                                validator_pubkey=0x01,
                                 amount=0,
                                 fee=Spec.get_fee(0),
                             )
@@ -143,7 +143,7 @@ pytestmark = pytest.mark.valid_from("Prague")
                     WithdrawalRequestTransaction(
                         requests=[
                             WithdrawalRequest(
-                                validator_public_key=0x02,
+                                validator_pubkey=0x02,
                                 amount=Spec.MAX_AMOUNT - 1,
                                 fee=Spec.get_fee(0),
                             )
@@ -159,7 +159,7 @@ pytestmark = pytest.mark.valid_from("Prague")
                     WithdrawalRequestTransaction(
                         requests=[
                             WithdrawalRequest(
-                                validator_public_key=i + 1,
+                                validator_pubkey=i + 1,
                                 amount=0 if i % 2 == 0 else Spec.MAX_AMOUNT,
                                 fee=Spec.get_fee(0),
                             )
@@ -176,12 +176,12 @@ pytestmark = pytest.mark.valid_from("Prague")
                     WithdrawalRequestTransaction(
                         requests=[
                             WithdrawalRequest(
-                                validator_public_key=0x01,
+                                validator_pubkey=0x01,
                                 amount=0,
                                 fee=0,
                             ),
                             WithdrawalRequest(
-                                validator_public_key=0x02,
+                                validator_pubkey=0x02,
                                 amount=Spec.MAX_AMOUNT - 1,
                                 fee=Spec.get_fee(0),
                             ),
@@ -197,12 +197,12 @@ pytestmark = pytest.mark.valid_from("Prague")
                     WithdrawalRequestTransaction(
                         requests=[
                             WithdrawalRequest(
-                                validator_public_key=0x01,
+                                validator_pubkey=0x01,
                                 amount=0,
                                 fee=Spec.get_fee(0),
                             ),
                             WithdrawalRequest(
-                                validator_public_key=0x02,
+                                validator_pubkey=0x02,
                                 amount=Spec.MAX_AMOUNT - 1,
                                 fee=0,
                             ),
@@ -218,7 +218,7 @@ pytestmark = pytest.mark.valid_from("Prague")
                     WithdrawalRequestTransaction(
                         requests=[
                             WithdrawalRequest(
-                                validator_public_key=0x01,
+                                validator_pubkey=0x01,
                                 amount=0,
                                 fee=Spec.get_fee(0),
                                 # Value obtained from trace minus one
@@ -226,7 +226,7 @@ pytestmark = pytest.mark.valid_from("Prague")
                                 valid=False,
                             ),
                             WithdrawalRequest(
-                                validator_public_key=0x02,
+                                validator_pubkey=0x02,
                                 amount=0,
                                 fee=Spec.get_fee(0),
                             ),
@@ -242,12 +242,12 @@ pytestmark = pytest.mark.valid_from("Prague")
                     WithdrawalRequestTransaction(
                         requests=[
                             WithdrawalRequest(
-                                validator_public_key=0x01,
+                                validator_pubkey=0x01,
                                 amount=0,
                                 fee=Spec.get_fee(0),
                             ),
                             WithdrawalRequest(
-                                validator_public_key=0x02,
+                                validator_pubkey=0x02,
                                 amount=0,
                                 fee=Spec.get_fee(0),
                                 # Value obtained from trace minus one
@@ -267,7 +267,7 @@ pytestmark = pytest.mark.valid_from("Prague")
                     WithdrawalRequestTransaction(
                         requests=[
                             WithdrawalRequest(
-                                validator_public_key=i + 1,
+                                validator_pubkey=i + 1,
                                 amount=0 if i % 2 == 0 else Spec.MAX_AMOUNT,
                                 fee=Spec.get_fee(0),
                             )
@@ -288,7 +288,7 @@ pytestmark = pytest.mark.valid_from("Prague")
                     WithdrawalRequestContract(
                         requests=[
                             WithdrawalRequest(
-                                validator_public_key=0x01,
+                                validator_pubkey=0x01,
                                 amount=0,
                                 fee=Spec.get_fee(0),
                             ),
@@ -304,7 +304,7 @@ pytestmark = pytest.mark.valid_from("Prague")
                     WithdrawalRequestContract(
                         requests=[
                             WithdrawalRequest(
-                                validator_public_key=i + 1,
+                                validator_pubkey=i + 1,
                                 amount=Spec.MAX_AMOUNT - 1 if i % 2 == 0 else 0,
                                 fee=Spec.get_fee(0),
                             )
@@ -321,14 +321,14 @@ pytestmark = pytest.mark.valid_from("Prague")
                     WithdrawalRequestContract(
                         requests=[
                             WithdrawalRequest(
-                                validator_public_key=1,
+                                validator_pubkey=1,
                                 amount=Spec.MAX_AMOUNT,
                                 fee=0,
                             )
                         ]
                         + [
                             WithdrawalRequest(
-                                validator_public_key=i + 1,
+                                validator_pubkey=i + 1,
                                 amount=Spec.MAX_AMOUNT - 1 if i % 2 == 0 else 0,
                                 fee=Spec.get_fee(0),
                             )
@@ -345,7 +345,7 @@ pytestmark = pytest.mark.valid_from("Prague")
                     WithdrawalRequestContract(
                         requests=[
                             WithdrawalRequest(
-                                validator_public_key=i + 1,
+                                validator_pubkey=i + 1,
                                 amount=Spec.MAX_AMOUNT - 1 if i % 2 == 0 else 0,
                                 fee=Spec.get_fee(0),
                             )
@@ -353,7 +353,7 @@ pytestmark = pytest.mark.valid_from("Prague")
                         ]
                         + [
                             WithdrawalRequest(
-                                validator_public_key=Spec.MAX_WITHDRAWAL_REQUESTS_PER_BLOCK,
+                                validator_pubkey=Spec.MAX_WITHDRAWAL_REQUESTS_PER_BLOCK,
                                 amount=Spec.MAX_AMOUNT - 1
                                 if (Spec.MAX_WITHDRAWAL_REQUESTS_PER_BLOCK - 1) % 2 == 0
                                 else 0,
@@ -371,7 +371,7 @@ pytestmark = pytest.mark.valid_from("Prague")
                     WithdrawalRequestContract(
                         requests=[
                             WithdrawalRequest(
-                                validator_public_key=1,
+                                validator_pubkey=1,
                                 amount=Spec.MAX_AMOUNT - 1,
                                 gas_limit=100,
                                 fee=Spec.get_fee(0),
@@ -380,7 +380,7 @@ pytestmark = pytest.mark.valid_from("Prague")
                         ]
                         + [
                             WithdrawalRequest(
-                                validator_public_key=i + 1,
+                                validator_pubkey=i + 1,
                                 amount=Spec.MAX_AMOUNT - 1 if i % 2 == 0 else 0,
                                 gas_limit=1_000_000,
                                 fee=Spec.get_fee(0),
@@ -399,7 +399,7 @@ pytestmark = pytest.mark.valid_from("Prague")
                     WithdrawalRequestContract(
                         requests=[
                             WithdrawalRequest(
-                                validator_public_key=i + 1,
+                                validator_pubkey=i + 1,
                                 amount=Spec.MAX_AMOUNT - 1 if i % 2 == 0 else 0,
                                 fee=Spec.get_fee(0),
                                 gas_limit=1_000_000,
@@ -409,7 +409,7 @@ pytestmark = pytest.mark.valid_from("Prague")
                         ]
                         + [
                             WithdrawalRequest(
-                                validator_public_key=Spec.MAX_WITHDRAWAL_REQUESTS_PER_BLOCK,
+                                validator_pubkey=Spec.MAX_WITHDRAWAL_REQUESTS_PER_BLOCK,
                                 amount=Spec.MAX_AMOUNT - 1,
                                 gas_limit=100,
                                 fee=Spec.get_fee(0),
@@ -427,7 +427,7 @@ pytestmark = pytest.mark.valid_from("Prague")
                     WithdrawalRequestContract(
                         requests=[
                             WithdrawalRequest(
-                                validator_public_key=i + 1,
+                                validator_pubkey=i + 1,
                                 amount=Spec.MAX_AMOUNT - 1 if i % 2 == 0 else 0,
                                 fee=Spec.get_fee(0),
                                 valid=False,
@@ -446,7 +446,7 @@ pytestmark = pytest.mark.valid_from("Prague")
                     WithdrawalRequestContract(
                         requests=[
                             WithdrawalRequest(
-                                validator_public_key=i + 1,
+                                validator_pubkey=i + 1,
                                 amount=Spec.MAX_AMOUNT - 1 if i % 2 == 0 else 0,
                                 fee=Spec.get_fee(0),
                                 valid=False,
@@ -470,7 +470,7 @@ pytestmark = pytest.mark.valid_from("Prague")
                     WithdrawalRequestContract(
                         requests=[
                             WithdrawalRequest(
-                                validator_public_key=0x01,
+                                validator_pubkey=0x01,
                                 amount=0,
                                 fee=Spec.get_fee(0),
                                 valid=False,
@@ -481,7 +481,7 @@ pytestmark = pytest.mark.valid_from("Prague")
                     WithdrawalRequestContract(
                         requests=[
                             WithdrawalRequest(
-                                validator_public_key=0x01,
+                                validator_pubkey=0x01,
                                 amount=0,
                                 fee=Spec.get_fee(0),
                                 valid=False,
@@ -492,7 +492,7 @@ pytestmark = pytest.mark.valid_from("Prague")
                     WithdrawalRequestContract(
                         requests=[
                             WithdrawalRequest(
-                                validator_public_key=0x01,
+                                validator_pubkey=0x01,
                                 amount=0,
                                 fee=Spec.get_fee(0),
                                 valid=False,
@@ -529,7 +529,7 @@ def test_withdrawal_requests(
             [],
             [
                 WithdrawalRequest(
-                    validator_public_key=0x01,
+                    validator_pubkey=0x01,
                     amount=0,
                     source_address=Address(0),
                 ),
@@ -542,7 +542,7 @@ def test_withdrawal_requests(
                 WithdrawalRequestTransaction(
                     requests=[
                         WithdrawalRequest(
-                            validator_public_key=0x01,
+                            validator_pubkey=0x01,
                             amount=0,
                             fee=Spec.get_fee(0),
                         ),
@@ -558,7 +558,7 @@ def test_withdrawal_requests(
                 WithdrawalRequestTransaction(
                     requests=[
                         WithdrawalRequest(
-                            validator_public_key=0x01,
+                            validator_pubkey=0x01,
                             amount=0,
                             fee=Spec.get_fee(0),
                         ),
@@ -567,7 +567,7 @@ def test_withdrawal_requests(
             ],
             [
                 WithdrawalRequest(
-                    validator_public_key=0x02,
+                    validator_pubkey=0x02,
                     amount=0,
                     source_address=TestAddress,
                 )
@@ -580,7 +580,7 @@ def test_withdrawal_requests(
                 WithdrawalRequestTransaction(
                     requests=[
                         WithdrawalRequest(
-                            validator_public_key=0x01,
+                            validator_pubkey=0x01,
                             amount=0,
                             fee=Spec.get_fee(0),
                         )
@@ -589,7 +589,7 @@ def test_withdrawal_requests(
             ],
             [
                 WithdrawalRequest(
-                    validator_public_key=0x01,
+                    validator_pubkey=0x01,
                     amount=1,
                     source_address=TestAddress,
                 )
@@ -602,7 +602,7 @@ def test_withdrawal_requests(
                 WithdrawalRequestTransaction(
                     requests=[
                         WithdrawalRequest(
-                            validator_public_key=0x01,
+                            validator_pubkey=0x01,
                             amount=0,
                             fee=Spec.get_fee(0),
                         )
@@ -611,7 +611,7 @@ def test_withdrawal_requests(
             ],
             [
                 WithdrawalRequest(
-                    validator_public_key=0x01,
+                    validator_pubkey=0x01,
                     amount=0,
                     source_address=TestAddress2,
                 )
@@ -624,12 +624,12 @@ def test_withdrawal_requests(
                 WithdrawalRequestTransaction(
                     requests=[
                         WithdrawalRequest(
-                            validator_public_key=0x01,
+                            validator_pubkey=0x01,
                             amount=0,
                             fee=Spec.get_fee(0),
                         ),
                         WithdrawalRequest(
-                            validator_public_key=0x02,
+                            validator_pubkey=0x02,
                             amount=0,
                             fee=Spec.get_fee(0),
                         ),
@@ -638,12 +638,12 @@ def test_withdrawal_requests(
             ],
             [
                 WithdrawalRequest(
-                    validator_public_key=0x02,
+                    validator_pubkey=0x02,
                     amount=0,
                     source_address=TestAddress,
                 ),
                 WithdrawalRequest(
-                    validator_public_key=0x01,
+                    validator_pubkey=0x01,
                     amount=0,
                     source_address=TestAddress,
                 ),
@@ -656,7 +656,7 @@ def test_withdrawal_requests(
                 WithdrawalRequestTransaction(
                     requests=[
                         WithdrawalRequest(
-                            validator_public_key=0x01,
+                            validator_pubkey=0x01,
                             amount=0,
                             fee=Spec.get_fee(0),
                         )
@@ -665,12 +665,12 @@ def test_withdrawal_requests(
             ],
             [
                 WithdrawalRequest(
-                    validator_public_key=0x01,
+                    validator_pubkey=0x01,
                     amount=0,
                     source_address=TestAddress,
                 ),
                 WithdrawalRequest(
-                    validator_public_key=0x01,
+                    validator_pubkey=0x01,
                     amount=0,
                     source_address=TestAddress,
                 ),

--- a/tests/prague/eip7685_general_purpose_el_requests/test_deposits_withdrawals.py
+++ b/tests/prague/eip7685_general_purpose_el_requests/test_deposits_withdrawals.py
@@ -54,7 +54,7 @@ pytestmark = pytest.mark.valid_from("Prague")
                 WithdrawalRequestTransaction(
                     requests=[
                         WithdrawalRequest(
-                            validator_public_key=0x01,
+                            validator_pubkey=0x01,
                             amount=0,
                             fee=1,
                         )
@@ -68,7 +68,7 @@ pytestmark = pytest.mark.valid_from("Prague")
                 WithdrawalRequestTransaction(
                     requests=[
                         WithdrawalRequest(
-                            validator_public_key=0x01,
+                            validator_pubkey=0x01,
                             amount=0,
                             fee=1,
                         )
@@ -104,7 +104,7 @@ pytestmark = pytest.mark.valid_from("Prague")
                 WithdrawalRequestTransaction(
                     requests=[
                         WithdrawalRequest(
-                            validator_public_key=0x01,
+                            validator_pubkey=0x01,
                             amount=0,
                             fee=1,
                         )
@@ -129,7 +129,7 @@ pytestmark = pytest.mark.valid_from("Prague")
                 WithdrawalRequestTransaction(
                     requests=[
                         WithdrawalRequest(
-                            validator_public_key=0x01,
+                            validator_pubkey=0x01,
                             amount=0,
                             fee=1,
                         )
@@ -149,7 +149,7 @@ pytestmark = pytest.mark.valid_from("Prague")
                 WithdrawalRequestTransaction(
                     requests=[
                         WithdrawalRequest(
-                            validator_public_key=0x01,
+                            validator_pubkey=0x01,
                             amount=1,
                             fee=1,
                         )
@@ -174,7 +174,7 @@ pytestmark = pytest.mark.valid_from("Prague")
                 WithdrawalRequestContract(
                     requests=[
                         WithdrawalRequest(
-                            validator_public_key=0x01,
+                            validator_pubkey=0x01,
                             amount=0,
                             fee=1,
                         )
@@ -188,7 +188,7 @@ pytestmark = pytest.mark.valid_from("Prague")
                 WithdrawalRequestContract(
                     requests=[
                         WithdrawalRequest(
-                            validator_public_key=0x01,
+                            validator_pubkey=0x01,
                             amount=0,
                             fee=1,
                         )
@@ -251,7 +251,7 @@ def test_valid_deposit_withdrawal_request_from_same_tx(
         index=0x0,
     )
     withdrawal_request = WithdrawalRequest(
-        validator_public_key=0x01,
+        validator_pubkey=0x01,
         amount=0,
     )
     if deposit_first:
@@ -348,7 +348,7 @@ def test_valid_deposit_withdrawal_request_from_same_tx(
                 WithdrawalRequestTransaction(
                     requests=[
                         WithdrawalRequest(
-                            validator_public_key=0x01,
+                            validator_pubkey=0x01,
                             amount=0,
                             fee=1,
                         )
@@ -368,7 +368,7 @@ def test_valid_deposit_withdrawal_request_from_same_tx(
             ],
             [
                 WithdrawalRequest(
-                    validator_public_key=0x01,
+                    validator_pubkey=0x01,
                     amount=0,
                     source_address=TestAddress,
                 ),


### PR DESCRIPTION
## 🗒️ Description
Update tests and framework to match changes described in https://github.com/ethereum/execution-apis/pull/549

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
