### PR TITLE
fix(evm_transition_tool): Remove evmone empty-to-string workaround

### DIFF
--- a/src/evm_transition_tool/evmone.py
+++ b/src/evm_transition_tool/evmone.py
@@ -37,11 +37,3 @@ class EvmOneTransitionTool(TransitionTool):
         Currently, evmone-t8n provides no way to determine supported forks.
         """
         return True
-
-    @classmethod
-    def empty_string_to(cls) -> bool:
-        """
-        Evmone requires an empty string within the `to` field for
-        contract-creating transactions.
-        """
-        return True

--- a/src/evm_transition_tool/transition_tool.py
+++ b/src/evm_transition_tool/transition_tool.py
@@ -163,14 +163,6 @@ class TransitionTool(FixtureVerifier):
 
         return cls.detect_binary_pattern.match(binary_output) is not None
 
-    @classmethod
-    def empty_string_to(cls) -> bool:
-        """
-        Returns True if the tool requires an empty string `to` field
-        for contract creating transactions.
-        """
-        return False
-
     def version(self) -> str:
         """
         Return name and version of tool used to state transition
@@ -257,15 +249,6 @@ class TransitionTool(FixtureVerifier):
         fork_name: str
         chain_id: int = field(default=1)
         reward: int = field(default=0)
-        empty_string_to: bool = field(default=False)
-
-        def __post_init__(self):
-            """
-            Ensure that the `to` field of transactions is not None
-            """
-            if self.empty_string_to:
-                for tx in self.txs:
-                    tx["to"] = tx.get("to") or ""
 
         def to_input(self) -> TransitionToolInput:
             """
@@ -532,14 +515,13 @@ class TransitionTool(FixtureVerifier):
             fork_name = "+".join([fork_name] + [str(eip) for eip in eips])
         if env.number == 0:
             reward = -1
-        t8n_data = TransitionTool.TransitionToolData(
+        t8n_data = self.TransitionToolData(
             alloc=alloc,
             txs=txs,
             env=env,
             fork_name=fork_name,
             chain_id=chain_id,
             reward=reward,
-            empty_string_to=self.empty_string_to(),
         )
 
         if self.t8n_use_stream:

--- a/src/evm_transition_tool/types.py
+++ b/src/evm_transition_tool/types.py
@@ -98,4 +98,4 @@ class TransitionToolOutput(CamelModel):
 
     alloc: Alloc
     result: Result
-    body: Bytes
+    body: Bytes | None = None


### PR DESCRIPTION
## 🗒️ Description
Removes the empty-to-string workaround since https://github.com/ethereum/evmone/issues/923 has been fixed and closed.

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
