### PR TITLE
fix(tests): EOF - EIP-3540: Remove Orphans Containers in Tests

### DIFF
--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/container.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/container.py
@@ -44,7 +44,9 @@ VALID: List[Container] = [
     Container(
         name="max_code_sections_plus_container",
         sections=[
-            Section.Code(Op.JUMPF[i + 1] if i < (MAX_CODE_SECTIONS - 1) else Op.STOP)
+            Section.Code(
+                Op.JUMPF[i + 1] if i < (MAX_CODE_SECTIONS - 1) else Op.RETURNCONTRACT[0](0, 0)
+            )
             for i in range(MAX_CODE_SECTIONS)
         ]
         + [
@@ -62,7 +64,9 @@ VALID: List[Container] = [
     Container(
         name="max_code_sections_plus_data_plus_container",
         sections=[
-            Section.Code(Op.JUMPF[i + 1] if i < (MAX_CODE_SECTIONS - 1) else Op.STOP)
+            Section.Code(
+                Op.JUMPF[i + 1] if i < (MAX_CODE_SECTIONS - 1) else Op.RETURNCONTRACT[0](0, 0)
+            )
             for i in range(MAX_CODE_SECTIONS)
         ]
         + [

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_all_opcodes_in_container.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_all_opcodes_in_container.py
@@ -8,7 +8,7 @@ import pytest
 from ethereum_test_tools import Bytecode, EOFTestFiller, Opcode
 from ethereum_test_tools import Opcodes as Op
 from ethereum_test_tools import UndefinedOpcodes
-from ethereum_test_tools.eof.v1 import Container, EOFException, Section
+from ethereum_test_tools.eof.v1 import Container, ContainerKind, EOFException, Section
 
 from .. import EOF_FORK_NAME
 
@@ -112,12 +112,16 @@ def test_all_opcodes_in_container(
     eof_test: EOFTestFiller,
     sections: List[Section],
     expect_exception: EOFException | None,
+    opcode: Opcode,
 ):
     """
     Test all opcodes inside valid container
     257 because 0x5B is duplicated
     """
-    eof_code = Container(sections=sections)
+    if opcode == Op.RETURNCONTRACT:
+        eof_code = Container(sections=sections, kind=ContainerKind.INITCODE)
+    else:
+        eof_code = Container(sections=sections)
 
     eof_test(
         data=eof_code,

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_all_opcodes_in_container.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_all_opcodes_in_container.py
@@ -1,7 +1,6 @@
 """
 EOF Container: check how every opcode behaves in the middle of the valid eof container code
 """
-
 from typing import List
 
 import pytest
@@ -90,25 +89,27 @@ def sections(
     """
     sections = [Section.Code(code=bytecode)]
 
-    if opcode == Op.CALLF:
-        sections.append(
-            Section.Code(
-                code=Op.RETF,
-                code_inputs=0,
-                code_outputs=0,
-                max_stack_height=0,
+    match opcode:
+        case Op.EOFCREATE | Op.RETURNCONTRACT:
+            sections.append(
+                Section.Container(
+                    container=Container(
+                        sections=[
+                            Section.Code(code=Op.REVERT(0, 0)),
+                        ]
+                    )
+                )
             )
-        )
-    sections += [
-        Section.Container(
-            container=Container(
-                sections=[
-                    Section.Code(code=Op.STOP),
-                ]
+        case Op.CALLF:
+            sections.append(
+                Section.Code(
+                    code=Op.RETF,
+                    code_inputs=0,
+                    code_outputs=0,
+                    max_stack_height=0,
+                )
             )
-        ),
-        Section.Data("1122334455667788" * 4),
-    ]
+    sections.append(Section.Data("1122334455667788" * 4))
     return sections
 
 

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_all_opcodes_in_container.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_all_opcodes_in_container.py
@@ -107,7 +107,9 @@ def sections(
     return sections
 
 
-@pytest.mark.parametrize("opcode", [op for op in list(Op) + list(UndefinedOpcodes)])
+@pytest.mark.parametrize(
+    "opcode", [op for op in list(Op) + list(UndefinedOpcodes) if op != Op.RETF]
+)
 def test_all_opcodes_in_container(
     eof_test: EOFTestFiller,
     sections: List[Section],

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_all_opcodes_in_container.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_all_opcodes_in_container.py
@@ -47,12 +47,6 @@ halting_opcodes = {
     Op.INVALID,
 }
 
-skip_opcodes = {
-    Op.RETF,  # RETF not allowed in first section
-    Op.EOFCREATE,  # EOFCREATE not allowed unless the second container is an initcode
-    Op.RETURNCONTRACT,  # RETURNCONTRACT unless inside an initcode
-}
-
 
 @pytest.fixture
 def expect_exception(opcode: Opcode) -> EOFException | None:
@@ -113,9 +107,7 @@ def sections(
     return sections
 
 
-@pytest.mark.parametrize(
-    "opcode", [op for op in list(Op) + list(UndefinedOpcodes) if op not in skip_opcodes]
-)
+@pytest.mark.parametrize("opcode", [op for op in list(Op) + list(UndefinedOpcodes)])
 def test_all_opcodes_in_container(
     eof_test: EOFTestFiller,
     sections: List[Section],


### PR DESCRIPTION

## 🗒️ Description
Update a couple of new tests trip the new "no orphan containers" rule.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
