### PR TITLE
new(tests): EOF - EIP-3540: Expand section size testing

### DIFF
--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/container.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/container.py
@@ -79,6 +79,40 @@ INVALID: List[Container] = [
         validity_error=EOFException.INCOMPLETE_SECTION_SIZE,
     ),
     Container(
+        name="code_section_count_0x8000_truncated",
+        raw_bytes=bytes([0xEF, 0x00, 0x01, 0x01, 0x00, 0x04, 0x02, 0x80, 0x00]),
+        validity_error=EOFException.TOO_MANY_CODE_SECTIONS,
+    ),
+    Container(
+        name="code_section_count_0xFFFF_truncated",
+        raw_bytes=bytes([0xEF, 0x00, 0x01, 0x01, 0x00, 0x04, 0x02, 0xFF, 0xFF]),
+        validity_error=EOFException.TOO_MANY_CODE_SECTIONS,
+    ),
+    Container(
+        name="code_section_count_0x8000",
+        raw_bytes=bytes(
+            [0xEF, 0x00, 0x01, 0x01, 0x00, 0x04, 0x02, 0x80, 0x00] + [0x00, 0x01] * 0x8000
+        ),
+        validity_error=EOFException.CONTAINER_SIZE_ABOVE_LIMIT,
+    ),
+    Container(
+        name="code_section_count_0xFFFF",
+        raw_bytes=bytes(
+            [0xEF, 0x00, 0x01, 0x01, 0x00, 0x04, 0x02, 0xFF, 0xFF] + [0x00, 0x01] * 0xFFFF
+        ),
+        validity_error=EOFException.CONTAINER_SIZE_ABOVE_LIMIT,
+    ),
+    Container(
+        name="code_section_size_0x8000_truncated",
+        raw_bytes=bytes([0xEF, 0x00, 0x01, 0x01, 0x00, 0x04, 0x02, 0x00, 0x01, 0x80, 0x00]),
+        validity_error=EOFException.MISSING_HEADERS_TERMINATOR,
+    ),
+    Container(
+        name="code_section_size_0xFFFF_truncated",
+        raw_bytes=bytes([0xEF, 0x00, 0x01, 0x01, 0x00, 0x04, 0x02, 0x00, 0x01, 0xFF, 0xFF]),
+        validity_error=EOFException.MISSING_HEADERS_TERMINATOR,
+    ),
+    Container(
         name="terminator_incomplete",
         raw_bytes=bytes(
             [0xEF, 0x00, 0x01, 0x01, 0x00, 0x04, 0x02, 0x00, 0x01, 0x00, 0x01, 0x04, 0x00, 0x00]

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_section_size.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_section_size.py
@@ -23,9 +23,12 @@ class SectionSize(IntEnum):
     Enum for the section size
     """
 
-    NORMAL = 0
+    NORMAL = -1
+    ZERO = 0
     UNDERSIZE = 2
     OVERSIZE = 100
+    HUGE = 0x8000
+    MAX = 0xFFFF
 
     def __str__(self) -> str:
         """
@@ -38,14 +41,23 @@ class SectionSize(IntEnum):
     "section_kind, section_size, exception",
     [
         (SectionKind.DATA, SectionSize.NORMAL, None),
+        (SectionKind.DATA, SectionSize.ZERO, EOFException.INVALID_SECTION_BODIES_SIZE),
         (SectionKind.DATA, SectionSize.UNDERSIZE, EOFException.INVALID_SECTION_BODIES_SIZE),
         (SectionKind.DATA, SectionSize.OVERSIZE, EOFException.TOPLEVEL_CONTAINER_TRUNCATED),
+        (SectionKind.DATA, SectionSize.HUGE, EOFException.TOPLEVEL_CONTAINER_TRUNCATED),
+        (SectionKind.DATA, SectionSize.MAX, EOFException.TOPLEVEL_CONTAINER_TRUNCATED),
+        (SectionKind.CODE, SectionSize.NORMAL, None),
+        (SectionKind.CODE, SectionSize.ZERO, EOFException.ZERO_SECTION_SIZE),
         (SectionKind.CODE, SectionSize.UNDERSIZE, EOFException.INVALID_SECTION_BODIES_SIZE),
         (SectionKind.CODE, SectionSize.OVERSIZE, EOFException.INVALID_SECTION_BODIES_SIZE),
-        (SectionKind.CODE, SectionSize.NORMAL, None),
+        (SectionKind.CODE, SectionSize.HUGE, EOFException.INVALID_SECTION_BODIES_SIZE),
+        (SectionKind.CODE, SectionSize.MAX, EOFException.INVALID_SECTION_BODIES_SIZE),
+        (SectionKind.TYPE, SectionSize.NORMAL, None),
+        (SectionKind.TYPE, SectionSize.ZERO, EOFException.ZERO_SECTION_SIZE),
         (SectionKind.TYPE, SectionSize.UNDERSIZE, EOFException.INVALID_TYPE_SECTION_SIZE),
         (SectionKind.TYPE, SectionSize.OVERSIZE, EOFException.INVALID_SECTION_BODIES_SIZE),
-        (SectionKind.TYPE, SectionSize.NORMAL, None),
+        (SectionKind.TYPE, SectionSize.HUGE, EOFException.INVALID_SECTION_BODIES_SIZE),
+        (SectionKind.TYPE, SectionSize.MAX, EOFException.INVALID_SECTION_BODIES_SIZE),
     ],
 )
 def test_section_size(


### PR DESCRIPTION
Includes a special case uncovered via fuzzing:
`ef0001 010000 028000`, courtesy @chfast
