### PR TITLE
fix(fw): Fix `CopyValidateModel`

### DIFF
--- a/src/ethereum_test_tools/common/types.py
+++ b/src/ethereum_test_tools/common/types.py
@@ -84,9 +84,9 @@ class CopyValidateModel(BaseModel):
 
     def copy(self: Model, **kwargs) -> Model:
         """
-        Creates a copy of the model with the updated fields.
+        Creates a copy of the model with the updated fields that are validated.
         """
-        return self.__class__(**(self.model_dump() | kwargs))
+        return self.__class__(**(self.model_dump(exclude_unset=True) | kwargs))
 
 
 class CamelModel(CopyValidateModel):

--- a/src/ethereum_test_tools/tests/test_types.py
+++ b/src/ethereum_test_tools/tests/test_types.py
@@ -19,7 +19,8 @@ from ..common import (
 from ..common.base_types import Address, Bloom, Bytes, Hash, HeaderNonce, ZeroPaddedHexNumber
 from ..common.constants import TestAddress, TestAddress2, TestPrivateKey
 from ..common.json import to_json
-from ..common.types import Alloc, DepositRequest, Requests
+from ..common.types import Alloc, CopyValidateModel, DepositRequest, Requests
+from ..eof.v1 import Container
 from ..exceptions import BlockException, TransactionException
 from ..spec.blockchain.types import (
     FixtureBlockBase,
@@ -1735,3 +1736,19 @@ def test_parsing(json_str: str, type_adapter: TypeAdapter, expected: Any):
     Test that parsing the given JSON string returns the expected object.
     """
     assert type_adapter.validate_json(json_str) == expected
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        Environment(),
+        Container(),
+    ],
+    ids=lambda model: model.__class__.__name__,
+)
+def test_model_copy(model: CopyValidateModel):
+    """
+    Test that the copy method returns a correct copy of the model.
+    """
+    assert to_json(model.copy()) == to_json(model)
+    assert model.copy().model_fields_set == model.model_fields_set


### PR DESCRIPTION
## 🗒️ Description
Fixes a bug where the `copy` method from `CopyValidateModel` includes unset fields when dumping the model to re-validate.

Produces identical fixtures as main branch.

Required for #676

@gumb0 

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
