### PR TITLE
new(test) EOFCREATE and RETURNCONTRACT opcode validation tests

### DIFF
--- a/src/ethereum_test_tools/exceptions/evmone_exceptions.py
+++ b/src/ethereum_test_tools/exceptions/evmone_exceptions.py
@@ -73,6 +73,7 @@ class EvmoneExceptionMapper:
         ExceptionMessage(
             EOFException.TOPLEVEL_CONTAINER_TRUNCATED, "err: toplevel_container_truncated"
         ),
+        ExceptionMessage(EOFException.ORPHAN_SUBCONTAINER, "err: unreferenced_subcontainer"),
     )
 
     def __init__(self) -> None:

--- a/src/ethereum_test_tools/exceptions/exceptions.py
+++ b/src/ethereum_test_tools/exceptions/exceptions.py
@@ -688,6 +688,10 @@ class EOFException(ExceptionBase):
     """
     Top-level EOF container has data section truncated
     """
+    ORPHAN_SUBCONTAINER = auto()
+    """
+    EOF container has an unreferenced subcontainer.
+    '"""
 
 
 """

--- a/src/ethereum_test_tools/spec/eof/eof_test.py
+++ b/src/ethereum_test_tools/spec/eof/eof_test.py
@@ -165,14 +165,14 @@ class EOFTest(BaseTest):
                         )
                     if expect_exception is None:
                         data["expect_exception"] = container.validity_error
-                if "container_kind" in container.model_fields_set:
+                if "kind" in container.model_fields_set:
                     if container_kind is not None:
-                        assert str(container.kind) == container_kind, (
+                        assert container.kind == container_kind, (
                             f"Container kind type {str(container.kind)} "
                             f"does not match test {container_kind}."
                         )
                     if container.kind != ContainerKind.RUNTIME:
-                        data["container_kind"] = str(container.kind)
+                        data["container_kind"] = container.kind
         return data
 
     @classmethod

--- a/src/ethereum_test_tools/spec/eof/eof_test.py
+++ b/src/ethereum_test_tools/spec/eof/eof_test.py
@@ -280,6 +280,7 @@ class EOFStateTest(EOFTest):
     Filler type that tests EOF containers and also generates a state/blockchain test.
     """
 
+    deploy_tx: bool = False
     tx_gas_limit: int = 10_000_000
     tx_data: Bytes = Bytes(b"")
     tx_sender_funding_amount: int = 1_000_000_000_000_000_000_000
@@ -306,16 +307,23 @@ class EOFStateTest(EOFTest):
         Generate the StateTest filler.
         """
         assert self.pre is not None, "pre must be set to generate a StateTest."
-        container_address = self.pre.deploy_contract(code=self.data)
         sender = self.pre.fund_eoa(amount=self.tx_sender_funding_amount)
-        tx = Transaction(
-            to=container_address,
-            gas_limit=self.tx_gas_limit,
-            gas_price=10,
-            protected=False,
-            data=self.tx_data,
-            sender=sender,
-        )
+        if self.deploy_tx:
+            tx = Transaction(
+                to=None,
+                gas_limit=self.tx_gas_limit,
+                data=self.data + self.tx_data,
+                sender=sender,
+            )
+            container_address = tx.created_contract
+        else:
+            container_address = self.pre.deploy_contract(code=self.data)
+            tx = Transaction(
+                to=container_address,
+                gas_limit=self.tx_gas_limit,
+                data=self.tx_data,
+                sender=sender,
+            )
         post = Alloc()
         post[container_address] = self.container_post
         return StateTest(

--- a/src/ethereum_test_tools/spec/eof/types.py
+++ b/src/ethereum_test_tools/spec/eof/types.py
@@ -44,7 +44,6 @@ class Vector(CamelModel):
     code: Bytes
     container_kind: ContainerKind | None
     results: Mapping[str, Result]
-    kind: str | None
 
 
 class Fixture(BaseFixture):

--- a/src/ethereum_test_tools/spec/eof/types.py
+++ b/src/ethereum_test_tools/spec/eof/types.py
@@ -44,7 +44,7 @@ class Vector(CamelModel):
     code: Bytes
     container_kind: ContainerKind | None
     results: Mapping[str, Result]
-    kind: str
+    kind: str | None
 
 
 class Fixture(BaseFixture):

--- a/src/ethereum_test_tools/spec/eof/types.py
+++ b/src/ethereum_test_tools/spec/eof/types.py
@@ -44,6 +44,7 @@ class Vector(CamelModel):
     code: Bytes
     container_kind: ContainerKind | None
     results: Mapping[str, Result]
+    kind: str
 
 
 class Fixture(BaseFixture):

--- a/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_eofcreate.py
+++ b/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_eofcreate.py
@@ -345,7 +345,6 @@ def test_eofcreate_in_initcode_reverts(
                 + Op.REVERT(0, 0),
             ),
             Section.Container(container=smallest_initcode_subcontainer),
-            Section.Container(container=smallest_runtime_subcontainer),
         ]
     )
 

--- a/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
+++ b/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
@@ -4,7 +4,7 @@ EOF Subcontainer tests covering simple cases.
 import pytest
 
 from ethereum_test_tools import Account, EOFException, EOFStateTestFiller, EOFTestFiller
-from ethereum_test_tools.eof.v1 import Container, Section
+from ethereum_test_tools.eof.v1 import Container, ContainerKind, Section
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 from .. import EOF_FORK_NAME
@@ -124,8 +124,8 @@ def test_orphan_container(
                 first_sub_container,
                 extra_sub_container,
             ],
+            kind=ContainerKind.INITCODE,
         ),
-        kind="initcode",
         expect_exception=EOFException.ORPHAN_SUBCONTAINER,
     )
 

--- a/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
+++ b/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
@@ -107,13 +107,13 @@ def test_reverting_container(
     [stop_sub_container, revert_sub_container, returncontract_sub_container],
     ids=["stop", "revert", "returncontract"],
 )
-def test_unreferenced_container(
+def test_orphan_container(
     eof_test: EOFTestFiller,
     zero_sub_container: Container,
     first_sub_container: Container,
     extra_sub_container: Container,
 ):
-    """Test revert containers"""
+    """Test orphaned containers"""
     eof_test(
         data=Container(
             sections=[
@@ -148,7 +148,7 @@ def test_container_combos_valid(
     zero_sub_container: Container,
     first_sub_container: Container,
 ):
-    """Test revert containers"""
+    """Test valid subcontainer reference / opcode combos"""
     eof_state_test(
         data=Container(
             sections=[
@@ -189,7 +189,7 @@ def test_container_combos_invalid(
     first_sub_container: Container,
     error: EOFException,
 ):
-    """Test revert containers"""
+    """Test invalid subcontainer reference / opcode combos"""
     eof_test(
         data=Container(
             sections=[
@@ -202,7 +202,7 @@ def test_container_combos_invalid(
 
 
 def test_container_both_kinds_same_sub(eof_test: EOFTestFiller):
-    """Test revert containers"""
+    """Test subcontainer conflicts (both EOFCREATE and RETURNCONTRACT Reference)"""
     eof_test(
         data=Container(
             sections=[
@@ -222,7 +222,7 @@ def test_container_both_kinds_same_sub(eof_test: EOFTestFiller):
 
 
 def test_container_both_kinds_different_sub(eof_test: EOFTestFiller):
-    """Test revert containers"""
+    """Test multiple kinds of subcontainer at the same level"""
     eof_test(
         data=Container(
             sections=[

--- a/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
+++ b/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
@@ -1,0 +1,241 @@
+"""
+EOF Subcontainer tests covering simple cases.
+"""
+import pytest
+
+from ethereum_test_tools import Account, EOFException, EOFStateTestFiller, EOFTestFiller
+from ethereum_test_tools.eof.v1 import Container, Section
+from ethereum_test_tools.vm.opcode import Opcodes as Op
+
+from .. import EOF_FORK_NAME
+from .helpers import slot_code_worked, value_code_worked
+
+REFERENCE_SPEC_GIT_PATH = "EIPS/eip-7620.md"
+REFERENCE_SPEC_VERSION = "52ddbcdddcf72dd72427c319f2beddeb468e1737"
+
+pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
+
+eofcreate_code_section = Section.Code(
+    code=Op.EOFCREATE[0](0, 0, 0, 0) + Op.SSTORE(slot_code_worked, value_code_worked) + Op.STOP,
+    max_stack_height=4,
+)
+returncontract_code_section = Section.Code(
+    code=Op.SSTORE(slot_code_worked, value_code_worked) + Op.RETURNCONTRACT[0](0, 0),
+    max_stack_height=2,
+)
+stop_sub_container = Section.Container(container=Container(sections=[Section.Code(code=Op.STOP)]))
+return_sub_container = Section.Container(
+    container=Container(sections=[Section.Code(code=Op.RETURN(0, 0), max_stack_height=2)])
+)
+revert_sub_container = Section.Container(
+    container=Container(sections=[Section.Code(code=Op.REVERT(0, 0), max_stack_height=2)])
+)
+returncontract_sub_container = Section.Container(
+    container=Container(
+        sections=[
+            Section.Code(
+                code=Op.RETURNCONTRACT[0](0, 0),
+                max_stack_height=2,
+            ),
+            stop_sub_container,
+        ],
+    )
+)
+
+
+def test_simple_create_from_deployed(
+    eof_state_test: EOFStateTestFiller,
+):
+    """Simple EOF creation from a deployed EOF container"""
+    eof_state_test(
+        data=Container(
+            sections=[
+                eofcreate_code_section,
+                returncontract_sub_container,
+            ],
+        ),
+        container_post=Account(storage={slot_code_worked: value_code_worked}),
+    )
+
+
+def test_simple_create_from_creation(
+    eof_state_test: EOFStateTestFiller,
+):
+    """Simple EOF creation from a create transaction container"""
+    eof_state_test(
+        data=Container(
+            sections=[
+                returncontract_code_section,
+                Section.Container(container=Container(sections=[Section.Code(code=Op.STOP)])),
+            ],
+        ),
+        container_post=Account(storage={slot_code_worked: value_code_worked}),
+    )
+
+
+@pytest.mark.parametrize(
+    "zero_section",
+    [eofcreate_code_section, returncontract_code_section],
+    ids=["eofcreate", "returncontract"],
+)
+def test_reverting_container(
+    eof_state_test: EOFStateTestFiller,
+    zero_section: Container,
+):
+    """Test revert containers"""
+    eof_state_test(
+        data=Container(
+            sections=[
+                zero_section,
+                revert_sub_container,
+            ],
+        ),
+        container_post=Account(storage={slot_code_worked: value_code_worked}),
+    )
+
+
+@pytest.mark.parametrize(
+    "zero_sub_container,first_sub_container",
+    [
+        (eofcreate_code_section, returncontract_sub_container),
+        (returncontract_code_section, stop_sub_container),
+    ],
+    ids=["eofcreate", "returncontract"],
+)
+@pytest.mark.parametrize(
+    "extra_sub_container",
+    [stop_sub_container, revert_sub_container, returncontract_sub_container],
+    ids=["stop", "revert", "returncontract"],
+)
+def test_unreferenced_container(
+    eof_test: EOFTestFiller,
+    zero_sub_container: Container,
+    first_sub_container: Container,
+    extra_sub_container: Container,
+):
+    """Test revert containers"""
+    eof_test(
+        data=Container(
+            sections=[
+                zero_sub_container,
+                first_sub_container,
+                extra_sub_container,
+            ],
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "zero_sub_container,first_sub_container",
+    [
+        pytest.param(
+            eofcreate_code_section,
+            returncontract_sub_container,
+            id="EOFCREATE/RETURNCONTRACT",
+        ),
+        pytest.param(returncontract_code_section, stop_sub_container, id="RETURNCONTRACT/STOP"),
+        pytest.param(
+            returncontract_code_section, return_sub_container, id="RETURNCONTRACT/RETURN"
+        ),
+        pytest.param(eofcreate_code_section, revert_sub_container, id="EOFCREATE/REVERT"),
+        pytest.param(
+            returncontract_code_section, revert_sub_container, id="RETURNCONTRACT/REVERT"
+        ),
+    ],
+)
+def test_container_combos_valid(
+    eof_state_test: EOFStateTestFiller,
+    zero_sub_container: Container,
+    first_sub_container: Container,
+):
+    """Test revert containers"""
+    eof_state_test(
+        data=Container(
+            sections=[
+                zero_sub_container,
+                first_sub_container,
+            ],
+        ),
+        container_post=Account(storage={slot_code_worked: value_code_worked}),
+    )
+
+
+@pytest.mark.parametrize(
+    "zero_sub_container,first_sub_container,error",
+    [
+        pytest.param(
+            eofcreate_code_section,
+            stop_sub_container,
+            EOFException.UNDEFINED_EXCEPTION,
+            id="EOFCREATE/STOP",
+        ),
+        pytest.param(
+            eofcreate_code_section,
+            return_sub_container,
+            EOFException.UNDEFINED_EXCEPTION,
+            id="EOFCREATE/RETURN",
+        ),
+        pytest.param(
+            returncontract_code_section,
+            returncontract_sub_container,
+            EOFException.UNDEFINED_EXCEPTION,
+            id="RETURNCONTRACT/RETURNCONTRACT",
+        ),
+    ],
+)
+def test_container_combos_invalid(
+    eof_test: EOFTestFiller,
+    zero_sub_container: Container,
+    first_sub_container: Container,
+    error: EOFException,
+):
+    """Test revert containers"""
+    eof_test(
+        data=Container(
+            sections=[
+                zero_sub_container,
+                first_sub_container,
+            ],
+        ),
+        expect_exception=error,
+    )
+
+
+def test_container_both_kinds_same_sub(eof_test: EOFTestFiller):
+    """Test revert containers"""
+    eof_test(
+        data=Container(
+            sections=[
+                Section.Code(
+                    code=Op.EOFCREATE[0](0, 0, 0, 0) + Op.JUMPF[1],
+                    max_stack_height=4,
+                ),
+                Section.Code(
+                    code=Op.RETURNCONTRACT[0](0, 0) + Op.STOP,
+                    max_stack_height=2,
+                ),
+                revert_sub_container,
+            ],
+        ),
+        expect_exception=EOFException.UNDEFINED_EXCEPTION,
+    )
+
+
+def test_container_both_kinds_different_sub(eof_test: EOFTestFiller):
+    """Test revert containers"""
+    eof_test(
+        data=Container(
+            sections=[
+                Section.Code(
+                    code=Op.EOFCREATE[0](0, 0, 0, 0) + Op.JUMPF[1],
+                    max_stack_height=4,
+                ),
+                Section.Code(
+                    code=Op.RETURNCONTRACT[1](0, 0),
+                    max_stack_height=2,
+                ),
+                returncontract_sub_container,
+                stop_sub_container,
+            ],
+        ),
+    )

--- a/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
+++ b/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
@@ -67,7 +67,7 @@ def test_simple_create_from_creation(
         data=Container(
             sections=[
                 returncontract_code_section,
-                Section.Container(container=Container(sections=[Section.Code(code=Op.STOP)])),
+                stop_sub_container,
             ],
         ),
         container_post=Account(storage={slot_code_worked: value_code_worked}),
@@ -117,7 +117,6 @@ def test_orphan_container(
 ):
     """Test orphaned containers"""
     eof_test(
-        deploy_tx=code_section == returncontract_code_section,
         data=Container(
             sections=[
                 code_section,
@@ -214,11 +213,9 @@ def test_container_both_kinds_same_sub(eof_test: EOFTestFiller):
             sections=[
                 Section.Code(
                     code=Op.EOFCREATE[0](0, 0, 0, 0) + Op.JUMPF[1],
-                    max_stack_height=4,
                 ),
                 Section.Code(
                     code=Op.RETURNCONTRACT[0](0, 0),
-                    max_stack_height=2,
                 ),
                 revert_sub_container,
             ],
@@ -234,11 +231,9 @@ def test_container_both_kinds_different_sub(eof_test: EOFTestFiller):
             sections=[
                 Section.Code(
                     code=Op.EOFCREATE[0](0, 0, 0, 0) + Op.JUMPF[1],
-                    max_stack_height=4,
                 ),
                 Section.Code(
                     code=Op.RETURNCONTRACT[1](0, 0),
-                    max_stack_height=2,
                 ),
                 returncontract_sub_container,
                 stop_sub_container,

--- a/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
+++ b/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
@@ -110,13 +110,13 @@ def test_reverting_container(
     ids=["stop", "revert", "returncontract"],
 )
 def test_orphan_container(
-    eof_state_test: EOFStateTestFiller,
+    eof_test: EOFTestFiller,
     code_section: Section,
     first_sub_container: Container,
     extra_sub_container: Container,
 ):
     """Test orphaned containers"""
-    eof_state_test(
+    eof_test(
         deploy_tx=code_section == returncontract_code_section,
         data=Container(
             sections=[
@@ -125,7 +125,8 @@ def test_orphan_container(
                 extra_sub_container,
             ],
         ),
-        container_post=Account(storage={slot_code_worked: value_code_worked}),
+        kind="initcode",
+        expect_exception=EOFException.ORPHAN_SUBCONTAINER,
     )
 
 


### PR DESCRIPTION

## 🗒️ Description
Test 3 rules
- Opcodes in subcontainers, by usage kind (EOFCREATE/RETURNCONTRACT)
- Mixed reference container (both EOFCREATE and RETURNCONTRACT)
- No unused containers

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
