### PR TITLE
new(tests): EIP-3540: extcode semantics on EOF init container mid-creation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Add tests for [EIP-7069: EOF - Revamped CALL instructions](https://eips.ethereum.org/EIPS/eip-7069) ([#595](https://github.com/ethereum/execution-spec-tests/pull/595)).
 - 🐞 Fix typos in self-destruct collision test from erroneous pytest parametrization ([#608](https://github.com/ethereum/execution-spec-tests/pull/608)).
 - ✨ Add tests for [EIP-3540: EOF - EVM Object Format v1](https://eips.ethereum.org/EIPS/eip-3540) ([#634](https://github.com/ethereum/execution-spec-tests/pull/634)).
+- ✨ Add tests execution semantics changes on [EIP-3540: EVM Object Format v1](https://eips.ethereum.org/EIPS/eip-3540) ([#571](https://github.com/ethereum/execution-spec-tests/pull/571), [#601](https://github.com/ethereum/execution-spec-tests/pull/601)).
 
 ### 🛠️ Framework
 

--- a/docs/writing_tests/test_markers.md
+++ b/docs/writing_tests/test_markers.md
@@ -86,6 +86,21 @@ In this example, the test will be parameterized for parameter `precompile` with 
 
 This marker is used to mark tests that are slow to run. These tests are not run during tox testing, and are only run when a release is being prepared.
 
+### pytest.mark.pre_alloc_modifier
+
+This marker is used to mark tests that access and modify the internal accounts of `pre` , instead of using the default `pre.deploy_contract` or `pre.fund_eoa` functions.
+
+This is sometimes necessary when the test requires a specific account state that is not possible to achieve using the default functions, but limits the environment in which the test can be run.
+
+```python
+import pytest
+
+@pytest.mark.pre_alloc_modifier
+def test_something_with_modified_pre(pre):
+    pre[0x0000000000000000000000000000000000000000] = Account(storage={0: 1})
+    ...
+```
+
 ### pytest.mark.skip("reason")
 
 This marker is used to skip a test with a reason.

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,6 +5,7 @@ python_files = *.py
 testpaths = tests/
 markers =
     slow
+    pre_alloc_modifier
 addopts = 
     -p pytest_plugins.test_filler.test_filler
     -p pytest_plugins.forks.forks

--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -324,6 +324,16 @@ class Storage(RootModel[Dict[StorageKeyValueType, StorageKeyValueType]]):
             elif other[key] != 0:
                 raise Storage.KeyValueMismatch(address=address, key=key, want=0, got=other[key])
 
+    def canary_storage(self, canary_value: int = 0xBA53) -> "Storage":
+        """
+        Returns a copy of the storage with the canary value in every key.
+
+        This is normally used to fill the storage with a known non-zero value as pre-allocation
+        for the test to properly verify that a value was actually modified during the execution
+        and not left as zero due to an error.
+        """
+        return Storage({key: HashInt(canary_value) for key in self.root})
+
 
 class Account(CopyValidateModel):
     """

--- a/src/ethereum_test_tools/eof/v1/__init__.py
+++ b/src/ethereum_test_tools/eof/v1/__init__.py
@@ -9,8 +9,9 @@ from typing import Dict, List, Optional, Tuple
 
 from pydantic import Field
 
-from ...common import Bytes
+from ...common import Address, Bytes
 from ...common.conversions import BytesConvertible
+from ...common.helpers import compute_eofcreate_address
 from ...common.types import CopyValidateModel
 from ...exceptions import EOFException
 from ...vm.opcode import Bytecode
@@ -415,6 +416,12 @@ class Container(CopyValidateModel):
         """
         kwargs.pop("kind", None)
         return cls(sections=[Section.Code(code=code, **kwargs)])
+
+    def eofcreate_address(self, creator_address: Address, salt: int) -> Address:
+        """
+        Computes the address of a contract created by this container.
+        """
+        return compute_eofcreate_address(creator_address, salt, self)
 
     def __bytes__(self) -> bytes:
         """

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_extcode.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_extcode.py
@@ -1,10 +1,21 @@
 """
 test execution semantics changes
 """
+from typing import Dict
+
 import pytest
 from ethereum.crypto.hash import keccak256
 
-from ethereum_test_tools import Account, Alloc, Environment, StateTestFiller, Storage, Transaction
+from ethereum_test_tools import (
+    Account,
+    Address,
+    Alloc,
+    Bytecode,
+    Environment,
+    StateTestFiller,
+    Storage,
+    Transaction,
+)
 from ethereum_test_tools.eof.v1 import Container, Section
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
@@ -65,6 +76,63 @@ def test_legacy_calls_eof_sstore(
         gas_price=10,
         protected=False,
         data="",
+    )
+
+    post = {
+        address_test_contract: Account(storage=storage_test),
+    }
+
+    state_test(
+        env=env,
+        pre=pre,
+        post=post,
+        tx=tx,
+    )
+
+
+@pytest.mark.pre_alloc_modifier
+def test_legacy_calls_mainnet_contracts(
+    state_test: StateTestFiller,
+    pre: Alloc,
+):
+    """
+    Test existing mainnet contracts that start with 0xef do not exhibit the same
+    behavior as the EOF contracts when using EXTCODE* opcodes.
+    """
+    env = Environment()
+    storage_test = Storage()
+
+    mainnet_contracts: Dict[Address, bytes] = {
+        Address(0xCA7BF67AB492B49806E24B6E2E4EC105183CAA01): b"\xef",
+        Address(0x897DA0F23CCC5E939EC7A53032C5E80FD1A947EC): b"\xef",
+        Address(
+            0x6E51D4D9BE52B623A3D3A2FA8D3C5E3E01175CD0
+        ): b"\xef\xf0\x9f\x91\x8b\xf0\x9f\x9f\xa9",
+    }
+
+    test_contract_code = Bytecode()
+    for address, code in mainnet_contracts.items():
+        test_contract_code += (
+            Op.SSTORE(storage_test.store_next(len(code)), Op.EXTCODESIZE(address))
+            + Op.EXTCODECOPY(address, 0, 0, Op.EXTCODESIZE(address))
+            + Op.SSTORE(storage_test.store_next(code.ljust(32, b"\0")), Op.MLOAD(0))
+            + Op.SSTORE(storage_test.store_next(keccak256(code)), Op.EXTCODEHASH(address))
+        )
+
+    address_test_contract = pre.deploy_contract(
+        test_contract_code,
+        storage=storage_test.canary_storage(),
+    )
+
+    for address, code in mainnet_contracts.items():
+        pre[address] = Account(code=code)
+
+    sender = pre.fund_eoa()
+
+    tx = Transaction(
+        sender=sender,
+        to=address_test_contract,
+        gas_limit=50000000,
     )
 
     post = {

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_extcode_initcontainer.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_extcode_initcontainer.py
@@ -1,0 +1,179 @@
+"""
+Test execution semantic changes on contracts mid-creation.
+"""
+import pytest
+
+from ethereum_test_tools import (
+    Account,
+    Address,
+    Alloc,
+    Bytecode,
+    Environment,
+    StateTestFiller,
+    Transaction,
+)
+from ethereum_test_tools.eof.v1 import Container, Section
+from ethereum_test_tools.vm.opcode import Opcodes as Op
+
+from .. import EOF_FORK_NAME
+from ..eip7620_eof_create.helpers import smallest_runtime_subcontainer
+
+pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
+
+REFERENCE_SPEC_GIT_PATH = "EIPS/eip-3540.md"
+REFERENCE_SPEC_VERSION = "137ecc2ae5d9ce23c3d5b77ef3c68851468e7433"
+
+key_legacy_ext_result = 0x01
+key_legacy_caller = 0x02
+
+# Parameters for testing EXTCODE* opcodes calling EOF containers mid-creation
+ext_code_pytest_params = [
+    pytest.param(
+        Op.SSTORE(key_legacy_ext_result, Op.EXTCODESIZE(Op.CALLER))
+        + Op.SSTORE(key_legacy_caller, Op.CALLER),
+        0,
+        id="EXTCODESIZE",
+    ),
+    pytest.param(
+        Op.EXTCODECOPY(Op.CALLER, 0, 0, 32)
+        + Op.SSTORE(key_legacy_ext_result, Op.MLOAD(0))
+        + Op.SSTORE(key_legacy_caller, Op.CALLER),
+        0,
+        id="EXTCODECOPY",
+    ),
+    pytest.param(
+        Op.SSTORE(key_legacy_ext_result, Op.EXTCODEHASH(Op.CALLER))
+        + Op.SSTORE(key_legacy_caller, Op.CALLER),
+        0xC5D2460186F7233C927E7DB2DCC703C0E500B653CA82273B7BFAD8045D85A470,
+        id="EXTCODEHASH",
+    ),
+]
+
+
+@pytest.fixture
+def address_legacy_contract(pre: Alloc, legacy_code: Bytecode) -> Address:  # noqa: D103
+    return pre.deploy_contract(
+        legacy_code,
+        storage={
+            key_legacy_ext_result: 0xB17D,  # a canary to be overwritten
+        },
+    )
+
+
+@pytest.fixture
+def init_container(address_legacy_contract: Address) -> Container:  # noqa: D103
+    return Container(
+        sections=[
+            Section.Code(
+                code=(Op.EXTCALL(address_legacy_contract, 0, 0, 0) + Op.RETURNCONTRACT[0](0, 0)),
+            ),
+            Section.Container(container=smallest_runtime_subcontainer),
+        ],
+    )
+
+
+@pytest.mark.parametrize(
+    "legacy_code,expected_result",
+    ext_code_pytest_params,
+)
+def test_legacy_calls_eof_init_container_sstore(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    address_legacy_contract: Address,
+    init_container: Container,
+    expected_result: int,
+):
+    """Test EXTCODE* opcodes calling EOF containers mid-creation"""
+    env = Environment()
+    salt = 0
+    eof_contract_creator_code = Container(
+        sections=[
+            Section.Code(
+                code=Op.SSTORE(0, Op.EOFCREATE[0](0, salt, 0, 0)) + Op.STOP,
+            ),
+            Section.Container(
+                container=init_container,
+            ),
+        ],
+    )
+
+    address_eof_contract_creator = pre.deploy_contract(eof_contract_creator_code)
+
+    created_contract_address = init_container.eofcreate_address(address_eof_contract_creator, salt)
+
+    tx = Transaction(
+        sender=pre.fund_eoa(),
+        to=address_eof_contract_creator,
+        gas_limit=50_000_000,
+    )
+
+    post = {
+        address_legacy_contract: Account(
+            storage={
+                key_legacy_ext_result: expected_result,
+                key_legacy_caller: created_contract_address,
+            }
+        ),
+        created_contract_address: Account(
+            code=smallest_runtime_subcontainer,
+        ),
+        address_eof_contract_creator: Account(
+            storage={
+                0: created_contract_address,
+            },
+            nonce=2,
+        ),
+    }
+
+    state_test(
+        env=env,
+        pre=pre,
+        post=post,
+        tx=tx,
+    )
+
+
+@pytest.mark.parametrize(
+    "legacy_code,expected_result",
+    ext_code_pytest_params,
+)
+@pytest.mark.with_all_contract_creating_tx_types
+def test_legacy_calls_eof_init_tx_container_sstore(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    address_legacy_contract: Address,
+    init_container: Container,
+    expected_result: int,
+    tx_type: int,
+):
+    """Test EXTCODE* opcodes calling EOF containers mid-creation from a creating transaction"""
+    env = Environment()
+
+    tx = Transaction(
+        sender=pre.fund_eoa(),
+        type=tx_type,
+        to=None,
+        gas_limit=1_000_000,
+        data=init_container,
+    )
+
+    created_contract_address = tx.created_contract
+
+    post = {
+        address_legacy_contract: Account(
+            storage={
+                key_legacy_ext_result: expected_result,
+                key_legacy_caller: created_contract_address,
+            }
+        ),
+        created_contract_address: Account(
+            code=smallest_runtime_subcontainer,
+        ),
+    }
+
+    state_test(
+        env=env,
+        pre=pre,
+        post=post,
+        tx=tx,
+    )

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -105,6 +105,7 @@ eips
 EIPs
 eip6110
 eip7002
+eip7620
 el
 endianness
 EngineAPI


### PR DESCRIPTION
## 🗒️ Description
Adds a test to verify the behavior of `EXTCODESIZE`, `EXTCODECOPY` and `EXTCODEHASH` when the target is an EOF container in the middle of creation.

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.