### PR TITLE
fix(docs): Add some execution cases to EOF test tracker

### DIFF
--- a/tests/prague/eip7692_eof_v1/tracker.md
+++ b/tests/prague/eip7692_eof_v1/tracker.md
@@ -193,6 +193,11 @@
 - [ ] All opcodes correctly account for stack inputs/outputs (ethereum/tests: src/EOFTestsFiller/EIP5450/validInvalidFiller.yml)
 - [ ] Check that unreachable code is invalid after all terminating instructions (ethereum/tests: src/EOFTestsFiller/EIP5450/validInvalidFiller.yml)
 
+### Execution
+
+- [ ] Max stack size (1024) in CALLF-ed function (ethereum/tests: src/EIPTestsFiller/StateTests/stEOF/stEIP4200/EOF1_CALLF_ExecutionFiller.yml)
+
+
 ## EIP-6206: EOF - JUMPF and non-returning functions
 
 ### Validation

--- a/tests/prague/eip7692_eof_v1/tracker.md
+++ b/tests/prague/eip7692_eof_v1/tracker.md
@@ -138,15 +138,15 @@
 
 ### Execution
 
-- [ ] RJUMP forwards
-- [ ] RJUMP backwards (ethereum/tests: src/EIPTestsFiller/StateTests/stEOF/stEIP4200/EOF1_RJUMP_RJUMPI_RJUMPV_ExecutionFiller.yml)
-- [ ] RJUMP with 0 offset (ethereum/tests: src/EIPTestsFiller/StateTests/stEOF/stEIP4200/EOF1_RJUMP_RJUMPI_RJUMPV_ExecutionFiller.yml)
-- [ ] RJUMPI forwards with condition true/false (ethereum/tests: src/EIPTestsFiller/StateTests/stEOF/stEIP4200/EOF1_RJUMP_RJUMPI_RJUMPV_ExecutionFiller.yml)
-- [ ] RJUMPI backwards with condition true/false (ethereum/tests: src/EIPTestsFiller/StateTests/stEOF/stEIP4200/EOF1_RJUMP_RJUMPI_RJUMPV_ExecutionFiller.yml)
-- [ ] RJUMPI with 0 offset with condition true/false (ethereum/tests: src/EIPTestsFiller/StateTests/stEOF/stEIP4200/EOF1_RJUMP_RJUMPI_RJUMPV_ExecutionFiller.yml)
-- [ ] RJUMPV with different case values (ethereum/tests: src/EIPTestsFiller/StateTests/stEOF/stEIP4200/EOF1_RJUMP_RJUMPI_RJUMPV_ExecutionFiller.yml)
-- [ ] RJUMPV with case value out of table bounds (ethereum/tests: src/EIPTestsFiller/StateTests/stEOF/stEIP4200/EOF1_RJUMP_RJUMPI_RJUMPV_ExecutionFiller.yml)
-- [ ] RJUMPV with max cases number (ethereum/tests: src/EIPTestsFiller/StateTests/stEOF/stEIP4200/EOF1_RJUMP_RJUMPI_RJUMPV_ExecutionFiller.yml)
+- [x] RJUMP forwards (eip7692_eof_v1/eip4200_relative_jumps/test_rjump.py::test_rjump_positive_negative)
+- [x] RJUMP backwards (eip7692_eof_v1/eip4200_relative_jumps/test_rjump.py::test_rjump_positive_negative)
+- [x] RJUMP with 0 offset (eip7692_eof_v1/eip4200_relative_jumps/test_rjump.py::test_rjump_zero)
+- [x] RJUMPI forwards with condition true/false (eip7692_eof_v1/eip4200_relative_jumps/test_rjumpi.py::test_rjumpi_condition_forwards)
+- [x] RJUMPI backwards with condition true/false (eip7692_eof_v1/eip4200_relative_jumps/test_rjumpi.py::test_rjumpi_condition_backwards)
+- [x] RJUMPI with 0 offset with condition true/false (eip7692_eof_v1/eip4200_relative_jumps/test_rjumpi.py::test_rjumpi_condition_zero)
+- [x] RJUMPV with different case values (eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py::test_rjumpv_condition)
+- [x] RJUMPV with case value out of table bounds (eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py::test_rjumpv_condition)
+- [x] RJUMPV with max cases number (eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py::test_rjumpv_condition eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py::test_rjumpv_full_table*)
 
 ## EIP-4750: EOF - Functions
 

--- a/tests/prague/eip7692_eof_v1/tracker.md
+++ b/tests/prague/eip7692_eof_v1/tracker.md
@@ -159,6 +159,12 @@
 - [ ] Sections reachable from other sections, but not reachable from section 0 (ethereum/tests: src/EOFTestsFiller/efValidation/unreachable_code_sections_Copier.json)
 - [ ] RETF with maximum number of outputs (ethereum/tests: src/EOFTestsFiller/EIP5450/validInvalidFiller.yml)
 
+### Execution
+
+- [ ] CALLF/RETF execution (ethereum/tests: src/EIPTestsFiller/StateTests/stEOF/stEIP4200/CALLF_RETF_ExecutionFiller.yml)
+- [ ] Dispatch to CALLF to different functions based on calldata (ethereum/tests: src/EIPTestsFiller/StateTests/stEOF/stEIP4200/CALLF_RETF_ExecutionFiller.yml)
+- [ ] Maximum number of code sections, calling each section with CALLF (ethereum/tests: src/EIPTestsFiller/StateTests/stEOF/stEIP4200/CALLF_RETF_ExecutionFiller.yml)
+
 ## EIP-5450: EOF - Stack Validation
 
 ### Validation

--- a/tests/prague/eip7692_eof_v1/tracker.md
+++ b/tests/prague/eip7692_eof_v1/tracker.md
@@ -136,6 +136,18 @@
 - [ ] RJUMPV out of section bounds (ethereum/tests: ./src/EOFTestsFiller/efValidation/EOF1_rjumpv_invalid_destination_Copier.json)
 - [ ] RJUMPV into immediate (ethereum/tests: ./src/EOFTestsFiller/efValidation/EOF1_rjumpv_invalid_destination_Copier.json)
 
+### Execution
+
+- [ ] RJUMP forwards
+- [ ] RJUMP backwards (ethereum/tests: src/EIPTestsFiller/StateTests/stEOF/stEIP4200/EOF1_RJUMP_RJUMPI_RJUMPV_ExecutionFiller.yml)
+- [ ] RJUMP with 0 offset (ethereum/tests: src/EIPTestsFiller/StateTests/stEOF/stEIP4200/EOF1_RJUMP_RJUMPI_RJUMPV_ExecutionFiller.yml)
+- [ ] RJUMPI forwards with condition true/false (ethereum/tests: src/EIPTestsFiller/StateTests/stEOF/stEIP4200/EOF1_RJUMP_RJUMPI_RJUMPV_ExecutionFiller.yml)
+- [ ] RJUMPI backwards with condition true/false (ethereum/tests: src/EIPTestsFiller/StateTests/stEOF/stEIP4200/EOF1_RJUMP_RJUMPI_RJUMPV_ExecutionFiller.yml)
+- [ ] RJUMPI with 0 offset with condition true/false (ethereum/tests: src/EIPTestsFiller/StateTests/stEOF/stEIP4200/EOF1_RJUMP_RJUMPI_RJUMPV_ExecutionFiller.yml)
+- [ ] RJUMPV with different case values (ethereum/tests: src/EIPTestsFiller/StateTests/stEOF/stEIP4200/EOF1_RJUMP_RJUMPI_RJUMPV_ExecutionFiller.yml)
+- [ ] RJUMPV with case value out of table bounds (ethereum/tests: src/EIPTestsFiller/StateTests/stEOF/stEIP4200/EOF1_RJUMP_RJUMPI_RJUMPV_ExecutionFiller.yml)
+- [ ] RJUMPV with max cases number (ethereum/tests: src/EIPTestsFiller/StateTests/stEOF/stEIP4200/EOF1_RJUMP_RJUMPI_RJUMPV_ExecutionFiller.yml)
+
 ## EIP-4750: EOF - Functions
 
 ### Validation


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
