### PR TITLE
feat(fw): Fix Bytecode stack calculation, Implemement `Section.Function` for EOF containers

### DIFF
--- a/src/ethereum_test_types/tests/test_eof_v1.py
+++ b/src/ethereum_test_types/tests/test_eof_v1.py
@@ -7,6 +7,8 @@ from typing import List, Tuple
 import pytest
 
 from ..eof.v1 import AutoSection, Container, Section, SectionKind
+from ..vm import Bytecode
+from ..vm import Opcodes as Op
 
 test_cases: List[Tuple[str, Container, str]] = [
     (
@@ -22,7 +24,7 @@ test_cases: List[Tuple[str, Container, str]] = [
         "Single code section",
         Container(
             sections=[
-                Section.Code("0x00"),
+                Section.Code(Op.STOP),
             ],
         ),
         "ef0001 01 0004 02 0001 0001 04 0000 00 00800000 00",
@@ -31,53 +33,53 @@ test_cases: List[Tuple[str, Container, str]] = [
         "Single code section, single container section",
         Container(
             sections=[
-                Section.Code("0x0A"),
-                Section.Container("0x0B"),
+                Section.Code(Op.EXP),
+                Section.Container(Container(raw_bytes=b"\x0b")),
             ],
         ),
-        "ef0001 01 0004 02 0001 0001 03 0001 0001 04 0000 00 00800000 0A 0B",
+        "ef0001 01 0004 02 0001 0001 03 0001 0001 04 0000 00 00800002 0A 0B",
     ),
     (
         "Single code section, single container section, single data",
         Container(
             sections=[
-                Section.Code("0x0A"),
-                Section.Container("0x0B"),
+                Section.Code(Op.EXP),
+                Section.Container(Container(raw_bytes=b"\x0b")),
                 Section.Data("0x0C"),
             ],
         ),
-        "ef0001 01 0004 02 0001 0001 03 0001 0001 04 0001 00 00800000 0A 0B 0C",
+        "ef0001 01 0004 02 0001 0001 03 0001 0001 04 0001 00 00800002 0A 0B 0C",
     ),
     (
         "Single code section, single container section, single data 2",
         Container(
             sections=[
-                Section.Code("0x0A"),
+                Section.Code(Op.EXP),
                 Section.Data("0x0C"),
-                Section.Container("0x0B"),
+                Section.Container(Container(raw_bytes=b"\x0b")),
             ],
         ),
-        "ef0001 01 0004 02 0001 0001 03 0001 0001 04 0001 00 00800000 0A 0B 0C",
+        "ef0001 01 0004 02 0001 0001 03 0001 0001 04 0001 00 00800002 0A 0B 0C",
     ),
     (
         "Single code section, multiple container section, single data",
         Container(
             sections=[
-                Section.Code("0x0A"),
-                Section.Container("0x0B"),
+                Section.Code(Op.EXP),
+                Section.Container(Container(raw_bytes=b"\x0b")),
                 Section.Data("0x0C"),
-                Section.Container("0x0D"),
+                Section.Container(Container(raw_bytes=b"\x0d")),
             ],
         ),
-        "ef0001 01 0004 02 0001 0001 03 0002 0001 0001 04 0001 00 00800000 0A 0B 0D 0C",
+        "ef0001 01 0004 02 0001 0001 03 0002 0001 0001 04 0001 00 00800002 0A 0B 0D 0C",
     ),
     (
         "Single code section, multiple container sections",
         Container(
             sections=[
-                Section.Code("0x00"),
-                Section.Container("0x0001"),
-                Section.Container("0x00"),
+                Section.Code(Op.STOP),
+                Section.Container(Container(raw_bytes=b"\0\1")),
+                Section.Container(Container(raw_bytes=b"\0")),
             ],
         ),
         "ef0001 01 0004 02 0001 0001 03 0002 0002 0001 04 0000 00 00800000 00 0001 00",
@@ -117,11 +119,11 @@ test_cases: List[Tuple[str, Container, str]] = [
         "Multiple sections",
         Container(
             sections=[
-                Section.Code("0x0e"),
+                Section.Code(Op.EXP),
                 Section.Data("0x0f"),
             ],
         ),
-        "ef0001 01 0004 02 0001 0001 04 0001 00 00800000 0e 0f",
+        "ef0001 01 0004 02 0001 0001 04 0001 00 00800002 0a 0f",
     ),
     (
         "Multiple type sections",
@@ -135,7 +137,7 @@ test_cases: List[Tuple[str, Container, str]] = [
                     kind=SectionKind.TYPE,
                     data="0x00000000",
                 ),
-                Section.Code("0x00"),
+                Section.Code(Op.STOP),
             ],
             auto_type_section=AutoSection.NONE,
         ),
@@ -146,7 +148,7 @@ test_cases: List[Tuple[str, Container, str]] = [
         Container(
             magic=b"\xEF\xFE",
             sections=[
-                Section.Code("0x00"),
+                Section.Code(Op.STOP),
             ],
         ),
         "effe01 01 0004 02 0001 0001 04 0000 00 00800000 00",
@@ -156,7 +158,7 @@ test_cases: List[Tuple[str, Container, str]] = [
         Container(
             version=b"\x02",
             sections=[
-                Section.Code("0x00"),
+                Section.Code(Op.STOP),
             ],
         ),
         "ef0002 01 0004 02 0001 0001 04 0000 00 00800000 00",
@@ -166,7 +168,7 @@ test_cases: List[Tuple[str, Container, str]] = [
         Container(
             sections=[
                 Section.Code(
-                    "0x00",
+                    Op.STOP,
                     custom_size=0xFFFF,
                 ),
             ],
@@ -177,39 +179,39 @@ test_cases: List[Tuple[str, Container, str]] = [
         "Nested EOF",
         Container(
             sections=[
-                Section.Code("0x00"),
+                Section.Code(Op.STOP),
                 Section(
                     kind=SectionKind.CONTAINER,
                     data=Container(
-                        sections=[Section.Code("0x01")],
+                        sections=[Section.Code(Op.ADD)],
                     ),
                 ),
             ],
         ),
         "ef0001 01 0004 02 0001 0001 03 0001 0014 04 0000 00 00800000 00"
-        "ef0001 01 0004 02 0001 0001 04 0000 00 00800000 01",
+        "ef0001 01 0004 02 0001 0001 04 0000 00 00800002 01",
     ),
     (
         "Nested EOF in Data",
         Container(
             sections=[
-                Section.Code("0x00"),
+                Section.Code(Op.STOP),
                 Section.Data(
                     data=Container(
-                        sections=[Section.Code("0x01")],
+                        sections=[Section.Code(Op.ADD)],
                     ),
                 ),
             ],
         ),
         "ef0001 01 0004 02 0001 0001 04 0014 00 00800000 00"
-        "ef0001 01 0004 02 0001 0001 04 0000 00 00800000 01",
+        "ef0001 01 0004 02 0001 0001 04 0000 00 00800002 01",
     ),
     (
         "Incomplete code section",
         Container(
             sections=[
                 Section.Code(
-                    code=b"",
+                    code=Bytecode(),
                     custom_size=0x02,
                 ),
             ],
@@ -220,23 +222,23 @@ test_cases: List[Tuple[str, Container, str]] = [
         "Trailing bytes after code section",
         Container(
             sections=[
-                Section.Code("0x600000"),
+                Section.Code(Op.PUSH1[0] + Op.STOP),
             ],
             extra=bytes.fromhex("deadbeef"),
         ),
-        "ef0001 01 0004 02 0001 0003 04 0000 00 00800000 600000 deadbeef",
+        "ef0001 01 0004 02 0001 0003 04 0000 00 00800001 600000 deadbeef",
     ),
     (
         "Multiple code sections",
         Container(
             sections=[
-                Section.Code("0x600000"),
-                Section.Code("0x600000"),
+                Section.Code(Op.PUSH1[0] + Op.STOP),
+                Section.Code(Op.PUSH1[0] + Op.STOP),
             ],
         ),
         """
             ef0001 01 0008 02 0002 0003 0003 04 0000 00
-            00800000 00800000
+            00800001 00800001
             600000
             600000
             """,
@@ -245,18 +247,18 @@ test_cases: List[Tuple[str, Container, str]] = [
         "No section terminator",
         Container(
             sections=[
-                Section.Code("0x600000"),
+                Section.Code(Op.PUSH1[0] + Op.STOP),
             ],
             header_terminator=bytes(),
         ),
-        "ef0001 01 0004 02 0001 0003 04 0000 00800000 600000",
+        "ef0001 01 0004 02 0001 0003 04 0000 00800001 600000",
     ),
     (
         "No auto type section",
         Container(
             auto_type_section=AutoSection.NONE,
             sections=[
-                Section.Code("0x00"),
+                Section.Code(Op.STOP),
             ],
         ),
         "ef0001 02 0001 0001 04 0000 00 00",
@@ -265,7 +267,7 @@ test_cases: List[Tuple[str, Container, str]] = [
         "Data section in types",
         Container(
             sections=[
-                Section.Code("0x00"),
+                Section.Code(Op.STOP),
                 Section.Data(
                     data="0x00",
                     force_type_listing=True,
@@ -283,7 +285,7 @@ test_cases: List[Tuple[str, Container, str]] = [
         Container(
             sections=[
                 Section.Code(
-                    "0x00",
+                    Op.STOP,
                     code_inputs=1,
                 ),
             ],
@@ -299,7 +301,7 @@ test_cases: List[Tuple[str, Container, str]] = [
         Container(
             sections=[
                 Section.Code(
-                    "0x00",
+                    Op.STOP,
                     code_inputs=0xFF,
                 ),
             ],
@@ -315,7 +317,7 @@ test_cases: List[Tuple[str, Container, str]] = [
         Container(
             sections=[
                 Section.Code(
-                    "0x00",
+                    Op.STOP,
                     code_outputs=1,
                 ),
             ],
@@ -331,7 +333,7 @@ test_cases: List[Tuple[str, Container, str]] = [
         Container(
             sections=[
                 Section.Code(
-                    "0x00",
+                    Op.STOP,
                     code_outputs=0xFF,
                 ),
             ],
@@ -347,7 +349,7 @@ test_cases: List[Tuple[str, Container, str]] = [
         Container(
             sections=[
                 Section.Code(
-                    "0x00",
+                    Op.STOP,
                     max_stack_height=0x0201,
                 ),
             ],
@@ -363,7 +365,7 @@ test_cases: List[Tuple[str, Container, str]] = [
         Container(
             sections=[
                 Section.Code(
-                    "0x00",
+                    Op.STOP,
                     max_stack_height=0xFFFF,
                 ),
             ],
@@ -379,10 +381,10 @@ test_cases: List[Tuple[str, Container, str]] = [
         Container(
             sections=[
                 Section.Code(
-                    "0x00",
+                    Op.STOP,
                     max_stack_height=0xFFFF,
                 ),
-                Section.Code("0x00"),
+                Section.Code(Op.STOP),
             ],
         ),
         """
@@ -398,9 +400,9 @@ test_cases: List[Tuple[str, Container, str]] = [
             sections=[
                 Section(
                     kind=SectionKind.TYPE,
-                    data="0x00",
+                    data=Op.STOP,
                 ),
-                Section.Code("0x00"),
+                Section.Code(Op.STOP),
             ],
         ),
         "ef0001 01 0001 02 0001 0001 04 0000 00 00 00",
@@ -413,7 +415,7 @@ test_cases: List[Tuple[str, Container, str]] = [
                     kind=SectionKind.TYPE,
                     data="0x0000000000",
                 ),
-                Section.Code("0x00"),
+                Section.Code(Op.STOP),
             ],
         ),
         "ef0001 01 0005 02 0001 0001 04 0000 00 0000000000 00",
@@ -423,7 +425,7 @@ test_cases: List[Tuple[str, Container, str]] = [
         Container(
             sections=[
                 Section(kind=SectionKind.TYPE, data="0x"),
-                Section.Code("0x00"),
+                Section.Code(Op.STOP),
             ],
             auto_type_section=AutoSection.NONE,
         ),
@@ -434,7 +436,7 @@ test_cases: List[Tuple[str, Container, str]] = [
         Container(
             sections=[
                 Section.Code(
-                    "0x305000",
+                    Op.ADDRESS + Op.POP + Op.STOP,
                     code_inputs=0,
                     code_outputs=128,  # Non returning
                     max_stack_height=1,
@@ -468,7 +470,7 @@ test_cases: List[Tuple[str, Container, str]] = [
         Container(
             sections=[
                 Section.Code(
-                    "0x305000",
+                    Op.ADDRESS + Op.POP + Op.STOP,
                     code_inputs=0,
                     code_outputs=128,  # Non returning
                     max_stack_height=1,
@@ -502,31 +504,38 @@ test_cases: List[Tuple[str, Container, str]] = [
         Container(
             sections=[
                 Section.Code(
-                    "0x5f35e2030000000300060009e50001e50002e50003e3000400",
+                    Op.PUSH0
+                    + Op.CALLDATALOAD
+                    + Op.RJUMPV[0, 3, 6, 9]
+                    + Op.JUMPF[1]
+                    + Op.JUMPF[2]
+                    + Op.JUMPF[3]
+                    + Op.CALLF[4]
+                    + Op.STOP,
                     code_inputs=0,
                     code_outputs=128,  # Non returning
                     max_stack_height=1,
                 ),
                 Section.Code(
-                    "0x5f5ff3",
+                    Op.RETURN(Op.PUSH0, Op.PUSH0),
                     code_inputs=0,
                     code_outputs=128,  # Non returning
                     max_stack_height=2,
                 ),
                 Section.Code(
-                    "0x5f5ffd",
+                    Op.REVERT(Op.PUSH0, Op.PUSH0),
                     code_inputs=0,
                     code_outputs=128,  # Non returning
                     max_stack_height=2,
                 ),
                 Section.Code(
-                    "0xfe",
+                    Op.INVALID,
                     code_inputs=0,
                     code_outputs=128,  # Non returning
                     max_stack_height=0,
                 ),
                 Section.Code(
-                    "0xe4",
+                    Op.RETF,
                     code_inputs=0,
                     code_outputs=0,
                     max_stack_height=0,
@@ -819,3 +828,32 @@ def remove_comments_from_string(input_string):
     # Join the cleaned lines back into a single string
     cleaned_string = "\n".join(cleaned_lines)
     return cleaned_string
+
+
+@pytest.mark.parametrize(
+    ["section", "expected_code_inputs", "expected_code_outputs", "expected_max_stack_height"],
+    [
+        (Section.Code(Op.STOP), 0, 0x80, 0),
+        (Section.Code(Op.STOP, code_inputs=1), 1, 0x80, 0),
+        (Section.Code(Op.STOP, code_outputs=1), 0, 1, 0),
+        (Section.Code(Op.STOP, max_stack_height=1), 0, 0x80, 1),
+        (Section.Code(Op.STOP, code_inputs=1, code_outputs=1, max_stack_height=1), 1, 1, 1),
+        (Section.Code(Op.ADD(0, 1) + Op.STOP), 0, 0x80, 2),
+        (Section.Function(Op.ADD(0, 1) + Op.RETF), 0, 1, 2),
+        (Section.Function(Op.ADD + Op.RETF, code_inputs=2), 2, 1, 2),
+        (Section.Function(Op.PUSH0 + Op.POP + Op.RETF, code_inputs=3), 3, 3, 4),
+        (Section.Function(Op.POP * 3 + Op.PUSH0 * 3 + Op.RETF), 3, 3, 3),
+    ],
+)
+def test_section_inputs_outputs_stack_calculations(
+    section: Section,
+    expected_code_inputs: int,
+    expected_code_outputs: int,
+    expected_max_stack_height: int,
+):
+    """
+    Test code section stack properties settings.
+    """
+    assert section.code_inputs == expected_code_inputs
+    assert section.code_outputs == expected_code_outputs
+    assert section.max_stack_height == expected_max_stack_height

--- a/src/ethereum_test_vm/tests/test_vm.py
+++ b/src/ethereum_test_vm/tests/test_vm.py
@@ -383,6 +383,23 @@ def test_macros():
         pytest.param(
             Op.POP(Op.CALL(1, 2, 3, 4, 5, 6, 7)), 0, 0, 7, 0, id="POP(CALL(1, 2, 3, 4, 5, 6, 7))"
         ),
+        pytest.param(Op.ADD + Op.RETF, 2, 1, 2, 2, id="Op.ADD + Op.RETF"),
+        pytest.param(
+            (Op.ADD + Op.RETF).with_min_stack_height(2),
+            2,
+            1,
+            2,
+            2,
+            id="(Op.ADD + Op.RETF).with_min_stack_height(2)",
+        ),
+        pytest.param(
+            (Op.ADD + Op.RETF).with_min_stack_height(3),
+            2,
+            1,
+            3,
+            3,
+            id="(Op.ADD + Op.RETF).with_min_stack_height(3)",
+        ),
     ],
 )
 def test_bytecode_properties(

--- a/src/ethereum_test_vm/tests/test_vm.py
+++ b/src/ethereum_test_vm/tests/test_vm.py
@@ -359,8 +359,11 @@ def test_macros():
 
 
 @pytest.mark.parametrize(
-    "bytecode,expected_popped_items,expected_pushed_items,"
-    "expected_max_stack_height,expected_min_stack_height",
+    (
+        "bytecode,"
+        + "expected_popped_items,expected_pushed_items,"
+        + "expected_max_stack_height,expected_min_stack_height"
+    ),
     [
         pytest.param(Op.PUSH1 + Op.POP, 0, 0, 1, 0, id="PUSH1 + POP"),
         pytest.param(Op.PUSH1 + Op.PUSH1, 0, 2, 2, 0, id="PUSH1 + PUSH1"),
@@ -399,6 +402,14 @@ def test_macros():
             3,
             3,
             id="(Op.ADD + Op.RETF).with_min_stack_height(3)",
+        ),
+        pytest.param(
+            (Op.PUSH0 + Op.POP + Op.RETF).with_min_stack_height(3),
+            0,
+            0,
+            4,
+            3,
+            id="(Op.PUSH0 + Op.POP + Op.RETF).with_min_stack_height(3)",
         ),
     ],
 )

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/container.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/container.py
@@ -4,7 +4,8 @@ Test EVM Object Format Version 1
 
 from typing import List
 
-from ethereum_test_tools import EOFException
+from ethereum_test_tools import Bytecode, EOFException
+from ethereum_test_tools import Opcodes as Op
 from ethereum_test_tools.eof.v1 import (
     VERSION_MAX_SECTION_KIND,
     AutoSection,
@@ -18,7 +19,6 @@ from ethereum_test_tools.eof.v1.constants import (
     MAX_CODE_SECTIONS,
     MAX_OPERAND_STACK_HEIGHT,
 )
-from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 INVALID: List[Container] = [
     Container(
@@ -198,7 +198,7 @@ INVALID: List[Container] = [
     Container(
         name="no_section_terminator_2",
         header_terminator=bytes(),
-        sections=[Section.Code(code="0x", custom_size=3)],
+        sections=[Section.Code(code=Bytecode(), custom_size=3)],
         validity_error=EOFException.INVALID_SECTION_BODIES_SIZE,
     ),
     Container(
@@ -239,7 +239,7 @@ INVALID: List[Container] = [
     Container(
         name="no_section_terminator_nonzero_2",
         header_terminator=b"03",
-        sections=[Section.Code(code="0x", custom_size=3)],
+        sections=[Section.Code(code=Bytecode(), custom_size=3)],
         validity_error=EOFException.MISSING_TERMINATOR,
     ),
     Container(
@@ -256,7 +256,7 @@ INVALID: List[Container] = [
     ),
     Container(
         name="no_code_section_contents",
-        sections=[Section.Code(code="0x", custom_size=0x01)],
+        sections=[Section.Code(code=Bytecode(), custom_size=0x01)],
         validity_error=EOFException.INVALID_SECTION_BODIES_SIZE,
     ),
     Container(
@@ -274,14 +274,14 @@ INVALID: List[Container] = [
     ),
     Container(
         name="empty_code_section",
-        sections=[Section.Code(code="0x")],
+        sections=[Section.Code(code=Bytecode())],
         # TODO the exception must be about code section EOFException.INVALID_CODE_SECTION,
         validity_error=EOFException.ZERO_SECTION_SIZE,
     ),
     Container(
         name="empty_code_section_with_non_empty_data",
         sections=[
-            Section.Code(code="0x"),
+            Section.Code(code=Bytecode()),
             Section.Data(data="0xDEADBEEF"),
         ],
         # TODO the exception must be about code section EOFException.INVALID_CODE_SECTION,
@@ -323,7 +323,7 @@ INVALID: List[Container] = [
     Container(
         name="no_section_terminator_3a",
         header_terminator=bytes(),
-        sections=[Section.Code(code="0x030004")],
+        sections=[Section.Code(code=Op.SUB + Op.STOP + Op.DIV)],
         # TODO the exception must be about terminator
         validity_error=EOFException.INVALID_SECTION_BODIES_SIZE,
     ),

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_container_size.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_container_size.py
@@ -84,7 +84,9 @@ def test_above_max_size_raw(
             Container(
                 sections=[
                     Section.Code(code=Op.STOP),
-                    Section.Container(container=Op.STOP, custom_size=MAX_INITCODE_SIZE),
+                    Section.Container(
+                        container=Container(raw_bytes=b"\0"), custom_size=MAX_INITCODE_SIZE
+                    ),
                 ]
             ),
             id="1st_container_section",
@@ -93,8 +95,10 @@ def test_above_max_size_raw(
             Container(
                 sections=[
                     Section.Code(code=Op.STOP),
-                    Section.Container(container=Op.STOP),
-                    Section.Container(container=Op.STOP, custom_size=MAX_INITCODE_SIZE),
+                    Section.Container(container=Container(raw_bytes=b"\0")),
+                    Section.Container(
+                        container=Container(raw_bytes=b"\0"), custom_size=MAX_INITCODE_SIZE
+                    ),
                 ]
             ),
             id="2nd_container_section",


### PR DESCRIPTION
## 🗒️ Description
- Fixes the stack calculation on some edge cases.
- Implements `Section.Function` which automatically calculates code inputs and outputs based on the code, or outputs based on a given code inputs (in case the bytecode pops less elements from the stack than the section's intended inputs).
- Makes `Bytecode` the only valid input type for `Section.Code`, and `Container` the only valid input type for `Section.Container`, so tests in `src/ethereum_test_tools/tests/test_eof_v1.py` and `tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_container_size.py` are now fixed to not pass any strings or other types to these methods.
## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
