### PR TITLE
bug(tests):  fix typos in selfdestruct test

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Add tests for [EIP-7685: General purpose execution layer requests](https://eips.ethereum.org/EIPS/eip-7685) ([#530](https://github.com/ethereum/execution-spec-tests/pull/530)).
 - ✨ Add tests for [EIP-2935: Serve historical block hashes from state](https://eips.ethereum.org/EIPS/eip-2935) ([#564](https://github.com/ethereum/execution-spec-tests/pull/564)).
 - ✨ Add tests for [EIP-4200: EOF - Static relative jumps](https://eips.ethereum.org/EIPS/eip-4200) ([#581](https://github.com/ethereum/execution-spec-tests/pull/581)).
+- 🐞 Fix typos in self-destruct collision test from erroneous pytest parametrization ([#608](https://github.com/ethereum/execution-spec-tests/pull/608)).
 
 ### 🛠️ Framework
 

--- a/tests/cancun/eip6780_selfdestruct/test_dynamic_create2_selfdestruct_collision.py
+++ b/tests/cancun/eip6780_selfdestruct/test_dynamic_create2_selfdestruct_collision.py
@@ -235,9 +235,7 @@ def test_dynamic_create2_selfdestruct_collision(
 )
 @pytest.mark.parametrize(
     "call_create2_contract_at_the_end",
-    [
-        (True, False),
-    ],
+    (True, False),
 )
 def test_dynamic_create2_selfdestruct_collision_two_different_transactions(
     env: Environment,
@@ -374,7 +372,11 @@ def test_dynamic_create2_selfdestruct_collision_two_different_transactions(
     post[create2_address] = (
         Account(balance=0, nonce=1, code=deploy_code, storage={create2_constructor_worked: 0x00})
         if create2_dest_already_in_state and fork >= Cancun
-        else Account.NONEXISTENT
+        else (
+            Account.NONEXISTENT
+            if call_create2_contract_at_the_end
+            else Account(balance=1000, nonce=1, code=deploy_code)
+        )
     )
 
     # after Cancun Create2 initcode is only executed if the contract did not already exist
@@ -419,11 +421,15 @@ def test_dynamic_create2_selfdestruct_collision_two_different_transactions(
         else:
             # first create2 fails, first calls totally removes the account
             # in the second transaction second create2 is successful
-            sendall_destination_balance += first_call_value + second_create2_value
+            sendall_destination_balance += first_call_value
+            if call_create2_contract_at_the_end:
+                sendall_destination_balance += second_create2_value
     else:
         # if no account in the state, first create2 successful, first call successful and removes
         # because it is removed in the next transaction second create2 successful
-        sendall_destination_balance = first_create2_value + first_call_value + second_create2_value
+        sendall_destination_balance = first_create2_value + first_call_value
+        if call_create2_contract_at_the_end:
+            sendall_destination_balance += second_create2_value
 
     if call_create2_contract_at_the_end:
         sendall_destination_balance += second_call_value


### PR DESCRIPTION
## 🗒️ Description
Fix typo found by Spencer in selfdestruct test that affected verkle experiments

## 🔗 Related Issues


## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
