### PR TITLE
chore(consume): update consume index file exception

### DIFF
--- a/src/pytest_plugins/consume/consume.py
+++ b/src/pytest_plugins/consume/consume.py
@@ -11,9 +11,7 @@ from urllib.parse import urlparse
 
 import pytest
 import requests
-import rich
 
-from cli.gen_index import generate_fixtures_index
 from ethereum_test_fixtures.consume import TestCases
 from ethereum_test_tools.utility.versioning import get_current_commit_hash_or_tag
 
@@ -143,10 +141,11 @@ def pytest_configure(config):  # noqa: D103
 
     index_file = input_source / "index.json"
     if not index_file.exists():
-        rich.print(f"Generating index file [bold cyan]{index_file}[/]...")
-    generate_fixtures_index(
-        Path(input_source), quiet_mode=False, force_flag=False, disable_infer_format=False
-    )
+        pytest.exit(
+            f"Index file not found within input source '{input_source}/'."
+            "\nPlease make sure the input source is the root of the fixture directory and"
+            "contains the `index.json` file."
+        )
     config.test_cases = TestCases.from_index_file(Path(input_source) / "index.json")
 
     if config.option.collectonly:

--- a/src/pytest_plugins/filler/filler.py
+++ b/src/pytest_plugins/filler/filler.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Generator, List, Type
 
 import pytest
+import rich
 from pytest_metadata.plugin import metadata_key  # type: ignore
 
 from cli.gen_index import generate_fixtures_index
@@ -618,6 +619,10 @@ def fixture_collector(
     fixture_collector.dump_fixtures()
     if do_fixture_verification:
         fixture_collector.verify_fixture_files(evm_fixture_verification)
+
+    index_file = output_dir / "index.json"
+    if not index_file.exists():
+        rich.print(f"\n\nGenerating fixture index file [bold cyan]{index_file}[/]...")
     generate_fixtures_index(
         output_dir, quiet_mode=False, force_flag=False, disable_infer_format=False
     )


### PR DESCRIPTION
## 🗒️ Description
Updates consume for the case where the index file is not found. It no longer re-generates this.

To me it makes sense to enforce this if the filler is now the index generator.

Open to not including this.
