### PR TITLE
fix(tests): remove unnecessary (orphan) subcontainer

### DIFF
--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_all_opcodes_in_container.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_all_opcodes_in_container.py
@@ -99,16 +99,7 @@ def sections(
                 max_stack_height=0,
             )
         )
-    sections += [
-        Section.Container(
-            container=Container(
-                sections=[
-                    Section.Code(code=Op.STOP),
-                ]
-            )
-        ),
-        Section.Data("1122334455667788" * 4),
-    ]
+    sections.append(Section.Data("1122334455667788" * 4))
     return sections
 
 


### PR DESCRIPTION
## 🗒️ Description

After https://github.com/ethereum/execution-spec-tests/pull/650/commits/09a917eb2b3b6d971d9bd105b52a35c10b120c11, when the subcontainer-requiring opcodes are skipped, a subcontainer isn't necessary (and also not allowed, since it is unreferenced). 

## 🔗 Related Issues

N/A

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
