### PR TITLE
refactor(tests,tw): EOF - Top-level container must not be truncated

### DIFF
--- a/src/ethereum_test_tools/exceptions/evmone_exceptions.py
+++ b/src/ethereum_test_tools/exceptions/evmone_exceptions.py
@@ -70,6 +70,9 @@ class EvmoneExceptionMapper:
         ExceptionMessage(EOFException.INVALID_MAX_STACK_HEIGHT, "err: invalid_max_stack_height"),
         ExceptionMessage(EOFException.INVALID_DATALOADN_INDEX, "err: invalid_dataloadn_index"),
         ExceptionMessage(EOFException.TRUNCATED_INSTRUCTION, "err: truncated_instruction"),
+        ExceptionMessage(
+            EOFException.TOPLEVEL_CONTAINER_TRUNCATED, "err: toplevel_container_truncated"
+        ),
     )
 
     def __init__(self) -> None:

--- a/src/ethereum_test_tools/exceptions/exceptions.py
+++ b/src/ethereum_test_tools/exceptions/exceptions.py
@@ -684,6 +684,10 @@ class EOFException(ExceptionBase):
     """
     EOF container's code section has truncated instruction.
     """
+    TOPLEVEL_CONTAINER_TRUNCATED = auto()
+    """
+    Top-level EOF container has data section truncated
+    """
 
 
 """

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/container.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/container.py
@@ -28,23 +28,6 @@ VALID: List[Container] = [
         ],
     ),
     Container(
-        # EOF allows truncated data section
-        name="no_data_section_contents",
-        sections=[
-            Section.Code(Op.STOP),
-            Section.Data(data="0x", custom_size=1),
-        ],
-        code="ef0001 010004 0200010001 040001 00 00800000 00",
-    ),
-    Container(
-        # EOF allows truncated data section
-        name="data_section_contents_incomplete",
-        sections=[
-            Section.Code(Op.STOP),
-            Section.Data(data="0xAABBCC", custom_size=4),
-        ],
-    ),
-    Container(
         name="max_code_sections",
         sections=[
             Section.Code(Op.JUMPF[i + 1] if i < (MAX_CODE_SECTIONS - 1) else Op.STOP)
@@ -330,6 +313,23 @@ INVALID: List[Container] = [
         ],
         # TODO the exception must be about code section EOFException.INVALID_CODE_SECTION,
         validity_error=EOFException.ZERO_SECTION_SIZE,
+    ),
+    Container(
+        name="no_data_section_contents",
+        sections=[
+            Section.Code(Op.STOP),
+            Section.Data(data="0x", custom_size=1),
+        ],
+        code="ef0001 010004 0200010001 040001 00 00800000 00",
+        validity_error=EOFException.TOPLEVEL_CONTAINER_TRUNCATED,
+    ),
+    Container(
+        name="data_section_contents_incomplete",
+        sections=[
+            Section.Code(Op.STOP),
+            Section.Data(data="0xAABBCC", custom_size=4),
+        ],
+        validity_error=EOFException.TOPLEVEL_CONTAINER_TRUNCATED,
     ),
     Container(
         name="data_section_preceding_code_section",

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_example_valid_invalid.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_example_valid_invalid.py
@@ -49,7 +49,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                 ],
             ),
             "ef0001010004020001000304000400008000013050000bad",
-            None,
+            EOFException.TOPLEVEL_CONTAINER_TRUNCATED,
             id="undersize_data_ok",
         ),
         pytest.param(

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_example_valid_invalid.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_example_valid_invalid.py
@@ -50,7 +50,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
             ),
             "ef0001010004020001000304000400008000013050000bad",
             EOFException.TOPLEVEL_CONTAINER_TRUNCATED,
-            id="undersize_data_ok",
+            id="undersize_data_not_ok_on_toplevel_container",
         ),
         pytest.param(
             # Check that EOF1 with too many or too few bytes fails

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -343,6 +343,7 @@ time15k
 timestamp
 todo
 toml
+toplevel
 tox
 Tox
 traceback


### PR DESCRIPTION
We are changing the EOF validation API (e.g. eofparse, EOF validation tests): the top-level EOF container must not have truncated/missing data section. This is how you would validate "genesis" EOF containers and is also less confusing for EOF tool users.

This change introduces new error kind: `TOPLEVEL_CONTAINER_TRUNCATED` and matches the recent change in evmone.

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
