### PR TITLE
new(tests): EIP-7069: Different RETURNDATACOPY oob

### DIFF
--- a/tests/prague/eip7692_eof_v1/eip7069_extcall/helpers.py
+++ b/tests/prague/eip7692_eof_v1/eip7069_extcall/helpers.py
@@ -7,7 +7,16 @@ import itertools
 _slot = itertools.count()
 next(_slot)  # don't use slot 0
 slot_code_worked = next(_slot)
+slot_eof_target_call_status = next(_slot)
+slot_legacy_target_call_status = next(_slot)
+slot_eof_target_returndata = next(_slot)
+slot_eof_target_returndatasize = next(_slot)
+slot_legacy_target_returndatasize = next(_slot)
+
 slot_last_slot = next(_slot)
+
+"""Storage value indicating an abort"""
+value_exceptional_abort_canary = 0x1984
 
 """Storage values for common testing fields"""
 value_code_worked = 0x2015

--- a/tests/prague/eip7692_eof_v1/eip7069_extcall/test_address_space_extension.py
+++ b/tests/prague/eip7692_eof_v1/eip7069_extcall/test_address_space_extension.py
@@ -10,6 +10,7 @@ from ethereum_test_tools.eof.v1 import Container, Section
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 from .. import EOF_FORK_NAME
+from .helpers import value_exceptional_abort_canary
 from .spec import CALL_SUCCESS, EXTCALL_REVERT, EXTCALL_SUCCESS
 
 REFERENCE_SPEC_GIT_PATH = "EIPS/eip-7069.md"
@@ -21,8 +22,6 @@ _slot = itertools.count(1)
 slot_top_level_call_status = next(_slot)
 slot_target_call_status = next(_slot)
 slot_target_returndata = next(_slot)
-
-value_exceptional_abort_canary = 0x1984
 
 
 @pytest.mark.parametrize(

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -246,6 +246,7 @@ num
 number
 ommer
 ommers
+oob
 opc
 oprypin
 origin


### PR DESCRIPTION
## 🗒️ Description

Simple test case covering the updated out-of-bounds behavior of RETURNDATACOPY accross legacy and EOF contracts.

I'm not sure whether to place this new test in the existing `7069_extcall` subdir or in its own, please advise.

## 🔗 Related Issues

Related update to the spec https://github.com/ethereum/EIPs/pull/8617. Update to evmone https://github.com/ethereum/evmone/pull/909

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
