### PR TITLE
fix(plugins/forks): remove `pytest.skip` from pytest_generate_tests

### DIFF
--- a/src/pytest_plugins/forks/forks.py
+++ b/src/pytest_plugins/forks/forks.py
@@ -443,12 +443,6 @@ def pytest_generate_tests(metafunc):
                     )
                 ]
                 metafunc.parametrize("fork", pytest_params, scope="function")
-            else:
-                # This will not be reported in the test execution output; it will be listed
-                # in the pytest collection summary at the start of the test run.
-                pytest.skip(
-                    f"{test_name} is not valid for any any of forks specified on the command-line."
-                )
         else:
             pytest_params = [
                 (


### PR DESCRIPTION
## 🗒️ Description
According to this stack-overflow answer https://stackoverflow.com/a/64937074 it is not recommended to call `pytest.skip` during `pytest_generate_tests` because it skips the entire module, which is what seems to be happening on PR #636, where there are two different `pytest.mark.valid_until` markers in two separate functions, and if the second one does not allow filling with the currently selected forks, none of the tests are executed.

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
