### PR TITLE
new(tests): EOF - EIP-3540: MAX_INITCODE_SIZE validation

### DIFF
--- a/src/ethereum_test_tools/exceptions/evmone_exceptions.py
+++ b/src/ethereum_test_tools/exceptions/evmone_exceptions.py
@@ -74,6 +74,9 @@ class EvmoneExceptionMapper:
             EOFException.TOPLEVEL_CONTAINER_TRUNCATED, "err: toplevel_container_truncated"
         ),
         ExceptionMessage(EOFException.ORPHAN_SUBCONTAINER, "err: unreferenced_subcontainer"),
+        ExceptionMessage(
+            EOFException.CONTAINER_SIZE_ABOVE_LIMIT, "err: container_size_above_limit"
+        ),
     )
 
     def __init__(self) -> None:

--- a/src/ethereum_test_tools/exceptions/exceptions.py
+++ b/src/ethereum_test_tools/exceptions/exceptions.py
@@ -692,6 +692,10 @@ class EOFException(ExceptionBase):
     """
     EOF container has an unreferenced subcontainer.
     '"""
+    CONTAINER_SIZE_ABOVE_LIMIT = auto()
+    """
+    EOF container is above size limit
+    """
 
 
 """

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_container_size.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_container_size.py
@@ -1,0 +1,114 @@
+"""
+EOF validation tests for EIP-3540 container size
+"""
+
+import pytest
+
+from ethereum_test_tools import EOFTestFiller
+from ethereum_test_tools import Opcodes as Op
+from ethereum_test_tools.eof.v1 import Container, EOFException, Section
+from ethereum_test_tools.eof.v1.constants import MAX_INITCODE_SIZE
+
+from .. import EOF_FORK_NAME
+
+REFERENCE_SPEC_GIT_PATH = "EIPS/eip-3540.md"
+REFERENCE_SPEC_VERSION = ""  # todo
+
+pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
+
+VALID_CONTAINER = Container(sections=[Section.Code(code=Op.STOP)])
+
+
+@pytest.mark.parametrize(
+    "over_limit",
+    [0, 1, 2, 2**16 - MAX_INITCODE_SIZE],
+)
+def test_max_size(
+    eof_test: EOFTestFiller,
+    over_limit: int,
+):
+    """
+    Verify EOF container valid at maximum size, invalid above
+    """
+    minimal_code = bytearray(bytes(VALID_CONTAINER))
+    # Expand the minimal EOF code by more noop code, reaching the desired target container size.
+    code = Container(
+        sections=[
+            Section.Code(
+                code=Op.JUMPDEST * (MAX_INITCODE_SIZE - len(minimal_code) + over_limit) + Op.STOP
+            )
+        ]
+    )
+    assert len(code) == MAX_INITCODE_SIZE + over_limit
+    eof_test(
+        data=bytes(code),
+        expect_exception=None if over_limit == 0 else EOFException.CONTAINER_SIZE_ABOVE_LIMIT,
+    )
+
+
+@pytest.mark.parametrize(
+    "size",
+    [MAX_INITCODE_SIZE + 1, MAX_INITCODE_SIZE * 2],
+)
+def test_above_max_size_raw(
+    eof_test: EOFTestFiller,
+    size: int,
+):
+    """
+    Verify EOF container invalid above maximum size, regardless of header contents
+    """
+    code = Op.INVALID * size
+    eof_test(
+        data=bytes(code),
+        expect_exception=EOFException.CONTAINER_SIZE_ABOVE_LIMIT,
+    )
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        pytest.param(
+            Container(sections=[Section.Code(code=Op.STOP, custom_size=MAX_INITCODE_SIZE)]),
+            id="1st_code_section",
+        ),
+        pytest.param(
+            Container(
+                sections=[
+                    Section.Code(code=Op.STOP),
+                    Section.Code(code=Op.STOP, custom_size=MAX_INITCODE_SIZE),
+                ]
+            ),
+            id="2nd_code_section",
+        ),
+        pytest.param(
+            Container(
+                sections=[
+                    Section.Code(code=Op.STOP),
+                    Section.Container(container=Op.STOP, custom_size=MAX_INITCODE_SIZE),
+                ]
+            ),
+            id="1st_container_section",
+        ),
+        pytest.param(
+            Container(
+                sections=[
+                    Section.Code(code=Op.STOP),
+                    Section.Container(container=Op.STOP),
+                    Section.Container(container=Op.STOP, custom_size=MAX_INITCODE_SIZE),
+                ]
+            ),
+            id="2nd_container_section",
+        ),
+    ],
+)
+def test_section_after_end_of_container(
+    eof_test: EOFTestFiller,
+    code: Container,
+):
+    """
+    Verify EOF container is invalid if any of sections declares above container size
+    """
+    eof_test(
+        data=bytes(code),
+        expect_exception=EOFException.INVALID_SECTION_BODIES_SIZE,
+    )

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_container_size.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_container_size.py
@@ -30,12 +30,12 @@ def test_max_size(
     """
     Verify EOF container valid at maximum size, invalid above
     """
-    minimal_code = bytearray(bytes(VALID_CONTAINER))
     # Expand the minimal EOF code by more noop code, reaching the desired target container size.
     code = Container(
         sections=[
             Section.Code(
-                code=Op.JUMPDEST * (MAX_INITCODE_SIZE - len(minimal_code) + over_limit) + Op.STOP
+                code=Op.JUMPDEST * (MAX_INITCODE_SIZE - len(VALID_CONTAINER) + over_limit)
+                + Op.STOP
             )
         ]
     )

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_container_size.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_container_size.py
@@ -12,7 +12,7 @@ from ethereum_test_tools.eof.v1.constants import MAX_INITCODE_SIZE
 from .. import EOF_FORK_NAME
 
 REFERENCE_SPEC_GIT_PATH = "EIPS/eip-3540.md"
-REFERENCE_SPEC_VERSION = ""  # todo
+REFERENCE_SPEC_VERSION = "6b313505c75afa49a4f34de39c609ebebc7be87f"
 
 pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
 

--- a/tests/prague/eip7692_eof_v1/eip7480_data_section/test_code_validation.py
+++ b/tests/prague/eip7692_eof_v1/eip7480_data_section/test_code_validation.py
@@ -17,6 +17,13 @@ REFERENCE_SPEC_VERSION = "3ee1334ef110420685f1c8ed63e80f9e1766c251"
 
 pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
 
+smallest_runtime_subcontainer = Container(
+    name="Runtime Subcontainer",
+    sections=[
+        Section.Code(code=Op.STOP),
+    ],
+)
+
 VALID: List[Container] = [
     Container(
         name="empty_data_section",
@@ -48,10 +55,9 @@ VALID: List[Container] = [
     Container(
         name="max_data_section",
         sections=[
-            Section.Code(
-                code=Op.ADDRESS + Op.POP + Op.STOP,
-            ),
-            Section.Data(data=("1122334455667788" * 8 * 1024)[2:]),
+            Section.Code(code=Op.STOP),
+            # Hits the 49152 bytes limit for the entire container
+            Section.Data(data=(b"12345678" * 6 * 1024)[len(smallest_runtime_subcontainer) :]),
         ],
     ),
     Container(
@@ -79,15 +85,6 @@ VALID: List[Container] = [
                 code=Op.DATALOADN[128 - 32] + Op.POP + Op.STOP,
             ),
             Section.Data(data="1122334455667788" * 16),
-        ],
-    ),
-    Container(
-        name="DATALOADN_max",
-        sections=[
-            Section.Code(
-                code=Op.DATALOADN[0xFFFF - 32] + Op.POP + Op.STOP,
-            ),
-            Section.Data(data=("1122334455667788" * 8 * 1024)[2:]),
         ],
     ),
 ]
@@ -121,6 +118,15 @@ INVALID: List[Container] = [
             Section.Data(data=("1122334455667788" * 4 * 1024)[2:]),
         ],
         validity_error=EOFException.INVALID_DATALOADN_INDEX,
+    ),
+    Container(
+        name="data_section_over_container_limit",
+        sections=[
+            Section.Code(code=Op.STOP),
+            # Over the 49152 bytes limit for the entire container
+            Section.Data(data=(b"12345678" * 6 * 1024)[len(smallest_runtime_subcontainer) - 1 :]),
+        ],
+        validity_error=EOFException.CONTAINER_SIZE_ABOVE_LIMIT,
     ),
 ]
 

--- a/tests/prague/eip7692_eof_v1/eip7480_data_section/test_code_validation.py
+++ b/tests/prague/eip7692_eof_v1/eip7480_data_section/test_code_validation.py
@@ -8,6 +8,7 @@ import pytest
 
 from ethereum_test_tools import EOFException, EOFTestFiller
 from ethereum_test_tools.eof.v1 import Container, Section
+from ethereum_test_tools.eof.v1.constants import MAX_INITCODE_SIZE
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 from .. import EOF_FORK_NAME

--- a/tests/prague/eip7692_eof_v1/eip7480_data_section/test_code_validation.py
+++ b/tests/prague/eip7692_eof_v1/eip7480_data_section/test_code_validation.py
@@ -57,7 +57,7 @@ VALID: List[Container] = [
         sections=[
             Section.Code(code=Op.STOP),
             # Hits the 49152 bytes limit for the entire container
-            Section.Data(data=(b"12345678" * 6 * 1024)[len(smallest_runtime_subcontainer) :]),
+            Section.Data(data=b"\x00" * (MAX_INITCODE_SIZE - len(smallest_runtime_subcontainer))),
         ],
     ),
     Container(


### PR DESCRIPTION
## 🗒️ Description

Add tests aligning with https://github.com/ethereum/EIPs/pull/8670 / https://github.com/ipsilon/eof/pull/125

## 🔗 Related Issues

na

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
