### PR TITLE
feat(tests): EOF - EIP-7620: Incompatible container kind validation error

### DIFF
--- a/src/ethereum_test_tools/exceptions/evmone_exceptions.py
+++ b/src/ethereum_test_tools/exceptions/evmone_exceptions.py
@@ -80,6 +80,9 @@ class EvmoneExceptionMapper:
         ExceptionMessage(
             EOFException.INVALID_CONTAINER_SECTION_INDEX, "err: invalid_container_section_index"
         ),
+        ExceptionMessage(
+            EOFException.INCOMPATIBLE_CONTAINER_KIND, "err: incompatible_container_kind"
+        ),
     )
 
     def __init__(self) -> None:

--- a/src/ethereum_test_tools/exceptions/exceptions.py
+++ b/src/ethereum_test_tools/exceptions/exceptions.py
@@ -700,6 +700,10 @@ class EOFException(ExceptionBase):
     """
     Instruction references container section that does not exist.
     """
+    INCOMPATIBLE_CONTAINER_KIND = auto()
+    """
+    Incompatible instruction found in a container of a specific kind.
+    """
 
 
 """

--- a/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
+++ b/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
@@ -187,24 +187,21 @@ def test_container_combos_valid(
 
 
 @pytest.mark.parametrize(
-    "code_section,first_sub_container,error",
+    "code_section,first_sub_container",
     [
         pytest.param(
             eofcreate_code_section,
             stop_sub_container,
-            EOFException.UNDEFINED_EXCEPTION,
             id="EOFCREATE/STOP",
         ),
         pytest.param(
             eofcreate_code_section,
             return_sub_container,
-            EOFException.UNDEFINED_EXCEPTION,
             id="EOFCREATE/RETURN",
         ),
         pytest.param(
             returncontract_code_section,
             returncontract_sub_container,
-            EOFException.UNDEFINED_EXCEPTION,
             id="RETURNCONTRACT/RETURNCONTRACT",
         ),
     ],
@@ -213,7 +210,6 @@ def test_container_combos_invalid(
     eof_test: EOFTestFiller,
     code_section: Section,
     first_sub_container: Container,
-    error: EOFException,
 ):
     """Test invalid subcontainer reference / opcode combos"""
     eof_test(
@@ -223,7 +219,7 @@ def test_container_combos_invalid(
                 first_sub_container,
             ],
         ),
-        expect_exception=error,
+        expect_exception=EOFException.INCOMPATIBLE_CONTAINER_KIND,
     )
 
 
@@ -241,7 +237,7 @@ def test_container_both_kinds_same_sub(eof_test: EOFTestFiller):
                 revert_sub_container,
             ],
         ),
-        expect_exception=EOFException.UNDEFINED_EXCEPTION,
+        expect_exception=EOFException.INCOMPATIBLE_CONTAINER_KIND,
     )
 
 


### PR DESCRIPTION
## 🗒️ Description

This adds new EOF validation error: incompatible container kind. And fixes existing tests.

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
