### PR TITLE
feat(fw): EOF - Add `containerKind` to EOF fixtures, add `--initcode` flag when calling evmone-eofparse

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -68,7 +68,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 - Cancun is now the latest deployed fork, and the development fork is now Prague ([#489](https://github.com/ethereum/execution-spec-tests/pull/489)).
 - Stable fixtures artifact `fixtures.tar.gz` has been renamed to `fixtures_stable.tar.gz` ([#573](https://github.com/ethereum/execution-spec-tests/pull/573))
-- EOF fixtures now contain a `containerKind` field that specifies whether the container should be interpreted as a runtime container or initcode container, `RUNTIME` or `INITCODE` respectively ([#651](https://github.com/ethereum/execution-spec-tests/pull/651))
+- EOF fixtures now contain an `containerKind` optional field that specifies whether the container should be interpreted as a runtime container (default when the field is missing) or initcode container, with string `RUNTIME` or `INITCODE` respectively ([#651](https://github.com/ethereum/execution-spec-tests/pull/651))
 
 ## 🔜 [v2.1.1](https://github.com/ethereum/execution-spec-tests/releases/tag/v2.1.1) - 2024-03-09
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -68,6 +68,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 - Cancun is now the latest deployed fork, and the development fork is now Prague ([#489](https://github.com/ethereum/execution-spec-tests/pull/489)).
 - Stable fixtures artifact `fixtures.tar.gz` has been renamed to `fixtures_stable.tar.gz` ([#573](https://github.com/ethereum/execution-spec-tests/pull/573))
+- EOF fixtures now contain a `containerKind` field that specifies whether the container should be interpreted as a runtime container or initcode container, `RUNTIME` or `INITCODE` respectively ([#651](https://github.com/ethereum/execution-spec-tests/pull/651))
 
 ## 🔜 [v2.1.1](https://github.com/ethereum/execution-spec-tests/releases/tag/v2.1.1) - 2024-03-09
 

--- a/src/ethereum_test_tools/eof/v1/__init__.py
+++ b/src/ethereum_test_tools/eof/v1/__init__.py
@@ -327,6 +327,10 @@ class Container(CopyValidateModel):
 
     TODO: Remove str
     """
+    initcode: bool = False
+    """
+    Whether the container is an initcode.
+    """
     raw_bytes: Optional[Bytes] = None
     """
     Optional raw bytes that represent the container.

--- a/src/ethereum_test_tools/eof/v1/__init__.py
+++ b/src/ethereum_test_tools/eof/v1/__init__.py
@@ -3,11 +3,16 @@ EVM Object Format Version 1 Library to generate bytecode for testing purposes
 """
 
 from dataclasses import dataclass
-from enum import Enum, IntEnum
+from enum import Enum, IntEnum, auto
 from functools import cached_property
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
-from pydantic import Field
+from pydantic import Field, GetCoreSchemaHandler
+from pydantic_core.core_schema import (
+    PlainValidatorFunctionSchema,
+    no_info_plain_validator_function,
+    to_string_ser_schema,
+)
 
 from ...common import Bytes
 from ...common.conversions import BytesConvertible
@@ -43,6 +48,33 @@ class SectionKind(IntEnum):
     def __str__(self) -> str:
         """
         Returns the string representation of the section kind
+        """
+        return self.name
+
+
+class ContainerKind(Enum):
+    """
+    Enum class of V1 valid container kind values.
+    """
+
+    RUNTIME = auto()
+    INITCODE = auto()
+
+    @staticmethod
+    def __get_pydantic_core_schema__(
+        source_type: Any, handler: GetCoreSchemaHandler
+    ) -> PlainValidatorFunctionSchema:
+        """
+        Calls the class constructor without info and appends the serialization schema.
+        """
+        return no_info_plain_validator_function(
+            source_type,
+            serialization=to_string_ser_schema(),
+        )
+
+    def __str__(self) -> str:
+        """
+        Returns the string representation of the container kind
         """
         return self.name
 
@@ -327,9 +359,9 @@ class Container(CopyValidateModel):
 
     TODO: Remove str
     """
-    initcode: bool = False
+    kind: ContainerKind = ContainerKind.RUNTIME
     """
-    Whether the container is an initcode.
+    Kind type of the container.
     """
     raw_bytes: Optional[Bytes] = None
     """

--- a/src/ethereum_test_tools/spec/eof/eof_test.py
+++ b/src/ethereum_test_tools/spec/eof/eof_test.py
@@ -137,6 +137,7 @@ class EOFTest(BaseTest):
 
     data: Bytes
     expect_exception: EOFException | None = None
+    initcode: bool = False
 
     supported_fixture_formats: ClassVar[List[FixtureFormats]] = [
         FixtureFormats.EOF_TEST,
@@ -182,6 +183,7 @@ class EOFTest(BaseTest):
             vectors={
                 "0": {
                     "code": self.data,
+                    "initcode": self.initcode,
                     "results": {
                         fork.blockchain_test_network_name(): {
                             "exception": self.expect_exception,

--- a/src/ethereum_test_tools/spec/eof/eof_test.py
+++ b/src/ethereum_test_tools/spec/eof/eof_test.py
@@ -137,7 +137,7 @@ class EOFTest(BaseTest):
 
     data: Bytes
     expect_exception: EOFException | None = None
-    container_kind: ContainerKind = ContainerKind.RUNTIME
+    container_kind: ContainerKind | None = None
 
     supported_fixture_formats: ClassVar[List[FixtureFormats]] = [
         FixtureFormats.EOF_TEST,
@@ -171,7 +171,8 @@ class EOFTest(BaseTest):
                             f"Container kind type {str(container.kind)} "
                             f"does not match test {container_kind}."
                         )
-                    data["container_kind"] = str(container.kind)
+                    if container.kind != ContainerKind.RUNTIME:
+                        data["container_kind"] = str(container.kind)
         return data
 
     @classmethod

--- a/src/ethereum_test_tools/spec/eof/eof_test.py
+++ b/src/ethereum_test_tools/spec/eof/eof_test.py
@@ -21,7 +21,7 @@ from ...eof.v1 import Container, ContainerKind
 from ...exceptions import EOFException, EvmoneExceptionMapper
 from ..base.base_test import BaseFixture, BaseTest
 from ..state.state_test import StateTest
-from .types import Fixture, Result
+from .types import Fixture, Result, Vector
 
 
 class EOFBaseException(Exception):
@@ -190,20 +190,19 @@ class EOFTest(BaseTest):
         """
         Generate the EOF test fixture.
         """
-        fixture = Fixture(
-            vectors={
-                "0": {
-                    "code": self.data,
-                    "container_kind": self.container_kind,
-                    "results": {
-                        fork.blockchain_test_network_name(): {
-                            "exception": self.expect_exception,
-                            "valid": self.expect_exception is None,
-                        }
-                    },
-                }
-            }
-        )
+        vectors = [
+            Vector(
+                code=self.data,
+                container_kind=self.container_kind,
+                results={
+                    fork.blockchain_test_network_name(): Result(
+                        exception=self.expect_exception,
+                        valid=self.expect_exception is None,
+                    ),
+                },
+            )
+        ]
+        fixture = Fixture(vectors=dict(enumerate(vectors)))
         try:
             eof_parse = EOFParse()
         except FileNotFoundError as e:

--- a/src/ethereum_test_tools/spec/eof/eof_test.py
+++ b/src/ethereum_test_tools/spec/eof/eof_test.py
@@ -135,7 +135,7 @@ class EOFTest(BaseTest):
     Filler type that tests EOF containers.
     """
 
-    data: Container
+    data: Bytes
     expect_exception: EOFException | None = None
     initcode: bool = False
 

--- a/src/ethereum_test_tools/spec/eof/types.py
+++ b/src/ethereum_test_tools/spec/eof/types.py
@@ -41,6 +41,7 @@ class Vector(CamelModel):
     """
 
     code: Bytes
+    initcode: bool
     results: Mapping[str, Result]
 
 

--- a/src/ethereum_test_tools/spec/eof/types.py
+++ b/src/ethereum_test_tools/spec/eof/types.py
@@ -42,7 +42,7 @@ class Vector(CamelModel):
     """
 
     code: Bytes
-    container_kind: ContainerKind
+    container_kind: ContainerKind | None
     results: Mapping[str, Result]
 
 

--- a/src/ethereum_test_tools/spec/eof/types.py
+++ b/src/ethereum_test_tools/spec/eof/types.py
@@ -11,6 +11,7 @@ from evm_transition_tool import FixtureFormats
 
 from ...common.base_types import Bytes
 from ...common.types import CamelModel
+from ...eof.v1 import ContainerKind
 from ...exceptions import EOFException
 from ..base.base_test import BaseFixture
 
@@ -41,7 +42,7 @@ class Vector(CamelModel):
     """
 
     code: Bytes
-    initcode: bool
+    container_kind: ContainerKind
     results: Mapping[str, Result]
 
 

--- a/src/ethereum_test_tools/spec/eof/types.py
+++ b/src/ethereum_test_tools/spec/eof/types.py
@@ -9,7 +9,7 @@ from pydantic import Field
 
 from evm_transition_tool import FixtureFormats
 
-from ...common.base_types import Bytes
+from ...common.base_types import Bytes, Number
 from ...common.types import CamelModel
 from ...eof.v1 import ContainerKind
 from ...exceptions import EOFException
@@ -51,6 +51,6 @@ class Fixture(BaseFixture):
     Fixture for a single EOFTest.
     """
 
-    vectors: Mapping[str, Vector]
+    vectors: Mapping[Number, Vector]
 
     format: ClassVar[FixtureFormats] = FixtureFormats.EOF_TEST


### PR DESCRIPTION
## 🗒️ Description
Introduces `kind` field in the `Container` class and the `EOFTest` class, used to mark a container as a specific kind of container, such as "INITCODE".
When the field is set:
- `evmone-eofparse` is called with the `--initcode` flag
- the output EOF fixture contains `containerKind: "INITCODE"` field in all vectors, by default it contains `containerKind: "RUNTIME"`.

Example of a test fixture JSON file after this change:
```json
{
    "tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_all_opcodes_in_container.py::test_all_opcodes_in_container[fork_CancunEIP7692-eof_test-opcode_STOP]": {
        "vectors": {
            "0": {
                "code": "0xef00010100040200010029030001001404002000008000146000600060006000600060006000600060006000600060006000600060006000600060006000600000ef000101000402000100010400000000800000001122334455667788112233445566778811223344556677881122334455667788",
                "containerKind": "INITCODE",  # NEW FIELD
                "results": {
                    "Prague": {
                        "result": true
                    }
                }
            }
        }
    }
}
```

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
