### PR TITLE
feat(all): Fuzzing

### DIFF
--- a/pytest-fuzz.ini
+++ b/pytest-fuzz.ini
@@ -7,6 +7,7 @@ markers =
     slow
     fuzzable
 addopts = 
+    -p pytest_plugins.filler.fuzzer
     -p pytest_plugins.filler.pre_alloc
     -p pytest_plugins.filler.filler
     -p pytest_plugins.forks.forks

--- a/setup.cfg
+++ b/setup.cfg
@@ -78,6 +78,7 @@ pytest_plugins =
 [options.entry_points]
 console_scripts =
     fill = cli.pytest_commands:fill
+    fuzz = cli.pytest_commands:fuzz
     tf = cli.pytest_commands:tf
     checkfixtures = cli.check_fixtures:check_fixtures
     consume = cli.pytest_commands:consume

--- a/src/cli/pytest_commands.py
+++ b/src/cli/pytest_commands.py
@@ -142,6 +142,23 @@ def fill(
     sys.exit(result)
 
 
+@click.command(context_settings=dict(ignore_unknown_options=True))
+@common_click_options
+def fuzz(
+    pytest_args: List[str],
+    help_flag: bool,
+    pytest_help_flag: bool,
+) -> None:
+    """
+    Entry point for the fuzz command.
+    """
+    args = handle_help_flags(pytest_args, help_flag, pytest_help_flag)
+    args += ["-c", "pytest-fuzz.ini"]
+    args = handle_stdout_flags(args)
+    result = pytest.main(args)
+    sys.exit(result)
+
+
 def get_hive_flags_from_env():
     """
     Read simulator flags from environment variables and convert them, as best as

--- a/src/pytest_plugins/filler/fuzzer.py
+++ b/src/pytest_plugins/filler/fuzzer.py
@@ -1,0 +1,97 @@
+"""
+Pytest plug-in that allows fuzzed parametrization.
+"""
+
+import inspect
+import random
+from copy import copy
+from typing import Annotated, Any, List, get_args, get_origin
+
+import pytest
+
+
+def pytest_addoption(parser: pytest.Parser):
+    """
+    Adds command-line options to pytest.
+    """
+    fuzzer_group = parser.getgroup("fuzzer", "Arguments defining fuzzer behavior")
+    fuzzer_group.addoption(
+        "--iterations",
+        action="store",
+        dest="iterations",
+        type=int,
+        default=1,
+        help=("Number of iterations per test to generate"),
+    )
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_report_header(config: pytest.Config):
+    """Add lines to pytest's console output header"""
+    if config.option.collectonly:
+        return
+    iterations = config.getoption("iterations")
+    return [f"{iterations}"]
+
+
+def pytest_generate_tests(metafunc: pytest.Metafunc):
+    """
+    Pytest hook used to dynamically generate fuzzed test cases.
+    """
+    markers = list(metafunc.definition.iter_markers("fuzzable"))
+    assert len(markers) <= 1, "Test should contain only one 'fuzzable' marker"
+
+    if len(markers) == 0:
+        pytest.skip("non-fuzzable")
+
+    fuzz_arguments = markers[0].args
+
+    pytest_params: List[Any] = []
+
+    # Remove existing parametrize markers that conflict with fuzzing
+    i = 0
+    while i < len(metafunc.definition.own_markers):
+        own_marker = metafunc.definition.own_markers[i]
+        if own_marker.name == "parametrize":
+            if type(own_marker.args[0]) is str:
+                parametrize_args = own_marker.args[0].split(",")
+            else:
+                parametrize_args = copy(own_marker.args[0])
+            if any(fuzz_argument in parametrize_args for fuzz_argument in fuzz_arguments):
+                for fuzz_argument in fuzz_arguments:
+                    if fuzz_argument in parametrize_args:
+                        parametrize_args.remove(fuzz_argument)
+                assert (
+                    len(parametrize_args) == 0
+                ), "`pytest.mark.parametrize` mixes fuzzable and non-fuzzable arguments"
+                del metafunc.definition.own_markers[i]
+        i += 1
+
+    iterations = metafunc.config.getoption("iterations")
+
+    fuzz_generators = []
+    parameters = inspect.signature(metafunc.function).parameters
+    for fuzz_argument in fuzz_arguments:
+        assert (
+            fuzz_argument in parameters
+        ), f"fuzz argument not found in function signature {fuzz_argument}"
+        annotation = parameters[fuzz_argument].annotation
+        if get_origin(annotation) is Annotated:
+            # Parameter type should be annotated with a fuzz generator
+            args = get_args(annotation)[1:]
+            # TODO: Create a fuzz generator type and match each argument until found
+            fuzz_generators.append(args[0])
+        elif annotation == int:
+            fuzz_generators.append(lambda: random.randint(0, 2**256))
+        else:
+            raise ValueError(
+                f"no fuzzer available for type {annotation} for parameter {fuzz_argument}"
+            )
+
+    for _ in range(iterations):
+        iteration_args = []
+        for fuzz_generator in fuzz_generators:
+            iteration_args.append(fuzz_generator())
+        pytest_params.append(pytest.param(*iteration_args))
+
+    metafunc.parametrize(f"{','.join(fuzz_arguments)}", pytest_params, scope="function")

--- a/tests/frontier/opcodes/test_fuzzing.py
+++ b/tests/frontier/opcodes/test_fuzzing.py
@@ -1,0 +1,55 @@
+"""
+Test fuzzer example.
+"""
+
+import random
+from typing import Annotated
+
+import pytest
+
+from ethereum_test_forks import Fork, Frontier, Homestead
+from ethereum_test_tools import Account, Alloc, Environment
+from ethereum_test_tools import Opcodes as Op
+from ethereum_test_tools import StateTestFiller, Transaction
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [(1, 1)],
+)
+@pytest.mark.fuzzable("key", "value")
+def test_sstore(
+    state_test: StateTestFiller,
+    fork: Fork,
+    pre: Alloc,
+    key: Annotated[int, lambda: random.randint(0, 2**64)],
+    value: int,
+):
+    """
+    Simple SSTORE test that can be fuzzed to generate any number of tests.
+    """
+    env = Environment()
+    sender = pre.fund_eoa()
+    post = {}
+
+    account_code = Op.SSTORE(key, value) + Op.STOP
+
+    account = pre.deploy_contract(account_code)
+
+    tx = Transaction(
+        to=account,
+        gas_limit=500000,
+        data="",
+        sender=sender,
+        protected=False if fork in [Frontier, Homestead] else True,
+    )
+
+    post = {
+        account: Account(
+            storage={
+                key: value,
+            }
+        )
+    }
+
+    state_test(env=env, pre=pre, post=post, tx=tx)

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -146,6 +146,9 @@ formatter
 fromhex
 frozenbidict
 func
+fuzz
+fuzzer
+fuzzable
 fp
 fp2
 g1


### PR DESCRIPTION
## 🗒️ Description
First iteration at implementation of idea in https://github.com/ethereum/execution-spec-tests/discussions/591

Implements the `fuzz` command that allows testers to mark a test as fuzzable, and then listing parameters that can be randomized:

```python
@pytest.mark.parametrize(
    "key,value",
    [(1, 1)],
)
@pytest.mark.fuzzable("key", "value")
def test_sstore(
    state_test: StateTestFiller,
    fork: Fork,
    pre: Alloc,
    key: Annotated[int, lambda: random.randint(0, 2**64)],
    value: int,
):
```

In this simple example, a test function is marked as fuzzable by adding the `@pytest.mark.fuzzable` decorator and as its parameters it lists two parameter names: "key" and "value".

When the `fuzz` command is executed and pointed to this file, the test is prepared by first removing its existing `pytest.mark.parametrize` that already contains "key" and "value" parameters, and then the test is re-parametrized to fuzzed values for both parameters.

The fuzzer reads the annotation of the test function signature and then proceeds to attempt to generate a fuzzing function for each one.

In the case of "value", the annotation is simply `int` so the default fuzzer for integers is used (`random.randint(0, 2**256)`).

In the case of "key", the type is annotated and the second parameter of the annotation is a callable lambda function which specifies how the value should be randomized, in this case, a random integer from 0 to 2**64.

We can implement many fuzzers for each type, including e.g., random opcodes, random code, random valid or invalid EOF code.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
