### PR TITLE
feat(ci): use solc-select for tox

### DIFF
--- a/.github/workflows/tox_verify.yaml
+++ b/.github/workflows/tox_verify.yaml
@@ -10,28 +10,23 @@ jobs:
         include:
           - os: ubuntu-latest
             python: '3.10'
-            solc: '0.8.20'
             evm-type: 'stable'
             tox-cmd: 'tox run-parallel --parallel-no-spinner'
           - os: ubuntu-latest
             python: '3.12'
-            solc: '0.8.23'
             evm-type: 'stable'
             tox-cmd: 'tox run-parallel --parallel-no-spinner'
           - os: ubuntu-latest
             python: '3.11'
-            solc: '0.8.21'
             evm-type: 'develop'
             tox-cmd: 'tox -e tests-develop'
           # Disabled to not be gated by evmone implementation
           # - os: ubuntu-latest
           #   python: '3.11'
-          #   solc: '0.8.21'
           #   evm-type: 'eip7692'
           #   tox-cmd: 'tox -e tests-eip7692'
           - os: macos-latest
             python: '3.11'
-            solc: '0.8.22'
             evm-type: 'stable'
             tox-cmd: 'tox run-parallel --parallel-no-spinner'
     steps:
@@ -47,13 +42,6 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           allow-prereleases: true
-      - name: Install solc compiler
-        run: |
-          if [ "$RUNNER_OS" == "Linux" ]; then PLATFORM="linux-amd64"; else PLATFORM="macosx-amd64"; fi
-          RELEASE_NAME=$(curl https://binaries.soliditylang.org/${PLATFORM}/list.json | jq -r --arg SOLC_VERSION "${{ matrix.solc }}" '.releases[$SOLC_VERSION]')
-          wget -O $GITHUB_WORKSPACE/bin/solc https://binaries.soliditylang.org/${PLATFORM}/$RELEASE_NAME
-          chmod a+x $GITHUB_WORKSPACE/bin/solc
-          echo $GITHUB_WORKSPACE/bin >> $GITHUB_PATH
       - name: Setup Tools/Dependencies Ubuntu
         if: runner.os == 'Linux'
         run: |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -51,6 +51,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - 🐞 Relax minor and patch dependency requirements to avoid conflicting package dependencies ([#510](https://github.com/ethereum/execution-spec-tests/pull/510)).
 - 🔀 Update all CI actions to use their respective Node.js 20 versions, ahead of their Node.js 16 version deprecations ([#527](https://github.com/ethereum/execution-spec-tests/pull/527)).
 - ✨ Releases now contain a `fixtures_eip7692.tar.gz` which contains all EOF fixtures ([#573](https://github.com/ethereum/execution-spec-tests/pull/573)).
+- ✨ Use `solc-select` for tox when running locally and within CI ([#604](https://github.com/ethereum/execution-spec-tests/pull/604)).
 
 ### 💥 Breaking Change
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,7 @@ install_requires =
     click>=8.0.0,<9
     pydantic>=2.6.3,<3
     rich>=13.7.0,<14
+    solc-select>=1.0.4
 
 [options.package_data]
 ethereum_test_tools =

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ eip7692 = CancunEIP7692
 [testenv]
 package = wheel
 wheel_build_env = .pkg
+commands_pre = solc-select use 0.8.24 --always-install
 
 [testenv:framework]
 description = Run checks on helper libraries and test framework
@@ -82,6 +83,8 @@ description = Run documentation checks
 extras =
     lint
     docs
+
+commands_pre =  # Override commands pre to not run solc-select install
 
 setenv =
     SPEC_TESTS_AUTO_GENERATE_FILES = true


### PR DESCRIPTION
## 🗒️ Description
Adds a step toward deprecating the requirement of solc for EEST (using solc-select instead).

Tox passes after merging this into my origin main, check recent commits:
https://github.com/spencer-tb/execution-spec-tests

I personally have not used an "installed solc" for the past 3 months, and instead used `solc-select`.
Due to the latter I've kept these changes trailing in my local repo for running tox.

## 🔗 Related Issues
https://github.com/ethereum/execution-spec-tests/pull/461 - planning to split the latter into smaller PRs, this PR being one of them.

Future PRs will include the deprecation of solc completely in within EEST in favor of solc-select.

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
