### PR TITLE
Changes to #691

### DIFF
--- a/src/ethereum_test_fixtures/__init__.py
+++ b/src/ethereum_test_fixtures/__init__.py
@@ -6,6 +6,7 @@ from typing import List, Type
 
 from .base import BaseFixture
 from .blockchain import Fixture as BlockchainFixture
+from .blockchain import FixtureCommon as BlockchainFixtureCommon
 from .blockchain import HiveFixture as BlockchainHiveFixture
 from .collector import FixtureCollector, TestInfo
 from .eof import Fixture as EOFFixture
@@ -23,6 +24,7 @@ __all__ = [
     "FIXTURE_TYPES",
     "BaseFixture",
     "BlockchainFixture",
+    "BlockchainFixtureCommon",
     "BlockchainHiveFixture",
     "EOFFixture",
     "FixtureCollector",

--- a/src/pytest_plugins/consume/hive_simulators/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/conftest.py
@@ -1,0 +1,197 @@
+"""
+Common pytest fixtures for the RLP and Engine simulators.
+"""
+import io
+import json
+import time
+from typing import Generator, List, Mapping, cast
+
+import pytest
+import rich
+from hive.client import Client, ClientType
+from hive.testing import HiveTest
+from pydantic import BaseModel
+
+from ethereum_test_base_types import Bytes, to_json
+from ethereum_test_fixtures import BlockchainFixtureCommon
+from ethereum_test_fixtures.consume import TestCaseIndexFile, TestCaseStream
+from ethereum_test_tools.rpc import EthRPC
+from pytest_plugins.consume.hive_simulators.ruleset import ruleset  # TODO: generate dynamically
+
+
+class TestCaseTimingData(BaseModel):
+    """
+    The times taken to perform the various steps of a test case (seconds).
+    """
+
+    __test__ = False
+    prepare_files: float | None = None  # start of test until client start
+    start_client: float | None = None
+    get_genesis: float | None = None
+    get_last_block: float | None = None
+    stop_client: float | None = None
+    total: float | None = None
+
+    @staticmethod
+    def format_float(num: float | None, precision: int = 4) -> str | None:
+        """
+        Format a float to a specific precision in significant figures.
+        """
+        if num is None:
+            return None
+        return f"{num:.{precision}f}"
+
+    def formatted(self, precision: int = 4) -> "TestCaseTimingData":
+        """
+        Return a new instance of the model with formatted float values.
+        """
+        data = {field: self.format_float(value, precision) for field, value in self}
+        return TestCaseTimingData(**data)
+
+
+@pytest.fixture(scope="function")
+def eth_rpc(client: Client) -> EthRPC:
+    """
+    Initialize ethereum RPC client for the execution client under test.
+    """
+    return EthRPC(ip=client.ip)
+
+
+@pytest.fixture(scope="function")
+def fixture_description(
+    blockchain_fixture: BlockchainFixtureCommon, test_case: TestCaseIndexFile | TestCaseStream
+) -> str:
+    """
+    Create the description of the current blockchain fixture test case.
+    """
+    description = f"Test id: {test_case.id}"
+    if "url" in blockchain_fixture.info:
+        description += f"\n\nTest source: {blockchain_fixture.info['url']}"
+    if "description" not in blockchain_fixture.info:
+        description += "\n\nNo description field provided in the fixture's 'info' section."
+    else:
+        description += f"\n\n{blockchain_fixture.info['description']}"
+    return description
+
+
+@pytest.fixture(scope="function")
+def t_test_start() -> float:
+    """
+    The time the test started; used to time fixture+file preparation and total time.
+    """
+    return time.perf_counter()
+
+
+@pytest.fixture(scope="function", autouse=True)
+def timing_data(request, t_test_start) -> Generator[TestCaseTimingData, None, None]:
+    """
+    Helper to record timing data for various stages of executing test case.
+    """
+    timing_data = TestCaseTimingData()
+    yield timing_data
+    timing_data.total = time.perf_counter() - t_test_start
+    rich.print(f"\nTimings (seconds): {timing_data.formatted()}")
+    if hasattr(request.node, "rep_call"):  # make available for test reports
+        request.node.rep_call.timings = timing_data
+
+
+@pytest.fixture(scope="function")
+@pytest.mark.usefixtures("timing_data")
+def client_genesis(blockchain_fixture: BlockchainFixtureCommon) -> dict:
+    """
+    Convert the fixture's genesis block header and pre-state to a client genesis state.
+    """
+    genesis = to_json(blockchain_fixture.genesis)  # NOTE: to_json() excludes None values
+    alloc = to_json(blockchain_fixture.pre)
+    # NOTE: nethermind requires account keys without '0x' prefix
+    genesis["alloc"] = {k.replace("0x", ""): v for k, v in alloc.items()}
+    return genesis
+
+
+@pytest.fixture(scope="function")
+def environment(blockchain_fixture: BlockchainFixtureCommon) -> dict:
+    """
+    Define the environment that hive will start the client with using the fork
+    rules specific for the simulator.
+    """
+    assert (
+        blockchain_fixture.fork in ruleset
+    ), f"fork '{blockchain_fixture.fork}' missing in hive ruleset"
+    return {
+        "HIVE_CHAIN_ID": "1",
+        "HIVE_FORK_DAO_VOTE": "1",
+        "HIVE_NODETYPE": "full",
+        **{k: f"{v:d}" for k, v in ruleset[blockchain_fixture.fork].items()},
+    }
+
+
+@pytest.fixture(scope="function")
+def blocks_rlp() -> List[Bytes]:
+    """
+    A list of the fixture's blocks encoded as RLP.
+
+    By default, no blocks are placed into this fixture, but `rlp` consumer will override this.
+    """
+    return []
+
+
+@pytest.fixture(scope="function")
+def buffered_genesis(client_genesis: dict) -> io.BufferedReader:
+    """
+    Create a buffered reader for the genesis block header of the current test
+    fixture.
+    """
+    genesis_json = json.dumps(client_genesis)
+    genesis_bytes = genesis_json.encode("utf-8")
+    return io.BufferedReader(cast(io.RawIOBase, io.BytesIO(genesis_bytes)))
+
+
+@pytest.fixture(scope="function")
+def buffered_blocks_rlp(blocks_rlp: List[bytes]) -> List[io.BufferedReader]:
+    """
+    Convert the RLP-encoded blocks of the current test fixture to buffered readers.
+    """
+    block_rlp_files = []
+    for _, block_rlp in enumerate(blocks_rlp):
+        block_rlp_stream = io.BytesIO(block_rlp)
+        block_rlp_files.append(io.BufferedReader(cast(io.RawIOBase, block_rlp_stream)))
+    return block_rlp_files
+
+
+@pytest.fixture(scope="function")
+def client_files(
+    buffered_genesis: io.BufferedReader,
+    buffered_blocks_rlp: list[io.BufferedReader],
+) -> Mapping[str, io.BufferedReader]:
+    """
+    Define the files that hive will start the client with.
+
+    The files are specified as a dictionary whose:
+    - Keys are the target file paths in the client's docker container, and,
+    - Values are in-memory buffered file objects.
+    """
+    files = {f"/blocks/{i + 1:04d}.rlp": rlp for i, rlp in enumerate(buffered_blocks_rlp)}
+    files["/genesis.json"] = buffered_genesis
+    return files
+
+
+@pytest.fixture(scope="function")
+def client(
+    hive_test: HiveTest,
+    client_files: dict,
+    environment: dict,
+    client_type: ClientType,
+) -> Generator[Client, None, None]:
+    """
+    Initialize the client with the appropriate files and environment variables.
+    """
+    client = hive_test.start_client(
+        client_type=client_type, environment=environment, files=client_files
+    )
+    error_message = (
+        f"Unable to connect to the client container ({client_type.name}) via Hive during test "
+        "setup. Check the client or Hive server logs for more information."
+    )
+    assert client is not None, error_message
+    yield client
+    client.stop()

--- a/src/pytest_plugins/consume/hive_simulators/engine/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/engine/conftest.py
@@ -4,24 +4,26 @@ Pytest fixtures for the `consume engine` simulator.
 Configures the hive back-end & EL clients for each individual test execution.
 """
 
-import io
-import json
 from pathlib import Path
-from typing import Generator, Mapping, cast
 
 import pytest
-from hive.client import Client, ClientType
-from hive.testing import HiveTest
+from hive.client import Client
 
-from ethereum_test_base_types.json import to_json
 from ethereum_test_fixtures import BlockchainHiveFixture
 from ethereum_test_fixtures.consume import TestCaseIndexFile, TestCaseStream
 from ethereum_test_fixtures.file import BlockchainHiveFixtures
-from ethereum_test_tools.rpc import EngineRPC, EthRPC
+from ethereum_test_tools.rpc import EngineRPC
 from pytest_plugins.consume.common import JsonSource
-from pytest_plugins.consume.hive_simulators.ruleset import ruleset  # TODO: generate dynamically
 
 TestCase = TestCaseIndexFile | TestCaseStream
+
+
+@pytest.fixture(scope="function")
+def engine_rpc(client: Client) -> EngineRPC:
+    """
+    Initialize engine RPC client for the execution client under test.
+    """
+    return EngineRPC(ip=client.ip)
 
 
 @pytest.fixture(scope="session")
@@ -37,23 +39,7 @@ def test_suite_description() -> str:
     """
     The description of the hive test suite used in this simulator.
     """
-    return "Execute blockchain tests by against clients using the `engine_newPayloadVX` method."
-
-
-@pytest.fixture(scope="function")
-def eth_rpc(client: Client) -> EthRPC:
-    """
-    Initialize ethereum RPC client for the execution client under test.
-    """
-    return EthRPC(ip=client.ip)
-
-
-@pytest.fixture(scope="function")
-def engine_rpc(client: Client) -> EngineRPC:
-    """
-    Initialize engine RPC client for the execution client under test.
-    """
-    return EngineRPC(ip=client.ip)
+    return "Execute blockchain tests by against clients using the Engine API."
 
 
 @pytest.fixture(scope="function")
@@ -78,90 +64,3 @@ def blockchain_fixture(fixture_source: JsonSource, test_case: TestCase) -> Block
         fixtures = BlockchainHiveFixtures.from_file(Path(fixture_source) / test_case.json_path)
         fixture = fixtures[test_case.id]
     return fixture
-
-
-@pytest.fixture(scope="function")
-def fixture_description(blockchain_fixture: BlockchainHiveFixture, test_case: TestCase) -> str:
-    """
-    Create the description of the current blockchain engine fixture test case.
-    """
-    description = f"Test id: {test_case.id}"
-    if "url" in blockchain_fixture.info:
-        description += f"\n\nTest source: {blockchain_fixture.info['url']}"
-    if "description" not in blockchain_fixture.info:
-        description += "\n\nNo description field provided in the fixture's 'info' section."
-    else:
-        description += f"\n\n{blockchain_fixture.info['description']}"
-    return description
-
-
-@pytest.fixture(scope="function")
-def client_genesis(blockchain_fixture: BlockchainHiveFixture) -> dict:
-    """
-    Convert the fixture's genesis block header and pre-state to a client genesis state.
-    """
-    genesis = to_json(blockchain_fixture.genesis)
-    alloc = to_json(blockchain_fixture.pre)
-    # NOTE: nethermind requires account keys without '0x' prefix
-    genesis["alloc"] = {k.replace("0x", ""): v for k, v in alloc.items()}
-    return genesis
-
-
-@pytest.fixture(scope="function")
-def buffered_genesis(client_genesis: dict) -> io.BufferedReader:
-    """
-    Create a buffered reader for the genesis block header of the current test
-    fixture.
-    """
-    genesis_json = json.dumps(client_genesis)
-    genesis_bytes = genesis_json.encode("utf-8")
-    return io.BufferedReader(cast(io.RawIOBase, io.BytesIO(genesis_bytes)))
-
-
-@pytest.fixture(scope="function")
-def client_files(buffered_genesis: io.BufferedReader) -> Mapping[str, io.BufferedReader]:
-    """
-    Define the files that hive will start the client with.
-    """
-    files = {}
-    files["/genesis.json"] = buffered_genesis
-    return files
-
-
-@pytest.fixture(scope="function")
-def environment(blockchain_fixture: BlockchainHiveFixture) -> dict:
-    """
-    Define the environment that hive will start the client with using the fork
-    rules specific for the simulator.
-    """
-    assert (
-        blockchain_fixture.fork in ruleset
-    ), f"fork '{blockchain_fixture.fork}' missing in hive ruleset"
-    return {
-        "HIVE_CHAIN_ID": "1",
-        "HIVE_FORK_DAO_VOTE": "1",
-        "HIVE_NODETYPE": "full",
-        **{k: f"{v:d}" for k, v in ruleset[blockchain_fixture.fork].items()},
-    }
-
-
-@pytest.fixture(scope="function")
-def client(
-    hive_test: HiveTest,
-    client_files: dict,
-    environment: dict,
-    client_type: ClientType,
-) -> Generator[Client, None, None]:
-    """
-    Initialize the client with the appropriate files and environment variables.
-    """
-    client = hive_test.start_client(
-        client_type=client_type, environment=environment, files=client_files
-    )
-    error_message = (
-        f"Unable to connect to the client container ({client_type.name}) via Hive during test "
-        "setup. Check the client or Hive server logs for more information."
-    )
-    assert client is not None, error_message
-    yield client
-    client.stop()

--- a/src/pytest_plugins/consume/hive_simulators/rlp/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/rlp/conftest.py
@@ -2,57 +2,18 @@
 Pytest fixtures and classes for the `consume rlp` hive simulator.
 """
 
-import io
-import json
-import time
 from pathlib import Path
-from typing import Generator, List, Mapping, Optional, cast
+from typing import List
 
 import pytest
-import rich
-from hive.client import Client, ClientType
-from hive.testing import HiveTest
-from pydantic import BaseModel
 
-from ethereum_test_base_types import Bytes, to_json
+from ethereum_test_base_types import Bytes
 from ethereum_test_fixtures import BlockchainFixture
 from ethereum_test_fixtures.consume import TestCaseIndexFile, TestCaseStream
 from ethereum_test_fixtures.file import BlockchainFixtures
-from ethereum_test_tools.rpc import EthRPC
 from pytest_plugins.consume.common import JsonSource
-from pytest_plugins.consume.hive_simulators.ruleset import ruleset  # TODO: generate dynamically
 
 TestCase = TestCaseIndexFile | TestCaseStream
-
-
-class TestCaseTimingData(BaseModel):
-    """
-    The times taken to perform the various steps of a test case (seconds).
-    """
-
-    __test__ = False
-    prepare_files: Optional[float] = None  # start of test until client start
-    start_client: Optional[float] = None
-    get_genesis: Optional[float] = None
-    get_last_block: Optional[float] = None
-    stop_client: Optional[float] = None
-    total: Optional[float] = None
-
-    @staticmethod
-    def format_float(num: float | None, precision: int = 4) -> str | None:
-        """
-        Format a float to a specific precision in significant figures.
-        """
-        if num is None:
-            return None
-        return f"{num:.{precision}f}"
-
-    def formatted(self, precision: int = 4) -> "TestCaseTimingData":
-        """
-        Return a new instance of the model with formatted float values.
-        """
-        data = {field: self.format_float(value, precision) for field, value in self}
-        return TestCaseTimingData(**data)
 
 
 @pytest.fixture(scope="session")
@@ -69,14 +30,6 @@ def test_suite_description() -> str:
     The description of the hive test suite used in this simulator.
     """
     return "Execute blockchain tests by providing RLP-encoded blocks to a client upon start-up."
-
-
-@pytest.fixture(scope="function")
-def eth_rpc(client: Client) -> EthRPC:
-    """
-    Initialize ethereum RPC client for the execution client under test.
-    """
-    return EthRPC(ip=client.ip)
 
 
 @pytest.fixture(scope="function")
@@ -104,138 +57,8 @@ def blockchain_fixture(fixture_source: JsonSource, test_case: TestCase) -> Block
 
 
 @pytest.fixture(scope="function")
-def fixture_description(
-    blockchain_fixture: BlockchainFixture, test_case: TestCaseIndexFile | TestCaseStream
-) -> str:
-    """
-    Create the description of the current blockchain fixture test case.
-    """
-    description = f"Test id: {test_case.id}"
-    if "url" in blockchain_fixture.info:
-        description += f"\n\nTest source: {blockchain_fixture.info['url']}"
-    if "description" not in blockchain_fixture.info:
-        description += "\n\nNo description field provided in the fixture's 'info' section."
-    else:
-        description += f"\n\n{blockchain_fixture.info['description']}"
-    return description
-
-
-@pytest.fixture(scope="function")
-def t_test_start() -> float:
-    """
-    The time the test started; used to time fixture+file preparation and total time.
-    """
-    return time.perf_counter()
-
-
-@pytest.fixture(scope="function", autouse=True)
-def timing_data(request, t_test_start) -> Generator[TestCaseTimingData, None, None]:
-    """
-    Helper to record timing data for various stages of executing test case.
-    """
-    timing_data = TestCaseTimingData()
-    yield timing_data
-    timing_data.total = time.perf_counter() - t_test_start
-    rich.print(f"\nTimings (seconds): {timing_data.formatted()}")
-    if hasattr(request.node, "rep_call"):  # make available for test reports
-        request.node.rep_call.timings = timing_data
-
-
-@pytest.fixture(scope="function")
-@pytest.mark.usefixtures("timing_data")
-def client_genesis(blockchain_fixture: BlockchainFixture) -> dict:
-    """
-    Convert the fixture's genesis block header and pre-state to a client genesis state.
-    """
-    genesis = to_json(blockchain_fixture.genesis)  # NOTE: to_json() excludes None values
-    alloc = to_json(blockchain_fixture.pre)
-    # NOTE: nethermind requires account keys without '0x' prefix
-    genesis["alloc"] = {k.replace("0x", ""): v for k, v in alloc.items()}
-    return genesis
-
-
-@pytest.fixture(scope="function")
 def blocks_rlp(blockchain_fixture: BlockchainFixture) -> List[Bytes]:
     """
     A list of the fixture's blocks encoded as RLP.
     """
     return [block.rlp for block in blockchain_fixture.blocks]
-
-
-@pytest.fixture(scope="function")
-def buffered_genesis(client_genesis: dict) -> io.BufferedReader:
-    """
-    Create a buffered reader for the genesis block header of the current test
-    fixture.
-    """
-    genesis_json = json.dumps(client_genesis)
-    genesis_bytes = genesis_json.encode("utf-8")
-    return io.BufferedReader(cast(io.RawIOBase, io.BytesIO(genesis_bytes)))
-
-
-@pytest.fixture(scope="function")
-def buffered_blocks_rlp(blocks_rlp: List[bytes]) -> List[io.BufferedReader]:
-    """
-    Convert the RLP-encoded blocks of the current test fixture to buffered readers.
-    """
-    block_rlp_files = []
-    for _, block_rlp in enumerate(blocks_rlp):
-        block_rlp_stream = io.BytesIO(block_rlp)
-        block_rlp_files.append(io.BufferedReader(cast(io.RawIOBase, block_rlp_stream)))
-    return block_rlp_files
-
-
-@pytest.fixture(scope="function")
-def client_files(
-    buffered_genesis: io.BufferedReader,
-    buffered_blocks_rlp: list[io.BufferedReader],
-) -> Mapping[str, io.BufferedReader]:
-    """
-    Define the files that hive will start the client with.
-
-    The files are specified as a dictionary whose:
-    - Keys are the target file paths in the client's docker container, and,
-    - Values are in-memory buffered file objects.
-    """
-    files = {f"/blocks/{i + 1:04d}.rlp": rlp for i, rlp in enumerate(buffered_blocks_rlp)}
-    files["/genesis.json"] = buffered_genesis
-    return files
-
-
-@pytest.fixture(scope="function")
-def environment(blockchain_fixture: BlockchainFixture) -> dict:
-    """
-    Define the environment that hive will start the client with using the fork
-    rules specific for the simulator.
-    """
-    assert (
-        blockchain_fixture.fork in ruleset
-    ), f"fork '{blockchain_fixture.fork}' missing in hive ruleset"
-    return {
-        "HIVE_CHAIN_ID": "1",
-        "HIVE_FORK_DAO_VOTE": "1",
-        "HIVE_NODETYPE": "full",
-        **{k: f"{v:d}" for k, v in ruleset[blockchain_fixture.fork].items()},
-    }
-
-
-@pytest.fixture(scope="function")
-def client(
-    hive_test: HiveTest,
-    client_files: dict,
-    environment: dict,
-    client_type: ClientType,
-) -> Generator[Client, None, None]:
-    """
-    Initialize the client with the appropriate files and environment variables.
-    """
-    client = hive_test.start_client(
-        client_type=client_type, environment=environment, files=client_files
-    )
-    error_message = (
-        f"Unable to connect to the client container ({client_type.name}) via Hive during test "
-        "setup. Check the client or Hive server logs for more information."
-    )
-    assert client is not None, error_message
-    yield client
-    client.stop()


### PR DESCRIPTION
## 🗒️ Description
Moves common fixtures from `src/pytest_plugins/consume/hive_simulators/rlp/conftest.py` and `src/pytest_plugins/consume/hive_simulators/engine/conftest.py` to a generalized form within `src/pytest_plugins/consume/hive_simulators/conftest.py`.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
