### PR TITLE
new(tests): EOF - EIP-7620: `EOFCREATE` and `RETURNCONTRACT` container validation tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Add tests for [EIP-7069: EOF - Revamped CALL instructions](https://eips.ethereum.org/EIPS/eip-7069) ([#595](https://github.com/ethereum/execution-spec-tests/pull/595)).
 - 🐞 Fix typos in self-destruct collision test from erroneous pytest parametrization ([#608](https://github.com/ethereum/execution-spec-tests/pull/608)).
 - ✨ Add tests for [EIP-3540: EOF - EVM Object Format v1](https://eips.ethereum.org/EIPS/eip-3540) ([#634](https://github.com/ethereum/execution-spec-tests/pull/634)).
+- ✨ Add tests for [EIP-7620: EOF Contract Creation](https://eips.ethereum.org/EIPS/eip-7620) ([#532](https://github.com/ethereum/execution-spec-tests/pull/532), [#640](https://github.com/ethereum/execution-spec-tests/pull/640)).
 
 ### 🛠️ Framework
 

--- a/src/ethereum_test_tools/exceptions/evmone_exceptions.py
+++ b/src/ethereum_test_tools/exceptions/evmone_exceptions.py
@@ -14,7 +14,16 @@ class ExceptionMessage:
     """Defines a mapping between an exception and a message."""
 
     exception: EOFException
-    message: str
+    message: str = ""
+
+    def __post_init__(self):
+        """
+        Set the default error message if none provided.
+        """
+        assert isinstance(self.exception, EOFException), "exception must be an EOFException"
+        # default message is "err: <exception_name in lowercase>"
+        if not self.message:
+            self.message = f"err: {self.exception.name.lower()}"
 
 
 class EvmoneExceptionMapper:
@@ -33,33 +42,23 @@ class EvmoneExceptionMapper:
             EOFException.MISSING_HEADERS_TERMINATOR, "err: section_headers_not_terminated"
         ),
         ExceptionMessage(EOFException.INVALID_VERSION, "err: eof_version_unknown"),
-        ExceptionMessage(
-            EOFException.INVALID_NON_RETURNING_FLAG, "err: invalid_non_returning_flag"
-        ),
+        ExceptionMessage(EOFException.INVALID_NON_RETURNING_FLAG),
         ExceptionMessage(EOFException.INVALID_MAGIC, "err: invalid_prefix"),
-        ExceptionMessage(
-            EOFException.INVALID_FIRST_SECTION_TYPE, "err: invalid_first_section_type"
-        ),
-        ExceptionMessage(
-            EOFException.INVALID_SECTION_BODIES_SIZE, "err: invalid_section_bodies_size"
-        ),
-        ExceptionMessage(EOFException.INVALID_TYPE_SECTION_SIZE, "err: invalid_type_section_size"),
-        ExceptionMessage(EOFException.INCOMPLETE_SECTION_SIZE, "err: incomplete_section_size"),
-        ExceptionMessage(EOFException.INCOMPLETE_SECTION_NUMBER, "err: incomplete_section_number"),
-        ExceptionMessage(EOFException.TOO_MANY_CODE_SECTIONS, "err: too_many_code_sections"),
-        ExceptionMessage(EOFException.ZERO_SECTION_SIZE, "err: zero_section_size"),
+        ExceptionMessage(EOFException.INVALID_FIRST_SECTION_TYPE),
+        ExceptionMessage(EOFException.INVALID_SECTION_BODIES_SIZE),
+        ExceptionMessage(EOFException.INVALID_TYPE_SECTION_SIZE),
+        ExceptionMessage(EOFException.INCOMPLETE_SECTION_SIZE),
+        ExceptionMessage(EOFException.INCOMPLETE_SECTION_NUMBER),
+        ExceptionMessage(EOFException.TOO_MANY_CODE_SECTIONS),
+        ExceptionMessage(EOFException.ZERO_SECTION_SIZE),
         ExceptionMessage(EOFException.MISSING_DATA_SECTION, "err: data_section_missing"),
-        ExceptionMessage(EOFException.UNDEFINED_INSTRUCTION, "err: undefined_instruction"),
-        ExceptionMessage(
-            EOFException.INPUTS_OUTPUTS_NUM_ABOVE_LIMIT, "err: inputs_outputs_num_above_limit"
-        ),
-        ExceptionMessage(EOFException.UNREACHABLE_INSTRUCTIONS, "err: unreachable_instructions"),
-        ExceptionMessage(EOFException.INVALID_RJUMP_DESTINATION, "err: invalid_rjump_destination"),
-        ExceptionMessage(EOFException.UNREACHABLE_CODE_SECTIONS, "err: unreachable_code_sections"),
-        ExceptionMessage(EOFException.STACK_UNDERFLOW, "err: stack_underflow"),
-        ExceptionMessage(
-            EOFException.MAX_STACK_HEIGHT_ABOVE_LIMIT, "err: max_stack_height_above_limit"
-        ),
+        ExceptionMessage(EOFException.UNDEFINED_INSTRUCTION),
+        ExceptionMessage(EOFException.INPUTS_OUTPUTS_NUM_ABOVE_LIMIT),
+        ExceptionMessage(EOFException.UNREACHABLE_INSTRUCTIONS),
+        ExceptionMessage(EOFException.INVALID_RJUMP_DESTINATION),
+        ExceptionMessage(EOFException.UNREACHABLE_CODE_SECTIONS),
+        ExceptionMessage(EOFException.STACK_UNDERFLOW),
+        ExceptionMessage(EOFException.MAX_STACK_HEIGHT_ABOVE_LIMIT),
         ExceptionMessage(
             EOFException.STACK_HIGHER_THAN_OUTPUTS, "err: stack_higher_than_outputs_required"
         ),
@@ -67,12 +66,13 @@ class EvmoneExceptionMapper:
             EOFException.JUMPF_DESTINATION_INCOMPATIBLE_OUTPUTS,
             "err: jumpf_destination_incompatible_outputs",
         ),
-        ExceptionMessage(EOFException.INVALID_MAX_STACK_HEIGHT, "err: invalid_max_stack_height"),
-        ExceptionMessage(EOFException.INVALID_DATALOADN_INDEX, "err: invalid_dataloadn_index"),
-        ExceptionMessage(EOFException.TRUNCATED_INSTRUCTION, "err: truncated_instruction"),
-        ExceptionMessage(
-            EOFException.TOPLEVEL_CONTAINER_TRUNCATED, "err: toplevel_container_truncated"
-        ),
+        ExceptionMessage(EOFException.INVALID_MAX_STACK_HEIGHT),
+        ExceptionMessage(EOFException.INVALID_DATALOADN_INDEX),
+        ExceptionMessage(EOFException.TRUNCATED_INSTRUCTION),
+        ExceptionMessage(EOFException.TOPLEVEL_CONTAINER_TRUNCATED),
+        ExceptionMessage(EOFException.INVALID_CONTAINER_SECTION_INDEX),
+        ExceptionMessage(EOFException.EOFCREATE_RUNTIME_CONTAINER),
+        ExceptionMessage(EOFException.RETURNCONTRACT_INITCONTAINER),
     )
 
     def __init__(self) -> None:

--- a/src/ethereum_test_tools/exceptions/exceptions.py
+++ b/src/ethereum_test_tools/exceptions/exceptions.py
@@ -688,6 +688,18 @@ class EOFException(ExceptionBase):
     """
     Top-level EOF container has data section truncated
     """
+    INVALID_CONTAINER_SECTION_INDEX = auto()
+    """
+    EOFCREATE or RETURNCONTRACT has invalid section index.
+    """
+    EOFCREATE_RUNTIME_CONTAINER = auto()
+    """
+    EOFCREATE tries to initialize a container using a runtime container.
+    """
+    RETURNCONTRACT_INITCONTAINER = auto()
+    """
+    RETURNCONTRACT tries to return an init-container.
+    """
 
 
 """

--- a/src/ethereum_test_tools/vm/opcode.py
+++ b/src/ethereum_test_tools/vm/opcode.py
@@ -5249,9 +5249,7 @@ class Opcodes(Opcode, Enum):
 
     """
 
-    RETURNCONTRACT = Opcode(
-        0xEE, popped_stack_items=2, pushed_stack_items=1, data_portion_length=1
-    )
+    RETURNCONTRACT = Opcode(0xEE, popped_stack_items=2, data_portion_length=1)
     """
     !!! Note: This opcode is under development
 

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -197,6 +197,7 @@ incrementing
 ini
 init
 initcode
+initcontainer
 instantiation
 io
 islice


### PR DESCRIPTION
## 🗒️ Description
Adds container validation tests for cases when the `EOFCREATE` and `RETURNCONTRACT` opcodes are misused.

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
