### PR TITLE
check patched tests coverage [TEST]

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -3,7 +3,7 @@ name: Evmone Coverage Report
 on:
   pull_request:
     paths:
-      - 'converted-ethereum-tests.txt' # This triggers the workflow only for changes in file.txt
+      - 'tests/**' # This triggers the workflow for any changes in the tests folder
 
 jobs:
   evmone-coverage-diff:
@@ -74,14 +74,16 @@ jobs:
       - name: Parse converted tests from converted-ethereum-tests.txt
         run: |
           echo "New lines introduced in converted-ethereum-tests.txt:"
-          lines=$(git diff origin/${{ github.base_ref }} HEAD -- converted-ethereum-tests.txt | grep "^+" | grep -v "^+++")
-          files=$(echo "$lines" | grep -oP '(?<=\+).+\.json')
-
-          if [ -z "$files" ]; then
-             echo "Error: No new JSON files found in converted-ethereum-tests.txt"
-              exit 1
+          lines=$(git diff origin/${{ github.base_ref }} HEAD -- converted-ethereum-tests.txt | grep "^+" | grep -v "^+++" || true)
+          if [ -z "$lines" ]; then
+              echo "No new lines in converted-ethereum-tests.txt, check updates instead:"
+              echo "converted_skip=true" >> $GITHUB_ENV
+              exit 0
+          else
+              echo "converted_skip=false" >> $GITHUB_ENV
           fi
 
+          files=$(echo "$lines" | grep -oP '(?<=\+).+\.json')
           for file in $files; do
               echo $file
           done
@@ -118,7 +120,7 @@ jobs:
                 exit 1
               fi
           done
-          
+
 
      # This command diffs the .py scripts introduced by a PR
       - name: Parse and fill introduced test sources
@@ -181,6 +183,46 @@ jobs:
           mkdir -p $PATCH_TEST_PATH
           find fixtures/state_tests -type f -name "*.json" -exec cp {} $PATCH_TEST_PATH \;
           find fixtures/eof_tests -type f -name "*.json" -exec cp {} $PATCH_TEST_PATH \;
+
+          if [ "${{ env.converted_skip }}" == 'true' ]; then
+            echo "--------------------"
+            echo "converted-ethereum-tests.txt seem untouched, try to fill pre-patched version of .py files:"
+
+            git checkout main
+            PREV_COMMIT=$(git rev-parse HEAD)
+            echo "Checkout head $PREV_COMMIT"
+
+            rm -r fixtures
+            rm filloutput.log
+            rm filloutputEOF.log
+            mkdir -p fixtures/state_tests
+            mkdir -p fixtures/eof_tests
+            echo "$files" | while read line; do
+              file=$(echo "$line" | cut -c 3-)
+              if [ ! -f "$file" ]; then
+                  continue
+              fi
+              fill "$file" --until=Cancun --evm-bin evmone-t8n || true >> filloutput.log 2>&1
+              (fill "$file" --fork=CancunEIP7692 --evm-bin evmone-t8n -k eof_test || true) > >(tee -a filloutput.log filloutputEOF.log) 2>&1
+            done
+
+            if grep -q "FAILURES" filloutput.log; then
+             echo "Error: failed to generate .py tests from before the PR."
+              exit 1
+            fi
+
+            filesState=$(find fixtures/state_tests -type f -name "*.json")
+            filesEOF=$(find fixtures/eof_tests -type f -name "*.json")
+            if [ -z "$filesState" ] && [ -z "$filesEOF" ]; then
+              echo "Error: No filled JSON fixtures found in fixtures from before the PR."
+               exit 1
+            fi
+
+            BASE_TEST_PATH=${{ github.workspace }}/evmtest_coverage/coverage/BASE_TESTS
+            mkdir -p $BASE_TEST_PATH
+            find fixtures/state_tests -type f -name "*.json" -exec cp {} $BASE_TEST_PATH \;
+            find fixtures/eof_tests -type f -name "*.json" -exec cp {} $BASE_TEST_PATH \;
+          fi
 
       - name: Print tests that will be covered
         if: ${{ env.retesteth_skip == 'false' || matrix.driver == 'native' }}

--- a/tests/homestead/coverage/__init__.py
+++ b/tests/homestead/coverage/__init__.py
@@ -1,3 +1,4 @@
 """
 Tests that fill coverage gaps when porting over from `ethereum/tests`.
+Unrelated change
 """


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
