### PR TITLE
fix(fw): EVM binary pattern for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ This guide installs stable versions of the required external (go-ethereum) `evm`
    cd execution-spec-tests
    python3 -m venv ./venv/
    source ./venv/bin/activate
-   pip install -e '.[docs,lint,test]'
+   pip install -e .[docs,lint,test]
    ```
 
 3. Verify the installation:

--- a/src/evm_transition_tool/geth.py
+++ b/src/evm_transition_tool/geth.py
@@ -21,7 +21,7 @@ class GethTransitionTool(TransitionTool):
     """
 
     default_binary = Path("evm")
-    detect_binary_pattern = compile(r"^evm version\b")
+    detect_binary_pattern = compile(r"^evm(.exe)? version\b")
     t8n_subcommand: Optional[str] = "t8n"
     statetest_subcommand: Optional[str] = "statetest"
     blocktest_subcommand: Optional[str] = "blocktest"


### PR DESCRIPTION
## 🗒️ Description
In windows, geth binary file ends with exe extension

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
