### PR TITLE
feat(consume): add reproducible consume/hive commands

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ `consume hive` command is now available to run all types of hive tests ([#712](https://github.com/ethereum/execution-spec-tests/pull/712)).
 - ✨ Generated fixtures now contain the test index `index.json` by default ([#716](https://github.com/ethereum/execution-spec-tests/pull/716)).
 - ✨ A metadata folder `.meta/` now stores all fixture metadata files by default ([#721](https://github.com/ethereum/execution-spec-tests/pull/721)).
+- ✨ Adds reproducible consume commands to hiveview ([#717](https://github.com/ethereum/execution-spec-tests/pull/717)).
 
 ### 🔧 EVM Tools
 

--- a/src/pytest_plugins/consume/consume.py
+++ b/src/pytest_plugins/consume/consume.py
@@ -70,7 +70,7 @@ def download_and_extract(url: str, base_directory: Path) -> Path:
     with tarfile.open(archive_path, "r:gz") as tar:
         tar.extractall(path=extract_to)
 
-    return extract_to
+    return extract_to / "fixtures"
 
 
 def pytest_addoption(parser):  # noqa: D103
@@ -164,9 +164,9 @@ def pytest_configure(config):  # noqa: D103
     index_file = input_source / ".meta" / "index.json"
     if not index_file.exists():
         rich.print(f"Generating index file [bold cyan]{index_file}[/]...")
-    generate_fixtures_index(
-        input_source, quiet_mode=False, force_flag=False, disable_infer_format=False
-    )
+        generate_fixtures_index(
+            input_source, quiet_mode=False, force_flag=False, disable_infer_format=False
+        )
     config.test_cases = TestCases.from_index_file(index_file)
 
     if config.option.collectonly:

--- a/src/pytest_plugins/consume/consume.py
+++ b/src/pytest_plugins/consume/consume.py
@@ -128,6 +128,12 @@ def pytest_configure(config):  # noqa: D103
         config.test_cases = TestCases.from_stream(sys.stdin)
         return
 
+    if input_source == "latest":  # TODO: align this with release tags
+        input_source = (
+            "https://github.com/ethereum/execution-spec-tests/releases/latest/download/"
+            "fixtures_develop.tar.gz"
+        )
+
     if is_url(input_source):
         cached_downloads_directory.mkdir(parents=True, exist_ok=True)
         input_source = download_and_extract(input_source, cached_downloads_directory)

--- a/src/pytest_plugins/consume/hive_simulators/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/conftest.py
@@ -41,9 +41,7 @@ def hive_consume_command(
         f"./hive --sim ethereum/{test_suite_name} "
         f"--client-file configs/develop.yaml "
         f"--client {client_type.name} "
-        f'--sim.limit "{test_case.id}" '
-        f"--docker.output "
-        f"--sim.loglevel 5"
+        f'--sim.limit "{test_case.id}"'
     )
 
 
@@ -56,12 +54,7 @@ def eest_consume_commands(
     """
     Commands to run the test within EEST using a hive dev back-end.
     """
-    hive_dev = (
-        f"./hive --dev --client-file configs/develop.yaml "
-        f"--client {client_type.name} "
-        f"--docker.output "
-        f"--sim.loglevel 5"
-    )
+    hive_dev = f"./hive --dev --client-file configs/develop.yaml " f"--client {client_type.name}"
     consume = f'consume {test_suite_name.split("-")[-1]} -k "{test_case.id}" -v --input=latest'
     return [hive_dev, consume]
 

--- a/src/pytest_plugins/consume/hive_simulators/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/conftest.py
@@ -4,7 +4,7 @@ Common pytest fixtures for the RLP and Engine simulators.
 
 import io
 import json
-from typing import Generator, cast
+from typing import Generator, List, cast
 
 import pytest
 import rich
@@ -29,11 +29,52 @@ def eth_rpc(client: Client) -> EthRPC:
 
 
 @pytest.fixture(scope="function")
+def hive_consume_command(
+    test_suite_name: str,
+    client_type: ClientType,
+    test_case: TestCaseIndexFile | TestCaseStream,
+) -> str:
+    """
+    Command to run the test within hive.
+    """
+    return (
+        f"./hive --sim ethereum/{test_suite_name} "
+        f"--client-file configs/develop.yaml "
+        f"--client {client_type.name} "
+        f'--sim.limit "{test_case.id}" '
+        f"--docker.output "
+        f"--sim.loglevel 5"
+    )
+
+
+@pytest.fixture(scope="function")
+def eest_consume_commands(
+    client_type: ClientType,
+    test_case: TestCaseIndexFile | TestCaseStream,
+) -> List[str]:
+    """
+    Commands to run the test within EEST using a hive dev back-end.
+    """
+    consume = f'consume engine -k "{test_case.id}" -v'
+    hive_dev = (
+        f"./hive --dev --client-file config/develop.yaml "
+        f"--client {client_type.name} "
+        f"--docker.output "
+        f"--sim.loglevel 5"
+    )
+    return [consume, hive_dev]
+
+
+@pytest.fixture(scope="function")
 def fixture_description(
-    blockchain_fixture: BlockchainFixtureCommon, test_case: TestCaseIndexFile | TestCaseStream
+    blockchain_fixture: BlockchainFixtureCommon,
+    test_case: TestCaseIndexFile | TestCaseStream,
+    hive_consume_command: str,
+    eest_consume_commands: List[str],
 ) -> str:
     """
     Create the description of the current blockchain fixture test case.
+    Includes reproducible commands to re-run the test case against the target client.
     """
     description = f"Test id: {test_case.id}"
     if "url" in blockchain_fixture.info:
@@ -41,7 +82,16 @@ def fixture_description(
     if "description" not in blockchain_fixture.info:
         description += "\n\nNo description field provided in the fixture's 'info' section."
     else:
-        description += f"\n\n{blockchain_fixture.info['description']}"
+        description += f"\n{blockchain_fixture.info['description']}"
+    description += (
+        f"\n\nCommand to reproduce entirely in hive:" f"\n<code>{hive_consume_command}</code>"
+    )
+    description += (
+        f"\n\nCommands to reproduce within EEST using a hive dev back-end:"
+        f"\n1. <code>{eest_consume_commands[0]}</code>"
+        f"\n2. <code>{eest_consume_commands[1]}</code>"
+    )
+    description = description.replace("\n", "<br/>")
     return description
 
 

--- a/src/pytest_plugins/consume/hive_simulators/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/conftest.py
@@ -55,7 +55,7 @@ def eest_consume_commands(
     Commands to run the test within EEST using a hive dev back-end.
     """
     hive_dev = f"./hive --dev --client-file configs/develop.yaml " f"--client {client_type.name}"
-    consume = f'consume {test_suite_name.split("-")[-1]} -k "{test_case.id}" -v --latest'
+    consume = f'consume {test_suite_name.split("-")[-1]} -v --latest -k "{test_case.id}"'
     return [hive_dev, consume]
 
 

--- a/src/pytest_plugins/consume/hive_simulators/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/conftest.py
@@ -54,7 +54,7 @@ def eest_consume_commands(
     """
     Commands to run the test within EEST using a hive dev back-end.
     """
-    hive_dev = f"./hive --dev --client-file configs/develop.yaml " f"--client {client_type.name}"
+    hive_dev = f"./hive --dev --client-file configs/develop.yaml --client {client_type.name}"
     consume = f'consume {test_suite_name.split("-")[-1]} -v --latest -k "{test_case.id}"'
     return [hive_dev, consume]
 

--- a/src/pytest_plugins/consume/hive_simulators/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/conftest.py
@@ -80,10 +80,11 @@ def fixture_description(
     description += (
         f"\n\nCommand to reproduce entirely in hive:" f"\n<code>{hive_consume_command}</code>"
     )
+    eest_commands = "\n".join(
+        f"{i+1}. <code>{cmd}</code>" for i, cmd in enumerate(eest_consume_commands)
+    )
     description += (
-        f"\n\nCommands to reproduce within EEST using a hive dev back-end:"
-        f"\n1. <code>{eest_consume_commands[0]}</code>"
-        f"\n2. <code>{eest_consume_commands[1]}</code>"
+        "\n\nCommands to reproduce within EEST using a hive dev back-end:" f"\n{eest_commands}"
     )
     description = description.replace("\n", "<br/>")
     return description

--- a/src/pytest_plugins/consume/hive_simulators/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/conftest.py
@@ -56,18 +56,14 @@ def eest_consume_commands(
     """
     Commands to run the test within EEST using a hive dev back-end.
     """
-    consume = (
-        f'consume {test_suite_name.split("-")[-1]} -k "{test_case.id}" -v '
-        f"--input=https://github.com/ethereum/"
-        f"execution-spec-tests/releases/latest/download/fixtures_develop.tar.gz"
-    )
     hive_dev = (
         f"./hive --dev --client-file configs/develop.yaml "
         f"--client {client_type.name} "
         f"--docker.output "
         f"--sim.loglevel 5"
     )
-    return [consume, hive_dev]
+    consume = f'consume {test_suite_name.split("-")[-1]} -k "{test_case.id}" -v --input=latest'
+    return [hive_dev, consume]
 
 
 @pytest.fixture(scope="function")

--- a/src/pytest_plugins/consume/hive_simulators/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/conftest.py
@@ -49,15 +49,20 @@ def hive_consume_command(
 
 @pytest.fixture(scope="function")
 def eest_consume_commands(
+    test_suite_name: str,
     client_type: ClientType,
     test_case: TestCaseIndexFile | TestCaseStream,
 ) -> List[str]:
     """
     Commands to run the test within EEST using a hive dev back-end.
     """
-    consume = f'consume engine -k "{test_case.id}" -v'
+    consume = (
+        f'consume {test_suite_name.split("-")[-1]} -k "{test_case.id}" -v '
+        f"--input=https://github.com/ethereum/"
+        f"execution-spec-tests/releases/latest/download/fixtures_develop.tar.gz"
+    )
     hive_dev = (
-        f"./hive --dev --client-file config/develop.yaml "
+        f"./hive --dev --client-file configs/develop.yaml "
         f"--client {client_type.name} "
         f"--docker.output "
         f"--sim.loglevel 5"
@@ -82,7 +87,7 @@ def fixture_description(
     if "description" not in blockchain_fixture.info:
         description += "\n\nNo description field provided in the fixture's 'info' section."
     else:
-        description += f"\n{blockchain_fixture.info['description']}"
+        description += f"\n\n{blockchain_fixture.info['description']}"
     description += (
         f"\n\nCommand to reproduce entirely in hive:" f"\n<code>{hive_consume_command}</code>"
     )

--- a/src/pytest_plugins/consume/hive_simulators/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/conftest.py
@@ -55,7 +55,7 @@ def eest_consume_commands(
     Commands to run the test within EEST using a hive dev back-end.
     """
     hive_dev = f"./hive --dev --client-file configs/develop.yaml " f"--client {client_type.name}"
-    consume = f'consume {test_suite_name.split("-")[-1]} -k "{test_case.id}" -v --input=latest'
+    consume = f'consume {test_suite_name.split("-")[-1]} -k "{test_case.id}" -v --latest'
     return [hive_dev, consume]
 
 

--- a/src/pytest_plugins/consume/hive_simulators/rlp/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/rlp/conftest.py
@@ -22,7 +22,7 @@ def test_suite_name() -> str:
     """
     The name of the hive test suite used in this simulator.
     """
-    return "eest-rlp"
+    return "eest-block-rlp"
 
 
 @pytest.fixture(scope="module")

--- a/src/pytest_plugins/filler/filler.py
+++ b/src/pytest_plugins/filler/filler.py
@@ -635,7 +635,7 @@ def fixture_collector(
     if do_fixture_verification:
         fixture_collector.verify_fixture_files(evm_fixture_verification)
     generate_fixtures_index(
-        output_dir, quiet_mode=True, force_flag=True, disable_infer_format=False
+        output_dir, quiet_mode=True, force_flag=False, disable_infer_format=False
     )
 
 

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -188,6 +188,7 @@ hexary
 HexNumber
 hexsha
 hexbytes
+hiveview
 homebrew
 html
 htmlpath


### PR DESCRIPTION
## 🗒️ Description
Adds the consume and hive commands to re-run a test case within hiveview. This is to aid test case reproduction for client devs incase of a failure.

Requires a small change to `app-suite.js` within hive: https://github.com/ethereum/hive/commit/cdbd33641dd2ba94133360535662e7309c34d83c#
You can test using this branch: https://github.com/spencer-tb/hive/tree/prague/devnet-1

Gives us the following on hiveview:
<img width="1025" alt="Screenshot 2024-07-27 at 18 52 03" src="https://github.com/user-attachments/assets/f53d2de9-5378-458d-8af2-e45f052efa9e">

## 🔗 Related Issues
N/A

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
