### PR TITLE
new(tests): eip-7620: RETURNCONTRACT validation tests [TEST]

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -119,12 +119,20 @@ jobs:
           python3 -m venv ./venv/
           source ./venv/bin/activate
 
-          # Fetch the base branch and the head branch
-          git fetch origin ${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
-          git fetch origin ${{ github.head_ref }}:refs/remotes/origin/${{ github.head_ref }}
+          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+              # Fetch changes when PR comes from remote repo
+              git fetch origin +refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
+              git fetch origin +refs/pull/${{ github.event.pull_request.number }}/head:refs/remotes/origin/PR-${{ github.event.pull_request.number }}
+              files=$(git diff --name-status origin/${{ github.base_ref }}...origin/PR-${{ github.event.pull_request.number }} -- tests/ | grep -E '^[AM]' | grep '\.py$')
+          else
+              # Fetch the base branch and the head branch
+              git fetch origin ${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
+              git fetch origin ${{ github.head_ref }}:refs/remotes/origin/${{ github.head_ref }}
 
-          # Perform the diff
-          files=$(git diff --name-status origin/${{ github.base_ref }}...origin/${{ github.head_ref }} -- tests/ | grep -E '^[AM]' | grep '\.py$')
+              # Perform the diff
+              files=$(git diff --name-status origin/${{ github.base_ref }}...origin/${{ github.head_ref }} -- tests/ | grep -E '^[AM]' | grep '\.py$')
+          fi
+
 
           echo "Modified or new .py files in tests folder:"
           echo "$files" | while read line; do

--- a/converted-ethereum-tests.txt
+++ b/converted-ethereum-tests.txt
@@ -1,0 +1,2 @@
+EOFTests/efValidation/EOF1_returncontract_invalid_.json
+EOFTests/efValidation/EOF1_returncontract_valid_.json

--- a/src/ethereum_test_tools/exceptions/evmone_exceptions.py
+++ b/src/ethereum_test_tools/exceptions/evmone_exceptions.py
@@ -77,6 +77,9 @@ class EvmoneExceptionMapper:
         ExceptionMessage(
             EOFException.CONTAINER_SIZE_ABOVE_LIMIT, "err: container_size_above_limit"
         ),
+        ExceptionMessage(
+            EOFException.INVALID_CONTAINER_SECTION_INDEX, "err: invalid_container_section_index"
+        ),
     )
 
     def __init__(self) -> None:

--- a/src/ethereum_test_tools/exceptions/exceptions.py
+++ b/src/ethereum_test_tools/exceptions/exceptions.py
@@ -696,6 +696,10 @@ class EOFException(ExceptionBase):
     """
     EOF container is above size limit
     """
+    INVALID_CONTAINER_SECTION_INDEX = auto()
+    """
+    Instruction references container section that does not exist.
+    """
 
 
 """

--- a/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_returncontract.py
+++ b/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_returncontract.py
@@ -1,0 +1,147 @@
+"""
+Tests for RETURNCONTRACT instruction validation
+"""
+
+from ethereum_test_tools import EOFTestFiller
+from ethereum_test_tools.eof.v1 import Container, Section
+from ethereum_test_tools.exceptions import EOFException
+from ethereum_test_tools.vm.opcode import Opcodes as Op
+
+REFERENCE_SPEC_GIT_PATH = "EIPS/eip-7620.md"
+REFERENCE_SPEC_VERSION = "f20b164b00ae5553f7536a6d7a83a0f254455e09"
+
+
+def test_returncontract_valid_index_0(
+    eof_test: EOFTestFiller,
+):
+    """Deploy container index 0"""
+    eof_test(
+        data=Container(
+            sections=[
+                Section.Code(
+                    code=Op.RETURNCONTRACT[0](0, 0),
+                ),
+                Section.Container(container=Container(sections=[Section.Code(code=Op.INVALID)])),
+            ],
+        )
+    )
+
+
+def test_returncontract_valid_index_1(
+    eof_test: EOFTestFiller,
+):
+    """Deploy container index 1"""
+    eof_test(
+        data=Container(
+            sections=[
+                Section.Code(
+                    code=Op.RJUMPI[6](0) + Op.RETURNCONTRACT[0](0, 0) + Op.RETURNCONTRACT[1](0, 0),
+                    max_stack_height=2,
+                ),
+                Section.Container(container=Container(sections=[Section.Code(code=Op.INVALID)])),
+                Section.Container(container=Container(sections=[Section.Code(code=Op.INVALID)])),
+            ],
+        )
+    )
+
+
+def test_returncontract_valid_index_255(
+    eof_test: EOFTestFiller,
+):
+    """Deploy container index 255"""
+    eof_test(
+        data=Container(
+            sections=[
+                Section.Code(
+                    sum((Op.RJUMPI[6](0) + Op.RETURNCONTRACT[i](0, 0)) for i in range(256))
+                    + Op.REVERT(0, 0),
+                    max_stack_height=2,
+                )
+            ]
+            + [Section.Container(container=Container(sections=[Section.Code(code=Op.INVALID)]))]
+            * 256
+        )
+    )
+
+
+def test_returncontract_invalid_truncated_immediate(
+    eof_test: EOFTestFiller,
+):
+    """Truncated immediate"""
+    eof_test(
+        data=Container(
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0 + Op.PUSH0 + Op.RETURNCONTRACT,
+                ),
+            ],
+        ),
+        expect_exception=EOFException.TRUNCATED_INSTRUCTION,
+    )
+
+
+def test_returncontract_invalid_index_0(
+    eof_test: EOFTestFiller,
+):
+    """Referring to non-existent container section index 0"""
+    eof_test(
+        data=Container(
+            sections=[
+                Section.Code(
+                    code=Op.RETURNCONTRACT[0](0, 0),
+                ),
+            ],
+        ),
+        expect_exception=EOFException.INVALID_CONTAINER_SECTION_INDEX,
+    )
+
+
+def test_returncontract_invalid_index_1(
+    eof_test: EOFTestFiller,
+):
+    """Referring to non-existent container section index 1"""
+    eof_test(
+        data=Container(
+            sections=[
+                Section.Code(
+                    code=Op.RETURNCONTRACT[1](0, 0),
+                ),
+                Section.Container(container=Container(sections=[Section.Code(code=Op.INVALID)])),
+            ],
+        ),
+        expect_exception=EOFException.INVALID_CONTAINER_SECTION_INDEX,
+    )
+
+
+def test_returncontract_invalid_index_255(
+    eof_test: EOFTestFiller,
+):
+    """Referring to non-existent container section index 255"""
+    eof_test(
+        data=Container(
+            sections=[
+                Section.Code(
+                    code=Op.RETURNCONTRACT[255](0, 0),
+                ),
+                Section.Container(container=Container(sections=[Section.Code(code=Op.INVALID)])),
+            ],
+        ),
+        expect_exception=EOFException.INVALID_CONTAINER_SECTION_INDEX,
+    )
+
+
+def test_returncontract_terminating(
+    eof_test: EOFTestFiller,
+):
+    """Unreachable code after RETURNCONTRACT"""
+    eof_test(
+        data=Container(
+            sections=[
+                Section.Code(
+                    code=Op.RETURNCONTRACT[0](0, 0) + Op.REVERT(0, 0),
+                ),
+                Section.Container(container=Container(sections=[Section.Code(code=Op.INVALID)])),
+            ],
+        ),
+        expect_exception=EOFException.UNREACHABLE_INSTRUCTIONS,
+    )

--- a/tests/prague/eip7692_eof_v1/tracker.md
+++ b/tests/prague/eip7692_eof_v1/tracker.md
@@ -219,9 +219,9 @@
 - [ ] EOFCREATE is not a valid terminating instruction (ethereum/tests: ./src/EOFTestsFiller/efValidation/EOF1_eofcreate_invalid_Copier.json)
 - [ ] EOFCREATE immediate referring to non-existing container (ethereum/tests: ./src/EOFTestsFiller/efValidation/EOF1_eofcreate_invalid_Copier.json)
 - [ ] EOFCREATE immediate referring to container with truncated data (ethereum/tests: ./src/EOFTestsFiller/efValidation/EOF1_eofcreate_invalid_Copier.json)
-- [ ] Valid RETURNCONTRACTs referring to various container numbers (ethereum/tests: ./src/EOFTestsFiller/efValidation/EOF1_returncontract_valid_Copier.json)
-- [ ] Truncated before RETURNCONTRACT immediate (ethereum/tests: ./src/EOFTestsFiller/efValidation/EOF1_returncontract_invalid_Copier.json)
-- [ ] RETURNCONTRACT immediate referring to non-existing container (ethereum/tests: ./src/EOFTestsFiller/efValidation/EOF1_returncontract_invalid_Copier.json)
-- [ ] Unreachable code after RETURNCONTRACT, check that RETURNCONTRACT is terminating (ethereum/tests: ./src/EOFTestsFiller/efValidation/EOF1_returncontract_invalid_Copier.json)
+- [x] Valid RETURNCONTRACTs referring to various container numbers (ethereum/tests: ./src/EOFTestsFiller/efValidation/EOF1_returncontract_valid_Copier.json)
+- [x] Truncated before RETURNCONTRACT immediate (ethereum/tests: ./src/EOFTestsFiller/efValidation/EOF1_returncontract_invalid_Copier.json)
+- [x] RETURNCONTRACT immediate referring to non-existing container (ethereum/tests: ./src/EOFTestsFiller/efValidation/EOF1_returncontract_invalid_Copier.json)
+- [x] Unreachable code after RETURNCONTRACT, check that RETURNCONTRACT is terminating (ethereum/tests: ./src/EOFTestsFiller/efValidation/EOF1_returncontract_invalid_Copier.json)
 
 ## EIP-7698: EOF - Creation transaction


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
