### PR TITLE
chore(tools/rpc): Improve RPC typing

### DIFF
--- a/src/ethereum_test_tools/rpc/rpc.py
+++ b/src/ethereum_test_tools/rpc/rpc.py
@@ -151,7 +151,7 @@ class EthRPC(BaseRPC):
 
     def send_transactions(self, transactions: List[Transaction]):
         """
-        `eth_sendRawTransaction`: Send a list of transactions to the client.
+        Uses `eth_sendRawTransaction` to send a list of transactions to the client.
         """
         for tx in transactions:
             self.send_transaction(tx)
@@ -187,7 +187,7 @@ class EthRPC(BaseRPC):
         self, transactions: List[Transaction], timeout: int = 60
     ) -> List[TransactionByHashResponse]:
         """
-        Uses `eth_getTransactionByHash` to wait for all transactions in list are included in a
+        Uses `eth_getTransactionByHash` to wait unitl all transactions in list are included in a
         block.
         """
         tx_hashes = [tx.hash for tx in transactions]
@@ -216,7 +216,7 @@ class EthRPC(BaseRPC):
 
     def send_wait_transactions(self, transactions: List[Transaction], timeout: int = 60):
         """
-        Sends a transaction and waits until it is included in a block.
+        Sends a list of transactions and waits until all of them are included in a block.
         """
         self.send_transactions(transactions)
         return self.wait_for_transactions(transactions, timeout)

--- a/src/ethereum_test_tools/rpc/rpc.py
+++ b/src/ethereum_test_tools/rpc/rpc.py
@@ -10,9 +10,18 @@ import requests
 from jwt import encode
 from tenacity import retry, stop_after_attempt, wait_exponential
 
-from ethereum_test_base_types import Address, Hash
-from ethereum_test_base_types.json import to_json
-from ethereum_test_tools.rpc.types import ForkchoiceState, ForkchoiceUpdateResponse, PayloadStatus
+from ethereum_test_base_types import Address, Bytes, Hash, to_json
+from ethereum_test_types import Transaction
+
+from .types import (
+    ForkchoiceState,
+    ForkchoiceUpdateResponse,
+    GetPayloadResponse,
+    JSONRPCError,
+    PayloadAttributes,
+    PayloadStatus,
+    TransactionByHashResponse,
+)
 
 BlockNumberType = Union[int, Literal["latest", "earliest", "pending"]]
 
@@ -62,19 +71,13 @@ class BaseRPC:
         response = requests.post(self.url, json=payload, headers=headers)
         response.raise_for_status()
         response_json = response.json()
+
+        if "error" in response_json:
+            exception = JSONRPCError(**response_json["error"])
+            raise exception.exception(method)
+
         assert "result" in response_json, "RPC response didn't contain a result field"
         result = response_json["result"]
-
-        if result is None or "error" in result:
-            error_info = "result is None; and therefore contains no error info"
-            error_code = None
-            if result is not None:
-                error_info = result["error"]
-                error_code = result["error"]["code"]
-            raise Exception(
-                f"Error calling JSON RPC {method}, code: {error_code}, " f"message: {error_info}"
-            )
-
         return result
 
 
@@ -106,6 +109,13 @@ class EthRPC(BaseRPC):
         block = hex(block_number) if isinstance(block_number, int) else block_number
         return int(self.post_request("getBalance", f"{address}", block), 16)
 
+    def get_code(self, address: Address, block_number: BlockNumberType = "latest") -> Bytes:
+        """
+        `eth_getCode`: Returns code at a given address.
+        """
+        block = hex(block_number) if isinstance(block_number, int) else block_number
+        return Bytes(self.post_request("getCode", f"{address}", block))
+
     def get_transaction_count(
         self, address: Address, block_number: BlockNumberType = "latest"
     ) -> int:
@@ -115,33 +125,101 @@ class EthRPC(BaseRPC):
         block = hex(block_number) if isinstance(block_number, int) else block_number
         return int(self.post_request("getTransactionCount", f"{address}", block), 16)
 
-    def get_transaction_by_hash(self, transaction_hash: str):
+    def get_transaction_by_hash(self, transaction_hash: Hash) -> TransactionByHashResponse:
         """
         `eth_getTransactionByHash`: Returns transaction details.
         """
-        return self.post_request("getTransactionByHash", f"{transaction_hash}")
+        return TransactionByHashResponse(
+            **self.post_request("getTransactionByHash", f"{transaction_hash}")
+        )
 
     def get_storage_at(
         self, address: Address, position: Hash, block_number: BlockNumberType = "latest"
-    ):
+    ) -> Hash:
         """
         `eth_getStorageAt`: Returns the value from a storage position at a given address.
         """
         block = hex(block_number) if isinstance(block_number, int) else block_number
-        return self.post_request("getStorageAt", f"{address}", f"{position}", block)
+        return Hash(self.post_request("getStorageAt", f"{address}", f"{position}", block))
+
+    def send_transaction(self, transaction: Transaction):
+        """
+        `eth_sendRawTransaction`: Send a transaction to the client.
+        """
+        result_hash = Hash(self.post_request("sendRawTransaction", f"0x{transaction.rlp.hex()}"))
+        assert result_hash == transaction.hash
+
+    def send_transactions(self, transactions: List[Transaction]):
+        """
+        `eth_sendRawTransaction`: Send a list of transactions to the client.
+        """
+        for tx in transactions:
+            self.send_transaction(tx)
 
     def storage_at_keys(
         self, account: Address, keys: List[Hash], block_number: BlockNumberType = "latest"
-    ) -> Dict:
+    ) -> Dict[Hash, Hash]:
         """
         Helper to retrieve the storage values for the specified keys at a given address and block
         number.
         """
-        results: Dict = {}
+        results: Dict[Hash, Hash] = {}
         for key in keys:
             storage_value = self.get_storage_at(account, key, block_number)
             results[key] = storage_value
         return results
+
+    def wait_for_transaction(
+        self, transaction: Transaction, timeout: int = 60
+    ) -> TransactionByHashResponse:
+        """
+        Uses `eth_getTransactionByHash` to wait until a transaction is included in a block.
+        """
+        tx_hash = transaction.hash
+        for _ in range(timeout):
+            tx = self.get_transaction_by_hash(tx_hash)
+            if tx.block_number is not None:
+                return tx
+            time.sleep(1)
+        raise Exception(f"Transaction {tx_hash} not included in a block after {timeout} seconds")
+
+    def wait_for_transactions(
+        self, transactions: List[Transaction], timeout: int = 60
+    ) -> List[TransactionByHashResponse]:
+        """
+        Uses `eth_getTransactionByHash` to wait for all transactions in list are included in a
+        block.
+        """
+        tx_hashes = [tx.hash for tx in transactions]
+        responses: List[TransactionByHashResponse] = []
+        for _ in range(timeout):
+            i = 0
+            while i < len(tx_hashes):
+                tx_hash = tx_hashes[i]
+                tx = self.get_transaction_by_hash(tx_hash)
+                if tx.block_number is not None:
+                    responses.append(tx)
+                    tx_hashes.pop(i)
+                else:
+                    i += 1
+            if not tx_hashes:
+                return responses
+            time.sleep(1)
+        raise Exception(f"Transaction {tx_hash} not included in a block after {timeout} seconds")
+
+    def send_wait_transaction(self, transaction: Transaction, timeout: int = 60):
+        """
+        Sends a transaction and waits until it is included in a block.
+        """
+        self.send_transaction(transaction)
+        return self.wait_for_transaction(transaction, timeout)
+
+    def send_wait_transactions(self, transactions: List[Transaction], timeout: int = 60):
+        """
+        Sends a transaction and waits until it is included in a block.
+        """
+        self.send_transactions(transactions)
+        return self.wait_for_transactions(transactions, timeout)
 
 
 class DebugRPC(EthRPC):
@@ -194,7 +272,7 @@ class EngineRPC(BaseRPC):
     def forkchoice_updated(
         self,
         forkchoice_state: ForkchoiceState,
-        payload_attributes: Dict | None = None,
+        payload_attributes: PayloadAttributes | None = None,
         *,
         version: int,
     ) -> ForkchoiceUpdateResponse:
@@ -205,6 +283,23 @@ class EngineRPC(BaseRPC):
             **self.post_request(
                 f"forkchoiceUpdatedV{version}",
                 to_json(forkchoice_state),
-                payload_attributes,
+                to_json(payload_attributes) if payload_attributes is not None else None,
+            )
+        )
+
+    def get_payload(
+        self,
+        payload_id: Bytes,
+        *,
+        version: int,
+    ) -> GetPayloadResponse:
+        """
+        `engine_getPayloadVX`: Retrieves a payload that was requested through
+        `engine_forkchoiceUpdatedVX`.
+        """
+        return GetPayloadResponse(
+            **self.post_request(
+                f"getPayloadV{version}",
+                f"{payload_id}",
             )
         )

--- a/src/ethereum_test_tools/rpc/types.py
+++ b/src/ethereum_test_tools/rpc/types.py
@@ -3,10 +3,59 @@ Types used in the RPC module for `eth` and `engine` namespaces' requests.
 """
 
 from enum import Enum
+from typing import List
 
 from pydantic import Field
 
-from ethereum_test_base_types import CamelModel, Hash, HexNumber
+from ethereum_test_base_types import Address, Bytes, CamelModel, Hash, HexNumber
+from ethereum_test_fixtures.blockchain import FixtureExecutionPayload
+from ethereum_test_types import Withdrawal
+
+
+class JSONRPCError(CamelModel):
+    """
+    Model to parse a JSON RPC error response.
+    """
+
+    code: int
+    message: str
+
+    def __str__(self) -> str:
+        """
+        Returns a string representation of the JSONRPCError.
+        """
+        return f"JSONRPCError(code={self.code}, message={self.message})"
+
+    def exception(self, method) -> Exception:
+        """
+        Returns an exception representation of the JSONRPCError.
+        """
+        return Exception(
+            f"Error calling JSON RPC {method}, code: {self.code}, " f"message: {self.message}"
+        )
+
+
+class TransactionByHashResponse(CamelModel):
+    """
+    Represents the response of a transaction by hash request.
+    """
+
+    block_hash: Hash | None = None
+    block_number: HexNumber | None = None
+
+    transaction_hash: Hash = Field(..., alias="hash")
+    from_address: Address = Field(..., alias="from")
+    to_address: Address | None = Field(..., alias="to")
+
+    ty: HexNumber = Field(..., alias="type")
+    gas_limit: HexNumber = Field(..., alias="gas")
+    gas_price: HexNumber
+    value: HexNumber
+    data: Bytes = Field(..., alias="input")
+    nonce: HexNumber
+    v: HexNumber
+    r: HexNumber
+    s: HexNumber
 
 
 class ForkchoiceState(CamelModel):
@@ -15,8 +64,8 @@ class ForkchoiceState(CamelModel):
     """
 
     head_block_hash: Hash = Field(Hash(0))
-    safety_block_hash: Hash = Field(Hash(0))
-    justified_block_hash: Hash = Field(Hash(0))
+    safe_block_hash: Hash = Field(Hash(0))
+    finalized_block_hash: Hash = Field(Hash(0))
 
 
 class PayloadStatusEnum(str, Enum):
@@ -47,4 +96,41 @@ class ForkchoiceUpdateResponse(CamelModel):
     """
 
     payload_status: PayloadStatus
-    payload_id: HexNumber | None
+    payload_id: Bytes | None
+
+
+class PayloadAttributes(CamelModel):
+    """
+    Represents the attributes of a payload.
+    """
+
+    timestamp: HexNumber
+    prev_randao: Hash
+    suggested_fee_recipient: Address
+    withdrawals: List[Withdrawal] | None = None
+    parent_beacon_block_root: Hash | None = None
+
+
+class BlobsBundle(CamelModel):
+    """
+    Represents the bundle of blobs.
+    """
+
+    commitments: List[Bytes]
+    proofs: List[Bytes]
+    blobs: List[Bytes]
+
+    def blob_versioned_hashes(self) -> List[Hash]:
+        """
+        Returns the versioned hashes of the blobs.
+        """
+        return [Hash(b"\1" + commitment[1:]) for commitment in self.commitments]
+
+
+class GetPayloadResponse(CamelModel):
+    """
+    Represents the response of a get payload request.
+    """
+
+    execution_payload: FixtureExecutionPayload
+    blobs_bundle: BlobsBundle | None = None

--- a/src/ethereum_test_types/types.py
+++ b/src/ethereum_test_types/types.py
@@ -843,6 +843,13 @@ class Transaction(TransactionGeneric[HexNumber], TransactionTransitionToolConver
             return eth_rlp.encode(self.payload_body)
 
     @cached_property
+    def hash(self) -> Hash:
+        """
+        Returns hash of the transaction.
+        """
+        return Hash(keccak256(self.rlp))
+
+    @cached_property
     def signing_bytes(self) -> bytes:
         """
         Returns the serialized bytes of the transaction used for signing.


### PR DESCRIPTION
## 🗒️ Description
Adds missing methods and typing to the `ethereum_test_tools/rpc` library.

Used in some draft PRs.

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
