### PR TITLE
fix(setup): Pin pydantic minor version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     trie>=2.0.2,<3
     semver>=3.0.1,<4
     click>=8.0.0,<9
-    pydantic>=2.6.3,<3
+    pydantic>=2.8.0,<2.9
     rich>=13.7.0,<14
     solc-select>=1.0.4
 

--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -1235,11 +1235,11 @@ class Transaction(TransactionGeneric[HexNumber], TransactionTransitionToolConver
 
         updated_values["secret_key"] = None
 
-        updated_tx = self.model_copy(update=updated_values)
+        updated_tx: "Transaction" = self.model_copy(update=updated_values)
 
         # Remove the secret key if requested
         if keep_secret_key:
-            updated_tx.secret_key = self.secret_key  # type: ignore
+            updated_tx.secret_key = self.secret_key
         return updated_tx
 
     @cached_property

--- a/src/ethereum_test_tools/spec/consume/types.py
+++ b/src/ethereum_test_tools/spec/consume/types.py
@@ -148,5 +148,5 @@ class TestCases(RootModel):
         Create a TestCases object from an index file.
         """
         with open(index_file, "r") as fd:
-            index = IndexFile.model_validate_json(fd.read())
-        return cls(root=index.test_cases)  # type: ignore
+            index: IndexFile = IndexFile.model_validate_json(fd.read())
+        return cls(root=index.test_cases)


### PR DESCRIPTION
## 🗒️ Description
Issue fixed in PR #660 was potentially caused by pydantic being automatically updated to 2.8.0.

This PR pins the minor version to be 2.8 so we don't have surprises in the future.

Also remove `type: ignore` introduced in #660.

## 🔗 Related Issues
None.

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.