### PR TITLE
feat(vm): Opcode keyword arguments

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -46,6 +46,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Enable loading of [ethereum/tests/BlockchainTests](https://github.com/ethereum/tests/tree/develop/BlockchainTests) ([#596](https://github.com/ethereum/execution-spec-tests/pull/596)).
 - 🔀 Refactor `gentest` to use `ethereum_test_tools.rpc.rpc` by adding to `get_transaction_by_hash`, `debug_trace_call` to `EthRPC` ([#568](https://github.com/ethereum/execution-spec-tests/pull/568)).
 - ✨ Write a properties file to the output directory and enable direct generation of a fixture tarball from `fill` via `--output=fixtures.tgz`([#627](https://github.com/ethereum/execution-spec-tests/pull/627)).
+- ✨ Some opcodes now support keyword arguments for their parameters ([#648](https://github.com/ethereum/execution-spec-tests/pull/648))
 
 ### 🔧 EVM Tools
 

--- a/src/ethereum_test_tools/tests/test_vm.py
+++ b/src/ethereum_test_tools/tests/test_vm.py
@@ -242,6 +242,51 @@ from ..vm.opcode import Opcodes as Op
             id="EXCHANGE[0x2 + 0xF, 0x3 + 0xF + 0xF]",
         ),
         pytest.param(Op.PUSH0 * 0, bytes(), id="PUSH0 * 0"),
+        pytest.param(
+            Op.CREATE(value=1, offset=2, size=3),
+            b"\x60\x03\x60\x02\x60\x01\xf0",
+            id="Op.CREATE(value=1, offset=2, size=3)",
+        ),
+        pytest.param(
+            Op.CREATE2(value=1, offset=2, size=3),
+            b"\x60\x00\x60\x03\x60\x02\x60\x01\xf5",
+            id="Op.CREATE2(value=1, offset=2, size=3)",
+        ),
+        pytest.param(
+            Op.CALL(address=1),
+            b"\x60\x00\x60\x00\x60\x00\x60\x00\x60\x00\x60\x01\x5A\xF1",
+            id="Op.CALL(address=1)",
+        ),
+        pytest.param(
+            Op.STATICCALL(address=1),
+            b"\x60\x00\x60\x00\x60\x00\x60\x00\x60\x01\x5A\xFA",
+            id="Op.STATICCALL(address=1)",
+        ),
+        pytest.param(
+            Op.CALLCODE(address=1),
+            b"\x60\x00\x60\x00\x60\x00\x60\x00\x60\x00\x60\x01\x5A\xF2",
+            id="Op.CALLCODE(address=1)",
+        ),
+        pytest.param(
+            Op.DELEGATECALL(address=1),
+            b"\x60\x00\x60\x00\x60\x00\x60\x00\x60\x01\x5A\xF4",
+            id="Op.DELEGATECALL(address=1)",
+        ),
+        pytest.param(
+            Op.EXTCALL(address=1),
+            b"\x60\x00\x60\x00\x60\x00\x60\x01\xF8",
+            id="Op.EXTCALL(address=1)",
+        ),
+        pytest.param(
+            Op.EXTSTATICCALL(address=1),
+            b"\x60\x00\x60\x00\x60\x01\xFB",
+            id="Op.EXTSTATICCALL(address=1)",
+        ),
+        pytest.param(
+            Op.EXTDELEGATECALL(address=1),
+            b"\x60\x00\x60\x00\x60\x01\xF9",
+            id="Op.EXTDELEGATECALL(address=1)",
+        ),
     ],
 )
 def test_opcodes(opcodes: bytes, expected: bytes):

--- a/src/ethereum_test_tools/vm/opcode.py
+++ b/src/ethereum_test_tools/vm/opcode.py
@@ -369,9 +369,7 @@ class Opcode(Bytecode):
             return obj
         raise TypeError("Opcode constructor '__new__' didn't return an instance!")
 
-    def __getitem__(
-        self, *args: "int | bytes | str | FixedSizeBytes | Iterable[int]"
-    ) -> "Bytecode":
+    def __getitem__(self, *args: "int | bytes | str | FixedSizeBytes | Iterable[int]") -> "Opcode":
         """
         Initialize a new instance of the opcode with the data portion set, and also clear
         the data portion variables to avoid reusing them.
@@ -413,13 +411,16 @@ class Opcode(Bytecode):
             and self.pushed_stack_items is not None
             and self.min_stack_height is not None
         )
-        new_opcode = Bytecode(
+        new_opcode = Opcode(
             bytes(self) + data_portion,
             popped_stack_items=self.popped_stack_items,
             pushed_stack_items=self.pushed_stack_items,
             min_stack_height=self.min_stack_height,
             max_stack_height=self.max_stack_height,
+            data_portion_length=0,
+            data_portion_formatter=None,
             unchecked_stack=self.unchecked_stack,
+            kwargs=self.kwargs,
         )
         new_opcode._name_ = self._name_
         return new_opcode


### PR DESCRIPTION
## 🗒️ Description
Introduce keyword arguments to some of the opcodes:
- `Op.CREATE`
- `Op.CREATE2`
- `Op.EOFCREATE`
- `Op.CALL`
- `Op.DELEGATECALL`
- `Op.STATICCALL`
- `Op.CALLCODE`
- `Op.EXTCALL`
- `Op.EXTSTATICCALL`
- `Op.EXTDELEGATECALL`

And most of the keyword arguments also have defaults, but they cannot be mixed with positional arguments, so this is valid:
```python
Op.CALL(address=0x1234)
```
but this is not:
```python
Op.CALL(Op.GAS, address=0x1234)
```

This feature allows easier parametrization, as we no longer have to workaround the cases where an opcode has different number of parameters or in different order:
```python
@pytest.mark.parametrize("op", [Op.CREATE, Op.CREATE2])
def test_example(op: Op):
    op(offset=0, size=1234)
```

And in this case the `salt` parameter of `CREATE2` is simply passed as zero (and also `value` for both options).

At the moment we allow extra keyword arguments (that do not belong to opcode called) but this is up for discussion.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
