### PR TITLE
fix(tests): EOF - Container type errors

### DIFF
--- a/src/ethereum_test_tools/spec/eof/eof_test.py
+++ b/src/ethereum_test_tools/spec/eof/eof_test.py
@@ -295,6 +295,26 @@ class EOFStateTest(EOFTest):
         FixtureFormats.BLOCKCHAIN_TEST_HIVE,
     ]
 
+    @model_validator(mode="before")
+    @classmethod
+    def check_container_type(cls, data: Any) -> Any:
+        """
+        Check if the container exception matches the expected exception.
+        """
+        if isinstance(data, dict):
+            container = data.get("data")
+            deploy_tx = data.get("deploy_tx")
+            container_kind = data.get("container_kind")
+            if deploy_tx is None:
+                if (
+                    container is not None
+                    and isinstance(container, Container)
+                    and "kind" in container.model_fields_set
+                    and container.kind == ContainerKind.INITCODE
+                ) or (container_kind is not None and container_kind == ContainerKind.INITCODE):
+                    data["deploy_tx"] = True
+        return data
+
     @classmethod
     def pytest_parameter_name(cls) -> str:
         """

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/container.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/container.py
@@ -4,8 +4,13 @@ Test EVM Object Format Version 1
 
 from typing import List
 
-from ethereum_test_tools.eof.v1 import VERSION_MAX_SECTION_KIND, AutoSection, Container, Section
-from ethereum_test_tools.eof.v1 import SectionKind as Kind
+from ethereum_test_tools.eof.v1 import (
+    VERSION_MAX_SECTION_KIND,
+    AutoSection,
+    Container,
+    Section,
+    SectionKind,
+)
 from ethereum_test_tools.eof.v1.constants import (
     MAX_CODE_INPUTS,
     MAX_CODE_OUTPUTS,
@@ -14,76 +19,6 @@ from ethereum_test_tools.eof.v1.constants import (
 )
 from ethereum_test_tools.exceptions import EOFException
 from ethereum_test_tools.vm.opcode import Opcodes as Op
-
-VALID: List[Container] = [
-    Container(
-        name="single_code_single_data_section",
-        sections=[
-            Section.Code(
-                code=Op.PUSH0 + Op.POP + Op.STOP,
-                max_stack_height=1,
-            ),
-            Section.Data(data="0x00"),
-        ],
-    ),
-    Container(
-        name="max_code_sections",
-        sections=[
-            Section.Code(Op.JUMPF[i + 1] if i < (MAX_CODE_SECTIONS - 1) else Op.STOP)
-            for i in range(MAX_CODE_SECTIONS)
-        ],
-    ),
-    Container(
-        name="max_code_sections_plus_data",
-        sections=[
-            Section.Code(Op.JUMPF[i + 1] if i < (MAX_CODE_SECTIONS - 1) else Op.STOP)
-            for i in range(MAX_CODE_SECTIONS)
-        ]
-        + [Section.Data(data="0x00")],
-    ),
-    Container(
-        name="max_code_sections_plus_container",
-        sections=[
-            Section.Code(
-                Op.JUMPF[i + 1] if i < (MAX_CODE_SECTIONS - 1) else Op.RETURNCONTRACT[0](0, 0)
-            )
-            for i in range(MAX_CODE_SECTIONS)
-        ]
-        + [
-            Section.Container(
-                container=Container(
-                    name="max_code_sections",
-                    sections=[
-                        Section.Code(Op.JUMPF[i + 1] if i < (MAX_CODE_SECTIONS - 1) else Op.STOP)
-                        for i in range(MAX_CODE_SECTIONS)
-                    ],
-                )
-            )
-        ],
-    ),
-    Container(
-        name="max_code_sections_plus_data_plus_container",
-        sections=[
-            Section.Code(
-                Op.JUMPF[i + 1] if i < (MAX_CODE_SECTIONS - 1) else Op.RETURNCONTRACT[0](0, 0)
-            )
-            for i in range(MAX_CODE_SECTIONS)
-        ]
-        + [
-            Section.Container(
-                container=Container(
-                    name="max_code_sections",
-                    sections=[
-                        Section.Code(Op.JUMPF[i + 1] if i < (MAX_CODE_SECTIONS - 1) else Op.STOP)
-                        for i in range(MAX_CODE_SECTIONS)
-                    ],
-                )
-            )
-        ]
-        + [Section.Data(data="0x00")],
-    ),
-    # TODO: Add more valid scenarios
-]
 
 INVALID: List[Container] = [
     Container(
@@ -202,7 +137,7 @@ INVALID: List[Container] = [
     Container(
         name="no_code_section",
         sections=[
-            Section(kind=Kind.TYPE, data=bytes([0] * 4)),
+            Section(kind=SectionKind.TYPE, data=bytes([0] * 4)),
             Section.Data("0x00"),
         ],
         auto_type_section=AutoSection.NONE,
@@ -471,8 +406,8 @@ INVALID: List[Container] = [
     Container(
         name="too_many_type_sections",
         sections=[
-            Section(kind=Kind.TYPE, data="0x00000000"),
-            Section(kind=Kind.TYPE, data="0x00000000"),
+            Section(kind=SectionKind.TYPE, data="0x00000000"),
+            Section(kind=SectionKind.TYPE, data="0x00000000"),
             Section.Code(Op.STOP),
         ],
         auto_type_section=AutoSection.NONE,
@@ -481,7 +416,7 @@ INVALID: List[Container] = [
     Container(
         name="empty_type_section",
         sections=[
-            Section(kind=Kind.TYPE, data="0x"),
+            Section(kind=SectionKind.TYPE, data="0x"),
             Section.Code(Op.STOP),
         ],
         auto_type_section=AutoSection.NONE,
@@ -491,7 +426,7 @@ INVALID: List[Container] = [
     Container(
         name="type_section_too_small_1",
         sections=[
-            Section(kind=Kind.TYPE, data="0x00"),
+            Section(kind=SectionKind.TYPE, data="0x00"),
             Section.Code(Op.STOP),
         ],
         auto_type_section=AutoSection.NONE,
@@ -500,7 +435,7 @@ INVALID: List[Container] = [
     Container(
         name="type_section_too_small_2",
         sections=[
-            Section(kind=Kind.TYPE, data="0x000000"),
+            Section(kind=SectionKind.TYPE, data="0x000000"),
             Section.Code(Op.STOP),
         ],
         auto_type_section=AutoSection.NONE,
@@ -509,7 +444,7 @@ INVALID: List[Container] = [
     Container(
         name="type_section_too_big",
         sections=[
-            Section(kind=Kind.TYPE, data="0x0000000000"),
+            Section(kind=SectionKind.TYPE, data="0x0000000000"),
             Section.Code(Op.STOP),
         ],
         auto_type_section=AutoSection.NONE,
@@ -523,7 +458,7 @@ INVALID: List[Container] = [
 EIP-4750 Valid and Invalid Containers
 """
 
-VALID += [
+VALID = [
     Container(
         name="single_code_section_max_stack_size",
         sections=[
@@ -633,7 +568,7 @@ INVALID += [
     Container(
         name="single_code_section_incomplete_type",
         sections=[
-            Section(kind=Kind.TYPE, data="0x00", custom_size=2),
+            Section(kind=SectionKind.TYPE, data="0x00", custom_size=2),
             Section.Code(Op.STOP),
         ],
         validity_error=EOFException.INVALID_SECTION_BODIES_SIZE,

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py
@@ -2,11 +2,14 @@
 EOF validation tests for EIP-3540 container format
 """
 
+
 import pytest
 
 from ethereum_test_tools import EOFTestFiller
 from ethereum_test_tools import Opcodes as Op
-from ethereum_test_tools.eof.v1 import Container, EOFException, Section
+from ethereum_test_tools.eof.v1 import Container, ContainerKind, Section
+from ethereum_test_tools.eof.v1.constants import MAX_CODE_SECTIONS
+from ethereum_test_tools.exceptions import EOFException
 
 from .. import EOF_FORK_NAME
 
@@ -50,4 +53,80 @@ def test_version_validation(
     eof_test(
         data=bytes(code),
         expect_exception=None if version == 1 else EOFException.INVALID_VERSION,
+    )
+
+
+@pytest.mark.parametrize("plus_data", [False, True])
+@pytest.mark.parametrize("plus_container", [False, True])
+def test_single_code_section(
+    eof_test: EOFTestFiller,
+    plus_data: bool,
+    plus_container: bool,
+):
+    """
+    Verify EOF container maximum number of code sections
+    """
+    sections = [Section.Code(Op.RETURNCONTRACT[0](0, 0) if plus_container else Op.STOP)]
+    if plus_container:
+        sections.append(
+            Section.Container(
+                container=Container(
+                    sections=[
+                        Section.Code(Op.JUMPF[i + 1] if i < (MAX_CODE_SECTIONS - 1) else Op.STOP)
+                        for i in range(MAX_CODE_SECTIONS)
+                    ],
+                )
+            )
+        )
+    if plus_data:
+        sections.append(Section.Data(data=b"\0"))
+    eof_test(
+        data=Container(
+            name="max_code_sections",
+            sections=sections,
+            kind=ContainerKind.INITCODE if plus_container else ContainerKind.RUNTIME,
+        ),
+    )
+
+
+@pytest.mark.parametrize("plus_data", [False, True])
+@pytest.mark.parametrize("plus_container", [False, True])
+def test_max_code_sections(
+    eof_test: EOFTestFiller,
+    plus_data: bool,
+    plus_container: bool,
+):
+    """
+    Verify EOF container maximum number of code sections
+    """
+    if plus_container:
+        sections = [
+            Section.Code(
+                Op.JUMPF[i + 1] if i < (MAX_CODE_SECTIONS - 1) else Op.RETURNCONTRACT[0](0, 0)
+            )
+            for i in range(MAX_CODE_SECTIONS)
+        ]
+        sections.append(
+            Section.Container(
+                container=Container(
+                    sections=[
+                        Section.Code(Op.JUMPF[i + 1] if i < (MAX_CODE_SECTIONS - 1) else Op.STOP)
+                        for i in range(MAX_CODE_SECTIONS)
+                    ],
+                )
+            )
+        )
+    else:
+        sections = [
+            Section.Code(Op.JUMPF[i + 1] if i < (MAX_CODE_SECTIONS - 1) else Op.STOP)
+            for i in range(MAX_CODE_SECTIONS)
+        ]
+    if plus_data:
+        sections.append(Section.Data(data=b"\0"))
+    eof_test(
+        data=Container(
+            name="max_code_sections",
+            sections=sections,
+            kind=ContainerKind.INITCODE if plus_container else ContainerKind.RUNTIME,
+        ),
     )


### PR DESCRIPTION
## 🗒️ Description
Fixes all container type errors in EOF tests, and move stuff out of `tests/prague/eip7692_eof_v1/eip3540_eof_v1/container.py`

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
