### PR TITLE
new(tests) Deep and wide EOF subcontainers

### DIFF
--- a/src/ethereum_test_exceptions/evmone_exceptions.py
+++ b/src/ethereum_test_exceptions/evmone_exceptions.py
@@ -84,6 +84,7 @@ class EvmoneExceptionMapper:
             EOFException.INCOMPATIBLE_CONTAINER_KIND, "err: incompatible_container_kind"
         ),
         ExceptionMessage(EOFException.STACK_HEIGHT_MISMATCH, "err: stack_height_mismatch"),
+        ExceptionMessage(EOFException.TOO_MANY_CONTAINERS, "err: too_many_container_sections"),
     )
 
     def __init__(self) -> None:

--- a/src/ethereum_test_exceptions/exceptions.py
+++ b/src/ethereum_test_exceptions/exceptions.py
@@ -708,6 +708,10 @@ class EOFException(ExceptionBase):
     """
     Incompatible instruction found in a container of a specific kind.
     """
+    TOO_MANY_CONTAINERS = auto()
+    """
+    EOF container header has too many sub-containers.
+    """
 
 
 """

--- a/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
+++ b/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
@@ -8,6 +8,8 @@ from ethereum_test_tools import Account, EOFException, EOFStateTestFiller, EOFTe
 from ethereum_test_tools.eof.v1 import Container, ContainerKind, Section
 from ethereum_test_tools.eof.v1.constants import MAX_BYTECODE_SIZE
 from ethereum_test_tools.vm.opcode import Opcodes as Op
+from ethereum_test_types.eof.v1.constants import MAX_INITCODE_SIZE
+from ethereum_test_vm import Bytecode
 
 from .. import EOF_FORK_NAME
 from .helpers import slot_code_worked, value_code_worked
@@ -467,4 +469,78 @@ def test_container_both_kinds_different_sub(eof_test: EOFTestFiller):
             ],
             kind=ContainerKind.INITCODE,
         ),
+    )
+
+
+def test_deep_container(eof_test: EOFTestFiller):
+    """Test a very deeply nested container"""
+    container = Container(
+        sections=[
+            Section.Code(
+                code=Op.PUSH0 + Op.PUSH0 + Op.PUSH0 + Op.PUSH0 + Op.EOFCREATE[0] + Op.STOP,
+            ),
+            Section.Container(
+                container=Container(
+                    sections=[
+                        Section.Code(
+                            code=Op.PUSH0 + Op.PUSH0 + Op.RETURNCONTRACT[0],
+                        ),
+                        stop_sub_container,
+                    ]
+                )
+            ),
+        ]
+    )
+    last_container = container
+    while len(container) < MAX_INITCODE_SIZE:
+        last_container = container
+        container = Container(
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0 + Op.PUSH0 + Op.PUSH0 + Op.PUSH0 + Op.EOFCREATE[0] + Op.STOP,
+                ),
+                Section.Container(
+                    container=Container(
+                        sections=[
+                            Section.Code(
+                                code=Op.PUSH0 + Op.PUSH0 + Op.RETURNCONTRACT[0],
+                            ),
+                            Section.Container(container=last_container),
+                        ]
+                    )
+                ),
+            ]
+        )
+
+    eof_test(data=last_container)
+
+
+def test_wide_container(eof_test: EOFTestFiller):
+    """Test a container with the maximum number of sub-containers"""
+    create_code: Bytecode = Op.STOP
+    for x in range(0, 256):
+        create_code = Op.EOFCREATE[x](0, 0, 0, 0) + create_code
+    eof_test(
+        data=Container(
+            sections=[
+                Section.Code(
+                    code=create_code,
+                ),
+                *(
+                    [
+                        Section.Container(
+                            container=Container(
+                                sections=[
+                                    Section.Code(
+                                        code=Op.PUSH0 + Op.PUSH0 + Op.RETURNCONTRACT[0],
+                                    ),
+                                    stop_sub_container,
+                                ]
+                            )
+                        )
+                    ]
+                    * 256
+                ),
+            ]
+        )
     )


### PR DESCRIPTION
## 🗒️ Description
EOF tests for a very deeply nested container and one level of all
possible containers.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
