### PR TITLE
fix(fw): Tox

### DIFF
--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -1239,7 +1239,7 @@ class Transaction(TransactionGeneric[HexNumber], TransactionTransitionToolConver
 
         # Remove the secret key if requested
         if keep_secret_key:
-            updated_tx.secret_key = self.secret_key
+            updated_tx.secret_key = self.secret_key  # type: ignore
         return updated_tx
 
     @cached_property

--- a/src/ethereum_test_tools/spec/consume/types.py
+++ b/src/ethereum_test_tools/spec/consume/types.py
@@ -149,4 +149,4 @@ class TestCases(RootModel):
         """
         with open(index_file, "r") as fd:
             index = IndexFile.model_validate_json(fd.read())
-        return cls(root=index.test_cases)
+        return cls(root=index.test_cases)  # type: ignore

--- a/src/ethereum_test_tools/tests/test_exceptions.py
+++ b/src/ethereum_test_tools/tests/test_exceptions.py
@@ -13,9 +13,9 @@ from ..exceptions import (
     TransactionExceptionInstanceOrList,
 )
 
-GenericExceptionListAdapter = TypeAdapter(ExceptionInstanceOrList)
-TransactionExceptionListAdapter = TypeAdapter(TransactionExceptionInstanceOrList)
-BlockExceptionListAdapter = TypeAdapter(BlockExceptionInstanceOrList)
+GenericExceptionListAdapter: TypeAdapter = TypeAdapter(ExceptionInstanceOrList)
+TransactionExceptionListAdapter: TypeAdapter = TypeAdapter(TransactionExceptionInstanceOrList)
+BlockExceptionListAdapter: TypeAdapter = TypeAdapter(BlockExceptionInstanceOrList)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## 🗒️ Description
Tox began failing for some unknown reason with the following mypy error:
```
src/ethereum_test_tools/tests/test_exceptions.py:16: error: Need type annotation for "GenericExceptionListAdapter"  [var-annotated]
src/ethereum_test_tools/tests/test_exceptions.py:17: error: Need type annotation for "TransactionExceptionListAdapter"  [var-annotated]
src/ethereum_test_tools/tests/test_exceptions.py:18: error: Need type annotation for "BlockExceptionListAdapter"  [var-annotated]
src/ethereum_test_tools/common/types.py:1242: error: Self? has no attribute "secret_key"  [attr-defined]
src/ethereum_test_tools/spec/consume/types.py:152: error: Self? has no attribute "test_cases"  [attr-defined]
Found 5 errors in 3 files (checked 123 source files)
```

This PR fixes all issues.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
