### PR TITLE
new(tests): EOFCREATE frame reverts with EOF container

### DIFF
--- a/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_eofcreate.py
+++ b/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_eofcreate.py
@@ -511,3 +511,58 @@ def test_address_collision(
         sender=sender,
     )
     state_test(env=env, pre=pre, post=post, tx=tx)
+
+
+def test_eofcreate_revert_eof_returndata(
+    state_test: StateTestFiller,
+    pre: Alloc,
+):
+    """
+    Verifies the return data is not being deployed, even if happens to be valid EOF
+    """
+    env = Environment()
+    code_reverts_with_calldata = Container(
+        name="Initcode Subcontainer reverting with its calldata",
+        sections=[
+            Section.Code(
+                code=Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE) + Op.REVERT(0, Op.CALLDATASIZE),
+                max_stack_height=3,
+            ),
+        ],
+    )
+
+    sender = pre.fund_eoa()
+    contract_address = pre.deploy_contract(
+        code=Container(
+            sections=[
+                Section.Code(
+                    code=Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE)
+                    + Op.SSTORE(slot_create_address, Op.EOFCREATE[0](0, 0, 0, Op.CALLDATASIZE))
+                    + Op.SSTORE(slot_returndata_size, Op.RETURNDATASIZE)
+                    + Op.STOP,
+                    max_stack_height=4,
+                ),
+                Section.Container(container=code_reverts_with_calldata),
+            ],
+        )
+    )
+
+    post = {
+        contract_address: Account(
+            storage={
+                slot_create_address: 0,
+                slot_returndata_size: len(smallest_runtime_subcontainer),
+            },
+        ),
+    }
+
+    tx = Transaction(
+        to=contract_address,
+        gas_limit=1_000_000,
+        sender=sender,
+        # Simplest possible valid EOF container, which is going to be
+        # revert-returned from initcode and must not end up being deployed.
+        data=smallest_runtime_subcontainer,
+    )
+
+    state_test(env=env, pre=pre, post=post, tx=tx)


### PR DESCRIPTION
## 🗒️ Description

Contributing an EOFCREATE edge case from https://github.com/ipsilon/execution-spec-tests/pull/1 upstream

## 🔗 Related Issues

N/A

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
