### PR TITLE
fix(github,configs): Temporarily disable `tox -e tests-develop`, update geth evm

### DIFF
--- a/.github/workflows/tox_verify.yaml
+++ b/.github/workflows/tox_verify.yaml
@@ -16,10 +16,11 @@ jobs:
             python: '3.12'
             evm-type: 'stable'
             tox-cmd: 'tox run-parallel --parallel-no-spinner'
-          - os: ubuntu-latest
-            python: '3.11'
-            evm-type: 'develop'
-            tox-cmd: 'tox -e tests-develop'
+          # Disabled to unavailable evm implementation for devnet-1
+          # - os: ubuntu-latest
+          #   python: '3.11'
+          #   evm-type: 'develop'
+          #   tox-cmd: 'tox -e tests-develop'
           # Disabled to not be gated by evmone implementation
           # - os: ubuntu-latest
           #   python: '3.11'

--- a/.github/workflows/tox_verify.yaml
+++ b/.github/workflows/tox_verify.yaml
@@ -16,7 +16,7 @@ jobs:
             python: '3.12'
             evm-type: 'stable'
             tox-cmd: 'tox run-parallel --parallel-no-spinner'
-          # Disabled to unavailable evm implementation for devnet-1
+          # Disabled due to unavailable evm implementation for devnet-1
           # - os: ubuntu-latest
           #   python: '3.11'
           #   evm-type: 'develop'

--- a/configs/evm.yaml
+++ b/configs/evm.yaml
@@ -6,7 +6,7 @@ stable:
 develop:
   impl: geth
   repo: lightclient/go-ethereum
-  ref: prague-devnet-0
+  ref: prague-devnet-1
   evm-bin: evm
 eip7692:
   impl: evmone


### PR DESCRIPTION
## 🗒️ Description
- Temporarily disable `tox -e tests-develop` until we have a stable devnet-1 implementation of the transition tool.
- Update geth's evm to `lightclient/prague-devnet-1`

## 🔗 Related Issues
#606 

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
