### PR TITLE
feat(filler): generate index

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 - 🐞 Fixed consume hive commands from spawning different hive test suites during the same test execution when using xdist ([#712](https://github.com/ethereum/execution-spec-tests/pull/712)).
 - ✨ `consume hive` command is now available to run all types of hive tests ([#712](https://github.com/ethereum/execution-spec-tests/pull/712)).
+- ✨ Generated fixtures now contain the test index `index.json` by default ([#716](https://github.com/ethereum/execution-spec-tests/pull/716)).
 
 ### 🔧 EVM Tools
 

--- a/src/pytest_plugins/filler/filler.py
+++ b/src/pytest_plugins/filler/filler.py
@@ -17,6 +17,7 @@ from typing import Generator, List, Type
 import pytest
 from pytest_metadata.plugin import metadata_key  # type: ignore
 
+from cli.gen_index import generate_fixtures_index
 from ethereum_test_base_types import Alloc, ReferenceSpec
 from ethereum_test_fixtures import FixtureCollector, FixtureFormats, TestInfo
 from ethereum_test_forks import (
@@ -617,6 +618,9 @@ def fixture_collector(
     fixture_collector.dump_fixtures()
     if do_fixture_verification:
         fixture_collector.verify_fixture_files(evm_fixture_verification)
+    generate_fixtures_index(
+        output_dir, quiet_mode=False, force_flag=False, disable_infer_format=False
+    )
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/src/pytest_plugins/filler/tests/test_filler.py
+++ b/src/pytest_plugins/filler/tests/test_filler.py
@@ -525,13 +525,29 @@ def test_fixture_output_based_on_command_line_args(
 
     all_files = get_all_files_in_directory(output_dir)
 
-    ini_file = None
     expected_fixtures_ini_filename = "fixtures.ini"
+    expected_fixtures_index_filename = "index.json"
+
+    ini_file = None
+    index_file = None
     for file in all_files:
         if file.name == expected_fixtures_ini_filename:
             ini_file = file
-            all_files.remove(file)
-            break
+        elif file.name == expected_fixtures_index_filename:
+            index_file = file
+
+    assert ini_file is not None, f"No {expected_fixtures_ini_filename} file was written"
+    assert index_file is not None, f"No {expected_fixtures_index_filename} file was written"
+
+    all_files = [
+        file
+        for file in all_files
+        if file.name
+        not in {
+            expected_fixtures_ini_filename,
+            expected_fixtures_index_filename,
+        }
+    ]
 
     for fixture_file, fixture_count in zip(expected_fixture_files, expected_fixture_counts):
         assert fixture_file.exists()


### PR DESCRIPTION
## 🗒️ Description
Filled tests now contain the `index.json` file by default.

## 🔗 Related Issues
#715 

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
