### PR TITLE
fix(fw,tests): Fix Op.DATALOADN stack

### DIFF
--- a/src/ethereum_test_tools/vm/opcode.py
+++ b/src/ethereum_test_tools/vm/opcode.py
@@ -4867,7 +4867,7 @@ class Opcodes(Opcode, Enum):
     Source: [eips.ethereum.org/EIPS/eip-7480](https://eips.ethereum.org/EIPS/eip-7480)
     """
 
-    DATALOADN = Opcode(0xD1, popped_stack_items=0, data_portion_length=2)
+    DATALOADN = Opcode(0xD1, pushed_stack_items=1, data_portion_length=2)
     """
     !!! Note: This opcode is under development
 

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_all_opcodes_in_container.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_all_opcodes_in_container.py
@@ -46,18 +46,6 @@ halting_opcodes = {
     Op.INVALID,
 }
 
-# Special eof opcodes that require [] operator
-eof_opcodes = {
-    Op.DATALOADN,
-    Op.RJUMPV,
-    Op.CALLF,
-    Op.RETF,
-    Op.JUMPF,
-    Op.EOFCREATE,
-    Op.RETURNCONTRACT,
-    Op.EXCHANGE,
-}
-
 
 def expect_exception(opcode: Opcode) -> EOFException | None:
     """
@@ -88,17 +76,6 @@ def make_opcode_valid_bytes(opcode: Opcode) -> Opcode | Bytecode:
     return code
 
 
-def eof_opcode_stack(opcode: Opcode) -> int:
-    """
-    Eof opcode has special stack influence
-    """
-    if opcode in eof_opcodes:
-        if opcode == Op.CALLF or opcode == Op.JUMPF or opcode == Op.EXCHANGE:
-            return 0
-        return 1
-    return 0
-
-
 @pytest.mark.parametrize("opcode", list(Op) + list(UndefinedOpcodes))
 def test_all_opcodes_in_container(eof_test: EOFTestFiller, opcode: Opcode):
     """
@@ -122,10 +99,7 @@ def test_all_opcodes_in_container(eof_test: EOFTestFiller, opcode: Opcode):
                 code=Op.PUSH1(00) * 20 + make_opcode_valid_bytes(opcode),
                 max_stack_height=max(
                     20,
-                    20
-                    + opcode.pushed_stack_items
-                    - opcode.popped_stack_items
-                    + eof_opcode_stack(opcode),
+                    20 + opcode.pushed_stack_items - opcode.popped_stack_items,
                 ),
             ),
             Section.Container(

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_all_opcodes_in_container.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_all_opcodes_in_container.py
@@ -2,6 +2,8 @@
 EOF Container: check how every opcode behaves in the middle of the valid eof container code
 """
 
+from typing import List
+
 import pytest
 
 from ethereum_test_tools import Bytecode, EOFTestFiller, Opcode
@@ -46,77 +48,85 @@ halting_opcodes = {
     Op.INVALID,
 }
 
+skip_opcodes = {
+    Op.RETF,  # RETF not allowed in first section
+    Op.EOFCREATE,  # EOFCREATE not allowed unless the second container is an initcode
+    Op.RETURNCONTRACT,  # RETURNCONTRACT unless inside an initcode
+}
 
+
+@pytest.fixture
 def expect_exception(opcode: Opcode) -> EOFException | None:
     """
     Returns exception that eof container reports when having this opcode in the middle of the code
     """
     if opcode in invalid_eof_opcodes or opcode in list(UndefinedOpcodes):
         return EOFException.UNDEFINED_INSTRUCTION
-
-    # RETF not allowed in first section
-    if opcode == Op.RETF:
-        return EOFException.INVALID_NON_RETURNING_FLAG
     return None
 
 
-def make_opcode_valid_bytes(opcode: Opcode) -> Opcode | Bytecode:
+@pytest.fixture
+def bytecode(opcode: Opcode) -> Opcode | Bytecode:
     """
     Construct a valid stack and bytes for the opcode
     """
-    code: Opcode | Bytecode
+    code: Opcode | Bytecode = Op.PUSH1[0] * 20
     if opcode.data_portion_length == 0 and opcode.data_portion_formatter is None:
-        code = opcode
-    elif opcode == Op.CALLF:
-        code = opcode[1]
+        code += opcode
     else:
-        code = opcode[0]
+        code += opcode[1 if opcode == Op.CALLF else 0]
     if opcode not in halting_opcodes:
         return code + Op.STOP
     return code
 
 
-@pytest.mark.parametrize("opcode", list(Op) + list(UndefinedOpcodes))
-def test_all_opcodes_in_container(eof_test: EOFTestFiller, opcode: Opcode):
+@pytest.fixture
+def sections(
+    opcode: Opcode,
+    bytecode: Opcode | Bytecode,
+) -> List[Section]:
     """
-    Test all opcodes inside valid container
-    257 because 0x5B is duplicated
+    Returns extra sections that are needed for the opcode
     """
-    section_call = []
+    sections = [Section.Code(code=bytecode)]
+
     if opcode == Op.CALLF:
-        section_call = [
+        sections.append(
             Section.Code(
                 code=Op.RETF,
                 code_inputs=0,
                 code_outputs=0,
                 max_stack_height=0,
             )
-        ]
+        )
+    sections += [
+        Section.Container(
+            container=Container(
+                sections=[
+                    Section.Code(code=Op.STOP),
+                ]
+            )
+        ),
+        Section.Data("1122334455667788" * 4),
+    ]
+    return sections
 
-    eof_code = Container(
-        sections=[
-            Section.Code(
-                code=Op.PUSH1(00) * 20 + make_opcode_valid_bytes(opcode),
-                max_stack_height=max(
-                    20,
-                    20 + opcode.pushed_stack_items - opcode.popped_stack_items,
-                ),
-            ),
-            Section.Container(
-                container=Container(
-                    sections=[
-                        Section.Code(code=Op.STOP),
-                    ]
-                )
-            ),
-        ]
-        + section_call
-        + [
-            Section.Data("1122334455667788" * 4),
-        ],
-    )
+
+@pytest.mark.parametrize(
+    "opcode", [op for op in list(Op) + list(UndefinedOpcodes) if op not in skip_opcodes]
+)
+def test_all_opcodes_in_container(
+    eof_test: EOFTestFiller,
+    sections: List[Section],
+    expect_exception: EOFException | None,
+):
+    """
+    Test all opcodes inside valid container
+    257 because 0x5B is duplicated
+    """
+    eof_code = Container(sections=sections)
 
     eof_test(
         data=eof_code,
-        expect_exception=expect_exception(opcode),
+        expect_exception=expect_exception,
     )


### PR DESCRIPTION
## 🗒️ Description

Fixes the DATALOADN stack specs in `opcode.py`, also removes the workarounds in one test

## 🔗 Related Issues

N/A

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
