### PR TITLE
feat(tests): use dynamic pre alloc within shanghai tests

### DIFF
--- a/src/pytest_plugins/filler/pre_alloc.py
+++ b/src/pytest_plugins/filler/pre_alloc.py
@@ -161,15 +161,19 @@ class Alloc(BaseAlloc):
     def fund_eoa(self, amount: NumberConvertible = 10**21, label: str | None = None) -> EOA:
         """
         Add a previously unused EOA to the pre-alloc with the balance specified by `amount`.
+
+        If amount is 0, nothing will be added to the pre-alloc but a new and unique EOA will be
+        returned.
         """
         eoa = next(self._eoa_iterator)
-        super().__setitem__(
-            eoa,
-            Account(
-                nonce=0,
-                balance=amount,
-            ),
-        )
+        if Number(amount) > 0:
+            super().__setitem__(
+                eoa,
+                Account(
+                    nonce=0,
+                    balance=amount,
+                ),
+            )
         return eoa
 
     def fund_address(self, address: Address, amount: NumberConvertible):

--- a/tests/shanghai/eip3651_warm_coinbase/conftest.py
+++ b/tests/shanghai/eip3651_warm_coinbase/conftest.py
@@ -1,0 +1,25 @@
+"""
+Fixtures for the EIP-3651 warm coinbase tests.
+"""
+
+import pytest
+
+from ethereum_test_tools import EOA, Alloc, Environment
+
+
+@pytest.fixture
+def env() -> Environment:  # noqa: D103
+    return Environment()
+
+
+@pytest.fixture
+def post() -> Alloc:  # noqa: D103
+    return Alloc()
+
+
+@pytest.fixture
+def sender(pre: Alloc) -> EOA:
+    """
+    Funded EOA used for sending transactions.
+    """
+    return pre.fund_eoa()

--- a/tests/shanghai/eip3651_warm_coinbase/spec.py
+++ b/tests/shanghai/eip3651_warm_coinbase/spec.py
@@ -1,0 +1,18 @@
+"""
+Defines EIP-3651 specification constants and functions.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ReferenceSpec:
+    """
+    Defines the reference spec version and git path.
+    """
+
+    git_path: str
+    version: str
+
+
+ref_spec_3651 = ReferenceSpec("EIPS/eip-3651.md", "d94c694c6f12291bb6626669c3e8587eef3adff1")

--- a/tests/shanghai/eip3855_push0/conftest.py
+++ b/tests/shanghai/eip3855_push0/conftest.py
@@ -1,0 +1,25 @@
+"""
+Fixtures for the EIP-3855 PUSH0 tests.
+"""
+
+import pytest
+
+from ethereum_test_tools import EOA, Alloc, Environment
+
+
+@pytest.fixture
+def env() -> Environment:  # noqa: D103
+    return Environment()
+
+
+@pytest.fixture
+def post() -> Alloc:  # noqa: D103
+    return Alloc()
+
+
+@pytest.fixture
+def sender(pre: Alloc) -> EOA:
+    """
+    Funded EOA used for sending transactions.
+    """
+    return pre.fund_eoa()

--- a/tests/shanghai/eip3855_push0/spec.py
+++ b/tests/shanghai/eip3855_push0/spec.py
@@ -1,0 +1,18 @@
+"""
+Defines EIP-3855 specification constants and functions.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ReferenceSpec:
+    """
+    Defines the reference spec version and git path.
+    """
+
+    git_path: str
+    version: str
+
+
+ref_spec_3855 = ReferenceSpec("EIPS/eip-3855.md", "42034250ae8dd4b21fdc6795773893c6f1e74d3a")

--- a/tests/shanghai/eip3860_initcode/conftest.py
+++ b/tests/shanghai/eip3860_initcode/conftest.py
@@ -1,0 +1,25 @@
+"""
+Fixtures for the EIP-3860 initcode tests.
+"""
+
+import pytest
+
+from ethereum_test_tools import EOA, Alloc, Environment
+
+
+@pytest.fixture
+def env() -> Environment:  # noqa: D103
+    return Environment()
+
+
+@pytest.fixture
+def post() -> Alloc:  # noqa: D103
+    return Alloc()
+
+
+@pytest.fixture
+def sender(pre: Alloc) -> EOA:
+    """
+    Funded EOA used for sending transactions.
+    """
+    return pre.fund_eoa()

--- a/tests/shanghai/eip3860_initcode/helpers.py
+++ b/tests/shanghai/eip3860_initcode/helpers.py
@@ -1,0 +1,72 @@
+"""
+Helpers for the EIP-3860 initcode tests.
+"""
+
+from ethereum_test_tools import Initcode, ceiling_division, eip_2028_transaction_data_cost
+from ethereum_test_tools.vm.opcode import Opcodes as Op
+
+from .spec import Spec
+
+KECCAK_WORD_COST = 6
+INITCODE_RESULTING_DEPLOYED_CODE = Op.STOP
+
+BASE_TRANSACTION_GAS = 21000
+CREATE_CONTRACT_BASE_GAS = 32000
+
+
+def calculate_initcode_word_cost(length: int) -> int:
+    """
+    Calculates the added word cost on contract creation added by the
+    length of the initcode based on the formula:
+    INITCODE_WORD_COST * ceil(len(initcode) / 32)
+    """
+    return Spec.INITCODE_WORD_COST * ceiling_division(length, 32)
+
+
+def calculate_create2_word_cost(length: int) -> int:
+    """
+    Calculates the added word cost on contract creation added by the
+    hashing of the initcode during create2 contract creation.
+    """
+    return KECCAK_WORD_COST * ceiling_division(length, 32)
+
+
+def calculate_create_tx_intrinsic_cost(initcode: Initcode) -> int:
+    """
+    Calculates the intrinsic gas cost of a transaction that contains initcode
+    and creates a contract
+    """
+    return (
+        BASE_TRANSACTION_GAS  # G_transaction
+        + CREATE_CONTRACT_BASE_GAS  # G_transaction_create
+        + eip_2028_transaction_data_cost(initcode)  # Transaction calldata cost
+        + calculate_initcode_word_cost(len(initcode))
+    )
+
+
+def calculate_create_tx_execution_cost(
+    initcode: Initcode,
+) -> int:
+    """
+    Calculates the total execution gas cost of a transaction that
+    contains initcode and creates a contract
+    """
+    cost = calculate_create_tx_intrinsic_cost(initcode)
+    cost += initcode.deployment_gas
+    cost += initcode.execution_gas
+    return cost
+
+
+def get_initcode_name(val: Initcode):
+    """
+    Helper function that returns an Initcode object's name to generate test
+    ids.
+    """
+    return val._name_
+
+
+def get_create_id(opcode: Op):
+    """
+    Helper function that returns the opcode name for the test id.
+    """
+    return opcode._name_.lower()

--- a/tests/shanghai/eip3860_initcode/spec.py
+++ b/tests/shanghai/eip3860_initcode/spec.py
@@ -1,0 +1,29 @@
+"""
+Defines EIP-3860 specification constants and functions.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ReferenceSpec:
+    """
+    Defines the reference spec version and git path.
+    """
+
+    git_path: str
+    version: str
+
+
+ref_spec_3860 = ReferenceSpec("EIPS/eip-3860.md", "5f8151e19ad1c99da4bafd514ce0e8ab89783c8f")
+
+
+@dataclass(frozen=True)
+class Spec:
+    """
+    Parameters from the EIP-3860 specifications as defined at
+    https://eips.ethereum.org/EIPS/eip-3860#parameters
+    """
+
+    MAX_INITCODE_SIZE = 49152
+    INITCODE_WORD_COST = 2

--- a/tests/shanghai/eip4895_withdrawals/conftest.py
+++ b/tests/shanghai/eip4895_withdrawals/conftest.py
@@ -1,0 +1,25 @@
+"""
+Fixtures for the EIP-4895 withdrawals tests.
+"""
+
+import pytest
+
+from ethereum_test_tools import EOA, Alloc, Environment
+
+
+@pytest.fixture
+def env() -> Environment:  # noqa: D103
+    return Environment()
+
+
+@pytest.fixture
+def post() -> Alloc:  # noqa: D103
+    return Alloc()
+
+
+@pytest.fixture
+def sender(pre: Alloc) -> EOA:
+    """
+    Funded EOA used for sending transactions.
+    """
+    return pre.fund_eoa()

--- a/tests/shanghai/eip4895_withdrawals/spec.py
+++ b/tests/shanghai/eip4895_withdrawals/spec.py
@@ -1,0 +1,18 @@
+"""
+Defines EIP-4895 specification constants and functions.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ReferenceSpec:
+    """
+    Defines the reference spec version and git path.
+    """
+
+    git_path: str
+    version: str
+
+
+ref_spec_4895 = ReferenceSpec("EIPS/eip-4895.md", "81af3b60b632bc9c03513d1d137f25410e3f4d34")


### PR DESCRIPTION
## 🗒️ Description
Updates all Shanghai tests to use dynamic pre allocation account addresses.

Refactors most tests to be more update with existing framework standards.

Adds additional call contents tests for EIP-3855: PUSH0 Instruction.

Todo: Update EIP-4895: Beacon chain withdrawals test cases.

## 🔗 Related Issues
Requires https://github.com/ethereum/execution-spec-tests/pull/584 to be merged to main.

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
