### PR TITLE
Init collision coverage fix [TEST]

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -8,6 +8,10 @@ on:
 jobs:
   evmone-coverage-diff:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        driver: [retesteth, native]
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -20,20 +24,12 @@ jobs:
           echo $(pwd)
           echo ${{ github.workspace }}
 
-          #install solc for `pip install -e .` command
-          curl -L --output solc "https://github.com/ethereum/solidity/releases/download/v0.8.25/solc-static-linux"
-          sudo mv solc /usr/local/bin
-          sudo chmod +x /usr/local/bin/solc
-          solc --version
-
           #install pyspec deps from root repo
           python3 --version
+          pip install --upgrade pip
           python3 -m venv ./venv/
           source ./venv/bin/activate
           pip install -e .
-
-          # fix pyspec dependecy
-          pip3 install solc-select
           solc-select use 0.8.25 --always-install
 
       # Required to fill .py tests
@@ -82,15 +78,37 @@ jobs:
           for file in $files; do
               echo $file
           done
+          echo "----------------"
+          echo "Discovered existing json tests that will be BASE files:"
+
 
           BASE_TESTS_PATH=${{ github.workspace }}/evmtest_coverage/coverage/BASE_TESTS
           mkdir -p $BASE_TESTS_PATH
           for file in $files; do
-              cp ${{ github.workspace }}/testpath/$file $BASE_TESTS_PATH
+              # Make sure each file exist at least in develop of legacy tests
+              file_found=0
+              file_path=${{ github.workspace }}/testpath/$file
+              if [ -e "$file_path" ]; then
+                file_found=1
+                cp $file_path $BASE_TESTS_PATH
+                echo $file_path
+              fi
+
+              # Do not search EOF files in legacy tests (assuming blockchain files we do not cover yet)
               if [[ "$file" == *"GeneralStateTests"* ]]; then
+                  file_path=${{ github.workspace }}/legacytestpath/Cancun/$file
                   base_name=$(basename "$file")
                   legacy_file_name="legacy_$base_name"
-                  cp ${{ github.workspace }}/legacytestpath/Cancun/$file $BASE_TESTS_PATH/$legacy_file_name
+                  if [ -e "$file_path" ]; then
+                    file_found=1
+                    cp $file_path $BASE_TESTS_PATH/$legacy_file_name
+                    echo $file_path
+                  fi
+              fi
+
+              if [ $file_found -eq 0 ]; then
+               echo "Error: Failed to find the test file $file in test repo"
+                exit 1
               fi
           done
           
@@ -120,19 +138,20 @@ jobs:
           echo "$files" | while read line; do
             file=$(echo "$line" | cut -c 3-)
             fill $file --until=Cancun --evm-bin evmone-t8n || true
-            fill $file --fork=CancunEIP7692 --evm-bin evmone-t8n || true
+            fill $file --fork=CancunEIP7692 --evm-bin evmone-t8n -k eof_test || true
           done
 
           filesState=$(find fixtures/state_tests -type f -name "*.json")
           filesEOF=$(find fixtures/eof_tests -type f -name "*.json")
-          if [ -z "$filesState" || -z "$filesEOF" ]; then
+          if [ -z "$filesState" ] && [ -z "$filesEOF" ]; then
               echo "Error: No filled JSON fixtures found in fixtures."
                exit 1
           fi
 
-          mkdir -p ${{ github.workspace }}/evmtest_coverage/coverage/PATCH_TESTS
-          find fixtures/state_tests -type f -name "*.json" -exec cp {} ${{ github.workspace }}/evmtest_coverage/coverage/PATCH_TESTS \;
-          find fixtures/eof_tests -type f -name "*.json" -exec cp {} ${{ github.workspace }}/evmtest_coverage/coverage/PATCH_TESTS \;
+          PATCH_TEST_PATH=${{ github.workspace }}/evmtest_coverage/coverage/PATCH_TESTS
+          mkdir -p $PATCH_TEST_PATH
+          find fixtures/state_tests -type f -name "*.json" -exec cp {} $PATCH_TEST_PATH \;
+          find fixtures/eof_tests -type f -name "*.json" -exec cp {} $PATCH_TEST_PATH \;
 
       - name: Print tests that will be covered
         run: |
@@ -147,14 +166,14 @@ jobs:
         with:
           image: winsvega/evmone-coverage-script:latest
           options: -v ${{ github.workspace }}/evmtest_coverage/coverage:/tests
-          run: /entrypoint.sh --mode=cover --testpath=/tests/BASE_TESTS --outputname=BASE
+          run: /entrypoint.sh --mode=cover --driver=${{ matrix.driver }} --testpath=/tests/BASE_TESTS --outputname=BASE
 
       - name: Run coverage of the PATCH tests
         uses: addnab/docker-run-action@v3
         with:
           image: winsvega/evmone-coverage-script:latest
           options: -v ${{ github.workspace }}/evmtest_coverage/coverage:/tests
-          run: /entrypoint.sh --mode=cover --testpath=/tests/PATCH_TESTS --outputname=PATCH
+          run: /entrypoint.sh --mode=cover --driver=${{ matrix.driver }} --testpath=/tests/PATCH_TESTS --outputname=PATCH
 
       - name: Run coverage DIFF of the PATCH tests compared to BASE tests
         uses: addnab/docker-run-action@v3

--- a/converted-ethereum-tests.txt
+++ b/converted-ethereum-tests.txt
@@ -1,4 +1,4 @@
-([#440](https://github.com/ethereum/execution-spec-tests/pull/440))
+([#636](https://github.com/ethereum/execution-spec-tests/pull/636))
 GeneralStateTests/stSStoreTest/InitCollision.json
 GeneralStateTests/stSStoreTest/InitCollisionNonZeroNonce.json
 GeneralStateTests/stSStoreTest/InitCollisionParis.json

--- a/converted-ethereum-tests.txt
+++ b/converted-ethereum-tests.txt
@@ -1,0 +1,4 @@
+([#440](https://github.com/ethereum/execution-spec-tests/pull/440))
+GeneralStateTests/stSStoreTest/InitCollision.json
+GeneralStateTests/stSStoreTest/InitCollisionNonZeroNonce.json
+GeneralStateTests/stSStoreTest/InitCollisionParis.json

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Add tests for [EIP-7069: EOF - Revamped CALL instructions](https://eips.ethereum.org/EIPS/eip-7069) ([#595](https://github.com/ethereum/execution-spec-tests/pull/595)).
 - 🐞 Fix typos in self-destruct collision test from erroneous pytest parametrization ([#608](https://github.com/ethereum/execution-spec-tests/pull/608)).
 - ✨ Add tests for [EIP-3540: EOF - EVM Object Format v1](https://eips.ethereum.org/EIPS/eip-3540) ([#634](https://github.com/ethereum/execution-spec-tests/pull/634)).
+- ✨ Add tests for [EIP-7610: Revert creation in case of non-empty storage](https://eips.ethereum.org/EIPS/eip-7610) ([#636](https://github.com/ethereum/execution-spec-tests/pull/636)).
 
 ### 🛠️ Framework
 

--- a/docs/writing_tests/test_markers.md
+++ b/docs/writing_tests/test_markers.md
@@ -101,6 +101,16 @@ def test_something_with_modified_pre(pre):
     ...
 ```
 
+```python
+import pytest
+
+@pytest.mark.pre_alloc_modifier
+def test_something_with_modified_pre():
+    # Test defines its own pre-alloc
+    pre = Alloc()
+    ...
+```
+
 ### pytest.mark.skip("reason")
 
 This marker is used to skip a test with a reason.

--- a/docs/writing_tests/test_markers.md
+++ b/docs/writing_tests/test_markers.md
@@ -86,6 +86,21 @@ In this example, the test will be parameterized for parameter `precompile` with 
 
 This marker is used to mark tests that are slow to run. These tests are not run during tox testing, and are only run when a release is being prepared.
 
+### pytest.mark.pre_alloc_modifier
+
+This marker is used to mark tests that access and modify the internal accounts of `pre` , instead of using the default `pre.deploy_contract` or `pre.fund_eoa` functions.
+
+This is sometimes necessary when the test requires a specific account state that is not possible to achieve using the default functions, but limits the environment in which the test can be run.
+
+```python
+import pytest
+
+@pytest.mark.pre_alloc_modifier
+def test_something_with_modified_pre(pre):
+    pre[0x0000000000000000000000000000000000000000] = Account(storage={0: 1})
+    ...
+```
+
 ### pytest.mark.skip("reason")
 
 This marker is used to skip a test with a reason.

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,6 +5,7 @@ python_files = *.py
 testpaths = tests/
 markers =
     slow
+    pre_alloc_modifier
 addopts = 
     -p pytest_plugins.test_filler.test_filler
     -p pytest_plugins.forks.forks

--- a/tests/paris/eip7610_create_collision/__init__.py
+++ b/tests/paris/eip7610_create_collision/__init__.py
@@ -1,0 +1,3 @@
+"""
+Cross-client Create Collision Tests
+"""

--- a/tests/paris/eip7610_create_collision/test_initcollision.py
+++ b/tests/paris/eip7610_create_collision/test_initcollision.py
@@ -1,0 +1,138 @@
+"""
+Test collision in CREATE/CREATE2 account creation, where the existing account only has a non-zero
+storage slot set.
+"""
+
+import pytest
+
+from ethereum_test_tools import Account, Alloc, Environment, Initcode
+from ethereum_test_tools import Opcodes as Op
+from ethereum_test_tools import (
+    StateTestFiller,
+    Transaction,
+    compute_create2_address,
+    compute_create_address,
+)
+
+REFERENCE_SPEC_GIT_PATH = "EIPS/eip-7610.md"
+REFERENCE_SPEC_VERSION = "80ef48d0bbb5a4939ade51caaaac57b5df6acd4e"
+
+
+@pytest.mark.parametrize("nonce", [0, 1])
+@pytest.mark.pre_alloc_modifier  # We need to modify the pre-alloc to include the collision
+@pytest.mark.with_all_contract_creating_tx_types
+@pytest.mark.valid_from("Paris")
+def test_init_collision_create_tx(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    nonce: int,
+    tx_type: int,
+):
+    """
+    Test that a contract creation transaction exceptionally aborts when the target address has a
+    non-empty storage.
+    """
+    env = Environment()
+
+    sender = pre.fund_eoa()
+
+    initcode = Initcode(
+        deploy_code=Op.STOP,
+        initcode_prefix=Op.SSTORE(0, 1) + Op.SSTORE(1, 0),
+    )
+
+    tx = Transaction(
+        sender=sender,
+        type=tx_type,
+        to=None,
+        data=initcode,
+        gas_limit=200_000,
+    )
+
+    created_contract_address = tx.created_contract
+
+    pre[created_contract_address] = Account(
+        storage={0x01: 0x01},
+        nonce=nonce,
+    )
+
+    state_test(
+        env=env,
+        pre=pre,
+        post={
+            created_contract_address: Account(
+                storage={0x01: 0x01},
+            ),
+        },
+        tx=tx,
+    )
+
+
+@pytest.mark.parametrize("opcode", [Op.CREATE, Op.CREATE2])
+@pytest.mark.parametrize("nonce", [0, 1])
+@pytest.mark.pre_alloc_modifier  # We need to modify the pre-alloc to include the collision
+@pytest.mark.valid_from("Paris")
+def test_init_collision_create_opcode(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    nonce: int,
+    opcode: Op,
+):
+    """
+    Test that a contract creation opcode exceptionally aborts when the target address has a
+    non-empty storage.
+    """
+    env = Environment()
+
+    sender = pre.fund_eoa()
+
+    initcode = Initcode(
+        deploy_code=Op.STOP,
+        initcode_prefix=Op.SSTORE(0, 1) + Op.SSTORE(1, 0),
+    )
+
+    salt = 0x0
+    salt_param = [salt] if opcode == Op.CREATE2 else []
+    assert len(initcode) <= 32
+    contract_creator_code = (
+        Op.MSTORE(0, Op.PUSH32(bytes(initcode).ljust(32, b"\0")))
+        + Op.SSTORE(0x01, opcode(0, 0, len(initcode), *salt_param))
+        + Op.STOP
+    )
+    contract_creator_address = pre.deploy_contract(
+        contract_creator_code,
+        storage={0x01: 0x01},
+    )
+    if opcode == Op.CREATE2:
+        created_contract_address = compute_create2_address(
+            contract_creator_address, salt, initcode
+        )
+    elif opcode == Op.CREATE:
+        created_contract_address = compute_create_address(contract_creator_address, 1)
+    else:
+        raise ValueError(f"Unknown opcode: {opcode}")
+
+    tx = Transaction(
+        sender=sender,
+        to=contract_creator_address,
+        data=initcode,
+        gas_price=10,
+        gas_limit=2_000_000,
+    )
+
+    pre[created_contract_address] = Account(
+        storage={0x01: 0x01},
+        nonce=nonce,
+    )
+
+    state_test(
+        env=env,
+        pre=pre,
+        post={
+            created_contract_address: Account(
+                storage={0x01: 0x01},
+            ),
+            contract_creator_address: Account(storage={0x01: 0x00}),
+        },
+        tx=tx,
+    )

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -105,6 +105,7 @@ eips
 EIPs
 eip6110
 eip7002
+eip7692
 el
 endianness
 EngineAPI


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
