### PR TITLE
chore(consume): fix `--input` when running from hive

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -54,8 +54,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Write a properties file to the output directory and enable direct generation of a fixture tarball from `fill` via `--output=fixtures.tgz`([#627](https://github.com/ethereum/execution-spec-tests/pull/627)).
 - 🔀 `ethereum_test_tools` library has been split into multiple libraries ([#645](https://github.com/ethereum/execution-spec-tests/pull/645)).
 - ✨ Add the consume engine simulator and refactor the consume simulator suite. ([#691](https://github.com/ethereum/execution-spec-tests/pull/691)).
-
-### 🔧 EVM Tools
+- 🐞 Prevents forcing consume to use stdin as an input when running from hive. ([#701](https://github.com/ethereum/execution-spec-tests/pull/701)).
 
 ### 📋 Misc
 

--- a/src/cli/pytest_commands.py
+++ b/src/cli/pytest_commands.py
@@ -187,6 +187,13 @@ def all_consume_test_paths() -> list:
     return [consume_test_paths(command) for command in get_args(ConsumeCommands)]
 
 
+def input_provided(args) -> bool:
+    """
+    Returns true if `--input` is provided via the command line.
+    """
+    return any(arg.startswith("--input") for arg in args)
+
+
 @click.group()
 def consume():
     """
@@ -203,7 +210,7 @@ def consume_direct(pytest_args, help_flag, pytest_help_flag):
     """
     args = handle_help_flags(pytest_args, help_flag, pytest_help_flag)
     args += ["-c", "pytest-consume.ini", "--rootdir", "./", consume_test_paths("direct")]
-    if not sys.stdin.isatty():  # the command is receiving input on stdin
+    if not input_provided(args) and not sys.stdin.isatty():  # command is receiving input on stdin
         args.extend(["-s", "--input=stdin"])
     pytest.main(args)
 
@@ -225,7 +232,7 @@ def consume_via_rlp(pytest_args, help_flag, pytest_help_flag):
         "pytest_plugins.pytest_hive.pytest_hive",
     ]
     args += get_hive_flags_from_env()
-    if not sys.stdin.isatty():  # the command is receiving input on stdin
+    if not input_provided(args) and not sys.stdin.isatty():  # command is receiving input on stdin
         args.extend(["-s", "--input=stdin"])
     pytest.main(args)
 
@@ -247,7 +254,7 @@ def consume_via_engine_api(pytest_args, help_flag, pytest_help_flag):
         "pytest_plugins.pytest_hive.pytest_hive",
     ]
     args += get_hive_flags_from_env()
-    if not sys.stdin.isatty():  # the command is receiving input on stdin
+    if not input_provided(args) and not sys.stdin.isatty():  # command is receiving input on stdin
         args.extend(["-s", "--input=stdin"])
     pytest.main(args)
 

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -333,6 +333,7 @@ StateTest
 StateTests
 StateTestFiller
 staticcalled
+stdin
 stExample
 str
 streetsidesoftware


### PR DESCRIPTION
## 🗒️ Description

This PR allows us to run consume commands using the following Dockerfile entrypoint from hive:
```dockerfile
ENTRYPOINT ["consume", "engine", "--input=https://.../execution-spec-tests/releases/.../fixtures.tar.gz", "-v"]
```

### Problem
The condition `if not sys.stdin.isatty():` checks if the standard input (stdin) is connected to a terminal. If it's not connected to a terminal, it implies that the input might be coming from a pipe or a file, which is why the command adds --input=stdin. 

In a Docker container, `sys.stdin.isatty()` returns False because Docker doesn't provide a terminal interface by default. This causes an issue where the input is incorrectly automatically set to stdin when running in Docker.

### Solution
To fix the latter we additionally check for `--input` within the consume command arguements. We do not supply this when piping.

## 🔗 Related Issues
N/A

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
