### PR TITLE
feat(fw): Add `is_state_test` flag to `Environment`

### DIFF
--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -917,6 +917,8 @@ class Environment(EnvironmentGeneric[Number]):
     withdrawals: List[Withdrawal] | None = Field(None)
     extra_data: Bytes = Field(Bytes(b"\x00"), exclude=True)
 
+    is_state_test: bool = Field(False)
+
     @computed_field  # type: ignore[misc]
     @cached_property
     def parent_hash(self) -> Hash | None:

--- a/src/ethereum_test_tools/spec/state/state_test.py
+++ b/src/ethereum_test_tools/spec/state/state_test.py
@@ -115,6 +115,7 @@ class StateTest(BaseTest):
         fork = fork.fork_at(self.env.number, self.env.timestamp)
 
         env = self.env.set_fork_requirements(fork)
+        env.is_state_test = True
         tx = self.tx.with_signature_and_sender(keep_secret_key=True)
         pre_alloc = Alloc.merge(
             Alloc.model_validate(fork.pre_allocation()),


### PR DESCRIPTION
## 🗒️ Description

Adds a flag `isStateTest` into the environment information that is passed to the t8n tool which is only set to `true` when executing the state tests, and should inhibit any block-level operations in order to reduce the changes to the state that are produced by:
- The mining reward
- Block Withdrawals
- System operations

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
