### PR TITLE
fix(fw): Change opcode with immediate name

### DIFF
--- a/src/ethereum_test_vm/opcode.py
+++ b/src/ethereum_test_vm/opcode.py
@@ -210,7 +210,7 @@ class Opcode(Bytecode):
             kwargs=self.kwargs,
             kwargs_defaults=self.kwargs_defaults,
         )
-        new_opcode._name_ = f"{self._name_}[0x{data_portion.hex()}]"
+        new_opcode._name_ = f"{self._name_}_0x{data_portion.hex()}"
         return new_opcode
 
     def __call__(

--- a/src/ethereum_test_vm/tests/test_vm.py
+++ b/src/ethereum_test_vm/tests/test_vm.py
@@ -345,8 +345,8 @@ def test_opcodes_repr():
     assert f"{Op.DELEGATECALL}" == "DELEGATECALL"
     assert f"{Om.OOG}" == "OOG"
     assert str(Op.ADD) == "ADD"
-    assert f"{Op.DUPN[1]}" == "DUPN[0x01]"
-    assert f"{Op.DATALOADN[1]}" == "DATALOADN[0x0001]"
+    assert f"{Op.DUPN[1]}" == "DUPN_0x01"
+    assert f"{Op.DATALOADN[1]}" == "DATALOADN_0x0001"
 
 
 def test_macros():


### PR DESCRIPTION

## 🗒️ Description
The naming convention of opcodes defined with immediates clashes with
fixture parsing code. Use an underscore instead of brackets

This allows opcodes with immediates to be parameters for tests and not throw strange errors when the fill fails due to the client tool.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
