### PR TITLE
use legacy tests to measure coverage as well

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -58,6 +58,15 @@ jobs:
             GeneralStateTests
             EOFTests
 
+      - name: Checkout ethereum/legacytests
+        uses: actions/checkout@v4
+        with:
+          repository: ethereum/legacytests
+          path: legacytestpath
+          sparse-checkout: |
+            Cancun/GeneralStateTests
+
+
       # This command diffs the file and filters in new lines
       - name: Parse converted tests from converted-ethereum-tests.txt
         run: |
@@ -74,9 +83,15 @@ jobs:
               echo $file
           done
 
-          mkdir -p ${{ github.workspace }}/evmtest_coverage/coverage/BASE_TESTS
+          BASE_TESTS_PATH=${{ github.workspace }}/evmtest_coverage/coverage/BASE_TESTS
+          mkdir -p $BASE_TESTS_PATH
           for file in $files; do
-              cp ${{ github.workspace }}/testpath/$file ${{ github.workspace }}/evmtest_coverage/coverage/BASE_TESTS
+              cp ${{ github.workspace }}/testpath/$file $BASE_TESTS_PATH
+              if [[ "$file" == *"GeneralStateTests"* ]]; then
+                  base_name=$(basename "$file")
+                  legacy_file_name="legacy_$base_name"
+                  cp ${{ github.workspace }}/legacytestpath/Cancun/$file $BASE_TESTS_PATH/$legacy_file_name
+              fi
           done
           
 


### PR DESCRIPTION
## 🗒️ Description
Fetch legacy tests to measure coverage as well (>Constantinople <=Cancun)
When converting .json tests. use it's most recent filled .json version as well as legacy version of the file to compare the coverage

## 🔗 Related Issues


## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
