### PR TITLE
feat(fw): use a metadata folder within fixtures

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - 🐞 Fixed consume hive commands from spawning different hive test suites during the same test execution when using xdist ([#712](https://github.com/ethereum/execution-spec-tests/pull/712)).
 - ✨ `consume hive` command is now available to run all types of hive tests ([#712](https://github.com/ethereum/execution-spec-tests/pull/712)).
 - ✨ Generated fixtures now contain the test index `index.json` by default ([#716](https://github.com/ethereum/execution-spec-tests/pull/716)).
+- ✨ A metadata folder `.meta/` now stores all fixture metadata files by default ([#721](https://github.com/ethereum/execution-spec-tests/pull/721)).
 
 ### 🔧 EVM Tools
 

--- a/src/cli/gen_index.py
+++ b/src/cli/gen_index.py
@@ -134,7 +134,7 @@ def generate_fixtures_index(
     if not quiet_mode:
         total_files = count_json_files_exclude_index(input_path)
 
-    output_file = Path(f"{input_path}/index.json")
+    output_file = Path(f"{input_path}/.meta/index.json")
     try:
         root_hash = HashableItem.from_folder(folder_path=input_path).hash()
     except (KeyError, TypeError):

--- a/src/cli/tests/test_pytest_fill_command.py
+++ b/src/cli/tests/test_pytest_fill_command.py
@@ -78,11 +78,11 @@ class TestHtmlReportFlags:
         return ["-k", "test_dup and state_test-DUP16", "--fork", "Frontier"]
 
     @pytest.fixture()
-    def default_html_report_filename(self):
+    def default_html_report_file_path(self):
         """
-        The default filename for fill's pytest html report.
+        The default file path for fill's pytest html report.
         """
-        return pytest_plugins.filler.filler.default_html_report_filename()
+        return pytest_plugins.filler.filler.default_html_report_file_path()
 
     @pytest.fixture(scope="function")
     def temp_dir(self) -> Generator[Path, None, None]:  # noqa: D102
@@ -113,12 +113,12 @@ class TestHtmlReportFlags:
         runner,
         temp_dir,
         fill_args,
-        default_html_report_filename,
+        default_html_report_file_path,
     ):
         """
         Test default pytest html behavior: Neither `--html` or `--output` is specified.
         """
-        default_html_path = temp_dir / default_html_report_filename
+        default_html_path = temp_dir / default_html_report_file_path
         result = runner.invoke(fill, fill_args)
         assert result.exit_code == pytest.ExitCode.OK
         assert default_html_path.exists()
@@ -128,12 +128,12 @@ class TestHtmlReportFlags:
         runner,
         temp_dir,
         fill_args,
-        default_html_report_filename,
+        default_html_report_file_path,
     ):
         """
         Test pytest html report is disabled with the `--no-html` flag.
         """
-        default_html_path = temp_dir / default_html_report_filename
+        default_html_path = temp_dir / default_html_report_file_path
         fill_args += ["--no-html"]
         result = runner.invoke(fill, fill_args)
         assert result.exit_code == pytest.ExitCode.OK
@@ -159,13 +159,13 @@ class TestHtmlReportFlags:
         runner,
         temp_dir,
         fill_args,
-        default_html_report_filename,
+        default_html_report_file_path,
     ):
         """
         Tests pytest html report generation with only the `--output` flag.
         """
         output_dir = temp_dir / "non_default_output_dir"
-        non_default_html_path = output_dir / default_html_report_filename
+        non_default_html_path = output_dir / default_html_report_file_path
         fill_args += ["--output", str(output_dir)]
         result = runner.invoke(fill, fill_args)
         assert result.exit_code == pytest.ExitCode.OK

--- a/src/pytest_plugins/consume/consume.py
+++ b/src/pytest_plugins/consume/consume.py
@@ -141,13 +141,13 @@ def pytest_configure(config):  # noqa: D103
             f"Specified fixture directory '{input_source}' does not contain any JSON files."
         )
 
-    index_file = input_source / ".meta/index.json"
+    index_file = input_source / ".meta" / "index.json"
     if not index_file.exists():
         rich.print(f"Generating index file [bold cyan]{index_file}[/]...")
     generate_fixtures_index(
-        Path(input_source), quiet_mode=False, force_flag=False, disable_infer_format=False
+        input_source, quiet_mode=False, force_flag=False, disable_infer_format=False
     )
-    config.test_cases = TestCases.from_index_file(Path(input_source) / "index.json")
+    config.test_cases = TestCases.from_index_file(index_file)
 
     if config.option.collectonly:
         return

--- a/src/pytest_plugins/consume/consume.py
+++ b/src/pytest_plugins/consume/consume.py
@@ -30,12 +30,12 @@ def default_input_directory() -> str:
     return "./fixtures"
 
 
-def default_html_report_filename() -> str:
+def default_html_report_file_path() -> str:
     """
-    The default file to store the generated HTML test report. Defined as a
+    The default filepath to store the generated HTML test report. Defined as a
     function to allow for easier testing.
     """
-    return "report_consume.html"
+    return ".meta/report_consume.html"
 
 
 def is_url(string: str) -> bool:
@@ -141,7 +141,7 @@ def pytest_configure(config):  # noqa: D103
             f"Specified fixture directory '{input_source}' does not contain any JSON files."
         )
 
-    index_file = input_source / "index.json"
+    index_file = input_source / ".meta/index.json"
     if not index_file.exists():
         rich.print(f"Generating index file [bold cyan]{index_file}[/]...")
     generate_fixtures_index(
@@ -154,7 +154,7 @@ def pytest_configure(config):  # noqa: D103
     if not config.getoption("disable_html") and config.getoption("htmlpath") is None:
         # generate an html report by default, unless explicitly disabled
         config.option.htmlpath = os.path.join(
-            config.getoption("fixture_source"), default_html_report_filename()
+            config.getoption("fixture_source"), default_html_report_file_path()
         )
 
 

--- a/src/pytest_plugins/filler/filler.py
+++ b/src/pytest_plugins/filler/filler.py
@@ -263,7 +263,11 @@ def pytest_configure(config):
         "t8n": t8n.version(),
         "solc": str(config.solc_version),
     }
-    command_line_args = "fill " + " ".join(config.invocation_params.args)
+    args = ["fill"] + [str(arg) for arg in config.invocation_params.args]
+    for i in range(len(args)):
+        if " " in args[i]:
+            args[i] = f'"{args[i]}"'
+    command_line_args = " ".join(args)
     config.stash[metadata_key]["Command-line args"] = f"<code>{command_line_args}</code>"
 
 

--- a/src/pytest_plugins/filler/tests/test_filler.py
+++ b/src/pytest_plugins/filler/tests/test_filler.py
@@ -524,42 +524,38 @@ def test_fixture_output_based_on_command_line_args(
     assert output_dir.exists()
 
     all_files = get_all_files_in_directory(output_dir)
+    meta_dir = os.path.join(output_dir, ".meta")
+    assert os.path.exists(meta_dir), f"The directory {meta_dir} does not exist"
 
-    expected_fixtures_ini_filename = "fixtures.ini"
-    expected_fixtures_index_filename = "index.json"
+    expected_ini_file = "fixtures.ini"
+    expected_index_file = "index.json"
 
     ini_file = None
     index_file = None
     for file in all_files:
-        if file.name == expected_fixtures_ini_filename:
+        if file.name == expected_ini_file:
             ini_file = file
-        elif file.name == expected_fixtures_index_filename:
+        elif file.name == expected_index_file:
             index_file = file
 
-    assert ini_file is not None, f"No {expected_fixtures_ini_filename} file was written"
-    assert index_file is not None, f"No {expected_fixtures_index_filename} file was written"
-
-    all_files = [
-        file
-        for file in all_files
-        if file.name
-        not in {
-            expected_fixtures_ini_filename,
-            expected_fixtures_index_filename,
-        }
+    all_fixtures = [
+        file for file in all_files if file.name not in {expected_ini_file, expected_index_file}
     ]
-
     for fixture_file, fixture_count in zip(expected_fixture_files, expected_fixture_counts):
-        assert fixture_file.exists()
-        assert fixture_count == count_keys_in_fixture(fixture_file)
+        assert fixture_file.exists(), f"{fixture_file} does not exist"
+        assert fixture_count == count_keys_in_fixture(
+            fixture_file
+        ), f"Fixture count mismatch for {fixture_file}"
 
-    assert set(all_files) == set(
+    assert set(all_fixtures) == set(
         expected_fixture_files
-    ), f"Unexpected files in directory: {set(all_files) - set(expected_fixture_files)}"
+    ), f"Unexpected files in directory: {set(all_fixtures) - set(expected_fixture_files)}"
 
-    assert ini_file is not None, f"No {expected_fixtures_ini_filename} file was written"
+    assert ini_file is not None, f"No {expected_ini_file} file was found in {meta_dir}"
     config = configparser.ConfigParser()
     config.read(ini_file)
+
+    assert index_file is not None, f"No {expected_index_file} file was found in {meta_dir}"
 
     properties = {key: value for key, value in config.items("fixtures")}
     assert "timestamp" in properties


### PR DESCRIPTION
## 🗒️ Description
Adds a `fixtures/.meta/` folder for the following metadata files that are generated from a `fill`/`consume` operation.
```tree
├── assets/
│   └── style.css
├── fixtures.ini
├── index.json
├── report_consume.html
└── report_fill.html
```

The aim of this PR is to clean the additional files created. Primarily so client devs can simply choose to ignore `.meta/` when executing tests from fixture releases within there CI or otherwise. This gives us freedom to dump anything within the folder for the long term.

## 🔗 Related Issues
N/A

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
