### PR TITLE
fix(fixtures): Fix index generation for EOF tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Generated fixtures now contain the test index `index.json` by default ([#716](https://github.com/ethereum/execution-spec-tests/pull/716)).
 - ✨ A metadata folder `.meta/` now stores all fixture metadata files by default ([#721](https://github.com/ethereum/execution-spec-tests/pull/721)).
 - 🐞 Fixed `fill` command index generation issue due to concurrency ([#725](https://github.com/ethereum/execution-spec-tests/pull/725)).
+- 🐞 Fixed fixture index generation on EOF tests ([#728](https://github.com/ethereum/execution-spec-tests/pull/728)).
 
 ### 🔧 EVM Tools
 

--- a/src/cli/gen_index.py
+++ b/src/cli/gen_index.py
@@ -60,6 +60,8 @@ def infer_fixture_format_from_path(file: Path) -> FixtureFormats:
         return FixtureFormats.BLOCKCHAIN_TEST
     if "state_tests" in file.parts:
         return FixtureFormats.STATE_TEST
+    if "eof_tests" in file.parts:
+        return FixtureFormats.EOF_TEST
     return FixtureFormats.UNSET_TEST_FORMAT
 
 

--- a/src/ethereum_test_exceptions/exceptions.py
+++ b/src/ethereum_test_exceptions/exceptions.py
@@ -3,7 +3,7 @@ Exceptions for invalid execution.
 """
 
 from enum import Enum, auto, unique
-from typing import Annotated, Any, List
+from typing import Annotated, Any, Dict, List
 
 from pydantic import BeforeValidator, GetCoreSchemaHandler, PlainSerializer
 from pydantic_core.core_schema import (
@@ -12,23 +12,57 @@ from pydantic_core.core_schema import (
     to_string_ser_schema,
 )
 
+_exception_classes: Dict[str, type] = {}
+
 
 class ExceptionBase(Enum):
     """
     Base class for exceptions.
     """
 
-    @staticmethod
+    def __init_subclass__(cls) -> None:
+        """
+        Register the exception class.
+        """
+        super().__init_subclass__()
+        _exception_classes[cls.__name__] = cls
+
+    @classmethod
     def __get_pydantic_core_schema__(
-        source_type: Any, handler: GetCoreSchemaHandler
+        cls, source_type: Any, handler: GetCoreSchemaHandler
     ) -> PlainValidatorFunctionSchema:
         """
         Calls the class constructor without info and appends the serialization schema.
         """
         return no_info_plain_validator_function(
-            source_type,
+            cls.from_str,
             serialization=to_string_ser_schema(),
         )
+
+    @classmethod
+    def from_str(cls, value: "str | ExceptionBase") -> "ExceptionBase":
+        """
+        Returns the ContainerKind enum value from a string.
+        """
+        if isinstance(value, ExceptionBase):
+            return value
+
+        class_name, enum_name = value.split(".")
+
+        if cls == ExceptionBase:
+            # Exception base automatically resolves the class
+            exception_class = _exception_classes.get(class_name, None)
+        else:
+            # Otherwise, use the class that the method is called on
+            exception_class = cls
+
+        if exception_class is None:
+            raise ValueError(f"No such exception class: {class_name}")
+
+        exception = getattr(exception_class, enum_name, None)
+        if exception is not None:
+            return exception
+        raise ValueError(f"No such exception in {class_name}: {value}")
 
     def __contains__(self, exception) -> bool:
         """
@@ -55,29 +89,12 @@ def to_pipe_str(value: Any) -> str:
     return str(value)
 
 
-def create_exception_from_str(exception_str: str) -> ExceptionBase:
-    """
-    Create an exception instance from its string representation.
-    """
-    class_name, enum_name = exception_str.split(".")
-    exception_class = globals().get(class_name, None)
-
-    if exception_class and issubclass(exception_class, ExceptionBase):
-        enum_value = getattr(exception_class, enum_name, None)
-        if enum_value and enum_value in exception_class:
-            return exception_class(enum_value)
-        else:
-            raise ValueError(f"No such enum in class: {exception_str}")
-    else:
-        raise ValueError(f"No such exception class: {class_name}")
-
-
-def from_pipe_str(value: Any) -> ExceptionBase | List[ExceptionBase]:
+def from_pipe_str(value: Any) -> str | List[str]:
     """
     Parses a single string as a pipe separated list into enum exceptions.
     """
     if isinstance(value, str):
-        exception_list = [create_exception_from_str(v) for v in value.split("|")]
+        exception_list = value.split("|")
         if len(exception_list) == 1:
             return exception_list[0]
         return exception_list
@@ -719,19 +736,19 @@ Pydantic Annotated Types
 """
 
 ExceptionInstanceOrList = Annotated[
-    TransactionException | BlockException | List[TransactionException | BlockException],
+    List[TransactionException | BlockException] | TransactionException | BlockException,
     BeforeValidator(from_pipe_str),
     PlainSerializer(to_pipe_str),
 ]
 
 TransactionExceptionInstanceOrList = Annotated[
-    TransactionException | List[TransactionException],
+    List[TransactionException] | TransactionException,
     BeforeValidator(from_pipe_str),
     PlainSerializer(to_pipe_str),
 ]
 
 BlockExceptionInstanceOrList = Annotated[
-    BlockException | List[BlockException],
+    List[BlockException] | BlockException,
     BeforeValidator(from_pipe_str),
     PlainSerializer(to_pipe_str),
 ]

--- a/src/ethereum_test_exceptions/exceptions.py
+++ b/src/ethereum_test_exceptions/exceptions.py
@@ -51,13 +51,14 @@ class ExceptionBase(Enum):
 
         if cls == ExceptionBase:
             # Exception base automatically resolves the class
-            exception_class = _exception_classes.get(class_name, None)
+            assert class_name in _exception_classes, f"No such exception class: {class_name}"
+            exception_class = _exception_classes[class_name]
         else:
             # Otherwise, use the class that the method is called on
+            assert (
+                cls.__name__ == class_name
+            ), f"Unexpected exception type: {class_name}, expected {cls.__name__}"
             exception_class = cls
-
-        if exception_class is None:
-            raise ValueError(f"No such exception class: {class_name}")
 
         exception = getattr(exception_class, enum_name, None)
         if exception is not None:

--- a/src/ethereum_test_fixtures/base.py
+++ b/src/ethereum_test_fixtures/base.py
@@ -64,7 +64,7 @@ class BaseFixture(CamelModel):
         if ref_spec is not None:
             ref_spec.write_info(self.info)
 
-    def get_fork(self) -> str:
+    def get_fork(self) -> str | None:
         """
         Returns the fork of the fixture as a string.
         """

--- a/src/ethereum_test_fixtures/blockchain.py
+++ b/src/ethereum_test_fixtures/blockchain.py
@@ -488,7 +488,7 @@ class FixtureCommon(BaseFixture):
     post_state: Alloc | None = Field(None)
     last_block_hash: Hash = Field(..., alias="lastblockhash")  # FIXME: lastBlockHash
 
-    def get_fork(self) -> str:
+    def get_fork(self) -> str | None:
         """
         Returns the fork of the fixture as a string.
         """

--- a/src/ethereum_test_fixtures/consume.py
+++ b/src/ethereum_test_fixtures/consume.py
@@ -24,7 +24,7 @@ class TestCaseBase(BaseModel):
 
     id: str
     fixture_hash: HexNumber | None
-    fork: str
+    fork: str | None
     format: FixtureFormats
     __test__ = False  # stop pytest from collecting this class as a test
 

--- a/src/ethereum_test_fixtures/eof.py
+++ b/src/ethereum_test_fixtures/eof.py
@@ -41,7 +41,7 @@ class Vector(CamelModel):
     """
 
     code: Bytes
-    container_kind: ContainerKind | None
+    container_kind: ContainerKind = ContainerKind.RUNTIME
     results: Mapping[str, Result]
 
 
@@ -53,3 +53,9 @@ class Fixture(BaseFixture):
     vectors: Mapping[Number, Vector]
 
     format: ClassVar[FixtureFormats] = FixtureFormats.EOF_TEST
+
+    def get_fork(self) -> str | None:
+        """
+        Returns the fork of the fixture as a string.
+        """
+        return None

--- a/src/ethereum_test_fixtures/file.py
+++ b/src/ethereum_test_fixtures/file.py
@@ -9,14 +9,15 @@ from pydantic import RootModel
 
 from .blockchain import EngineFixture as BlockchainEngineFixture
 from .blockchain import Fixture as BlockchainFixture
+from .eof import Fixture as EOFFixture
 from .formats import FixtureFormats
 from .state import Fixture as StateFixture
 
 FixtureFormatsValues = Literal[
-    "blockchain_test_engine", "blockchain_test", "state_test", "unset_test_format"
+    "blockchain_test_engine", "blockchain_test", "state_test", "eof_test", "unset_test_format"
 ]
 
-FixtureModel = BlockchainFixture | BlockchainEngineFixture | StateFixture
+FixtureModel = BlockchainFixture | BlockchainEngineFixture | StateFixture | EOFFixture
 
 
 class BaseFixturesRootModel(RootModel):
@@ -103,9 +104,11 @@ class BaseFixturesRootModel(RootModel):
             FixtureFormats.BLOCKCHAIN_TEST: BlockchainFixtures,
             FixtureFormats.BLOCKCHAIN_TEST_ENGINE: BlockchainEngineFixtures,
             FixtureFormats.STATE_TEST: StateFixtures,
+            FixtureFormats.EOF_TEST: EOFFixtures,
             FixtureFormats.BLOCKCHAIN_TEST.value: BlockchainFixtures,
             FixtureFormats.BLOCKCHAIN_TEST_ENGINE.value: BlockchainEngineFixtures,
             FixtureFormats.STATE_TEST.value: StateFixtures,
+            FixtureFormats.EOF_TEST.value: EOFFixtures,
         }
 
         if fixture_format not in [None, "unset_test_format", FixtureFormats.UNSET_TEST_FORMAT]:
@@ -154,3 +157,13 @@ class StateFixtures(BaseFixturesRootModel):
     """
 
     root: Dict[str, StateFixture]
+
+
+class EOFFixtures(BaseFixturesRootModel):
+    """
+    Defines a top-level model containing multiple state test fixtures in a
+    dictionary of (fixture-name, fixture) pairs. This is the format used in JSON
+    fixture files for EOF tests.
+    """
+
+    root: Dict[str, EOFFixture]

--- a/src/ethereum_test_fixtures/state.py
+++ b/src/ethereum_test_fixtures/state.py
@@ -115,7 +115,7 @@ class Fixture(BaseFixture):
 
     format: ClassVar[FixtureFormats] = FixtureFormats.STATE_TEST
 
-    def get_fork(self) -> str:
+    def get_fork(self) -> str | None:
         """
         Returns the fork of the fixture as a string.
         """

--- a/src/ethereum_test_fixtures/tests/test_eof.py
+++ b/src/ethereum_test_fixtures/tests/test_eof.py
@@ -1,0 +1,107 @@
+"""
+Test the EOF fixture types.
+"""
+
+from typing import Any, Dict
+
+import pytest
+
+from ethereum_test_base_types import Bytes, to_json
+from ethereum_test_exceptions import EOFException
+
+from ..eof import ContainerKind, Fixture, Result, Vector
+
+
+@pytest.mark.parametrize(
+    ["can_be_deserialized", "model_instance", "json_repr"],
+    [
+        pytest.param(
+            True,
+            Fixture(
+                vectors={
+                    1: Vector(
+                        code=Bytes(b"\x00"),
+                        container_kind=ContainerKind.INITCODE,
+                        results={
+                            "result1": Result(
+                                exception=None,
+                                valid=True,
+                            ),
+                        },
+                    ),
+                }
+            ),
+            {
+                "vectors": {
+                    "1": {
+                        "code": "0x00",
+                        "containerKind": "INITCODE",
+                        "results": {
+                            "result1": {
+                                "result": True,
+                            },
+                        },
+                    },
+                },
+            },
+            id="eof_fixture",
+        ),
+        pytest.param(
+            True,
+            Fixture(
+                vectors={
+                    1: Vector(
+                        code=Bytes(b"\x00"),
+                        container_kind=ContainerKind.RUNTIME,
+                        results={
+                            "result1": Result(
+                                exception=EOFException.INVALID_MAGIC,
+                                valid=False,
+                            ),
+                        },
+                    ),
+                }
+            ),
+            {
+                "vectors": {
+                    "1": {
+                        "code": "0x00",
+                        "containerKind": "RUNTIME",
+                        "results": {
+                            "result1": {
+                                "exception": "EOFException.INVALID_MAGIC",
+                                "result": False,
+                            },
+                        },
+                    },
+                },
+            },
+            id="eof_fixture_with_exception",
+        ),
+    ],
+)
+class TestPydanticModelConversion:
+    """
+    Test that Pydantic models are converted to and from JSON correctly.
+    """
+
+    def test_json_serialization(
+        self, can_be_deserialized: bool, model_instance: Any, json_repr: str | Dict[str, Any]
+    ):
+        """
+        Test that to_json returns the expected JSON for the given object.
+        """
+        serialized = to_json(model_instance)
+        serialized.pop("_info")
+        assert serialized == json_repr
+
+    def test_json_deserialization(
+        self, can_be_deserialized: bool, model_instance: Any, json_repr: str | Dict[str, Any]
+    ):
+        """
+        Test that to_json returns the expected JSON for the given object.
+        """
+        if not can_be_deserialized:
+            pytest.skip(reason="The model instance in this case can not be deserialized")
+        model_type = type(model_instance)
+        assert model_type(**json_repr) == model_instance

--- a/src/ethereum_test_types/eof/v1/__init__.py
+++ b/src/ethereum_test_types/eof/v1/__init__.py
@@ -69,9 +69,20 @@ class ContainerKind(Enum):
         Calls the class constructor without info and appends the serialization schema.
         """
         return no_info_plain_validator_function(
-            source_type,
+            source_type.from_str,
             serialization=to_string_ser_schema(),
         )
+
+    @staticmethod
+    def from_str(value: "str | ContainerKind | None") -> "ContainerKind | None":
+        """
+        Returns the ContainerKind enum value from a string.
+        """
+        if value is None:
+            return None
+        if isinstance(value, ContainerKind):
+            return value
+        return ContainerKind[value.upper()]
 
     def __str__(self) -> str:
         """


### PR DESCRIPTION
## 🗒️ Description
Fixture filling was failing due to the index generation not supporting parsing EOF tests.

Fixed:
- EOF fixture parsing due to `ContainerKind` not parsing correctly on read
- `EOFException` parsing due to not being supported by `from_pipe_str` function
- Refactored `ExceptionBase` and subclasses string parsing 

## 🔗 Related Issues
Closes #724

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.