### PR TITLE
test eof container custom_size field

### DIFF
--- a/src/ethereum_test_tools/eof/v1/__init__.py
+++ b/src/ethereum_test_tools/eof/v1/__init__.py
@@ -40,6 +40,12 @@ class SectionKind(IntEnum):
     CONTAINER = 3
     DATA = 4
 
+    def __str__(self) -> str:
+        """
+        Returns the string representation of the section kind
+        """
+        return self.name
+
 
 class AutoSection(Enum):
     """

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_example_valid_invalid.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_example_valid_invalid.py
@@ -36,55 +36,6 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
             id="simple_eof_1_deploy",
         ),
         pytest.param(
-            # Check that EOF1 undersize data is ok (4 declared, 2 provided)
-            # https://github.com/ipsilon/eof/blob/main/spec/eof.md#data-section-lifecycle
-            Container(
-                name="EOF1V0016",
-                sections=[
-                    Section.Code(
-                        code=Op.ADDRESS + Op.POP + Op.STOP,
-                        max_stack_height=1,
-                    ),
-                    Section.Data("0x0bad", custom_size=4),
-                ],
-            ),
-            "ef0001010004020001000304000400008000013050000bad",
-            EOFException.TOPLEVEL_CONTAINER_TRUNCATED,
-            id="undersize_data_not_ok_on_toplevel_container",
-        ),
-        pytest.param(
-            # Check that EOF1 with too many or too few bytes fails
-            Container(
-                name="EOF1I0006",
-                sections=[
-                    Section.Code(
-                        code=Op.ADDRESS + Op.POP + Op.STOP,
-                        max_stack_height=1,
-                    ),
-                    Section.Data("0x0bad60A70BAD", custom_size=4),
-                ],
-            ),
-            "ef0001010004020001000304000400008000013050000bad60A70BAD",
-            EOFException.INVALID_SECTION_BODIES_SIZE,
-            id="oversize_data_fail",
-        ),
-        pytest.param(
-            # Check that data section size is valid
-            Container(
-                name="EOF1V0001",
-                sections=[
-                    Section.Code(
-                        code=Op.ADDRESS + Op.POP + Op.STOP,
-                        max_stack_height=1,
-                    ),
-                    Section.Data("0x0bad60A7"),
-                ],
-            ),
-            "ef0001010004020001000304000400008000013050000bad60A7",
-            None,
-            id="data_ok",
-        ),
-        pytest.param(
             # Check that EOF1 with an illegal opcode fails
             Container(
                 name="EOF1I0008",

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_section_size.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_section_size.py
@@ -1,0 +1,95 @@
+"""
+EOF Container, test custom_size field for sections
+"""
+
+from enum import IntEnum
+
+import pytest
+
+from ethereum_test_tools import EOFTestFiller
+from ethereum_test_tools import Opcodes as Op
+from ethereum_test_tools.eof.v1 import Container, EOFException, Section, SectionKind
+
+from .. import EOF_FORK_NAME
+
+REFERENCE_SPEC_GIT_PATH = "EIPS/eip-3540.md"
+REFERENCE_SPEC_VERSION = "8dcb0a8c1c0102c87224308028632cc986a61183"
+
+pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
+
+
+class SectionSize(IntEnum):
+    """
+    Enum for the section size
+    """
+
+    NORMAL = 0
+    UNDERSIZE = 2
+    OVERSIZE = 100
+
+    def __str__(self) -> str:
+        """
+        Returns the string representation of the section kind
+        """
+        return self.name
+
+
+@pytest.mark.parametrize(
+    "section_kind, section_size, exception",
+    [
+        (SectionKind.DATA, SectionSize.NORMAL, None),
+        (SectionKind.DATA, SectionSize.UNDERSIZE, EOFException.INVALID_SECTION_BODIES_SIZE),
+        (SectionKind.DATA, SectionSize.OVERSIZE, EOFException.TOPLEVEL_CONTAINER_TRUNCATED),
+        (SectionKind.CODE, SectionSize.UNDERSIZE, EOFException.INVALID_SECTION_BODIES_SIZE),
+        (SectionKind.CODE, SectionSize.OVERSIZE, EOFException.INVALID_SECTION_BODIES_SIZE),
+        (SectionKind.CODE, SectionSize.NORMAL, None),
+        (SectionKind.TYPE, SectionSize.UNDERSIZE, EOFException.INVALID_TYPE_SECTION_SIZE),
+        (SectionKind.TYPE, SectionSize.OVERSIZE, EOFException.INVALID_SECTION_BODIES_SIZE),
+        (SectionKind.TYPE, SectionSize.NORMAL, None),
+    ],
+)
+def test_section_size(
+    eof_test: EOFTestFiller,
+    section_size: SectionSize,
+    section_kind: SectionKind,
+    exception: EOFException,
+):
+    """
+    Test custom_size is auto, more or less then the actual size of the section
+    """
+    eof_code = Container()
+
+    if section_size != SectionSize.NORMAL and section_kind == SectionKind.TYPE:
+        eof_code.sections.append(
+            Section(
+                kind=SectionKind.TYPE,
+                data="0x00800001",
+                custom_size=section_size,
+            ),
+        )
+
+    if section_size != SectionSize.NORMAL and section_kind == SectionKind.CODE:
+        eof_code.sections.append(
+            Section.Code(
+                code=Op.ADDRESS + Op.POP + Op.STOP,
+                max_stack_height=1,
+                custom_size=section_size,
+            )
+        )
+    else:
+        eof_code.sections.append(
+            Section.Code(
+                code=Op.ADDRESS + Op.POP + Op.STOP,
+                max_stack_height=1,
+            )
+        )
+
+    if section_size != SectionSize.NORMAL and section_kind == SectionKind.DATA:
+        eof_code.sections.append(Section.Data("0x00daaa", custom_size=section_size))
+    else:
+        eof_code.sections.append(Section.Data("0x00aaaa"))
+
+    eof_test(
+        data=eof_code,
+        expect_exception=exception,
+    )


### PR DESCRIPTION
## 🗒️ Description
test eof container custom_size field
this analyze ori test collection and extend with pyspec his test cases

## 🔗 Related Issues


## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
