### PR TITLE
feat: coverage script check file existance in tests

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -78,15 +78,37 @@ jobs:
           for file in $files; do
               echo $file
           done
+          echo "----------------"
+          echo "Discovered existing json tests that will be BASE files:"
+
 
           BASE_TESTS_PATH=${{ github.workspace }}/evmtest_coverage/coverage/BASE_TESTS
           mkdir -p $BASE_TESTS_PATH
           for file in $files; do
-              cp ${{ github.workspace }}/testpath/$file $BASE_TESTS_PATH
+              # Make sure each file exist at least in develop or legacy tests
+              file_found=0
+              file_path=${{ github.workspace }}/testpath/$file
+              if [ -e "$file_path" ]; then
+                file_found=1
+                cp $file_path $BASE_TESTS_PATH
+                echo $file_path
+              fi
+
+              # Do not search EOF files in legacy tests (assuming blockchain files we do not cover yet)
               if [[ "$file" == *"GeneralStateTests"* ]]; then
+                  file_path=${{ github.workspace }}/legacytestpath/Cancun/$file
                   base_name=$(basename "$file")
                   legacy_file_name="legacy_$base_name"
-                  cp ${{ github.workspace }}/legacytestpath/Cancun/$file $BASE_TESTS_PATH/$legacy_file_name
+                  if [ -e "$file_path" ]; then
+                    file_found=1
+                    cp $file_path $BASE_TESTS_PATH/$legacy_file_name
+                    echo $file_path
+                  fi
+              fi
+
+              if [ $file_found -eq 0 ]; then
+               echo "Error: Failed to find the test file $file in test repo"
+                exit 1
               fi
           done
           


### PR DESCRIPTION
## 🗒️ Description
When parsing coverage tests file, check that the tests are found in /tests and /legacytests repositories

## 🔗 Related Issues
https://github.com/ethereum/execution-spec-tests/pull/636

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
