### PR TITLE
fix(tests): EOF - EIP-3540: EXTCODECOPY a hard-coded size for EOF target

### DIFF
--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_extcode.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_extcode.py
@@ -47,7 +47,7 @@ def test_legacy_calls_eof_sstore(
             Op.EXTCODEHASH(address_legacy_contract),
         )
         + Op.SSTORE(storage_test.store_next(2), Op.EXTCODESIZE(address_eof_contract))
-        + Op.EXTCODECOPY(address_eof_contract, 0x20, 0, Op.EXTCODESIZE(address_eof_contract))
+        + Op.EXTCODECOPY(address_eof_contract, 0x20, 0, 6)
         + Op.SSTORE(storage_test.store_next(b"\xef" + (b"\0" * 31)), Op.MLOAD(0x20))
         + Op.SSTORE(
             storage_test.store_next(keccak256(b"\xef\x00")),


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
The test takes the result of `EXTCODESIZE` as the size for the `EXTCODECOPY`.
In a world where the `EXTCODESIZE` is properly implemented for an EOF target but the `EXTCODECOPY` is not, the result from `EXTCODECOPY` will still be correct since `EXTCODESIZE` outputs 2 and the first 2 bytes of any EOF container will be `0xef00`. This change recommends a random size (say 6) so that the difference between correct and incorrect implementations can manifest itself in the `SSTORE`

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
