### PR TITLE
feat(consume): Enhance timing data

### DIFF
--- a/src/cli/pytest_commands.py
+++ b/src/cli/pytest_commands.py
@@ -107,7 +107,7 @@ def handle_help_flags(
         return list(pytest_args)
 
 
-def handle_stdout_flags(args):
+def handle_stdout_flags(args: List[str]) -> List[str]:
     """
     If the user has requested to write to stdout, add pytest arguments in order
     to suppress pytest's test session header and summary output.
@@ -123,6 +123,15 @@ def handle_stdout_flags(args):
         if any(arg == "-n" or arg.startswith("-n=") for arg in args):
             sys.exit("error: xdist-plugin not supported with --output=stdout (remove -n args).")
         args.extend(["-qq", "-s", "--no-html"])
+    return args
+
+
+def handle_timing_data_flag(args: List[str]) -> List[str]:
+    """
+    Consume only. If the user requests timing data ensure stdout is captured.
+    """
+    if "--timing-data" in args and "-s" not in args:
+        args.append("-s")
     return args
 
 
@@ -209,6 +218,7 @@ def consume_direct(pytest_args, help_flag, pytest_help_flag):
     Clients consume directly via the `blocktest` interface.
     """
     args = handle_help_flags(pytest_args, help_flag, pytest_help_flag)
+    args = handle_timing_data_flag(args)
     args += ["-c", "pytest-consume.ini", "--rootdir", "./", consume_test_paths("direct")]
     if not input_provided(args) and not sys.stdin.isatty():  # command is receiving input on stdin
         args.extend(["-s", "--input=stdin"])
@@ -222,6 +232,7 @@ def consume_via_rlp(pytest_args, help_flag, pytest_help_flag):
     Clients consume RLP-encoded blocks on startup.
     """
     args = handle_help_flags(pytest_args, help_flag, pytest_help_flag)
+    args = handle_timing_data_flag(args)
     args += [
         "-c",
         "pytest-consume.ini",
@@ -244,6 +255,7 @@ def consume_via_engine_api(pytest_args, help_flag, pytest_help_flag):
     Clients consume via the Engine API.
     """
     args = handle_help_flags(pytest_args, help_flag, pytest_help_flag)
+    args = handle_timing_data_flag(args)
     args += [
         "-c",
         "pytest-consume.ini",
@@ -266,6 +278,7 @@ def consume_all(pytest_args, help_flag, pytest_help_flag):
     Clients consume via all available methods (direct, rlp, engine).
     """
     args = handle_help_flags(pytest_args, help_flag, pytest_help_flag)
+    args = handle_timing_data_flag(args)
     args += [
         "-c",
         "pytest-consume.ini",

--- a/src/pytest_plugins/consume/consume.py
+++ b/src/pytest_plugins/consume/consume.py
@@ -94,6 +94,13 @@ def pytest_addoption(parser):  # noqa: D103
         help="Only consume tests for the specified fork.",
     )
     consume_group.addoption(
+        "--timing-data",
+        action="store_true",
+        dest="timing_data",
+        default=False,
+        help="Log the timing data for each test case execution.",
+    )
+    consume_group.addoption(
         "--no-html",
         action="store_true",
         dest="disable_html",

--- a/src/pytest_plugins/consume/hive_simulators/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/conftest.py
@@ -50,9 +50,10 @@ def total_timing_data(request) -> Generator[TimingData, None, None]:
     """
     Helper to record timing data for various stages of executing test case.
     """
-    with TimingData("Total") as total_timing_data:
+    with TimingData("Total (seconds)") as total_timing_data:
         yield total_timing_data
-    rich.print(f"\nTimings (seconds): \n{total_timing_data.formatted()}")
+    if request.config.getoption("timing_data"):
+        rich.print(f"\n{total_timing_data.formatted()}")
     if hasattr(request.node, "rep_call"):  # make available for test reports
         request.node.rep_call.timings = total_timing_data
 

--- a/src/pytest_plugins/consume/hive_simulators/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/conftest.py
@@ -4,14 +4,12 @@ Common pytest fixtures for the RLP and Engine simulators.
 
 import io
 import json
-import time
 from typing import Generator, cast
 
 import pytest
 import rich
 from hive.client import Client, ClientType
 from hive.testing import HiveTest
-from pydantic import BaseModel
 
 from ethereum_test_base_types import to_json
 from ethereum_test_fixtures import BlockchainFixtureCommon
@@ -19,35 +17,7 @@ from ethereum_test_fixtures.consume import TestCaseIndexFile, TestCaseStream
 from ethereum_test_tools.rpc import EthRPC
 from pytest_plugins.consume.hive_simulators.ruleset import ruleset  # TODO: generate dynamically
 
-
-class TestCaseTimingData(BaseModel):
-    """
-    The times taken to perform the various steps of a test case (seconds).
-    """
-
-    __test__ = False
-    prepare_files: float | None = None  # start of test until client start
-    start_client: float | None = None
-    get_genesis: float | None = None
-    test_case_execution: float | None = None
-    stop_client: float | None = None
-    total: float | None = None
-
-    @staticmethod
-    def format_float(num: float | None, precision: int = 4) -> str | None:
-        """
-        Format a float to a specific precision in significant figures.
-        """
-        if num is None:
-            return None
-        return f"{num:.{precision}f}"
-
-    def formatted(self, precision: int = 4) -> "TestCaseTimingData":
-        """
-        Return a new instance of the model with formatted float values.
-        """
-        data = {field: self.format_float(value, precision) for field, value in self}
-        return TestCaseTimingData(**data)
+from .timing import TimingData
 
 
 @pytest.fixture(scope="function")
@@ -75,22 +45,14 @@ def fixture_description(
     return description
 
 
-@pytest.fixture(scope="function")
-def t_test_start() -> float:
-    """
-    Used to time fixture & file preparation and total time.
-    """
-    return time.perf_counter()
-
-
 @pytest.fixture(scope="function", autouse=True)
-def timing_data(request, t_test_start) -> Generator[TestCaseTimingData, None, None]:
+def timing_data(request) -> Generator[TimingData, None, None]:
     """
     Helper to record timing data for various stages of executing test case.
     """
-    timing_data = TestCaseTimingData()
+    timing_data = TimingData()
     yield timing_data
-    timing_data.total = time.perf_counter() - t_test_start
+    timing_data.finish()
     rich.print(f"\nTimings (seconds): {timing_data.formatted()}")
     if hasattr(request.node, "rep_call"):  # make available for test reports
         request.node.rep_call.timings = timing_data
@@ -143,25 +105,22 @@ def client(
     client_files: dict,  # configured within: rlp/conftest.py & engine/conftest.py
     environment: dict,
     client_type: ClientType,
-    timing_data: TestCaseTimingData,
-    t_test_start: float,
+    timing_data: TimingData,
 ) -> Generator[Client, None, None]:
     """
     Initialize the client with the appropriate files and environment variables.
     """
-    timing_data.prepare_files = time.perf_counter() - t_test_start
-    t_start = time.perf_counter()
+    timing_data.record("prepare_files")
     client = hive_test.start_client(
         client_type=client_type, environment=environment, files=client_files
     )
-    timing_data.start_client = time.perf_counter() - t_start
+    timing_data.record("start_client")
     error_message = (
         f"Unable to connect to the client container ({client_type.name}) via Hive during test "
         "setup. Check the client or Hive server logs for more information."
     )
     assert client is not None, error_message
     yield client
+    timing_data.record("test_case_execution")
     client.stop()
-    t_start = time.perf_counter()
-    client.stop()
-    timing_data.stop_client = time.perf_counter() - t_start
+    timing_data.record("stop_client")

--- a/src/pytest_plugins/consume/hive_simulators/engine/test_via_engine.py
+++ b/src/pytest_plugins/consume/hive_simulators/engine/test_via_engine.py
@@ -4,9 +4,6 @@ from the Engine API. The simulator uses the `BlockchainEngineFixtures` to test a
 
 Each `engine_newPayloadVX` is verified against the appropriate VALID/INVALID responses.
 """
-
-import time
-
 from ethereum_test_fixtures import BlockchainEngineFixture, FixtureFormats
 from ethereum_test_fixtures.blockchain import FixtureHeader
 from ethereum_test_tools.rpc import EngineRPC, EthRPC
@@ -14,11 +11,12 @@ from ethereum_test_tools.rpc.types import ForkchoiceState, PayloadStatusEnum
 from pytest_plugins.consume.hive_simulators.exceptions import GenesisBlockMismatchException
 
 from ...decorator import fixture_format
+from ..timing import TimingData
 
 
 @fixture_format(FixtureFormats.BLOCKCHAIN_TEST_ENGINE)
 def test_via_engine(
-    timing_data,
+    timing_data: TimingData,
     eth_rpc: EthRPC,
     engine_rpc: EngineRPC,
     blockchain_fixture: BlockchainEngineFixture,
@@ -29,7 +27,6 @@ def test_via_engine(
     `engine_newPayloadVX` method from the Engine API.
     3. For valid payloads a forkchoice update is performed to finalize the chain.
     """
-    t_engine = time.perf_counter()
     # Send a initial forkchoice update
     forkchoice_response = engine_rpc.forkchoice_updated(
         forkchoice_state=ForkchoiceState(
@@ -38,22 +35,24 @@ def test_via_engine(
         payload_attributes=None,
         version=blockchain_fixture.payloads[0].forkchoice_updated_version,
     )
+    timing_data.record("initial_forkchoice_updated")
     assert (
         forkchoice_response.payload_status.status == PayloadStatusEnum.VALID
     ), f"unexpected status on forkchoice updated to genesis: {forkchoice_response}"
 
     genesis_block = eth_rpc.get_block_by_number(0)
-    timing_data.get_genesis = time.perf_counter() - t_engine
+    timing_data.record("get_genesis")
     if genesis_block["hash"] != str(blockchain_fixture.genesis.block_hash):
         raise GenesisBlockMismatchException(
             expected_header=blockchain_fixture.genesis, got_header=FixtureHeader(**genesis_block)
         )
 
-    for payload in blockchain_fixture.payloads:
+    for i, payload in enumerate(blockchain_fixture.payloads):
         payload_response = engine_rpc.new_payload(
             *payload.params,
             version=payload.new_payload_version,
         )
+        timing_data.record(f"new_payload_{i}")
         assert payload_response.status == (
             PayloadStatusEnum.VALID if payload.valid() else PayloadStatusEnum.INVALID
         ), f"unexpected status: {payload_response}"
@@ -66,7 +65,7 @@ def test_via_engine(
                 payload_attributes=None,
                 version=payload.forkchoice_updated_version,
             )
+            timing_data.record(f"forkchoice_updated_{i}")
             assert (
                 forkchoice_response.payload_status.status == PayloadStatusEnum.VALID
             ), f"unexpected status: {forkchoice_response}"
-    timing_data.test_case_execution = time.perf_counter() - timing_data.get_genesis - t_engine

--- a/src/pytest_plugins/consume/hive_simulators/rlp/test_via_rlp.py
+++ b/src/pytest_plugins/consume/hive_simulators/rlp/test_via_rlp.py
@@ -23,12 +23,15 @@ def test_via_rlp(
     1. Check the client genesis block hash matches `blockchain_fixture.genesis.block_hash`.
     2. Check the client last block hash matches `blockchain_fixture.last_block_hash`.
     """
-    genesis_block = eth_rpc.get_block_by_number(0)
-    timing_data.record("get_genesis")
-    if genesis_block["hash"] != str(blockchain_fixture.genesis.block_hash):
-        raise GenesisBlockMismatchException(
-            expected_header=blockchain_fixture.genesis, got_header=FixtureHeader(**genesis_block)
-        )
-    block = eth_rpc.get_block_by_number("latest")
-    timing_data.record("get_latest_block")
-    assert block["hash"] == str(blockchain_fixture.last_block_hash), "hash mismatch in last block"
+    with timing_data.time("Get genesis block"):
+        genesis_block = eth_rpc.get_block_by_number(0)
+        if genesis_block["hash"] != str(blockchain_fixture.genesis.block_hash):
+            raise GenesisBlockMismatchException(
+                expected_header=blockchain_fixture.genesis,
+                got_header=FixtureHeader(**genesis_block),
+            )
+    with timing_data.time("Get latest block"):
+        block = eth_rpc.get_block_by_number("latest")
+        assert block["hash"] == str(
+            blockchain_fixture.last_block_hash
+        ), "hash mismatch in last block"

--- a/src/pytest_plugins/consume/hive_simulators/rlp/test_via_rlp.py
+++ b/src/pytest_plugins/consume/hive_simulators/rlp/test_via_rlp.py
@@ -4,20 +4,18 @@ A hive based simulator that executes RLP-encoded blocks against clients. The sim
 
 Clients consume the genesis and RLP-encoded blocks from input files upon start-up.
 """
-
-import time
-
 from ethereum_test_fixtures import BlockchainFixture, FixtureFormats
 from ethereum_test_fixtures.blockchain import FixtureHeader
 from ethereum_test_tools.rpc import EthRPC
 from pytest_plugins.consume.hive_simulators.exceptions import GenesisBlockMismatchException
 
 from ...decorator import fixture_format
+from ..timing import TimingData
 
 
 @fixture_format(FixtureFormats.BLOCKCHAIN_TEST)
 def test_via_rlp(
-    timing_data,
+    timing_data: TimingData,
     eth_rpc: EthRPC,
     blockchain_fixture: BlockchainFixture,
 ):
@@ -25,13 +23,12 @@ def test_via_rlp(
     1. Check the client genesis block hash matches `blockchain_fixture.genesis.block_hash`.
     2. Check the client last block hash matches `blockchain_fixture.last_block_hash`.
     """
-    t_rlp = time.perf_counter()
     genesis_block = eth_rpc.get_block_by_number(0)
-    timing_data.get_genesis = time.perf_counter() - t_rlp
+    timing_data.record("get_genesis")
     if genesis_block["hash"] != str(blockchain_fixture.genesis.block_hash):
         raise GenesisBlockMismatchException(
             expected_header=blockchain_fixture.genesis, got_header=FixtureHeader(**genesis_block)
         )
     block = eth_rpc.get_block_by_number("latest")
-    timing_data.test_case_execution = time.perf_counter() - timing_data.get_genesis - t_rlp
+    timing_data.record("get_latest_block")
     assert block["hash"] == str(blockchain_fixture.last_block_hash), "hash mismatch in last block"

--- a/src/pytest_plugins/consume/hive_simulators/timing.py
+++ b/src/pytest_plugins/consume/hive_simulators/timing.py
@@ -1,0 +1,54 @@
+"""
+Test timing class used to time tests.
+"""
+
+import time
+from typing import Dict
+
+
+class TimingData:
+    """
+    The times taken to perform the various steps of a test case (seconds).
+    """
+
+    start_time: float
+    last_time: float
+    timings: Dict[str, float] = {}
+
+    def __init__(self):
+        """
+        Initialize the timing data.
+        """
+        self.start_time = self.last_time = time.perf_counter()
+
+    @staticmethod
+    def format_float(num: float | None, precision: int = 4) -> str | None:
+        """
+        Format a float to a specific precision in significant figures.
+        """
+        if num is None:
+            return None
+        return f"{num:.{precision}f}"
+
+    def record(self, name: str) -> None:
+        """
+        Record the time taken since the last time recorded.
+        """
+        current_time = time.perf_counter()
+        self.timings[name] = current_time - self.last_time
+        self.last_time = current_time
+
+    def finish(self) -> None:
+        """
+        Record the time taken since the last time recorded.
+        """
+        self.timings["total"] = time.perf_counter() - self.start_time
+
+    def formatted(self, precision: int = 4) -> Dict[str, str | None]:
+        """
+        Return a new instance of the model with formatted float values.
+        """
+        data = {
+            field: self.format_float(value, precision) for field, value in self.timings.items()
+        }
+        return data


### PR DESCRIPTION
## 🗒️ Description
Creates `TimingData` class to better manage the time metrics of a consume test.

The formatted output now looks like this:
```
src/pytest_plugins/consume/hive_simulators/engine/test_via_engine.py .
Timings (seconds): 
Total: 0.7915
  Start client: 0.5919
  Test case execution: 0.0126
    Initial forkchoice update: 0.0028
    Get genesis block: 0.0020
    Payloads execution: 0.0073
      Payload 1: 0.0073
        engine_newPayloadV4: 0.0043
        engine_forkchoiceUpdatedV3: 0.0030
  Stop client: 0.1718
```

And the sections are recorded even in case of an exception due to the context management of the new class (using `with`).

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
