### PR TITLE
fix(specs,transition_tool): Trace dump fixes

### DIFF
--- a/src/ethereum_test_specs/eof.py
+++ b/src/ethereum_test_specs/eof.py
@@ -349,6 +349,7 @@ class EOFStateTest(EOFTest):
             tx=tx,
             env=self.env,
             post=post,
+            t8n_dump_dir=self.t8n_dump_dir,
         )
 
     def generate(

--- a/src/evm_transition_tool/transition_tool.py
+++ b/src/evm_transition_tool/transition_tool.py
@@ -365,13 +365,13 @@ class TransitionTool(FixtureVerifier):
                 continue
             with open(file_path, "r+") as file:
                 output_contents[key] = json.load(file)
-
+        output = TransitionToolOutput(**output_contents)
         if self.trace:
-            self.collect_traces(output_contents["result"]["receipts"], temp_dir, debug_output_path)
+            self.collect_traces(output.result.receipts, temp_dir, debug_output_path)
 
         temp_dir.cleanup()
 
-        return TransitionToolOutput(**output_contents)
+        return output
 
     def _evaluate_stream(
         self,


### PR DESCRIPTION
## 🗒️ Description
Fixes trace dumping in two scenarios.

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.