### PR TITLE
refactor(fw): use pydantic PrivateAttr for model class params

### DIFF
--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -32,6 +32,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    PrivateAttr,
     RootModel,
     TypeAdapter,
     computed_field,
@@ -575,9 +576,9 @@ class Alloc(RootModel[Dict[Address, Account | None]]):
 
     root: Dict[Address, Account | None] = Field(default_factory=dict, validate_default=True)
 
-    _alloc_mode: ClassVar[AllocMode] = AllocMode.PERMISSIVE
-    _start_contract_address: ClassVar[int] = 0x1000
-    _contract_address_increments: ClassVar[int] = 0x100
+    _alloc_mode: AllocMode = PrivateAttr(default=AllocMode.PERMISSIVE)
+    _start_contract_address: int = PrivateAttr(default=0x1000)
+    _contract_address_increments: int = PrivateAttr(default=0x100)
 
     @dataclass(kw_only=True)
     class UnexpectedAccount(Exception):


### PR DESCRIPTION
## 🗒️ Description
Using `PrivateAttr` seems to be a more standard way of achieving this in pydantic:
https://docs.pydantic.dev/latest/concepts/models/#private-model-attributes

## 🔗 Related Issues
#584 

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
