### PR TITLE
fix(cli): `RJUMPV` in `evm_bytes_to_python`

### DIFF
--- a/src/cli/evm_bytes_to_python.py
+++ b/src/cli/evm_bytes_to_python.py
@@ -31,9 +31,16 @@ def process_evm_bytes(evm_bytes_hex_string: Any) -> str:  # noqa: D103
             raise ValueError(f"Unknown opcode: {opcode_byte}")
 
         if opcode.data_portion_length > 0:
-            data_portion = evm_bytes[: opcode.data_portion_length]
+            data_portion = hex(int.from_bytes(evm_bytes[: opcode.data_portion_length], "big"))
             evm_bytes = evm_bytes[opcode.data_portion_length :]
-            opcodes_strings.append(f'Op.{opcode._name_}("0x{data_portion.hex()}")')
+            opcodes_strings.append(f"Op.{opcode._name_}[{data_portion}]")
+        elif opcode == Op.RJUMPV:
+            max_index = evm_bytes.pop(0)
+            operands: List[str] = []
+            for _ in range(max_index + 1):
+                operands.append(hex(int.from_bytes(evm_bytes[:2], "big")))
+                evm_bytes = evm_bytes[2:]
+            opcodes_strings.append(f"Op.{opcode._name_}[{','.join(operands)}]")
         else:
             opcodes_strings.append(f"Op.{opcode._name_}")
 

--- a/src/cli/tests/test_evm_bytes_to_python.py
+++ b/src/cli/tests/test_evm_bytes_to_python.py
@@ -10,11 +10,11 @@ from ..evm_bytes_to_python import process_evm_bytes
 
 basic_vector = [
     "0x60008080808061AAAA612d5ff1600055",
-    'Op.PUSH1("0x00") + Op.DUP1 + Op.DUP1 + Op.DUP1 + Op.DUP1 + Op.PUSH2("0xaaaa") + Op.PUSH2("0x2d5f") + Op.CALL + Op.PUSH1("0x00") + Op.SSTORE',  # noqa: E501
+    "Op.PUSH1[0x0] + Op.DUP1 + Op.DUP1 + Op.DUP1 + Op.DUP1 + Op.PUSH2[0xaaaa] + Op.PUSH2[0x2d5f] + Op.CALL + Op.PUSH1[0x0] + Op.SSTORE",  # noqa: E501
 ]
 complex_vector = [
     "0x7fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebf5f527fc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedf6020527fe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff60405260786040356020355f35608a565b5f515f55602051600155604051600255005b5e56",  # noqa: E501
-    'Op.PUSH32("0xa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebf") + Op.PUSH0 + Op.MSTORE + Op.PUSH32("0xc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedf") + Op.PUSH1("0x20") + Op.MSTORE + Op.PUSH32("0xe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff") + Op.PUSH1("0x40") + Op.MSTORE + Op.PUSH1("0x78") + Op.PUSH1("0x40") + Op.CALLDATALOAD + Op.PUSH1("0x20") + Op.CALLDATALOAD + Op.PUSH0 + Op.CALLDATALOAD + Op.PUSH1("0x8a") + Op.JUMP + Op.JUMPDEST + Op.PUSH0 + Op.MLOAD + Op.PUSH0 + Op.SSTORE + Op.PUSH1("0x20") + Op.MLOAD + Op.PUSH1("0x01") + Op.SSTORE + Op.PUSH1("0x40") + Op.MLOAD + Op.PUSH1("0x02") + Op.SSTORE + Op.STOP + Op.JUMPDEST + Op.MCOPY + Op.JUMP',  # noqa: E501
+    "Op.PUSH32[0xa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebf] + Op.PUSH0 + Op.MSTORE + Op.PUSH32[0xc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedf] + Op.PUSH1[0x20] + Op.MSTORE + Op.PUSH32[0xe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff] + Op.PUSH1[0x40] + Op.MSTORE + Op.PUSH1[0x78] + Op.PUSH1[0x40] + Op.CALLDATALOAD + Op.PUSH1[0x20] + Op.CALLDATALOAD + Op.PUSH0 + Op.CALLDATALOAD + Op.PUSH1[0x8a] + Op.JUMP + Op.JUMPDEST + Op.PUSH0 + Op.MLOAD + Op.PUSH0 + Op.SSTORE + Op.PUSH1[0x20] + Op.MLOAD + Op.PUSH1[0x1] + Op.SSTORE + Op.PUSH1[0x40] + Op.MLOAD + Op.PUSH1[0x2] + Op.SSTORE + Op.STOP + Op.JUMPDEST + Op.MCOPY + Op.JUMP",  # noqa: E501
 ]
 
 
@@ -42,13 +42,18 @@ DUPLICATES = [Op.NOOP]
 )
 def test_individual_opcodes(opcode):
     """Test each opcode individually"""
+    data_portion = b""
     if opcode.data_portion_length > 0:
-        expected_output = f'Op.{opcode._name_}("0x")'
+        expected_output = f"Op.{opcode._name_}[0x0]"
+        data_portion = b"\x00" * opcode.data_portion_length
+    elif opcode == Op.RJUMPV:
+        expected_output = f"Op.{opcode._name_}[0x0]"
+        data_portion = b"\0\0\0"
     else:
         expected_output = f"Op.{opcode._name_}"
 
-    bytecode = opcode.int().to_bytes(1, byteorder="big").hex()
-    assert process_evm_bytes("0x" + bytecode) == expected_output
+    bytecode = opcode.int().to_bytes(1, byteorder="big") + data_portion
+    assert process_evm_bytes("0x" + bytecode.hex()) == expected_output
 
 
 def test_invalid_opcode():
@@ -60,4 +65,5 @@ def test_invalid_opcode():
 def test_unknown_opcode():
     """Opcode not defined in Op"""
     with pytest.raises(ValueError):
+        process_evm_bytes("0x0F")
         process_evm_bytes("0x0F")


### PR DESCRIPTION
## 🗒️ Description
Small fix to `evm_bytes_to_python` to properly parse `RJUMPV` data portion.

We could make this a bit cleaner in the future by providing a function in `class Opcode` that could be overridden by the opcodes to provide custom logic on data-portion parsing.

Also the output now contains the data portion as an integer instead of an hex-formatted string:
```
"0xe30001"
```
before:
```
Op.CALLF("0x0001")
```
now:
```
Op.CALLF[0x1]
```

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.