### PR TITLE
support coverage script for EOF tests

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -11,9 +11,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.ref }} # Checks out the PR branch
-          fetch-depth: 0 # Necessary to fetch all history for diff
 
       - name: Fetch target branch
         run: git fetch origin ${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
@@ -23,17 +20,21 @@ jobs:
           echo $(pwd)
           echo ${{ github.workspace }}
 
+          #install solc for `pip install -e .` command
+          curl -L --output solc "https://github.com/ethereum/solidity/releases/download/v0.8.25/solc-static-linux"
+          sudo mv solc /usr/local/bin
+          sudo chmod +x /usr/local/bin/solc
+          solc --version
+
           #install pyspec deps from root repo
           python3 --version
           python3 -m venv ./venv/
           source ./venv/bin/activate
           pip install -e .
 
-          #install solc
-          curl -L --output solc "https://github.com/ethereum/solidity/releases/download/v0.8.25/solc-static-linux"
-          sudo mv solc /usr/local/bin
-          sudo chmod +x /usr/local/bin/solc
-          solc --version
+          # fix pyspec dependecy
+          pip3 install solc-select
+          solc-select use 0.8.25 --always-install
 
       # Required to fill .py tests
       - name: Build GO EVM
@@ -55,7 +56,7 @@ jobs:
           path: testpath
           sparse-checkout: |
             GeneralStateTests
-
+            EOFTests
 
       # This command diffs the file and filters in new lines
       - name: Parse converted tests from converted-ethereum-tests.txt
@@ -85,7 +86,13 @@ jobs:
           python3 -m venv ./venv/
           source ./venv/bin/activate
 
-          files=$(git diff --name-status origin/${{ github.base_ref }}...HEAD -- tests/ | grep -E '^[AM]' | grep '\.py$')
+          # Fetch the base branch and the head branch
+          git fetch origin ${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
+          git fetch origin ${{ github.head_ref }}:refs/remotes/origin/${{ github.head_ref }}
+
+          # Perform the diff
+          files=$(git diff --name-status origin/${{ github.base_ref }}...origin/${{ github.head_ref }} -- tests/ | grep -E '^[AM]' | grep '\.py$')
+
           echo "Modified or new .py files in tests folder:"
           echo "$files" | while read line; do
             file=$(echo "$line" | cut -c 3-)
@@ -93,19 +100,24 @@ jobs:
           done
 
           # fill new tests
+          mkdir -p fixtures/state_tests
+          mkdir -p fixtures/eof_tests
           echo "$files" | while read line; do
             file=$(echo "$line" | cut -c 3-)
-            fill $file --until=Cancun --evm-bin evmone-t8n
+            fill $file --until=Cancun --evm-bin evmone-t8n || true
+            fill $file --fork=CancunEIP7692 --evm-bin evmone-t8n || true
           done
 
-          files=$(find fixtures/state_tests -type f -name "*.json")
-          if [ -z "$files" ]; then
-              echo "Error: No filled JSON fixtures found in fixtures/state_tests."
+          filesState=$(find fixtures/state_tests -type f -name "*.json")
+          filesEOF=$(find fixtures/eof_tests -type f -name "*.json")
+          if [ -z "$filesState" || -z "$filesEOF" ]; then
+              echo "Error: No filled JSON fixtures found in fixtures."
                exit 1
           fi
 
           mkdir -p ${{ github.workspace }}/evmtest_coverage/coverage/PATCH_TESTS
           find fixtures/state_tests -type f -name "*.json" -exec cp {} ${{ github.workspace }}/evmtest_coverage/coverage/PATCH_TESTS \;
+          find fixtures/eof_tests -type f -name "*.json" -exec cp {} ${{ github.workspace }}/evmtest_coverage/coverage/PATCH_TESTS \;
 
       - name: Print tests that will be covered
         run: |


### PR DESCRIPTION
## 🗒️ Description
Fix evmone coverage script issue with PRs from remote repos
Support EOF tests coverage

## 🔗 Related Issues
https://github.com/ethereum/execution-spec-tests/pull/598

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
