### PR TITLE
fix(ci): add solc-select to fill stage of build fixtures

### DIFF
--- a/.github/actions/build-fixtures/action.yaml
+++ b/.github/actions/build-fixtures/action.yaml
@@ -23,14 +23,6 @@ runs:
       id: evm-builder
       with:
         type: ${{ steps.properties.outputs.evm-type }}
-    - name: Install solc compiler
-      shell: bash
-      run: |
-        if [ "$RUNNER_OS" == "Linux" ]; then PLATFORM="linux-amd64"; else PLATFORM="macosx-amd64"; fi
-        RELEASE_NAME=$(curl https://binaries.soliditylang.org/${PLATFORM}/list.json | jq -r --arg SOLC_VERSION "${{ steps.properties.outputs.solc }}" '.releases[$SOLC_VERSION]')
-        wget -O $GITHUB_WORKSPACE/bin/solc https://binaries.soliditylang.org/${PLATFORM}/$RELEASE_NAME
-        chmod a+x $GITHUB_WORKSPACE/bin/solc
-        echo $GITHUB_WORKSPACE/bin >> $GITHUB_PATH
     - name: Run fixtures fill
       shell: bash
       run: |
@@ -38,6 +30,7 @@ runs:
         python -m venv env
         source env/bin/activate
         pip install -e .
+        solc-select use 0.8.25 --always-install
         fill -n auto --evm-bin=${{ steps.evm-builder.outputs.evm-bin }} ${{ steps.properties.outputs.fill-params }}
     - name: Create fixtures info file
       shell: bash

--- a/.github/actions/build-fixtures/action.yaml
+++ b/.github/actions/build-fixtures/action.yaml
@@ -30,7 +30,7 @@ runs:
         python -m venv env
         source env/bin/activate
         pip install -e .
-        solc-select use 0.8.25 --always-install
+        solc-select use  ${{ steps.properties.outputs.solc }} --always-install
         fill -n auto --evm-bin=${{ steps.evm-builder.outputs.evm-bin }} ${{ steps.properties.outputs.fill-params }}
     - name: Create fixtures info file
       shell: bash


### PR DESCRIPTION
## 🗒️ Description
Fixes the new `solc-select` dependency required to build fixtures, for both stable/develop fixture releases as well and feature (EOF/Verkle) fixture releases.

## 🔗 Related Issues
This was an oversight from the following PR: https://github.com/ethereum/execution-spec-tests/pull/604

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md) - no addition.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
