### PR TITLE
fix(evm_transition_tool): fix `--evm-dump-dir`

### DIFF
--- a/src/evm_transition_tool/file_utils.py
+++ b/src/evm_transition_tool/file_utils.py
@@ -2,11 +2,12 @@
 Methods to work with the filesystem and json
 """
 
-import json
 import os
 import stat
 from json import dump
 from typing import Any, Dict
+
+from pydantic import BaseModel, RootModel
 
 
 def write_json_file(data: Dict[str, Any], file_path: str) -> None:
@@ -14,7 +15,7 @@ def write_json_file(data: Dict[str, Any], file_path: str) -> None:
     Write a JSON file to the given path.
     """
     with open(file_path, "w") as f:
-        json.dump(data, f, ensure_ascii=False, indent=4)
+        dump(data, f, ensure_ascii=False, indent=4)
 
 
 def dump_files_to_directory(output_path: str, files: Dict[str, Any]) -> None:
@@ -33,7 +34,15 @@ def dump_files_to_directory(output_path: str, files: Dict[str, Any]) -> None:
             os.makedirs(os.path.join(output_path, rel_path), exist_ok=True)
         file_path = os.path.join(output_path, file_rel_path)
         with open(file_path, "w") as f:
-            if isinstance(file_contents, str):
+            if isinstance(file_contents, BaseModel) or isinstance(file_contents, RootModel):
+                f.write(
+                    file_contents.model_dump_json(
+                        indent=4,
+                        exclude_none=True,
+                        by_alias=True,
+                    )
+                )
+            elif isinstance(file_contents, str):
                 f.write(file_contents)
             else:
                 dump(file_contents, f, ensure_ascii=True, indent=4)

--- a/src/evm_transition_tool/transition_tool.py
+++ b/src/evm_transition_tool/transition_tool.py
@@ -405,10 +405,8 @@ class TransitionTool(FixtureVerifier):
             dump_files_to_directory(
                 debug_output_path,
                 {
-                    "output/alloc.json": output.alloc.model_dump(mode="json", **model_dump_config),
-                    "output/result.json": output.result.model_dump(
-                        mode="json", **model_dump_config
-                    ),
+                    "output/alloc.json": output.alloc,
+                    "output/result.json": output.result,
                     "output/txs.rlp": str(output.body),
                 },
             )
@@ -476,8 +474,8 @@ class TransitionTool(FixtureVerifier):
             debug_output_path,
             {
                 "args.py": args,
-                "input/alloc.json": stdin.alloc.model_dump(mode="json", **model_dump_config),
-                "input/env.json": stdin.env.model_dump(mode="json", **model_dump_config),
+                "input/alloc.json": stdin.alloc,
+                "input/env.json": stdin.env,
                 "input/txs.json": [
                     tx.model_dump(mode="json", **model_dump_config) for tx in stdin.txs
                 ],


### PR DESCRIPTION
## 🗒️ Description
Fix JSON dump when using `--evm-dump-dir`.

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
