### PR TITLE
fix(plugins): Root folder name in generated .tar.gz

### DIFF
--- a/src/pytest_plugins/test_filler/test_filler.py
+++ b/src/pytest_plugins/test_filler/test_filler.py
@@ -592,7 +592,7 @@ def create_tarball(
         with tarfile.open(tarball_filename, "w:gz") as tar:
             for file in source_dir.rglob("*"):
                 if file.suffix in {".json", ".ini"}:
-                    arcname = file.relative_to(source_dir.parent)
+                    arcname = Path("fixtures") / file.relative_to(source_dir)
                     tar.add(file, arcname=arcname)
 
 


### PR DESCRIPTION
## 🗒️ Description
Fixes the name of the root folder in the generated .tar.gz file to always be `fixtures` instead of the name of the output folder.

@pdobacz 

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
