### PR TITLE
feat(fw,forks,tests): Add EVM code type marker

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Generated fixtures now contain the test index `index.json` by default ([#716](https://github.com/ethereum/execution-spec-tests/pull/716)).
 - ✨ A metadata folder `.meta/` now stores all fixture metadata files by default ([#721](https://github.com/ethereum/execution-spec-tests/pull/721)).
 - 🐞 Fixed `fill` command index generation issue due to concurrency ([#725](https://github.com/ethereum/execution-spec-tests/pull/725)).
+- ✨ Added `with_all_evm_code_types` and `with_all_call_opcodes` markers, which allow automatic parametrization of tests to EOF ([#610](https://github.com/ethereum/execution-spec-tests/pull/610)).
 
 ### 🔧 EVM Tools
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,9 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 ### 🧪 Test Cases
 
+- ✨ EIP-4844 test `tests/cancun/eip4844_blobs/test_point_evaluation_precompile.py` includes an EOF test case ([#610](https://github.com/ethereum/execution-spec-tests/pull/610)).
+- ✨ Example test `tests/frontier/opcodes/test_dup.py` now includes EOF parametrization ([#610](https://github.com/ethereum/execution-spec-tests/pull/610)).
+
 ### 🛠️ Framework
 
 - 🐞 Fixed consume hive commands from spawning different hive test suites during the same test execution when using xdist ([#712](https://github.com/ethereum/execution-spec-tests/pull/712)).
@@ -16,6 +19,8 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ A metadata folder `.meta/` now stores all fixture metadata files by default ([#721](https://github.com/ethereum/execution-spec-tests/pull/721)).
 - 🐞 Fixed `fill` command index generation issue due to concurrency ([#725](https://github.com/ethereum/execution-spec-tests/pull/725)).
 - ✨ Added `with_all_evm_code_types` and `with_all_call_opcodes` markers, which allow automatic parametrization of tests to EOF ([#610](https://github.com/ethereum/execution-spec-tests/pull/610)).
+- ✨ Code generators `Conditional` and `Switch` now support EOF by adding parameter `evm_code_type` ([#610](https://github.com/ethereum/execution-spec-tests/pull/610)).
+- ✨ `fill` command now supports parameter `--evm-code-type` that can be (currently) set to `legacy` or `eof_v1` to force all test smart contracts to deployed in normal or in EOF containers ([#610](https://github.com/ethereum/execution-spec-tests/pull/610)).
 
 ### 🔧 EVM Tools
 

--- a/docs/writing_tests/test_markers.md
+++ b/docs/writing_tests/test_markers.md
@@ -53,7 +53,7 @@ import pytest
 
 @pytest.mark.with_all_tx_types
 @pytest.mark.valid_from("Berlin")
-def test_something_with_all_tx_types(tx_type):
+def test_something_with_all_tx_types(tx_type: int):
     pass
 ```
 
@@ -74,11 +74,49 @@ import pytest
 
 @pytest.mark.with_all_precompiles
 @pytest.mark.valid_from("Shanghai")
-def test_something_with_all_precompiles(precompile):
+def test_something_with_all_precompiles(precompile: int):
     pass
 ```
 
 In this example, the test will be parameterized for parameter `precompile` with values `[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]` for fork Shanghai, but with values `[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]` for fork Cancun (because of EIP-4844).
+
+### pytest.mark.with_all_evm_code_types
+
+This marker is used to automatically parameterize a test with all EVM code types that are valid for the fork being tested.
+
+```python
+import pytest
+
+@pytest.mark.with_all_evm_code_types
+@pytest.mark.valid_from("Frontier")
+def test_something_with_all_evm_code_types(pre: Alloc):
+    pass
+```
+
+In this example, the test will be parameterized for parameter `evm_code_type` only with value `[EVMCodeType.LEGACY]` starting on fork Frontier, and eventually it will be parametrized with with values `[EVMCodeType.LEGACY, EVMCodeType.EOF_V1]` on the EOF activation fork.
+
+In all calls to `pre.deploy_contract`, if the code parameter is `Bytecode` type, and `evm_code_type==EVMCodeType.EOF_V1`, the bytecode will be automatically wrapped in an EOF V1 container.
+
+Code wrapping might fail in the following circumstances:
+
+- The code contains invalid EOF V1 opcodes.
+- The code does not end with a valid EOF V1 terminating opcode (such as `Op.STOP` or `Op.REVERT` or `Op.RETURN`).
+
+In the case where the code wrapping fails, `evm_code_type` can be added as a parameter to the test and the bytecode can be dynamically modified to be compatible with the EOF V1 container.
+
+```python
+import pytest
+
+@pytest.mark.with_all_evm_code_types
+@pytest.mark.valid_from("Frontier")
+def test_something_with_all_evm_code_types(pre: Alloc, evm_code_type: EVMCodeType):
+    code = Op.SSTORE(1, 1)
+    if evm_code_type == EVMCodeType.EOF_V1:
+        # Modify the bytecode to be compatible with EOF V1 container
+        code += Op.STOP
+    pre.deploy_contract(code)
+    ...
+```
 
 ## Other Markers
 

--- a/docs/writing_tests/test_markers.md
+++ b/docs/writing_tests/test_markers.md
@@ -118,6 +118,23 @@ def test_something_with_all_evm_code_types(pre: Alloc, evm_code_type: EVMCodeTyp
     ...
 ```
 
+### pytest.mark.with_all_call_opcodes
+
+This marker is used to automatically parameterize a test with all EVM call opcodes that are valid for the fork being tested.
+
+```python
+import pytest
+
+@pytest.mark.with_all_call_opcodes
+@pytest.mark.valid_from("Frontier")
+def test_something_with_all_call_opcodes(pre: Alloc, call_opcode: Op):
+    ...
+```
+
+In this example, the test will be parametrized for parameter `call_opcode` with values `[Op.CALL, Op.CALLCODE]` starting on fork Frontier, `[Op.CALL, Op.CALLCODE, Op.DELEGATECALL]` on fork Homestead, `[Op.CALL, Op.CALLCODE, Op.DELEGATECALL, Op.STATICCALL]` on fork Byzantium, and eventually it will be parametrized with with values `[Op.CALL, Op.CALLCODE, Op.DELEGATECALL, Op.STATICCALL, Op.EXTCALL, Op.EXTSTATICCALL, Op.EXTDELEGATECALL]` on the EOF activation fork.
+
+Parameter `evm_code_type` will also be parametrized with the correct EVM code type for the opcode under test.
+
 ## Other Markers
 
 ### pytest.mark.slow

--- a/src/cli/tests/test_pytest_fill_command.py
+++ b/src/cli/tests/test_pytest_fill_command.py
@@ -26,7 +26,9 @@ def test_fill_help(runner):
     """
     result = runner.invoke(fill, ["--help"])
     assert result.exit_code == pytest.ExitCode.OK
-    assert "[--evm-bin EVM_BIN] [--traces]" in result.output
+    assert "[--evm-bin EVM_BIN]" in result.output
+    assert "[--traces]" in result.output
+    assert "[--evm-code-type EVM_CODE_TYPE]" in result.output
     assert "--help" in result.output
     assert "Arguments defining evm executable behavior:" in result.output
 

--- a/src/ethereum_test_forks/base_fork.py
+++ b/src/ethereum_test_forks/base_fork.py
@@ -3,9 +3,11 @@ Abstract base class for Ethereum forks
 """
 
 from abc import ABC, ABCMeta, abstractmethod
-from typing import Any, ClassVar, List, Mapping, Optional, Protocol, Type
+from typing import Any, ClassVar, List, Mapping, Optional, Protocol, Tuple, Type
 
 from semver import Version
+
+from ethereum_test_vm import EVMCodeType, Opcodes
 
 from .base_decorators import prefer_transition_to_method
 
@@ -257,6 +259,24 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
     ) -> Optional[int]:
         """
         Returns `None` if the forks canonical chain cannot be set using the forkchoice method.
+        """
+        pass
+
+    @classmethod
+    @abstractmethod
+    def evm_code_types(cls, block_number: int = 0, timestamp: int = 0) -> List[EVMCodeType]:
+        """
+        Returns the list of EVM code types supported by the fork.
+        """
+        pass
+
+    @classmethod
+    @abstractmethod
+    def call_opcodes(
+        cls, block_number: int = 0, timestamp: int = 0
+    ) -> List[Tuple[Opcodes, EVMCodeType]]:
+        """
+        Returns the list of tuples with the call opcodes and its corresponding EVM code type.
         """
         pass
 

--- a/src/ethereum_test_tools/__init__.py
+++ b/src/ethereum_test_tools/__init__.py
@@ -58,6 +58,7 @@ from ethereum_test_types import (
 )
 from ethereum_test_vm import (
     Bytecode,
+    EVMCodeType,
     Macro,
     Macros,
     Opcode,
@@ -105,6 +106,7 @@ __all__ = (
     "EOFStateTestFiller",
     "EOFTest",
     "EOFTestFiller",
+    "EVMCodeType",
     "FixtureCollector",
     "Hash",
     "Header",

--- a/src/ethereum_test_tools/__init__.py
+++ b/src/ethereum_test_tools/__init__.py
@@ -64,6 +64,7 @@ from ethereum_test_vm import (
     OpcodeCallArg,
     Opcodes,
     UndefinedOpcodes,
+    call_return_code,
 )
 
 from .code import (
@@ -135,6 +136,7 @@ __all__ = (
     "Yul",
     "YulCompiler",
     "add_kzg_version",
+    "call_return_code",
     "ceiling_division",
     "compute_create_address",
     "compute_create2_address",

--- a/src/ethereum_test_tools/code/generators.py
+++ b/src/ethereum_test_tools/code/generators.py
@@ -2,7 +2,7 @@
 Code generating classes and functions.
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import List, SupportsBytes
 
 from ethereum_test_types import ceiling_division
@@ -189,27 +189,13 @@ class Conditional(Bytecode):
     Helper class used to generate conditional bytecode.
     """
 
-    condition: Bytecode | Op
-    """
-    Condition bytecode which must return the true or false condition of the conditional statement.
-    """
-
-    if_true: Bytecode | Op | None
-    """
-    Bytecode to execute if the condition is true.
-    """
-
-    if_false: Bytecode | Op | None
-    """
-    Bytecode to execute if the condition is false.
-    """
-
     def __new__(
         cls,
         *,
         condition: Bytecode | Op,
-        if_true: Bytecode | Op | None,
-        if_false: Bytecode | Op | None,
+        if_true: Bytecode | Op = Bytecode(),
+        if_false: Bytecode | Op = Bytecode(),
+        evm_code_type: EVMCodeType = EVMCodeType.LEGACY,
     ):
         """
         Assemble the conditional bytecode by generating the necessary jump and
@@ -218,28 +204,29 @@ class Conditional(Bytecode):
 
         In the future, PC usage should be replaced by using RJUMP and RJUMPI
         """
-        # First we append a jumpdest to the start of the true branch
-        if_true = Op.JUMPDEST + if_true
+        if evm_code_type == EVMCodeType.LEGACY:
+            # First we append a jumpdest to the start of the true branch
+            if_true = Op.JUMPDEST + if_true
 
-        # Then we append the unconditional jump to the end of the false branch, used to skip the
-        # true branch
-        if_false += Op.JUMP(Op.ADD(Op.PC, len(if_true) + 3))
+            # Then we append the unconditional jump to the end of the false branch, used to skip
+            # the true branch
+            if_false += Op.JUMP(Op.ADD(Op.PC, len(if_true) + 3))
 
-        # Then we need to do the conditional jump by skipping the false branch
-        condition = Op.JUMPI(Op.ADD(Op.PC, len(if_false) + 3), condition)
+            # Then we need to do the conditional jump by skipping the false branch
+            condition = Op.JUMPI(Op.ADD(Op.PC, len(if_false) + 3), condition)
+
+        elif evm_code_type == EVMCodeType.EOF_V1:
+            if_false += Op.RJUMP[len(if_true)]
+            condition = Op.RJUMPI[len(if_false)](condition)
 
         # Finally we append the true and false branches, and the condition, plus the jumpdest at
         # the very end
         bytecode = condition + if_false + if_true + Op.JUMPDEST
 
-        instance = super().__new__(cls, bytecode)
-        instance.condition = condition
-        instance.if_true = if_true
-        instance.if_false = if_false
-        return instance
+        return super().__new__(cls, bytecode)
 
 
-@dataclass
+@dataclass(kw_only=True)
 class Case:
     """
     Small helper class to represent a single, generic case in a `Switch` cases
@@ -251,8 +238,7 @@ class Case:
     terminating: bool = False
 
 
-@dataclass
-class CalldataCase:
+class CalldataCase(Case):
     """
     Small helper class to represent a single case whose condition depends
     on the value of the contract's calldata in a Switch case statement.
@@ -264,18 +250,12 @@ class CalldataCase:
     optionally `position`) and may not be set directly.
     """
 
-    action: Bytecode | Op
-    value: int | str | bytes | SupportsBytes
-    position: int = 0
-    condition: Bytecode | Op = field(init=False)
-    terminating: bool = False
-
-    def __post_init__(self):
+    def __init__(self, value: int | str | Bytecode, position: int = 0, **kwargs):
         """
         Generate the condition base on `value` and `position`.
         """
-        self.condition = Op.EQ(Op.CALLDATALOAD(self.position), self.value)
-        self.action = self.action
+        condition = Op.EQ(Op.CALLDATALOAD(position), value)
+        super().__init__(condition=condition, **kwargs)
 
 
 class Switch(Bytecode):
@@ -297,9 +277,9 @@ class Switch(Bytecode):
     executed.
     """
 
-    cases: List[Case | CalldataCase]
+    cases: List[Case]
     """
-    A list of Case or CalldataCase: The first element with a condition that
+    A list of Cases: The first element with a condition that
     evaluates to a non-zero value is the one that is executed.
     """
 
@@ -312,7 +292,7 @@ class Switch(Bytecode):
         cls,
         *,
         default_action: Bytecode | Op | None = None,
-        cases: List[Case | CalldataCase],
+        cases: List[Case],
         evm_code_type: EVMCodeType = EVMCodeType.LEGACY,
     ):
         """

--- a/src/ethereum_test_types/tests/test_eof_v1.py
+++ b/src/ethereum_test_types/tests/test_eof_v1.py
@@ -6,6 +6,9 @@ from typing import List, Tuple
 
 import pytest
 
+from ethereum_test_base_types import to_json
+from ethereum_test_base_types.pydantic import CopyValidateModel
+
 from ..eof.v1 import AutoSection, Container, Section, SectionKind
 
 test_cases: List[Tuple[str, Container, str]] = [
@@ -819,3 +822,18 @@ def remove_comments_from_string(input_string):
     # Join the cleaned lines back into a single string
     cleaned_string = "\n".join(cleaned_lines)
     return cleaned_string
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        Container(),
+    ],
+    ids=lambda model: model.__class__.__name__,
+)
+def test_model_copy(model: CopyValidateModel):
+    """
+    Test that the copy method returns a correct copy of the model.
+    """
+    assert to_json(model.copy()) == to_json(model)
+    assert model.copy().model_fields_set == model.model_fields_set

--- a/src/ethereum_test_types/tests/test_types.py
+++ b/src/ethereum_test_types/tests/test_types.py
@@ -10,7 +10,6 @@ from pydantic import TypeAdapter
 from ethereum_test_base_types import Address, TestPrivateKey, to_json
 from ethereum_test_base_types.pydantic import CopyValidateModel
 
-from ..eof.v1 import Container
 from ..types import (
     AccessList,
     Account,
@@ -877,7 +876,6 @@ def test_parsing(json_str: str, type_adapter: TypeAdapter, expected: Any):
     "model",
     [
         Environment(),
-        Container(),
     ],
     ids=lambda model: model.__class__.__name__,
 )

--- a/src/ethereum_test_types/types.py
+++ b/src/ethereum_test_types/types.py
@@ -47,6 +47,7 @@ from ethereum_test_base_types.conversions import (
 )
 from ethereum_test_exceptions import TransactionException
 from ethereum_test_forks import Fork
+from ethereum_test_vm import EVMCodeType
 
 
 # Sentinel classes
@@ -269,6 +270,7 @@ class Alloc(BaseAlloc):
         balance: NumberConvertible = 0,
         nonce: NumberConvertible = 1,
         address: Address | None = None,
+        evm_code_type: EVMCodeType | None = None,
         label: str | None = None,
     ) -> Address:
         """

--- a/src/ethereum_test_vm/__init__.py
+++ b/src/ethereum_test_vm/__init__.py
@@ -4,6 +4,7 @@ Ethereum Virtual Machine related definitions and utilities.
 
 from .bytecode import Bytecode
 from .evm_types import EVMCodeType
+from .helpers import call_return_code
 from .opcode import Macro, Macros, Opcode, OpcodeCallArg, Opcodes, UndefinedOpcodes
 
 __all__ = (
@@ -15,4 +16,5 @@ __all__ = (
     "OpcodeCallArg",
     "Opcodes",
     "UndefinedOpcodes",
+    "call_return_code",
 )

--- a/src/ethereum_test_vm/__init__.py
+++ b/src/ethereum_test_vm/__init__.py
@@ -3,13 +3,15 @@ Ethereum Virtual Machine related definitions and utilities.
 """
 
 from .bytecode import Bytecode
+from .evm_types import EVMCodeType
 from .opcode import Macro, Macros, Opcode, OpcodeCallArg, Opcodes, UndefinedOpcodes
 
 __all__ = (
     "Bytecode",
-    "Opcode",
+    "EVMCodeType",
     "Macro",
     "Macros",
+    "Opcode",
     "OpcodeCallArg",
     "Opcodes",
     "UndefinedOpcodes",

--- a/src/ethereum_test_vm/bytecode.py
+++ b/src/ethereum_test_vm/bytecode.py
@@ -30,6 +30,8 @@ class Bytecode:
     max_stack_height: int
     min_stack_height: int
 
+    terminating: bool
+
     def __new__(
         cls,
         bytes_or_byte_code_base: "bytes | Bytecode | None" = None,
@@ -38,6 +40,7 @@ class Bytecode:
         pushed_stack_items: int | None = None,
         max_stack_height: int | None = None,
         min_stack_height: int | None = None,
+        terminating: bool = False,
         name: str = "",
     ):
         """
@@ -50,6 +53,7 @@ class Bytecode:
             instance.pushed_stack_items = 0
             instance.min_stack_height = 0
             instance.max_stack_height = 0
+            instance.terminating = False
             instance._name_ = name
             return instance
 
@@ -62,6 +66,7 @@ class Bytecode:
             obj.pushed_stack_items = bytes_or_byte_code_base.pushed_stack_items
             obj.min_stack_height = bytes_or_byte_code_base.min_stack_height
             obj.max_stack_height = bytes_or_byte_code_base.max_stack_height
+            obj.terminating = bytes_or_byte_code_base.terminating
             obj._name_ = bytes_or_byte_code_base._name_
             return obj
 
@@ -80,6 +85,7 @@ class Bytecode:
                 obj.max_stack_height = max(obj.popped_stack_items, obj.pushed_stack_items)
             else:
                 obj.max_stack_height = max_stack_height
+            obj.terminating = terminating
             obj._name_ = name
             return obj
 
@@ -155,6 +161,7 @@ class Bytecode:
             pushed_stack_items=c_push,
             min_stack_height=c_min,
             max_stack_height=c_max,
+            terminating=other.terminating,
         )
 
     def __radd__(self, other: "Bytecode | int | None") -> "Bytecode":

--- a/src/ethereum_test_vm/evm_types.py
+++ b/src/ethereum_test_vm/evm_types.py
@@ -1,0 +1,21 @@
+"""
+EVM types definitions.
+"""
+
+
+from enum import Enum
+
+
+class EVMCodeType(str, Enum):
+    """
+    Enum representing the type of EVM code that is supported in a given fork.
+    """
+
+    LEGACY = "legacy"
+    EOF_V1 = "eof_v1"
+
+    def __str__(self) -> str:
+        """
+        Return the name of the EVM code type.
+        """
+        return self.name

--- a/src/ethereum_test_vm/helpers.py
+++ b/src/ethereum_test_vm/helpers.py
@@ -15,6 +15,6 @@ def call_return_code(opcode: Op, success: bool, *, revert: bool = False) -> int:
         if success:
             return 0
         if revert:
-            return 2
-        return 1
+            return 1
+        return 2
     raise ValueError(f"Not a call opcode: {opcode}")

--- a/src/ethereum_test_vm/helpers.py
+++ b/src/ethereum_test_vm/helpers.py
@@ -1,0 +1,20 @@
+"""
+Helper functions for the EVM.
+"""
+
+from .opcode import Opcodes as Op
+
+
+def call_return_code(opcode: Op, success: bool, *, revert: bool = False) -> int:
+    """
+    Returns the return code for a CALL operation.
+    """
+    if opcode in [Op.CALL, Op.CALLCODE, Op.DELEGATECALL, Op.STATICCALL]:
+        return int(success)
+    elif opcode in [Op.EXTCALL, Op.EXTDELEGATECALL, Op.EXTSTATICCALL]:
+        if success:
+            return 0
+        if revert:
+            return 2
+        return 1
+    raise ValueError(f"Not a call opcode: {opcode}")

--- a/src/ethereum_test_vm/opcode.py
+++ b/src/ethereum_test_vm/opcode.py
@@ -106,6 +106,7 @@ class Opcode(Bytecode):
         data_portion_formatter=None,
         stack_properties_modifier=None,
         unchecked_stack=False,
+        terminating: bool = False,
         kwargs: List[str] | None = None,
         kwargs_defaults: KW_ARGS_DEFAULTS_TYPE = {},
     ):
@@ -134,6 +135,7 @@ class Opcode(Bytecode):
                 pushed_stack_items=pushed_stack_items,
                 max_stack_height=max_stack_height,
                 min_stack_height=min_stack_height,
+                terminating=terminating,
             )
             obj.data_portion_length = data_portion_length
             obj.data_portion_formatter = data_portion_formatter
@@ -207,6 +209,7 @@ class Opcode(Bytecode):
             data_portion_length=0,
             data_portion_formatter=None,
             unchecked_stack=self.unchecked_stack,
+            terminating=self.terminating,
             kwargs=self.kwargs,
             kwargs_defaults=self.kwargs_defaults,
         )
@@ -426,7 +429,7 @@ class Opcodes(Opcode, Enum):
     Do !! NOT !! remove or modify existing opcodes from this list.
     """
 
-    STOP = Opcode(0x00)
+    STOP = Opcode(0x00, terminating=True)
     """
     STOP()
     ----
@@ -4931,7 +4934,7 @@ class Opcodes(Opcode, Enum):
     [ipsilon/eof/blob/main/spec/eof.md](https://github.com/ipsilon/eof/blob/main/spec/eof.md)
     """
 
-    RETF = Opcode(0xE4)
+    RETF = Opcode(0xE4, terminating=True)
     """
     !!! Note: This opcode is under development
 
@@ -4956,7 +4959,7 @@ class Opcodes(Opcode, Enum):
     3
     """
 
-    JUMPF = Opcode(0xE5, data_portion_length=2)
+    JUMPF = Opcode(0xE5, data_portion_length=2, terminating=True)
     """
     !!! Note: This opcode is under development
 
@@ -5130,7 +5133,7 @@ class Opcodes(Opcode, Enum):
 
     """
 
-    RETURNCONTRACT = Opcode(0xEE, popped_stack_items=2, data_portion_length=1)
+    RETURNCONTRACT = Opcode(0xEE, popped_stack_items=2, data_portion_length=1, terminating=True)
     """
     !!! Note: This opcode is under development
 
@@ -5287,7 +5290,7 @@ class Opcodes(Opcode, Enum):
     Source: [evm.codes/#F2](https://www.evm.codes/#F2)
     """
 
-    RETURN = Opcode(0xF3, popped_stack_items=2, kwargs=["offset", "size"])
+    RETURN = Opcode(0xF3, popped_stack_items=2, kwargs=["offset", "size"], terminating=True)
     """
     RETURN(offset, size)
     ----
@@ -5592,7 +5595,7 @@ class Opcodes(Opcode, Enum):
     3
     """
 
-    REVERT = Opcode(0xFD, popped_stack_items=2, kwargs=["offset", "size"])
+    REVERT = Opcode(0xFD, popped_stack_items=2, kwargs=["offset", "size"], terminating=True)
     """
     REVERT(offset, size)
     ----
@@ -5618,7 +5621,7 @@ class Opcodes(Opcode, Enum):
     Source: [evm.codes/#FD](https://www.evm.codes/#FD)
     """
 
-    INVALID = Opcode(0xFE)
+    INVALID = Opcode(0xFE, terminating=True)
     """
     INVALID()
     ----

--- a/src/pytest_plugins/filler/pre_alloc.py
+++ b/src/pytest_plugins/filler/pre_alloc.py
@@ -28,6 +28,8 @@ from ethereum_test_base_types.conversions import (
 )
 from ethereum_test_types import EOA
 from ethereum_test_types import Alloc as BaseAlloc
+from ethereum_test_types.eof.v1 import Container
+from ethereum_test_vm import EVMCodeType
 
 CONTRACT_START_ADDRESS_DEFAULT = 0x1000
 CONTRACT_ADDRESS_INCREMENTS_DEFAULT = 0x100
@@ -64,6 +66,15 @@ def pytest_addoption(parser: pytest.Parser):
         type=str,
         help="The address increment value to each deployed contract by a test.",
     )
+    pre_alloc_group.addoption(
+        "--evm-code-type",
+        action="store",
+        dest="evm_code_type",
+        default=None,
+        type=EVMCodeType,
+        choices=list(EVMCodeType),
+        help="Type of EVM code to deploy in each test by default.",
+    )
 
 
 class AllocMode(IntEnum):
@@ -83,6 +94,7 @@ class Alloc(BaseAlloc):
     _alloc_mode: AllocMode = PrivateAttr(...)
     _contract_address_iterator: Iterator[Address] = PrivateAttr(...)
     _eoa_iterator: Iterator[EOA] = PrivateAttr(...)
+    _evm_code_type: EVMCodeType | None = PrivateAttr(None)
 
     def __init__(
         self,
@@ -90,6 +102,7 @@ class Alloc(BaseAlloc):
         alloc_mode: AllocMode,
         contract_address_iterator: Iterator[Address],
         eoa_iterator: Iterator[EOA],
+        evm_code_type: EVMCodeType | None = None,
         **kwargs,
     ):
         """
@@ -99,6 +112,7 @@ class Alloc(BaseAlloc):
         self._alloc_mode = alloc_mode
         self._contract_address_iterator = contract_address_iterator
         self._eoa_iterator = eoa_iterator
+        self._evm_code_type = evm_code_type
 
     def __setitem__(self, address: Address | FixedSizeBytesConvertible, account: Account | None):
         """
@@ -108,6 +122,19 @@ class Alloc(BaseAlloc):
             raise ValueError("Cannot set items in strict mode")
         super().__setitem__(address, account)
 
+    def code_pre_processor(
+        self, code: BytesConvertible, *, evm_code_type: EVMCodeType | None
+    ) -> BytesConvertible:
+        """
+        Pre-processes the code before setting it.
+        """
+        if evm_code_type is None:
+            evm_code_type = self._evm_code_type
+        if evm_code_type == EVMCodeType.EOF_V1:
+            if not isinstance(code, Container):
+                return Container.Code(code)
+        return code
+
     def deploy_contract(
         self,
         code: BytesConvertible,
@@ -116,6 +143,7 @@ class Alloc(BaseAlloc):
         balance: NumberConvertible = 0,
         nonce: NumberConvertible = 1,
         address: Address | None = None,
+        evm_code_type: EVMCodeType | None = None,
         label: str | None = None,
     ) -> Address:
         """
@@ -139,7 +167,7 @@ class Alloc(BaseAlloc):
             Account(
                 nonce=nonce,
                 balance=balance,
-                code=code,
+                code=self.code_pre_processor(code, evm_code_type=evm_code_type),
                 storage=storage,
             ),
         )
@@ -247,11 +275,24 @@ def eoa_iterator() -> Iterator[EOA]:
     return iter(eoa_by_index(i).copy() for i in count())
 
 
+@pytest.fixture(autouse=True)
+def evm_code_type(request: pytest.FixtureRequest) -> EVMCodeType:
+    """
+    Returns the default EVM code type for all tests (LEGACY).
+    """
+    parameter_evm_code_type = request.config.getoption("evm_code_type")
+    if parameter_evm_code_type is not None:
+        assert type(parameter_evm_code_type) is EVMCodeType, "Invalid EVM code type"
+        return parameter_evm_code_type
+    return EVMCodeType.LEGACY
+
+
 @pytest.fixture(scope="function")
 def pre(
     alloc_mode: AllocMode,
     contract_address_iterator: Iterator[Address],
     eoa_iterator: Iterator[EOA],
+    evm_code_type: EVMCodeType,
 ) -> Alloc:
     """
     Returns the default pre allocation for all tests (Empty alloc).
@@ -260,4 +301,5 @@ def pre(
         alloc_mode=alloc_mode,
         contract_address_iterator=contract_address_iterator,
         eoa_iterator=eoa_iterator,
+        evm_code_type=evm_code_type,
     )

--- a/src/pytest_plugins/filler/pre_alloc.py
+++ b/src/pytest_plugins/filler/pre_alloc.py
@@ -29,7 +29,7 @@ from ethereum_test_base_types.conversions import (
 from ethereum_test_types import EOA
 from ethereum_test_types import Alloc as BaseAlloc
 from ethereum_test_types.eof.v1 import Container
-from ethereum_test_vm import EVMCodeType
+from ethereum_test_vm import Bytecode, EVMCodeType, Opcodes
 
 CONTRACT_START_ADDRESS_DEFAULT = 0x1000
 CONTRACT_ADDRESS_INCREMENTS_DEFAULT = 0x100
@@ -132,6 +132,8 @@ class Alloc(BaseAlloc):
             evm_code_type = self._evm_code_type
         if evm_code_type == EVMCodeType.EOF_V1:
             if not isinstance(code, Container):
+                if isinstance(code, Bytecode) and not code.terminating:
+                    return Container.Code(code + Opcodes.STOP)
                 return Container.Code(code)
         return code
 

--- a/src/pytest_plugins/forks/forks.py
+++ b/src/pytest_plugins/forks/forks.py
@@ -173,7 +173,7 @@ fork_covariant_descriptors = [
     CovariantDescriptor(
         marker_name="with_all_evm_code_types",
         description="marks a test to be parametrized for all EVM code types at parameter named"
-        " evm_code_type of type EVMCodeType",
+        " `evm_code_type` of type `EVMCodeType`, such as `LEGACY` and `EOF_V1`",
         fork_attribute_name="evm_code_types",
         parameter_name="evm_code_type",
     ),

--- a/src/pytest_plugins/forks/forks.py
+++ b/src/pytest_plugins/forks/forks.py
@@ -81,18 +81,35 @@ class ForkParametrizer:
         """
         Return the parameter names for the test case.
         """
-        return ["fork"] + [p.name for p in self.fork_covariant_parameters]
+        parameter_names = ["fork"]
+        for p in self.fork_covariant_parameters:
+            if "," in p.name:
+                parameter_names.extend(p.name.split(","))
+            else:
+                parameter_names.append(p.name)
+        return parameter_names
 
     def get_parameter_values(self) -> List[Any]:
         """
         Return the parameter values for the test case.
         """
-        return [
-            pytest.param(*params, marks=[self.mark] if self.mark else [])
+        param_value_combinations = [
+            params
             for params in itertools.product(
                 [self.fork],
                 *[p.values for p in self.fork_covariant_parameters],
             )
+        ]
+        for i in range(len(param_value_combinations)):
+            # if the parameter is a tuple, we need to flatten it
+            param_value_combinations[i] = list(
+                itertools.chain.from_iterable(
+                    [v] if not isinstance(v, tuple) else v for v in param_value_combinations[i]
+                )
+            )
+        return [
+            pytest.param(*params, marks=[self.mark] if self.mark else [])
+            for params in param_value_combinations
         ]
 
 
@@ -159,6 +176,13 @@ fork_covariant_descriptors = [
         " evm_code_type of type EVMCodeType",
         fork_attribute_name="evm_code_types",
         parameter_name="evm_code_type",
+    ),
+    CovariantDescriptor(
+        marker_name="with_all_call_opcodes",
+        description="marks a test to be parametrized for all *CALL opcodes at parameter named"
+        " call_opcode, and also the appropriate EVM code type at parameter named evm_code_type",
+        fork_attribute_name="call_opcodes",
+        parameter_name="call_opcode,evm_code_type",
     ),
 ]
 

--- a/src/pytest_plugins/forks/forks.py
+++ b/src/pytest_plugins/forks/forks.py
@@ -153,6 +153,13 @@ fork_covariant_descriptors = [
         fork_attribute_name="precompiles",
         parameter_name="precompile",
     ),
+    CovariantDescriptor(
+        marker_name="with_all_evm_code_types",
+        description="marks a test to be parametrized for all EVM code types at parameter named"
+        " evm_code_type of type EVMCodeType",
+        fork_attribute_name="evm_code_types",
+        parameter_name="evm_code_type",
+    ),
 ]
 
 

--- a/src/pytest_plugins/help/help.py
+++ b/src/pytest_plugins/help/help.py
@@ -50,6 +50,7 @@ def show_test_help(config):
             "fork range",
             "filler location",
             "defining debug",
+            "pre-allocation behavior",
         ]
     elif pytest_ini.name in [
         "pytest-consume.ini",

--- a/tests/cancun/eip4844_blobs/test_point_evaluation_precompile.py
+++ b/tests/cancun/eip4844_blobs/test_point_evaluation_precompile.py
@@ -17,9 +17,9 @@ note: Adding a new test
     - z
     - y
     - kzg_proof
-    - success
+    - result
 
-    These values correspond to a single call of the precompile, and `success` refers to
+    These values correspond to a single call of the precompile, and `result` refers to
     whether the call should succeed or fail.
 
     All other `pytest.fixture` fixtures can be parametrized to generate new combinations and test
@@ -29,20 +29,25 @@ note: Adding a new test
 import glob
 import json
 import os
-from typing import Dict, Iterator, List, Optional
+from enum import Enum
+from itertools import count
+from typing import Dict, List, Optional
 
 import pytest
 
 from ethereum_test_tools import (
+    EOA,
     Account,
     Address,
+    Alloc,
     Block,
     BlockchainTestFiller,
+    Bytecode,
     Environment,
     StateTestFiller,
     Storage,
-    TestAddress,
     Transaction,
+    call_return_code,
     eip_2028_transaction_data_cost,
 )
 from ethereum_test_tools.vm.opcode import Opcodes as Op
@@ -52,6 +57,16 @@ from .spec import Spec, ref_spec_4844
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_4844.git_path
 REFERENCE_SPEC_VERSION = ref_spec_4844.version
+
+
+class Result(str, Enum):
+    """
+    Result of the point evaluation precompile.
+    """
+
+    SUCCESS = "success"
+    FAILURE = "failure"
+    OUT_OF_GAS = "out_of_gas"
 
 
 @pytest.fixture
@@ -82,7 +97,7 @@ def precompile_input(
 
 
 @pytest.fixture
-def call_type() -> Op:
+def call_opcode() -> Op:
     """
     Type of call to use to call the precompile.
 
@@ -102,105 +117,132 @@ def call_gas() -> int:
     return Spec.POINT_EVALUATION_PRECOMPILE_GAS
 
 
+precompile_caller_storage_keys = count()
+key_call_return_code = next(precompile_caller_storage_keys)
+key_return_1 = next(precompile_caller_storage_keys)
+key_return_2 = next(precompile_caller_storage_keys)
+key_return_length = next(precompile_caller_storage_keys)
+key_return_copy_1 = next(precompile_caller_storage_keys)
+key_return_copy_2 = next(precompile_caller_storage_keys)
+
+
 @pytest.fixture
-def precompile_caller_account(call_type: Op, call_gas: int) -> Account:
+def precompile_caller_storage() -> Storage.StorageDictType:
+    """
+    Storage for the precompile caller contract.
+    """
+    return {
+        key_call_return_code: 0xBA5E,
+        key_return_1: 0xBA5E,
+        key_return_2: 0xBA5E,
+        key_return_length: 0xBA5E,
+        key_return_copy_1: 0xBA5E,
+        key_return_copy_2: 0xBA5E,
+    }
+
+
+@pytest.fixture
+def precompile_caller_code(call_opcode: Op, call_gas: int) -> Bytecode:
     """
     Code to call the point evaluation precompile.
     """
     precompile_caller_code = Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE)
-    if call_type == Op.CALL or call_type == Op.CALLCODE:
-        precompile_caller_code += Op.SSTORE(
-            0,
-            call_type(  # type: ignore # https://github.com/ethereum/execution-spec-tests/issues/348 # noqa: E501
-                call_gas,
-                Spec.POINT_EVALUATION_PRECOMPILE_ADDRESS,
-                0x00,
-                0x00,
-                Op.CALLDATASIZE,
-                0x00,
-                0x40,
-            ),
-        )  # Store the result of the precompile call in storage slot 0
-    elif call_type == Op.DELEGATECALL or call_type == Op.STATICCALL:
-        # Delegatecall and staticcall use one less argument
-        precompile_caller_code += Op.SSTORE(
-            0,
-            call_type(  # type: ignore # https://github.com/ethereum/execution-spec-tests/issues/348 # noqa: E501
-                call_gas,
-                Spec.POINT_EVALUATION_PRECOMPILE_ADDRESS,
-                0x00,
-                Op.CALLDATASIZE,
-                0x00,
-                0x40,
-            ),
-        )
+    precompile_caller_code += Op.SSTORE(
+        key_call_return_code,
+        call_opcode(  # type: ignore # https://github.com/ethereum/execution-spec-tests/issues/348 # noqa: E501
+            gas=call_gas,
+            address=Spec.POINT_EVALUATION_PRECOMPILE_ADDRESS,
+            args_offset=0x00,
+            args_size=Op.CALLDATASIZE,
+            ret_offset=0x00,
+            ret_size=0x40,
+        ),
+    )  # Store the result of the precompile call in storage slot 0
     precompile_caller_code += (
         # Save the returned values into storage
-        Op.SSTORE(1, Op.MLOAD(0x00))
-        + Op.SSTORE(2, Op.MLOAD(0x20))
+        Op.SSTORE(key_return_1, Op.MLOAD(0x00))
+        + Op.SSTORE(key_return_2, Op.MLOAD(0x20))
         # Save the returned data length into storage
-        + Op.SSTORE(3, Op.RETURNDATASIZE)
+        + Op.SSTORE(key_return_length, Op.RETURNDATASIZE)
         # Save the returned data using RETURNDATACOPY into storage
         + Op.RETURNDATACOPY(0, 0, Op.RETURNDATASIZE)
-        + Op.SSTORE(4, Op.MLOAD(0x00))
-        + Op.SSTORE(5, Op.MLOAD(0x20))
+        + Op.SSTORE(key_return_copy_1, Op.MLOAD(0x00))
+        + Op.SSTORE(key_return_copy_2, Op.MLOAD(0x20))
+        + Op.STOP
     )
-    return Account(
-        nonce=0,
-        code=precompile_caller_code,
-        balance=0x10**18,
+    return precompile_caller_code
+
+
+@pytest.fixture
+def precompile_caller_balance() -> int:
+    """
+    Storage for the precompile caller contract.
+    """
+    return 0
+
+
+@pytest.fixture
+def precompile_caller_address(
+    pre: Alloc,
+    precompile_caller_code: Bytecode,
+    precompile_caller_storage: Storage.StorageDictType,
+    precompile_caller_balance: int,
+) -> Address:
+    """
+    Address of the code to call the point evaluation precompile.
+    """
+    return pre.deploy_contract(
+        precompile_caller_code,
+        storage=precompile_caller_storage,
+        balance=precompile_caller_balance,
     )
 
 
 @pytest.fixture
-def precompile_caller_address() -> Address:
+def sender(pre: Alloc) -> EOA:
     """
-    Address of the precompile caller account.
+    Returns the sender account.
     """
-    return Address(0x100)
-
-
-@pytest.fixture
-def pre(
-    precompile_caller_account: Account,
-    precompile_caller_address: Address,
-) -> Dict:
-    """
-    Prepares the pre state of all test cases, by setting the balance of the
-    source account of all test transactions, and the precompile caller account.
-    """
-    return {
-        TestAddress: Account(
-            nonce=0,
-            balance=0x10**18,
-        ),
-        precompile_caller_address: precompile_caller_account,
-    }
+    return pre.fund_eoa()
 
 
 @pytest.fixture
 def tx(
     precompile_caller_address: Address,
     precompile_input: bytes,
+    sender: EOA,
 ) -> Transaction:
     """
     Prepares transaction used to call the precompile caller account.
     """
     return Transaction(
-        ty=2,
-        nonce=0,
+        sender=sender,
         data=precompile_input,
         to=precompile_caller_address,
-        value=0,
-        gas_limit=Spec.POINT_EVALUATION_PRECOMPILE_GAS * 20,
-        max_fee_per_gas=7,
-        max_priority_fee_per_gas=0,
+        gas_limit=Spec.POINT_EVALUATION_PRECOMPILE_GAS * 100,
     )
+
+
+@pytest.fixture
+def success(
+    result: Result,
+    call_opcode: Op,
+) -> bool:
+    """
+    Prepares expected success or failure for each test.
+    """
+    if call_opcode == Op.EXTDELEGATECALL:
+        return False
+    if result == Result.OUT_OF_GAS and call_opcode in [Op.EXTCALL, Op.EXTSTATICCALL]:
+        return True
+
+    return result == Result.SUCCESS
 
 
 @pytest.fixture
 def post(
     success: bool,
+    call_opcode: Op,
     precompile_caller_address: Address,
     precompile_input: bytes,
 ) -> Dict:
@@ -209,29 +251,33 @@ def post(
     failure of the precompile call.
     """
     expected_storage: Storage.StorageDictType = dict()
+    # CALL operation return code
+    expected_storage[key_call_return_code] = call_return_code(
+        call_opcode, success, revert=call_opcode != Op.EXTDELEGATECALL
+    )
     if success:
-        # CALL operation success
-        expected_storage[0] = 1
         # Success return values
-        expected_storage[1] = Spec.FIELD_ELEMENTS_PER_BLOB
-        expected_storage[2] = Spec.BLS_MODULUS
+        expected_storage[key_return_1] = Spec.FIELD_ELEMENTS_PER_BLOB
+        expected_storage[key_return_2] = Spec.BLS_MODULUS
         # Success return values size
-        expected_storage[3] = 64
+        expected_storage[key_return_length] = 64
         # Success return values from RETURNDATACOPY
-        expected_storage[4] = Spec.FIELD_ELEMENTS_PER_BLOB
-        expected_storage[5] = Spec.BLS_MODULUS
+        expected_storage[key_return_copy_1] = Spec.FIELD_ELEMENTS_PER_BLOB
+        expected_storage[key_return_copy_2] = Spec.BLS_MODULUS
 
     else:
-        # CALL operation failure
-        expected_storage[0] = 0
         # Failure returns zero values
-        expected_storage[3] = 0
+        expected_storage[key_return_length] = 0
 
         # Input parameters were not overwritten since the CALL failed
-        expected_storage[1] = precompile_input[0:32]
-        expected_storage[2] = precompile_input[32:64]
-        expected_storage[4] = expected_storage[1]
-        expected_storage[5] = expected_storage[2]
+        expected_storage[key_return_1] = precompile_input[0:32]
+        expected_storage[key_return_2] = precompile_input[32:64]
+        expected_storage[key_return_copy_1] = expected_storage[1]
+        expected_storage[key_return_copy_2] = expected_storage[2]
+    if call_opcode in [Op.EXTCALL, Op.EXTSTATICCALL, Op.EXTDELEGATECALL]:
+        # Input parameters were not overwritten
+        expected_storage[key_return_1] = precompile_input[0:32]
+        expected_storage[key_return_2] = precompile_input[32:64]
     return {
         precompile_caller_address: Account(
             storage=expected_storage,
@@ -245,11 +291,11 @@ def post(
         pytest.param(Spec.BLS_MODULUS - 1, 0, INF_POINT, INF_POINT, None, id="in_bounds_z"),
     ],
 )
-@pytest.mark.parametrize("success", [True])
+@pytest.mark.parametrize("result", [Result.SUCCESS])
 @pytest.mark.valid_from("Cancun")
-def test_valid_precompile_calls(
+def test_valid_inputs(
     state_test: StateTestFiller,
-    pre: Dict,
+    pre: Alloc,
     tx: Transaction,
     post: Dict,
 ):
@@ -298,11 +344,11 @@ def test_valid_precompile_calls(
         "correct_proof_1_incorrect_versioned_hash_version_0xff",
     ],
 )
-@pytest.mark.parametrize("success", [False])
+@pytest.mark.parametrize("result", [Result.FAILURE])
 @pytest.mark.valid_from("Cancun")
-def test_invalid_precompile_calls(
+def test_invalid_inputs(
     state_test: StateTestFiller,
-    pre: Dict,
+    pre: Alloc,
     tx: Transaction,
     post: Dict,
 ):
@@ -331,10 +377,11 @@ def kzg_point_evaluation_vector_from_dict(data: dict):
         raise ValueError("Missing 'input' key in data")
     if "output" not in data:
         raise ValueError("Missing 'output' key in data")
-    if isinstance(data["output"], bool):
-        success = data["output"]
+    output = data["output"]
+    if isinstance(output, bool):
+        result = Result.SUCCESS if output else Result.FAILURE
     else:
-        success = False
+        result = Result.FAILURE
     input = data["input"]
     if "commitment" not in input or not isinstance(input["commitment"], str):
         raise ValueError("Missing 'commitment' key in data['input']")
@@ -355,7 +402,7 @@ def kzg_point_evaluation_vector_from_dict(data: dict):
         y,
         commitment,
         proof,
-        success,
+        result,
         id=name,
     )
 
@@ -413,14 +460,14 @@ def all_external_vectors() -> List:
 
 
 @pytest.mark.parametrize(
-    "z,y,kzg_commitment,kzg_proof,success",
+    "z,y,kzg_commitment,kzg_proof,result",
     all_external_vectors(),
 )
 @pytest.mark.parametrize("versioned_hash", [None])
 @pytest.mark.valid_from("Cancun")
-def test_point_evaluation_precompile_external_vectors(
+def test_external_vectors(
     state_test: StateTestFiller,
-    pre: Dict,
+    pre: Alloc,
     tx: Transaction,
     post: Dict,
 ):
@@ -439,32 +486,24 @@ def test_point_evaluation_precompile_external_vectors(
 
 
 @pytest.mark.parametrize(
-    "call_gas,y,success",
+    "call_gas,y,result",
     [
-        (Spec.POINT_EVALUATION_PRECOMPILE_GAS, 0, True),
-        (Spec.POINT_EVALUATION_PRECOMPILE_GAS, 1, False),
-        (Spec.POINT_EVALUATION_PRECOMPILE_GAS - 1, 0, False),
+        (Spec.POINT_EVALUATION_PRECOMPILE_GAS, 0, Result.SUCCESS),
+        (Spec.POINT_EVALUATION_PRECOMPILE_GAS, 1, Result.FAILURE),
+        (Spec.POINT_EVALUATION_PRECOMPILE_GAS - 1, 0, Result.OUT_OF_GAS),
     ],
     ids=["correct", "incorrect", "insufficient_gas"],
 )
-@pytest.mark.parametrize(
-    "call_type",
-    [
-        Op.CALL,
-        Op.DELEGATECALL,
-        Op.CALLCODE,
-        Op.STATICCALL,
-    ],
-)
+@pytest.mark.with_all_call_opcodes
 @pytest.mark.parametrize(
     "z,kzg_commitment,kzg_proof,versioned_hash",
     [[Z, INF_POINT, INF_POINT, None]],
     ids=[""],
 )
 @pytest.mark.valid_from("Cancun")
-def test_point_evaluation_precompile_calls(
+def test_call_opcode_types(
     state_test: StateTestFiller,
-    pre: Dict,
+    pre: Alloc,
     tx: Transaction,
     post: Dict,
 ):
@@ -502,10 +541,11 @@ def test_point_evaluation_precompile_calls(
     ids=["correct_proof", "incorrect_proof"],
 )
 @pytest.mark.valid_from("Cancun")
-def test_point_evaluation_precompile_gas_tx_to(
+def test_tx_entry_point(
     state_test: StateTestFiller,
     precompile_input: bytes,
     call_gas: int,
+    pre: Alloc,
     proof_correct: bool,
 ):
     """
@@ -516,12 +556,7 @@ def test_point_evaluation_precompile_gas_tx_to(
     - Using correct and incorrect proofs
     """
     start_balance = 10**18
-    pre = {
-        TestAddress: Account(
-            nonce=0,
-            balance=start_balance,
-        ),
-    }
+    sender = pre.fund_eoa(amount=start_balance)
 
     # Gas is appended the intrinsic gas cost of the transaction
     intrinsic_gas_cost = 21_000 + eip_2028_transaction_data_cost(precompile_input)
@@ -538,18 +573,15 @@ def test_point_evaluation_precompile_gas_tx_to(
     fee_per_gas = 7
 
     tx = Transaction(
-        ty=2,
-        nonce=0,
+        sender=sender,
         data=precompile_input,
         to=Address(Spec.POINT_EVALUATION_PRECOMPILE_ADDRESS),
-        value=0,
         gas_limit=call_gas + intrinsic_gas_cost,
-        max_fee_per_gas=7,
-        max_priority_fee_per_gas=0,
+        gas_price=fee_per_gas,
     )
 
     post = {
-        TestAddress: Account(
+        sender: Account(
             nonce=1,
             balance=start_balance - (consumed_gas * fee_per_gas),
         )
@@ -568,41 +600,33 @@ def test_point_evaluation_precompile_gas_tx_to(
     [[Z, 0, INF_POINT, INF_POINT, None]],
     ids=["correct_proof"],
 )
+@pytest.mark.parametrize("precompile_caller_storage", [{}], ids=[""])
+@pytest.mark.parametrize("precompile_caller_balance", [1], ids=[""])
+@pytest.mark.parametrize(
+    "precompile_caller_code",
+    [
+        Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE)
+        + Op.SSTORE(
+            Op.NUMBER,
+            Op.CALL(
+                address=Spec.POINT_EVALUATION_PRECOMPILE_ADDRESS,
+                value=1,
+                args_size=Op.CALLDATASIZE,
+            ),
+        )
+    ],
+    ids=[""],
+)
 @pytest.mark.valid_at_transition_to("Cancun")
-def test_point_evaluation_precompile_before_fork(
+def test_precompile_before_fork(
     state_test: StateTestFiller,
-    pre: Dict,
+    pre: Alloc,
     tx: Transaction,
+    precompile_caller_address: Address,
 ):
     """
     Test calling the Point Evaluation Precompile before the appropriate fork.
     """
-    precompile_caller_code = Op.SSTORE(
-        Op.NUMBER,
-        Op.CALL(
-            Op.GAS,
-            Spec.POINT_EVALUATION_PRECOMPILE_ADDRESS,
-            1,  # Value
-            0,  # Zero-length calldata
-            0,
-            0,  # Zero-length return
-            0,
-        ),
-    )
-    precompile_caller_address = Address(0x100)
-
-    pre = {
-        TestAddress: Account(
-            nonce=0,
-            balance=0x10**18,
-        ),
-        precompile_caller_address: Account(
-            nonce=0,
-            code=precompile_caller_code,
-            balance=0x10**18,
-        ),
-    }
-
     post = {
         precompile_caller_address: Account(
             storage={1: 1},
@@ -614,7 +638,6 @@ def test_point_evaluation_precompile_before_fork(
     }
 
     state_test(
-        tag="point_evaluation_precompile_before_fork",
         pre=pre,
         env=Environment(timestamp=7_500),
         post=post,
@@ -622,61 +645,72 @@ def test_point_evaluation_precompile_before_fork(
     )
 
 
+FORK_TIMESTAMP = 15_000
+PRE_FORK_BLOCK_RANGE = range(999, FORK_TIMESTAMP, 1_000)
+
+
 @pytest.mark.parametrize(
     "z,y,kzg_commitment,kzg_proof,versioned_hash",
     [[Z, 0, INF_POINT, INF_POINT, None]],
     ids=["correct_proof"],
 )
+@pytest.mark.parametrize("precompile_caller_storage", [{}], ids=[""])
+@pytest.mark.parametrize("precompile_caller_balance", [len(PRE_FORK_BLOCK_RANGE)], ids=[""])
+@pytest.mark.parametrize(
+    "precompile_caller_code",
+    [
+        Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE)
+        + Op.SSTORE(
+            Op.NUMBER,
+            Op.CALL(
+                address=Spec.POINT_EVALUATION_PRECOMPILE_ADDRESS,
+                value=1,
+                args_size=Op.CALLDATASIZE,
+            ),
+        )
+    ],
+    ids=[""],
+)
 @pytest.mark.valid_at_transition_to("Cancun")
-def test_point_evaluation_precompile_during_fork(
+def test_precompile_during_fork(
     blockchain_test: BlockchainTestFiller,
-    pre: Dict,
-    tx: Transaction,
+    pre: Alloc,
+    precompile_caller_address: Address,
+    precompile_input: bytes,
+    sender: EOA,
 ):
     """
     Test calling the Point Evaluation Precompile before the appropriate fork.
     """
-    precompile_caller_code = Op.SSTORE(
-        Op.NUMBER,
-        Op.CALL(
-            Op.GAS,
-            Spec.POINT_EVALUATION_PRECOMPILE_ADDRESS,
-            1,  # Value
-            0,  # Zero-length calldata
-            0,
-            0,  # Zero-length return
-            0,
-        ),
-    )
-    precompile_caller_address = Address(0x100)
-
-    pre = {
-        TestAddress: Account(
-            nonce=0,
-            balance=0x10**18,
-        ),
-        precompile_caller_address: Account(
-            nonce=0,
-            code=precompile_caller_code,
-            balance=0x10**18,
-        ),
-    }
-
-    def tx_generator() -> Iterator[Transaction]:
-        nonce = 0  # Initial value
-        while True:
-            yield tx.with_nonce(nonce)
-            nonce = nonce + 1
-
-    iter_tx = tx_generator()
-
-    FORK_TIMESTAMP = 15_000
-    PRE_FORK_BLOCK_RANGE = range(999, FORK_TIMESTAMP, 1_000)
-
     # Blocks before fork
-    blocks = [Block(timestamp=t, txs=[next(iter_tx)]) for t in PRE_FORK_BLOCK_RANGE]
+    blocks = [
+        Block(
+            timestamp=t,
+            txs=[
+                Transaction(
+                    sender=sender,
+                    data=precompile_input,
+                    to=precompile_caller_address,
+                    gas_limit=Spec.POINT_EVALUATION_PRECOMPILE_GAS * 100,
+                )
+            ],
+        )
+        for t in PRE_FORK_BLOCK_RANGE
+    ]
     # Block after fork
-    blocks += [Block(timestamp=FORK_TIMESTAMP, txs=[next(iter_tx)])]
+    blocks += [
+        Block(
+            timestamp=FORK_TIMESTAMP,
+            txs=[
+                Transaction(
+                    sender=sender,
+                    data=precompile_input,
+                    to=precompile_caller_address,
+                    gas_limit=Spec.POINT_EVALUATION_PRECOMPILE_GAS * 100,
+                )
+            ],
+        )
+    ]
 
     post = {
         precompile_caller_address: Account(
@@ -689,7 +723,6 @@ def test_point_evaluation_precompile_during_fork(
     }
 
     blockchain_test(
-        tag="point_evaluation_precompile_before_fork",
         pre=pre,
         post=post,
         blocks=blocks,

--- a/tests/cancun/eip4844_blobs/test_point_evaluation_precompile.py
+++ b/tests/cancun/eip4844_blobs/test_point_evaluation_precompile.py
@@ -253,7 +253,7 @@ def post(
     expected_storage: Storage.StorageDictType = dict()
     # CALL operation return code
     expected_storage[key_call_return_code] = call_return_code(
-        call_opcode, success, revert=call_opcode != Op.EXTDELEGATECALL
+        call_opcode, success, revert=call_opcode == Op.EXTDELEGATECALL
     )
     if success:
         # Success return values

--- a/tests/frontier/opcodes/test_dup.py
+++ b/tests/frontier/opcodes/test_dup.py
@@ -33,6 +33,7 @@ from ethereum_test_tools import StateTestFiller, Storage, Transaction
     ],
     ids=lambda op: str(op),
 )
+@pytest.mark.with_all_evm_code_types
 def test_dup(
     state_test: StateTestFiller,
     fork: str,
@@ -58,7 +59,7 @@ def test_dup(
     account_code += dup_opcode
 
     # Save each stack value into different keys in storage
-    account_code += sum(Op.PUSH1(i) + Op.SSTORE for i in range(0x11))
+    account_code += sum(Op.PUSH1(i) + Op.SSTORE for i in range(0x11)) + Op.STOP
 
     account = pre.deploy_contract(account_code)
 

--- a/tests/frontier/opcodes/test_dup.py
+++ b/tests/frontier/opcodes/test_dup.py
@@ -59,7 +59,7 @@ def test_dup(
     account_code += dup_opcode
 
     # Save each stack value into different keys in storage
-    account_code += sum(Op.PUSH1(i) + Op.SSTORE for i in range(0x11)) + Op.STOP
+    account_code += sum(Op.PUSH1(i) + Op.SSTORE for i in range(0x11))
 
     account = pre.deploy_contract(account_code)
 

--- a/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
+++ b/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
@@ -6,9 +6,8 @@ import pytest
 
 from ethereum_test_tools import Account, EOFException, EOFStateTestFiller, EOFTestFiller
 from ethereum_test_tools.eof.v1 import Container, ContainerKind, Section
-from ethereum_test_tools.eof.v1.constants import MAX_BYTECODE_SIZE
+from ethereum_test_tools.eof.v1.constants import MAX_BYTECODE_SIZE, MAX_INITCODE_SIZE
 from ethereum_test_tools.vm.opcode import Opcodes as Op
-from ethereum_test_types.eof.v1.constants import MAX_INITCODE_SIZE
 from ethereum_test_vm import Bytecode
 
 from .. import EOF_FORK_NAME

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -128,6 +128,7 @@ EthereumJS
 ethereum's
 evaluatable
 evm
+EVMCodeType
 evmone
 Evmone
 executables


### PR DESCRIPTION
## 🗒️ Description

### `@pytest.mark.with_all_evm_code_types` marker
Adds the `with_all_evm_code_types` marker that can be added to a test as follows:
```python
@pytest.mark.with_all_evm_code_types
@pytest.mark.valid_from("Frontier")
def test_something_with_all_evm_code_types(evm_code_type: EVMCodeType):
    pass
```
and the test will be parameterized for parameter `evm_code_type` only with value `[EVMCodeType.LEGACY]` starting on fork Frontier, and eventually it will be parametrized with with values `[EVMCodeType.LEGACY, EVMCodeType.EOF_V1]` on the EOF activation fork.

Adding the `evm_code_type` parameter to the function signature is optional and can be done only if required.

In all calls to `pre.deploy_contract`, if the code parameter is `Bytecode` type, and `evm_code_type==EVMCodeType.EOF_V1`, the bytecode will be automatically wrapped in an EOF V1 container.

Code wrapping might fail in the following circumstances:

- The code contains invalid EOF V1 opcodes.
- The code does not end with a valid EOF V1 terminating opcode (such as `Op.STOP` or `Op.REVERT` or `Op.RETURN`).

In the case where the code wrapping fails, `evm_code_type` can be added as a parameter to the test and the bytecode can be dynamically modified to be compatible with the EOF V1 container.

### `@pytest.mark.with_all_call_opcodes` marker

This marker is used to automatically parameterize a test with all EVM call opcodes that are valid for the fork being tested.

```python
import pytest

@pytest.mark.with_all_call_opcodes
@pytest.mark.valid_from("Frontier")
def test_something_with_all_call_opcodes(pre: Alloc, call_opcode: Op):
    ...
```

In this example, the test will be parametrized for parameter `call_opcode` with values `[Op.CALL, Op.CALLCODE]` starting on fork Frontier, `[Op.CALL, Op.CALLCODE, Op.DELEGATECALL]` on fork Homestead, `[Op.CALL, Op.CALLCODE, Op.DELEGATECALL, Op.STATICCALL]` on fork Byzantium, and eventually it will be parametrized with with values `[Op.CALL, Op.CALLCODE, Op.DELEGATECALL, Op.STATICCALL, Op.EXTCALL, Op.EXTSTATICCALL, Op.EXTDELEGATECALL]` on the EOF activation fork.

Parameter `evm_code_type` will also be parametrized with the correct EVM code type for the opcode under test.

### Code Generators `Switch` and `Conditional`

Code generators `Switch` and `Conditional` have been updated to take the `evm_code_type` and correctly generate EOF V1 code in case of `EVMCodeType.EOF_V1`.

### `--evm-code-type` parameter for `fill`

Parameter `--evm-code-type` to force all tests to be filled with an specific EVM code type and, while most tests would currently fail because of their incompatibility with EOF, it can serve the purpose of exploring which tests could be easily updated for EOF.

### `call_return_code` helper

This function returns the correct return code depending on the give opcode, whether a success is expected or not, and whether a revert is expected or not.

It is useful to automatically set the correct storage expectations depending on the type of call used, since all legacy `*CALL` opcodes and the EOF `EXT*CALL` opcodes return different values.

### Fork Covariant Processor Changes

Changes were required to `src/pytest_plugins/forks/forks.py` to allow markers to parametrize two or more parameters at the same time, depending on the fork. It was necessary because the new marker `with_all_call_opcodes` parametrizes `call_opcode` and `evm_code_type` at the same time.

### Example tests updated

The following tests were updated as an example of how an updated test would look like:
- tests/cancun/eip4844_blobs/test_point_evaluation_precompile.py
- tests/frontier/opcodes/test_dup.py

## 🔗 Related Issues
None

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
