### PR TITLE
refactor(tests): Remaining pre alloc updates

### DIFF
--- a/docs/writing_tests/test_markers.md
+++ b/docs/writing_tests/test_markers.md
@@ -141,6 +141,15 @@ Parameter `evm_code_type` will also be parametrized with the correct EVM code ty
 
 This marker is used to mark tests that are slow to run. These tests are not run during tox testing, and are only run when a release is being prepared.
 
+### pytest.mark.pre_alloc_modify
+
+This marker is used to mark tests that modify the pre-alloc in a way that would be impractical to reproduce in a real-world scenario.
+
+Examples of this include:
+
+- Modifying the pre-alloc to have a balance of 2^256 - 1.
+- Address collisions that would require hash collisions.
+
 ### pytest.mark.skip("reason")
 
 This marker is used to skip a test with a reason.

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,6 +5,7 @@ python_files = *.py
 testpaths = tests/
 markers =
     slow
+    pre_alloc_modify
 addopts = 
     -p pytest_plugins.filler.pre_alloc
     -p pytest_plugins.filler.filler

--- a/src/ethereum_test_types/helpers.py
+++ b/src/ethereum_test_types/helpers.py
@@ -10,6 +10,7 @@ from ethereum.rlp import encode
 
 from ethereum_test_base_types.base_types import Address, Bytes, Hash
 from ethereum_test_base_types.conversions import BytesConvertible, FixedSizeBytesConvertible
+from ethereum_test_vm import Opcodes as Op
 
 from .types import EOA
 
@@ -26,18 +27,29 @@ def ceiling_division(a: int, b: int) -> int:
     return -(a // -b)
 
 
-def compute_create_address(address: FixedSizeBytesConvertible | EOA, nonce: int = 0) -> Address:
+def compute_create_address(
+    *,
+    address: FixedSizeBytesConvertible | EOA,
+    nonce: int = 0,
+    salt: int = 0,
+    initcode: BytesConvertible = b"",
+    opcode: Op = Op.CREATE,
+) -> Address:
     """
     Compute address of the resulting contract created using a transaction
     or the `CREATE` opcode.
     """
-    if isinstance(address, EOA):
-        nonce = address.nonce
-    else:
-        address = Address(address)
-    nonce_bytes = bytes() if nonce == 0 else nonce.to_bytes(length=1, byteorder="big")
-    hash = keccak256(encode([address, nonce_bytes]))
-    return Address(hash[-20:])
+    if opcode == Op.CREATE:
+        if isinstance(address, EOA):
+            nonce = address.nonce
+        else:
+            address = Address(address)
+        nonce_bytes = bytes() if nonce == 0 else nonce.to_bytes(length=1, byteorder="big")
+        hash = keccak256(encode([address, nonce_bytes]))
+        return Address(hash[-20:])
+    if opcode == Op.CREATE2:
+        return compute_create2_address(address, salt, initcode)
+    raise ValueError("Unsupported opcode")
 
 
 def compute_create2_address(

--- a/src/ethereum_test_types/tests/test_helpers.py
+++ b/src/ethereum_test_types/tests/test_helpers.py
@@ -70,7 +70,7 @@ def test_compute_create_address(address: str | int, nonce: int, expected_contrac
     - https://etherscan.io/address/0x06012c8cf97bead5deae237070f9587f8e7a266d
 
     """
-    assert compute_create_address(address, nonce) == expected_contract_address
+    assert compute_create_address(address=address, nonce=nonce) == expected_contract_address
 
 
 @pytest.mark.parametrize(

--- a/tests/byzantium/eip198_modexp_precompile/test_modexp.py
+++ b/tests/byzantium/eip198_modexp_precompile/test_modexp.py
@@ -261,7 +261,7 @@ def test_modexp(
 
     post = {}
     if output.call_return_code != "0x00":
-        contract_address = compute_create_address(account, 1)
+        contract_address = compute_create_address(address=account, nonce=1)
         post[contract_address] = Account(code=output.returned_data)
     post[account] = Account(storage={0: output.call_return_code})
 

--- a/tests/cancun/eip1153_tstore/test_tstorage_create_contexts.py
+++ b/tests/cancun/eip1153_tstore/test_tstorage_create_contexts.py
@@ -7,9 +7,9 @@ from enum import unique
 
 import pytest
 
-from ethereum_test_tools import Account, Address, Bytecode, Environment, Initcode
+from ethereum_test_tools import Account, Address, Alloc, Bytecode, Environment, Initcode
 from ethereum_test_tools import Opcodes as Op
-from ethereum_test_tools import StateTestFiller, TestAddress, Transaction, compute_create_address
+from ethereum_test_tools import StateTestFiller, Transaction, compute_create_address
 
 from . import CreateOpcodeParams, PytestParameterEnum
 from .spec import ref_spec_1153
@@ -18,9 +18,6 @@ REFERENCE_SPEC_GIT_PATH = ref_spec_1153.git_path
 REFERENCE_SPEC_VERSION = ref_spec_1153.version
 
 pytestmark = [pytest.mark.valid_from("Cancun")]
-
-# the address that creates the contract with create/create2
-creator_address = 0x100
 
 
 @unique
@@ -137,24 +134,20 @@ class TestTransientStorageInContractCreation:
         deploy_code: Bytecode,
         constructor_code: Bytecode,
     ) -> Initcode:
-        initcode = Initcode(deploy_code=deploy_code, initcode_prefix=constructor_code)
-        return initcode
+        return Initcode(deploy_code=deploy_code, initcode_prefix=constructor_code)
 
     @pytest.fixture()
     def creator_contract_code(  # noqa: D102
         self,
         opcode: Op,
         create2_salt: int,
-        created_contract_address: Address,
     ) -> Bytecode:
-        contract_call = Op.SSTORE(4, Op.CALL(address=created_contract_address))
         return (
             Op.TSTORE(0, 0x0100)
             + Op.TSTORE(1, 0x0200)
             + Op.TSTORE(2, 0x0300)
             + Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE)
-            + opcode(size=Op.CALLDATASIZE, salt=create2_salt)
-            + contract_call
+            + Op.SSTORE(4, Op.CALL(address=opcode(size=Op.CALLDATASIZE, salt=create2_salt)))
             # Save the state of transient storage following call to storage; the transient
             # storage should not have been overwritten
             + Op.SSTORE(0, Op.TLOAD(0))
@@ -163,12 +156,17 @@ class TestTransientStorageInContractCreation:
         )
 
     @pytest.fixture()
+    def creator_address(self, pre: Alloc, creator_contract_code: Bytecode) -> Address:
+        """The address that creates the contract with create/create2"""
+        return pre.deploy_contract(creator_contract_code)
+
+    @pytest.fixture()
     def expected_creator_storage(self) -> dict:  # noqa: D102
         return {0: 0x0100, 1: 0x0200, 2: 0x0300, 4: 0x0001}
 
     @pytest.fixture()
     def created_contract_address(  # noqa: D102
-        self, opcode: Op, create2_salt: int, initcode: Initcode
+        self, creator_address: Address, opcode: Op, create2_salt: int, initcode: Initcode
     ) -> Address:
         return compute_create_address(
             address=creator_address,
@@ -181,7 +179,8 @@ class TestTransientStorageInContractCreation:
     def test_contract_creation(
         self,
         state_test: StateTestFiller,
-        creator_contract_code: Bytecode,
+        pre: Alloc,
+        creator_address: Address,
         created_contract_address: Address,
         initcode: Initcode,
         deploy_code: Bytecode,
@@ -191,20 +190,13 @@ class TestTransientStorageInContractCreation:
         """
         Test transient storage in contract creation contexts.
         """
-        pre = {
-            TestAddress: Account(balance=100_000_000_000_000),
-            creator_address: Account(
-                code=creator_contract_code,
-                nonce=1,
-            ),
-        }
+        sender = pre.fund_eoa()
 
         tx = Transaction(
-            nonce=0,
+            sender=sender,
             to=creator_address,
             data=initcode,
-            gas_limit=1_000_000_000_000,
-            gas_price=10,
+            gas_limit=1_000_000,
         )
 
         post = {

--- a/tests/cancun/eip1153_tstore/test_tstorage_selfdestruct.py
+++ b/tests/cancun/eip1153_tstore/test_tstorage_selfdestruct.py
@@ -30,7 +30,7 @@ pytestmark = [pytest.mark.valid_from("Cancun")]
 # Addresses
 caller_address = 0x100
 copy_from_initcode_address = 0x200
-callee_address = compute_create_address(caller_address, 1)
+callee_address = compute_create_address(address=caller_address, nonce=1)
 
 CREATE_CODE = Op.EXTCODECOPY(
     copy_from_initcode_address, 0, 0, Op.EXTCODESIZE(copy_from_initcode_address)

--- a/tests/cancun/eip1153_tstore/test_tstorage_selfdestruct.py
+++ b/tests/cancun/eip1153_tstore/test_tstorage_selfdestruct.py
@@ -9,15 +9,9 @@ from typing import Dict
 
 import pytest
 
-from ethereum_test_tools import Account, Bytecode, CalldataCase, Environment, Initcode
+from ethereum_test_tools import Account, Alloc, Bytecode, CalldataCase, Environment, Hash, Initcode
 from ethereum_test_tools import Opcodes as Op
-from ethereum_test_tools import (
-    StateTestFiller,
-    Switch,
-    TestAddress,
-    Transaction,
-    compute_create_address,
-)
+from ethereum_test_tools import StateTestFiller, Switch, Transaction, compute_create_address
 
 from . import PytestParameterEnum
 from .spec import ref_spec_1153
@@ -27,21 +21,20 @@ REFERENCE_SPEC_VERSION = ref_spec_1153.version
 
 pytestmark = [pytest.mark.valid_from("Cancun")]
 
-# Addresses
-caller_address = 0x100
-copy_from_initcode_address = 0x200
-callee_address = compute_create_address(address=caller_address, nonce=1)
-
-CREATE_CODE = Op.EXTCODECOPY(
-    copy_from_initcode_address, 0, 0, Op.EXTCODESIZE(copy_from_initcode_address)
-) + Op.CREATE(0, 0, Op.EXTCODESIZE(copy_from_initcode_address))
+CREATE_CODE = Op.CALLDATACOPY(size=Op.CALLDATASIZE) + Op.CREATE(size=Op.CALLDATASIZE)
 
 
 def call_option(option_number: int) -> Bytecode:
     """
     Return the bytecode for a call to the callee contract with the given option number.
     """
-    return Op.MSTORE(0, option_number) + Op.CALL(Op.GAS, callee_address, 0, 0, 32, 0, 32)
+    return Op.MSTORE(value=option_number) + Op.CALL(
+        address=Op.SLOAD(0),
+        args_offset=0,
+        args_size=32,
+        ret_offset=0,
+        ret_size=32,
+    )
 
 
 @unique
@@ -58,9 +51,10 @@ class SelfDestructCases(PytestParameterEnum):
             "Then re-enter the contract and attempt to TLOAD the transient value.",
         ),
         "pre_existing_contract": True,
-        "caller_bytecode": Op.SSTORE(0, call_option(1))
-        + Op.SSTORE(1, call_option(2))
-        + Op.SSTORE(2, Op.MLOAD(0)),
+        "caller_bytecode": Op.SSTORE(0, Op.CALLDATALOAD(0))
+        + Op.SSTORE(1, call_option(1))
+        + Op.SSTORE(2, call_option(2))
+        + Op.SSTORE(3, Op.MLOAD(0)),
         "callee_bytecode": Switch(
             cases=[
                 CalldataCase(value=1, action=Op.TSTORE(0xFF, 0x100) + Op.SELFDESTRUCT(0)),
@@ -68,9 +62,9 @@ class SelfDestructCases(PytestParameterEnum):
             ],
         ),
         "expected_storage": {
-            0: 0x01,
             1: 0x01,
-            2: 0x100,
+            2: 0x01,
+            3: 0x100,
         },
     }
 
@@ -92,7 +86,6 @@ class SelfDestructCases(PytestParameterEnum):
             ],
         ),
         "expected_storage": {
-            0: callee_address,
             1: 0x01,
             2: 0x01,
             3: 0x100,
@@ -105,7 +98,9 @@ class SelfDestructCases(PytestParameterEnum):
             "and use TLOAD upon return from the inner self-destructing call.",
         ),
         "pre_existing_contract": True,
-        "caller_bytecode": Op.SSTORE(0, call_option(1)) + Op.SSTORE(1, Op.MLOAD(0)),
+        "caller_bytecode": Op.SSTORE(0, Op.CALLDATALOAD(0))
+        + Op.SSTORE(1, call_option(1))
+        + Op.SSTORE(2, Op.MLOAD(0)),
         "callee_bytecode": Switch(
             cases=[
                 CalldataCase(
@@ -119,8 +114,8 @@ class SelfDestructCases(PytestParameterEnum):
             ],
         ),
         "expected_storage": {
-            0: 0x01,
-            1: 0x100,
+            1: 0x01,
+            2: 0x100,
         },
     }
 
@@ -139,7 +134,14 @@ class SelfDestructCases(PytestParameterEnum):
                 CalldataCase(
                     value=1,
                     action=Op.TSTORE(0xFF, 0x100)
-                    + call_option(2)
+                    + Op.MSTORE(value=2)
+                    + Op.CALL(
+                        address=Op.ADDRESS,
+                        args_offset=0,
+                        args_size=32,
+                        ret_offset=0,
+                        ret_size=32,
+                    )
                     + Op.MSTORE(0, Op.TLOAD(0xFF))
                     + Op.RETURN(0, 32),
                 ),
@@ -147,7 +149,6 @@ class SelfDestructCases(PytestParameterEnum):
             ],
         ),
         "expected_storage": {
-            0: callee_address,
             1: 0x01,
             2: 0x100,
         },
@@ -159,10 +160,11 @@ class SelfDestructCases(PytestParameterEnum):
             "Lastly use TLOAD on another re-entry",
         ),
         "pre_existing_contract": True,
-        "caller_bytecode": Op.SSTORE(0, call_option(1))
-        + Op.SSTORE(1, call_option(2))
-        + Op.SSTORE(2, call_option(3))
-        + Op.SSTORE(3, Op.MLOAD(0)),
+        "caller_bytecode": Op.SSTORE(0, Op.CALLDATALOAD(0))
+        + Op.SSTORE(1, call_option(1))
+        + Op.SSTORE(2, call_option(2))
+        + Op.SSTORE(3, call_option(3))
+        + Op.SSTORE(4, Op.MLOAD(0)),
         "callee_bytecode": Switch(
             cases=[
                 CalldataCase(value=1, action=Op.SELFDESTRUCT(0)),
@@ -171,10 +173,10 @@ class SelfDestructCases(PytestParameterEnum):
             ],
         ),
         "expected_storage": {
-            0: 0x01,
             1: 0x01,
             2: 0x01,
-            3: 0x100,
+            3: 0x01,
+            4: 0x100,
         },
     }
 
@@ -197,7 +199,6 @@ class SelfDestructCases(PytestParameterEnum):
             ],
         ),
         "expected_storage": {
-            0: callee_address,
             1: 0x01,
             2: 0x01,
             3: 0x01,
@@ -209,29 +210,35 @@ class SelfDestructCases(PytestParameterEnum):
 @SelfDestructCases.parametrize()
 def test_reentrant_selfdestructing_call(
     state_test: StateTestFiller,
-    pre_existing_contract,
-    caller_bytecode,
-    callee_bytecode,
-    expected_storage,
+    pre: Alloc,
+    pre_existing_contract: bool,
+    caller_bytecode: Bytecode,
+    callee_bytecode: Bytecode,
+    expected_storage: Dict,
 ):
     """
     Test transient storage in different reentrancy contexts after selfdestructing.
     """
     env = Environment()
 
-    pre = {
-        TestAddress: Account(balance=10**40),
-        caller_address: Account(code=caller_bytecode, nonce=1),
-        copy_from_initcode_address: Account(code=Initcode(deploy_code=callee_bytecode)),
-    }
+    caller_address = pre.deploy_contract(code=caller_bytecode)
 
+    data: Hash | Bytecode
     if pre_existing_contract:
-        pre[callee_address] = Account(code=callee_bytecode)
+        callee_address = pre.deploy_contract(code=callee_bytecode)
+        data = Hash(callee_address)
+    else:
+        callee_address = compute_create_address(address=caller_address, nonce=1)
+        data = Initcode(deploy_code=callee_bytecode)
 
     tx = Transaction(
+        sender=pre.fund_eoa(),
         to=caller_address,
         gas_limit=1_000_000,
+        data=data,
     )
+
+    expected_storage[0] = callee_address
 
     post: Dict = {caller_address: Account(storage=expected_storage)}
 

--- a/tests/cancun/eip4788_beacon_root/test_beacon_root_contract.py
+++ b/tests/cancun/eip4788_beacon_root/test_beacon_root_contract.py
@@ -26,12 +26,12 @@ from ethereum_test_forks import Fork
 from ethereum_test_tools import (
     Account,
     Address,
+    Alloc,
     Block,
     BlockchainTestFiller,
     Bytecode,
     Hash,
     Storage,
-    TestAddress,
     Transaction,
     Withdrawal,
 )
@@ -65,7 +65,7 @@ def test_beacon_root_contract_calls(
     blockchain_test: BlockchainTestFiller,
     beacon_root: bytes,
     timestamp: int,
-    pre: Dict,
+    pre: Alloc,
     tx: Transaction,
     post: Dict,
 ):
@@ -120,7 +120,7 @@ def test_beacon_root_contract_timestamps(
     blockchain_test: BlockchainTestFiller,
     beacon_root: bytes,
     timestamp: int,
-    pre: Dict,
+    pre: Alloc,
     tx: Transaction,
     post: Dict,
 ):
@@ -155,7 +155,7 @@ def test_calldata_lengths(
     blockchain_test: BlockchainTestFiller,
     beacon_root: bytes,
     timestamp: int,
-    pre: Dict,
+    pre: Alloc,
     tx: Transaction,
     post: Dict,
 ):
@@ -185,7 +185,7 @@ def test_beacon_root_equal_to_timestamp(
     blockchain_test: BlockchainTestFiller,
     beacon_root: bytes,
     timestamp: int,
-    pre: Dict,
+    pre: Alloc,
     tx: Transaction,
     post: Dict,
 ):
@@ -210,7 +210,7 @@ def test_tx_to_beacon_root_contract(
     blockchain_test: BlockchainTestFiller,
     beacon_root: bytes,
     timestamp: int,
-    pre: Dict,
+    pre: Alloc,
     tx: Transaction,
     post: Dict,
 ):
@@ -237,7 +237,7 @@ def test_invalid_beacon_root_calldata_value(
     blockchain_test: BlockchainTestFiller,
     beacon_root: bytes,
     timestamp: int,
-    pre: Dict,
+    pre: Alloc,
     tx: Transaction,
     post: Dict,
 ):
@@ -260,7 +260,7 @@ def test_beacon_root_selfdestruct(
     blockchain_test: BlockchainTestFiller,
     beacon_root: bytes,
     timestamp: int,
-    pre: Dict,
+    pre: Alloc,
     tx: Transaction,
     post: Dict,
 ):
@@ -268,24 +268,32 @@ def test_beacon_root_selfdestruct(
     Tests that self destructing the beacon root address transfers actors balance correctly.
     """
     # self destruct actor
-    pre[Address(0x1337)] = Account(
-        code=Op.SELFDESTRUCT(Spec.BEACON_ROOTS_ADDRESS),
+    self_destruct_actor_address = pre.deploy_contract(
+        Op.SELFDESTRUCT(Spec.BEACON_ROOTS_ADDRESS),
         balance=0xBA1,
     )
     # self destruct caller
-    pre[Address(0xCC)] = Account(
-        code=Op.CALL(100000, Address(0x1337), 0, 0, 0, 0, 0)
-        + Op.SSTORE(0, Op.BALANCE(Spec.BEACON_ROOTS_ADDRESS)),
+    self_destruct_caller_address = pre.deploy_contract(
+        Op.CALL(gas=100_000, address=self_destruct_actor_address)
+        + Op.SSTORE(0, Op.BALANCE(Spec.BEACON_ROOTS_ADDRESS))
     )
     post = {
-        Address(0xCC): Account(
+        self_destruct_caller_address: Account(
             storage=Storage({0: 0xBA1}),  # type: ignore
         )
     }
     blockchain_test(
         pre=pre,
         blocks=[
-            Block(txs=[Transaction(nonce=0, to=Address(0xCC), gas_limit=100000, gas_price=10)])
+            Block(
+                txs=[
+                    Transaction(
+                        sender=pre.fund_eoa(),
+                        to=self_destruct_caller_address,
+                        gas_limit=100_000,
+                    )
+                ]
+            )
         ],
         post=post,
     )
@@ -335,10 +343,10 @@ def test_beacon_root_selfdestruct(
 @pytest.mark.valid_from("Cancun")
 def test_multi_block_beacon_root_timestamp_calls(
     blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
     timestamps: Iterator[int],
     beacon_roots: Iterator[bytes],
     block_count: int,
-    tx: Transaction,
     call_gas: int,
     call_value: int,
 ):
@@ -356,18 +364,14 @@ def test_multi_block_beacon_root_timestamp_calls(
     buffer, which might have been overwritten by a later block.
     """
     blocks: List[Block] = []
-    pre = {
-        TestAddress: Account(
-            nonce=0,
-            balance=0x10**10,
-        ),
-    }
     post = {}
 
     timestamps_storage: Dict[int, int] = {}
     roots_storage: Dict[int, bytes] = {}
 
     all_timestamps: List[int] = []
+
+    sender = pre.fund_eoa()
 
     for timestamp, beacon_root, i in zip(timestamps, beacon_roots, range(block_count)):
         timestamp_index = timestamp % Spec.HISTORY_BUFFER_LENGTH
@@ -380,7 +384,6 @@ def test_multi_block_beacon_root_timestamp_calls(
 
         current_call_account_code = Bytecode()
         current_call_account_expected_storage = Storage()
-        current_call_account_address = Address(0x100 + i)
 
         # We are going to call the beacon roots contract once for every timestamp of the current
         # and all previous blocks, and check that the returned beacon root is still correct only
@@ -411,19 +414,19 @@ def test_multi_block_beacon_root_timestamp_calls(
                 Op.MLOAD(0x20),
             )
 
-        pre[current_call_account_address] = Account(
-            code=current_call_account_code,
-        )
+        current_call_account_address = pre.deploy_contract(current_call_account_code)
+
         post[current_call_account_address] = Account(
             storage=current_call_account_expected_storage,
         )
         blocks.append(
             Block(
                 txs=[
-                    tx.copy(
-                        nonce=i,
-                        to=Address(0x100 + i),
+                    Transaction(
+                        sender=sender,
+                        to=current_call_account_address,
                         data=Hash(timestamp),
+                        gas_limit=1_000_000,
                     )
                 ],
                 parent_beacon_block_root=beacon_root,
@@ -461,10 +464,10 @@ def test_multi_block_beacon_root_timestamp_calls(
 @pytest.mark.valid_at_transition_to("Cancun")
 def test_beacon_root_transition(
     blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
     timestamps: Iterator[int],
     beacon_roots: Iterator[bytes],
     block_count: int,
-    tx: Transaction,
     call_gas: int,
     call_value: int,
     fork: Fork,
@@ -474,12 +477,6 @@ def test_beacon_root_transition(
     transition timestamp do not contain beacon roots in the pre-deployed contract.
     """
     blocks: List[Block] = []
-    pre = {
-        TestAddress: Account(
-            nonce=0,
-            balance=0x10**10,
-        ),
-    }
     post = {}
 
     timestamps_storage: Dict[int, int] = {}
@@ -487,6 +484,8 @@ def test_beacon_root_transition(
 
     all_timestamps: List[int] = []
     timestamps_in_beacon_root_contract: List[int] = []
+
+    sender = pre.fund_eoa()
 
     for timestamp, beacon_root, i in zip(timestamps, beacon_roots, range(block_count)):
         timestamp_index = timestamp % Spec.HISTORY_BUFFER_LENGTH
@@ -504,7 +503,6 @@ def test_beacon_root_transition(
 
         current_call_account_code = Bytecode()
         current_call_account_expected_storage = Storage()
-        current_call_account_address = Address(0x100 + i)
 
         # We are going to call the beacon roots contract once for every timestamp of the current
         # and all previous blocks, and check that the returned beacon root is correct only
@@ -536,19 +534,18 @@ def test_beacon_root_transition(
                 Op.MLOAD(0x20),
             )
 
-        pre[current_call_account_address] = Account(
-            code=current_call_account_code,
-        )
+        current_call_account_address = pre.deploy_contract(current_call_account_code)
         post[current_call_account_address] = Account(
             storage=current_call_account_expected_storage,
         )
         blocks.append(
             Block(
                 txs=[
-                    tx.copy(
-                        nonce=i,
-                        to=Address(0x100 + i),
+                    Transaction(
+                        sender=sender,
+                        to=current_call_account_address,
                         data=Hash(timestamp),
+                        gas_limit=1_000_000,
                     )
                 ],
                 parent_beacon_block_root=beacon_root if transitioned else None,
@@ -582,7 +579,7 @@ def test_beacon_root_transition(
 @pytest.mark.valid_at_transition_to("Cancun")
 def test_no_beacon_root_contract_at_transition(
     blockchain_test: BlockchainTestFiller,
-    pre: Dict,
+    pre: Alloc,
     beacon_roots: Iterator[bytes],
     tx: Transaction,
     timestamp: int,
@@ -654,7 +651,7 @@ def test_no_beacon_root_contract_at_transition(
 @pytest.mark.valid_at_transition_to("Cancun")
 def test_beacon_root_contract_deploy(
     blockchain_test: BlockchainTestFiller,
-    pre: Dict,
+    pre: Alloc,
     beacon_root: bytes,
     tx: Transaction,
     timestamp: int,

--- a/tests/cancun/eip4844_blobs/common.py
+++ b/tests/cancun/eip4844_blobs/common.py
@@ -81,7 +81,6 @@ random_blob_hashes = add_kzg_version(
 )
 
 
-
 class BlobhashContext:
     """
     A utility class for mapping common EVM opcodes in different contexts

--- a/tests/cancun/eip4844_blobs/common.py
+++ b/tests/cancun/eip4844_blobs/common.py
@@ -80,16 +80,6 @@ random_blob_hashes = add_kzg_version(
     Spec.BLOB_COMMITMENT_VERSION_KZG,
 )
 
-# Blobhash index values for test_blobhash_gas_cost
-blobhash_index_values = [
-    0x00,
-    0x01,
-    0x02,
-    0x03,
-    0x04,
-    2**256 - 1,
-    0xA12C8B6A8B11410C7D98D790E1098F1ED6D93CB7A64711481AAAB1848E13212F,
-]
 
 
 class BlobhashContext:
@@ -272,15 +262,15 @@ class BlobhashContext:
         Maps contract creation to a specific context to a specific address.
         """
         contract = {
-            "tx_created_contract": compute_create_address(TestAddress, 0),
+            "tx_created_contract": compute_create_address(address=TestAddress, nonce=0),
             "create": compute_create_address(
-                cls.address("create"),
-                0,
+                address=cls.address("create"),
+                nonce=0,
             ),
             "create2": compute_create2_address(
-                cls.address("create2"),
-                0,
-                cls.code("initcode"),
+                address=cls.address("create2"),
+                salt=0,
+                initcode=cls.code("initcode"),
             ),
         }
         contract = contract.get(context_name)

--- a/tests/cancun/eip5656_mcopy/test_mcopy_contexts.py
+++ b/tests/cancun/eip5656_mcopy/test_mcopy_contexts.py
@@ -4,28 +4,15 @@ abstract: Tests [EIP-5656: MCOPY - Memory copying instruction](https://eips.ethe
 
 """  # noqa: E501
 from itertools import cycle, islice
-from typing import List, Mapping, Tuple
+from typing import Mapping
 
 import pytest
 
-from ethereum_test_tools import Account, Bytecode, Environment, OpcodeCallArg
+from ethereum_test_tools import Account, Address, Alloc, Bytecode, Environment
 from ethereum_test_tools import Opcodes as Op
-from ethereum_test_tools import (
-    StateTestFiller,
-    Storage,
-    TestAddress,
-    Transaction,
-    ceiling_division,
-)
+from ethereum_test_tools import StateTestFiller, Storage, Transaction, ceiling_division
 
 from .common import REFERENCE_SPEC_GIT_PATH, REFERENCE_SPEC_VERSION
-
-# Code address used to call the test bytecode on every test case.
-code_address = 0x100
-
-# Code address of the callee contract
-callee_address = 0x200
-
 
 REFERENCE_SPEC_GIT_PATH = REFERENCE_SPEC_GIT_PATH
 REFERENCE_SPEC_VERSION = REFERENCE_SPEC_VERSION
@@ -89,94 +76,80 @@ def initial_memory(
 
 
 @pytest.fixture
-def caller_bytecode(
-    callee_bytecode: Bytecode,
-    opcode: Op,
-) -> Bytecode:
-    """
-    Bytecode to be used by the top level call to make a successful call to the callee,
-    or execute initcode.
-    """
-    args: List[OpcodeCallArg] = []
-    if opcode in [Op.CALL, Op.CALLCODE]:
-        args = [Op.GAS(), callee_address, 0, 0, 0, 0, 0]
-    elif opcode in [Op.DELEGATECALL, Op.STATICCALL]:
-        args = [Op.GAS(), callee_address, 0, 0, 0, 0]
-    elif opcode in [Op.CREATE, Op.CREATE2]:
-        # First copy the initcode that uses mcopy
-        if opcode == Op.CREATE:
-            args = [0, 0, len(callee_bytecode)]
-        else:
-            args = [0, 0, len(callee_bytecode), 0]
-
-    return opcode(*args)
+def caller_storage() -> Storage:  # noqa: D103
+    return Storage()
 
 
 @pytest.fixture
-def bytecode_storage(
+def caller_bytecode(
     initial_memory: bytes,
-    caller_bytecode: Bytecode,
-) -> Tuple[Bytecode, Storage.StorageDictType]:
+    callee_address: Address,
+    callee_bytecode: Bytecode,
+    opcode: Op,
+    caller_storage: Storage,
+) -> Bytecode:
     """
     Prepares the bytecode and storage for the test, based on the starting memory and the final
     memory that resulted from the copy.
     """
     bytecode = Bytecode()
-    storage: Storage.StorageDictType = {}
 
     # Fill memory with initial values
     for i in range(0, len(initial_memory), 0x20):
         bytecode += Op.MSTORE(i, Op.PUSH32(initial_memory[i : i + 0x20]))
 
     # Perform the call to the contract that is going to perform mcopy
-    bytecode += caller_bytecode
+    if opcode in [Op.CALL, Op.CALLCODE, Op.DELEGATECALL, Op.STATICCALL]:
+        bytecode += opcode(address=callee_address)
+    elif opcode in [Op.CREATE, Op.CREATE2]:
+        bytecode += opcode(size=len(callee_bytecode))
 
     # First save msize
     bytecode += Op.SSTORE(100_000, Op.MSIZE())
-    storage[100_000] = ceiling_division(len(initial_memory), 0x20) * 0x20
+    caller_storage[100_000] = ceiling_division(len(initial_memory), 0x20) * 0x20
 
     # Store all memory in the initial range to verify the MCOPY in the subcall did not affect
     # this level's memory
     for w in range(0, len(initial_memory) // 0x20):
         bytecode += Op.SSTORE(w, Op.MLOAD(w * 0x20))
-        storage[w] = initial_memory[w * 0x20 : w * 0x20 + 0x20]
+        caller_storage[w] = initial_memory[w * 0x20 : w * 0x20 + 0x20]
 
-    return (bytecode, storage)
-
-
-@pytest.fixture
-def pre(  # noqa: D103
-    bytecode_storage: Tuple[Bytecode, Storage.StorageDictType],
-    callee_bytecode: Bytecode,
-) -> Mapping:
-    return {
-        TestAddress: Account(balance=10**40),
-        code_address: Account(code=bytecode_storage[0]),
-        callee_address: Account(code=callee_bytecode),
-    }
+    return bytecode
 
 
 @pytest.fixture
-def tx() -> Transaction:  # noqa: D103
+def caller_address(pre: Alloc, caller_bytecode) -> Address:  # noqa: D103
+    return pre.deploy_contract(caller_bytecode)
+
+
+@pytest.fixture
+def callee_address(pre: Alloc, callee_bytecode) -> Address:  # noqa: D103
+    return pre.deploy_contract(callee_bytecode)
+
+
+@pytest.fixture
+def tx(pre: Alloc, caller_address: Address) -> Transaction:  # noqa: D103
     return Transaction(
-        to=code_address,
+        sender=pre.fund_eoa(),
+        to=caller_address,
         gas_limit=1_000_000,
     )
 
 
 @pytest.fixture
 def post(  # noqa: D103
-    bytecode_storage: Tuple[bytes, Storage.StorageDictType],
+    caller_address: Address,
+    caller_storage: Storage,
+    callee_address: Address,
     opcode: Op,
 ) -> Mapping:
-    caller_storage = bytecode_storage[1]
     callee_storage: Storage.StorageDictType = {}
     if opcode in [Op.DELEGATECALL, Op.CALLCODE]:
         caller_storage[200_000] = 1
     elif opcode in [Op.CALL]:
         callee_storage[200_000] = 1
     return {
-        code_address: Account(storage=caller_storage),
+        caller_address: Account(storage=caller_storage),
         callee_address: Account(storage=callee_storage),
     }
 
@@ -188,14 +161,12 @@ def post(  # noqa: D103
         Op.DELEGATECALL,
         Op.STATICCALL,
         Op.CALLCODE,
-        Op.CREATE,
-        Op.CREATE2,
     ],
 )
 @pytest.mark.valid_from("Cancun")
 def test_no_memory_corruption_on_upper_call_stack_levels(
     state_test: StateTestFiller,
-    pre: Mapping[str, Account],
+    pre: Alloc,
     post: Mapping[str, Account],
     tx: Transaction,
 ):
@@ -206,8 +177,38 @@ def test_no_memory_corruption_on_upper_call_stack_levels(
       - `CALLCODE`
       - `DELEGATECALL`
       - `STATICCALL`
+
+    TODO: [EOF] Add EOF EXT*CALL opcodes
+    """
+    state_test(
+        env=Environment(),
+        pre=pre,
+        post=post,
+        tx=tx,
+    )
+
+
+@pytest.mark.parametrize(
+    "opcode",
+    [
+        Op.CREATE,
+        Op.CREATE2,
+    ],
+)
+@pytest.mark.valid_from("Cancun")
+def test_no_memory_corruption_on_upper_create_stack_levels(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    post: Mapping[str, Account],
+    tx: Transaction,
+):
+    """
+    Perform a subcall with any of the following opcodes, which uses MCOPY during its execution,
+    and verify that the caller's memory is unaffected:
       - `CREATE`
       - `CREATE2`
+
+    TODO: [EOF] Add EOFCREATE opcode
     """
     state_test(
         env=Environment(),

--- a/tests/cancun/eip6780_selfdestruct/test_selfdestruct.py
+++ b/tests/cancun/eip6780_selfdestruct/test_selfdestruct.py
@@ -4,15 +4,17 @@ abstract: Tests [EIP-6780: SELFDESTRUCT only in same transaction](https://eips.e
 
 """  # noqa: E501
 
-from itertools import count, cycle
+from itertools import cycle
 from typing import Dict, List
 
 import pytest
 
 from ethereum_test_forks import Cancun, Fork
 from ethereum_test_tools import (
+    EOA,
     Account,
     Address,
+    Alloc,
     Block,
     BlockchainTestFiller,
     Bytecode,
@@ -21,7 +23,6 @@ from ethereum_test_tools import (
     Initcode,
     StateTestFiller,
     Storage,
-    TestAddress,
     Transaction,
     compute_create_address,
 )
@@ -31,9 +32,8 @@ from ethereum_test_tools.vm.opcode import Opcodes as Op
 REFERENCE_SPEC_GIT_PATH = "EIPS/eip-6780.md"
 REFERENCE_SPEC_VERSION = "2f8299df31bb8173618901a03a8366a3183479b0"
 
-SELFDESTRUCT_ENABLE_FORK = Cancun
+SELFDESTRUCT_DISABLE_FORK = Cancun
 
-PRE_EXISTING_SELFDESTRUCT_ADDRESS = Address("0x1111111111111111111111111111111111111111")
 """
 Address of a pre-existing contract that self-destructs.
 """
@@ -44,11 +44,15 @@ SELF_ADDRESS = Address(0x01)
 # Sentinel value to indicate that the contract should not self-destruct.
 NO_SELFDESTRUCT = Address(0x00)
 
+PRE_DEPLOY_CONTRACT_1 = "pre_deploy_contract_1"
+PRE_DEPLOY_CONTRACT_2 = "pre_deploy_contract_2"
+PRE_DEPLOY_CONTRACT_3 = "pre_deploy_contract_3"
+
 
 @pytest.fixture
 def eip_enabled(fork: Fork) -> bool:
     """Whether the EIP is enabled or not."""
-    return fork >= SELFDESTRUCT_ENABLE_FORK
+    return fork >= SELFDESTRUCT_DISABLE_FORK
 
 
 @pytest.fixture
@@ -60,21 +64,37 @@ def env() -> Environment:
 
 
 @pytest.fixture
-def sendall_recipient_addresses() -> List[Address]:
-    """List of possible addresses that can receive a SENDALL operation."""
-    return [Address(0x1234)]
+def sendall_recipient_addresses(request: pytest.FixtureRequest, pre: Alloc) -> List[Address]:
+    """
+    List of addresses that receive the SENDALL operation in any test.
+
+    If the test case requires a pre-existing contract, it will be deployed here.
+
+    By default the list is a single pre-deployed contract that unconditionally sets storage.
+    """
+    address_list = getattr(request, "param", [PRE_DEPLOY_CONTRACT_1])
+    deployed_contracts: Dict[str, Address] = {}
+    return_list = []
+    for sendall_recipient in address_list:
+        if type(sendall_recipient) is str:
+            if sendall_recipient not in deployed_contracts:
+                deployed_contracts[sendall_recipient] = pre.deploy_contract(
+                    code=Op.SSTORE(0, 0),
+                    storage={0: 1},
+                )
+            return_list.append(deployed_contracts[sendall_recipient])
+        else:
+            return_list.append(sendall_recipient)
+    return return_list
 
 
 def selfdestruct_code_preset(
     *,
     sendall_recipient_addresses: List[Address],
-    pre_bytecode: Bytecode,
 ) -> Bytecode:
     """Return a bytecode that self-destructs."""
-    bytecode = pre_bytecode
-
     # First we register entry into the contract
-    bytecode += Op.SSTORE(0, Op.ADD(Op.SLOAD(0), 1))
+    bytecode = Op.SSTORE(0, Op.ADD(Op.SLOAD(0), 1))
 
     if len(sendall_recipient_addresses) != 1:
         # Load the recipient address from calldata, each test case needs to pass the addresses as
@@ -96,130 +116,28 @@ def selfdestruct_code_preset(
         sendall_recipient = sendall_recipient_addresses[0]
         assert sendall_recipient != NO_SELFDESTRUCT, "test error"
         if sendall_recipient == SELF_ADDRESS:
-            # Use the self address of the contract we are creating
-            # sendall_recipient = "address()"
-            # TODO: Fix this
-            pass
-        bytecode += Op.SELFDESTRUCT(sendall_recipient_addresses[0])
+            bytecode += Op.SELFDESTRUCT(Op.ADDRESS)
+        else:
+            bytecode += Op.SELFDESTRUCT(sendall_recipient_addresses[0])
         bytecode += Op.SSTORE(0, 0)
-    return bytecode
-
-
-@pytest.fixture
-def selfdestruct_pre_bytecode() -> Bytecode:
-    """Code run before attempting to self-destruct, by default it's empty."""
-    return Bytecode()
+    return bytecode + Op.STOP
 
 
 @pytest.fixture
 def selfdestruct_code(
-    selfdestruct_pre_bytecode: Bytecode,
     sendall_recipient_addresses: List[Address],
 ) -> Bytecode:
     """
     Creates the default self-destructing bytecode,
     which can be modified by each test if necessary.
     """
-    return selfdestruct_code_preset(
-        sendall_recipient_addresses=sendall_recipient_addresses,
-        pre_bytecode=selfdestruct_pre_bytecode,
-    )
+    return selfdestruct_code_preset(sendall_recipient_addresses=sendall_recipient_addresses)
 
 
 @pytest.fixture
-def self_destructing_initcode() -> bool:
-    """
-    Whether the contract shall self-destruct during initialization.
-    By default it does not.
-    """
-    return False
-
-
-@pytest.fixture
-def selfdestruct_contract_initcode(
-    selfdestruct_code: Bytecode,
-    self_destructing_initcode: bool,
-) -> Bytecode:
-    """Prepares an initcode that creates a self-destructing account."""
-    if self_destructing_initcode:
-        return selfdestruct_code
-    return Initcode(deploy_code=selfdestruct_code)
-
-
-@pytest.fixture
-def initcode_copy_from_address() -> Address:
-    """Address of a pre-existing contract we use to simply copy initcode from."""
-    return Address(0xABCD)
-
-
-@pytest.fixture
-def entry_code_address() -> Address:
-    """Address where the entry code will run."""
-    return compute_create_address(address=TestAddress, nonce=0)
-
-
-@pytest.fixture
-def selfdestruct_contract_address(
-    create_opcode: Op,
-    entry_code_address: Address,
-    selfdestruct_contract_initcode: Bytecode,
-) -> Address:
-    """Returns the address of the self-destructing contract."""
-    return compute_create_address(
-        address=entry_code_address,
-        nonce=1,
-        salt=0,
-        initcode=selfdestruct_contract_initcode,
-        opcode=create_opcode,
-    )
-
-
-@pytest.fixture
-def pre(
-    initcode_copy_from_address: Address,
-    selfdestruct_contract_initcode: Bytecode,
-    selfdestruct_contract_address: Address,
-    selfdestruct_contract_initial_balance: int,
-    selfdestruct_pre_bytecode: Bytecode,
-    sendall_recipient_addresses: List[Address],
-) -> Dict[Address, Account]:
-    """Pre-state of all tests"""
-    pre = {
-        TestAddress: Account(balance=100_000_000_000_000_000_000),
-        initcode_copy_from_address: Account(code=selfdestruct_contract_initcode),
-    }
-
-    if (
-        selfdestruct_contract_initial_balance > 0
-        and selfdestruct_contract_address != PRE_EXISTING_SELFDESTRUCT_ADDRESS
-    ):
-        pre[selfdestruct_contract_address] = Account(balance=selfdestruct_contract_initial_balance)
-
-    # Also put a pre-existing copy of the self-destruct contract in a known place
-    pre[PRE_EXISTING_SELFDESTRUCT_ADDRESS] = Account(
-        code=selfdestruct_code_preset(
-            sendall_recipient_addresses=sendall_recipient_addresses,
-            pre_bytecode=selfdestruct_pre_bytecode,
-        ),
-        balance=selfdestruct_contract_initial_balance,
-    )
-
-    # Send-all recipient accounts contain code that unconditionally resets an storage key upon
-    # entry, so we can check that it was not executed
-    for i in range(len(sendall_recipient_addresses)):
-        if sendall_recipient_addresses[i] == SELF_ADDRESS:
-            sendall_recipient_addresses[i] = selfdestruct_contract_address
-        address = sendall_recipient_addresses[i]
-        if (
-            address != PRE_EXISTING_SELFDESTRUCT_ADDRESS
-            and address != selfdestruct_contract_address
-        ):
-            pre[address] = Account(
-                code=Op.SSTORE(0, 0),
-                storage={0: 1},
-            )
-
-    return pre
+def sender(pre: Alloc) -> EOA:
+    """EOA that will be used to send transactions."""
+    return pre.fund_eoa()
 
 
 @pytest.mark.parametrize("create_opcode", [Op.CREATE, Op.CREATE2])
@@ -228,7 +146,7 @@ def pre(
     [
         pytest.param(
             1,
-            [Address(0x1000)],
+            [PRE_DEPLOY_CONTRACT_1],
             id="single_call",
         ),
         pytest.param(
@@ -238,7 +156,7 @@ def pre(
         ),
         pytest.param(
             2,
-            [Address(0x1000)],
+            [PRE_DEPLOY_CONTRACT_1],
             id="multiple_calls_single_sendall_recipient",
         ),
         pytest.param(
@@ -248,43 +166,41 @@ def pre(
         ),
         pytest.param(
             3,
-            [Address(0x1000), Address(0x2000), Address(0x3000)],
+            [PRE_DEPLOY_CONTRACT_1, PRE_DEPLOY_CONTRACT_2, PRE_DEPLOY_CONTRACT_3],
             id="multiple_calls_multiple_sendall_recipients",
         ),
         pytest.param(
             3,
-            [SELF_ADDRESS, Address(0x2000), Address(0x3000)],
+            [SELF_ADDRESS, PRE_DEPLOY_CONTRACT_2, PRE_DEPLOY_CONTRACT_3],
             id="multiple_calls_multiple_sendall_recipients_including_self",
         ),
         pytest.param(
             3,
-            [Address(0x1000), Address(0x2000), SELF_ADDRESS],
+            [PRE_DEPLOY_CONTRACT_1, PRE_DEPLOY_CONTRACT_2, SELF_ADDRESS],
             id="multiple_calls_multiple_sendall_recipients_including_self_last",
         ),
         pytest.param(
             6,
-            [SELF_ADDRESS, Address(0x2000), Address(0x3000)],
+            [SELF_ADDRESS, PRE_DEPLOY_CONTRACT_2, PRE_DEPLOY_CONTRACT_3],
             id="multiple_calls_multiple_repeating_sendall_recipients_including_self",
         ),
         pytest.param(
             6,
-            [Address(0x1000), Address(0x2000), SELF_ADDRESS],
+            [PRE_DEPLOY_CONTRACT_1, PRE_DEPLOY_CONTRACT_2, SELF_ADDRESS],
             id="multiple_calls_multiple_repeating_sendall_recipients_including_self_last",
         ),
     ],
+    indirect=["sendall_recipient_addresses"],
 )
 @pytest.mark.parametrize("selfdestruct_contract_initial_balance", [0, 100_000])
 @pytest.mark.valid_from("Shanghai")
 def test_create_selfdestruct_same_tx(
     state_test: StateTestFiller,
     env: Environment,
-    pre: Dict[Address, Account],
-    entry_code_address: Address,
+    pre: Alloc,
+    sender: EOA,
     selfdestruct_code: Bytecode,
-    selfdestruct_contract_initcode: Bytecode,
-    selfdestruct_contract_address: Address,
     sendall_recipient_addresses: List[Address],
-    initcode_copy_from_address: Address,
     create_opcode: Op,
     call_times: int,
     selfdestruct_contract_initial_balance: int,
@@ -300,25 +216,30 @@ def test_create_selfdestruct_same_tx(
         - Different initial balances for the self-destructing contract
         - Different opcodes: CREATE, CREATE2
     """
+    selfdestruct_contract_initcode = Initcode(deploy_code=selfdestruct_code)
+    initcode_copy_from_address = pre.deploy_contract(selfdestruct_contract_initcode)
     # Our entry point is an initcode that in turn creates a self-destructing contract
     entry_code_storage = Storage()
+
+    # Bytecode used to create the contract, can be CREATE or CREATE2
+    create_bytecode = create_opcode(size=len(selfdestruct_contract_initcode))
+    selfdestruct_contract_address = compute_create_address(
+        address=compute_create_address(address=sender, nonce=0),
+        nonce=1,
+        initcode=selfdestruct_contract_initcode,
+        opcode=create_opcode,
+    )
+    for i in range(len(sendall_recipient_addresses)):
+        if sendall_recipient_addresses[i] == SELF_ADDRESS:
+            sendall_recipient_addresses[i] = selfdestruct_contract_address
+    if selfdestruct_contract_initial_balance > 0:
+        pre.fund_address(selfdestruct_contract_address, selfdestruct_contract_initial_balance)
 
     # Create a dict to record the expected final balances
     sendall_final_balances = dict(
         zip(sendall_recipient_addresses, [0] * len(sendall_recipient_addresses))
     )
     selfdestruct_contract_current_balance = selfdestruct_contract_initial_balance
-
-    # Bytecode used to create the contract, can be CREATE or CREATE2
-    create_args = [
-        0,  # Value
-        0,  # Offset
-        len(selfdestruct_contract_initcode),  # Length
-    ]
-    if create_opcode == Op.CREATE2:
-        # CREATE2 requires a salt argument
-        create_args.append(0)
-    create_bytecode = create_opcode(*create_args)
 
     # Entry code that will be executed, creates the contract and then calls it in the same tx
     entry_code = (
@@ -349,6 +270,7 @@ def test_create_selfdestruct_same_tx(
 
     # Call the self-destructing contract multiple times as required, increasing the wei sent each
     # time
+    entry_code_balance = 0
     for i, sendall_recipient in zip(range(call_times), cycle(sendall_recipient_addresses)):
         entry_code += Op.MSTORE(0, sendall_recipient)
         entry_code += Op.SSTORE(
@@ -363,6 +285,7 @@ def test_create_selfdestruct_same_tx(
                 0,
             ),
         )
+        entry_code_balance += i
         selfdestruct_contract_current_balance += i
 
         # Balance is always sent to other contracts
@@ -393,13 +316,19 @@ def test_create_selfdestruct_same_tx(
     # values for verification.
     entry_code += Op.RETURN(max(len(selfdestruct_contract_initcode), 32), 1)
 
+    tx = Transaction(
+        value=entry_code_balance,
+        data=entry_code,
+        sender=sender,
+        to=None,
+        gas_limit=500_000,
+    )
+
+    entry_code_address = tx.created_contract
+
     post: Dict[Address, Account] = {
         entry_code_address: Account(
-            code="0x00",
             storage=entry_code_storage,
-        ),
-        initcode_copy_from_address: Account(
-            code=selfdestruct_contract_initcode,
         ),
     }
 
@@ -409,36 +338,20 @@ def test_create_selfdestruct_same_tx(
 
     post[selfdestruct_contract_address] = Account.NONEXISTENT  # type: ignore
 
-    nonce = count()
-    tx = Transaction(
-        ty=0x0,
-        value=100_000,
-        data=entry_code,
-        chain_id=0x0,
-        nonce=next(nonce),
-        to=None,
-        gas_limit=100_000_000,
-        gas_price=10,
-        protected=False,
-    )
-
     state_test(env=env, pre=pre, post=post, tx=tx)
 
 
 @pytest.mark.parametrize("create_opcode", [Op.CREATE, Op.CREATE2])
 @pytest.mark.parametrize("call_times", [0, 1])
 @pytest.mark.parametrize("selfdestruct_contract_initial_balance", [0, 100_000])
-@pytest.mark.parametrize("self_destructing_initcode", [True], ids=[""])
 @pytest.mark.valid_from("Shanghai")
 def test_self_destructing_initcode(
     state_test: StateTestFiller,
     env: Environment,
-    pre: Dict[Address, Account],
-    entry_code_address: Address,
-    selfdestruct_contract_initcode: Bytecode,
-    selfdestruct_contract_address: Address,
+    pre: Alloc,
+    sender: EOA,
+    selfdestruct_code: Bytecode,
     sendall_recipient_addresses: List[Address],
-    initcode_copy_from_address: Address,
     create_opcode: Op,
     call_times: int,  # Number of times to call the self-destructing contract in the same tx
     selfdestruct_contract_initial_balance: int,
@@ -453,20 +366,20 @@ def test_self_destructing_initcode(
         - Different opcodes: CREATE, CREATE2
         - Different number of calls to the self-destructing contract in the same tx
     """
+    initcode_copy_from_address = pre.deploy_contract(selfdestruct_code)
     # Our entry point is an initcode that in turn creates a self-destructing contract
     entry_code_storage = Storage()
     sendall_amount = 0
 
     # Bytecode used to create the contract, can be CREATE or CREATE2
-    create_args = [
-        0,  # Value
-        0,  # Offset
-        len(selfdestruct_contract_initcode),  # Length
-    ]
-    if create_opcode == Op.CREATE2:
-        # CREATE2 requires a salt argument
-        create_args.append(0)
-    create_bytecode = create_opcode(*create_args)
+    create_bytecode = create_opcode(size=len(selfdestruct_code))
+
+    selfdestruct_contract_address = compute_create_address(
+        address=compute_create_address(address=sender, nonce=0),
+        nonce=1,
+        initcode=selfdestruct_code,
+        opcode=create_opcode,
+    )
 
     # Entry code that will be executed, creates the contract and then calls it in the same tx
     entry_code = (
@@ -475,7 +388,7 @@ def test_self_destructing_initcode(
             initcode_copy_from_address,
             0,
             0,
-            len(selfdestruct_contract_initcode),
+            len(selfdestruct_code),
         )
         # And we store the created address for verification purposes
         + Op.SSTORE(
@@ -497,6 +410,7 @@ def test_self_destructing_initcode(
 
     # Call the self-destructing contract multiple times as required, increasing the wei sent each
     # time
+    entry_code_balance = 0
     for i in range(call_times):
         entry_code += Op.SSTORE(
             entry_code_storage.store_next(1),
@@ -510,6 +424,7 @@ def test_self_destructing_initcode(
                 0,
             ),
         )
+        entry_code_balance += i
 
         entry_code += Op.SSTORE(
             entry_code_storage.store_next(0),
@@ -518,58 +433,46 @@ def test_self_destructing_initcode(
 
     # Lastly return zero so the entry point contract is created and we can retain the stored
     # values for verification.
-    entry_code += Op.RETURN(max(len(selfdestruct_contract_initcode), 32), 1)
+    entry_code += Op.RETURN(max(len(selfdestruct_code), 32), 1)
 
     if selfdestruct_contract_initial_balance > 0:
         # Address where the contract is created already had some balance,
         # which must be included in the send-all operation
         sendall_amount += selfdestruct_contract_initial_balance
+        pre.fund_address(selfdestruct_contract_address, selfdestruct_contract_initial_balance)
+
+    tx = Transaction(
+        value=entry_code_balance,
+        data=entry_code,
+        sender=sender,
+        to=None,
+        gas_limit=500_000,
+    )
+
+    entry_code_address = tx.created_contract
 
     post: Dict[Address, Account] = {
         entry_code_address: Account(
-            code="0x00",
             storage=entry_code_storage,
         ),
         selfdestruct_contract_address: Account.NONEXISTENT,  # type: ignore
-        initcode_copy_from_address: Account(
-            code=selfdestruct_contract_initcode,
-        ),
         sendall_recipient_addresses[0]: Account(balance=sendall_amount, storage={0: 1}),
     }
-
-    nonce = count()
-    tx = Transaction(
-        ty=0x0,
-        value=100_000,
-        data=entry_code,
-        chain_id=0x0,
-        nonce=next(nonce),
-        to=None,
-        gas_limit=100_000_000,
-        gas_price=10,
-        protected=False,
-    )
 
     state_test(env=env, pre=pre, post=post, tx=tx)
 
 
 @pytest.mark.parametrize("tx_value", [0, 100_000])
 @pytest.mark.parametrize("selfdestruct_contract_initial_balance", [0, 100_000])
-@pytest.mark.parametrize(
-    "selfdestruct_contract_address", [compute_create_address(address=TestAddress, nonce=0)]
-)
-@pytest.mark.parametrize("self_destructing_initcode", [True], ids=[""])
 @pytest.mark.valid_from("Shanghai")
 def test_self_destructing_initcode_create_tx(
     state_test: StateTestFiller,
     env: Environment,
-    pre: Dict[Address, Account],
+    pre: Alloc,
+    sender: EOA,
     tx_value: int,
-    entry_code_address: Address,
-    selfdestruct_contract_initcode: Bytecode,
-    selfdestruct_contract_address: Address,
+    selfdestruct_code: Bytecode,
     sendall_recipient_addresses: List[Address],
-    initcode_copy_from_address: Address,
     selfdestruct_contract_initial_balance: int,
 ):
     """
@@ -581,31 +484,23 @@ def test_self_destructing_initcode_create_tx(
         - Different initial balances for the self-destructing contract
         - Different transaction value amounts
     """
-    assert entry_code_address == selfdestruct_contract_address
+    tx = Transaction(
+        sender=sender,
+        value=tx_value,
+        data=selfdestruct_code,
+        to=None,
+        gas_limit=500_000,
+    )
+    selfdestruct_contract_address = tx.created_contract
+    pre.fund_address(selfdestruct_contract_address, selfdestruct_contract_initial_balance)
 
     # Our entry point is an initcode that in turn creates a self-destructing contract
     sendall_amount = selfdestruct_contract_initial_balance + tx_value
 
     post: Dict[Address, Account] = {
         selfdestruct_contract_address: Account.NONEXISTENT,  # type: ignore
-        initcode_copy_from_address: Account(
-            code=selfdestruct_contract_initcode,
-        ),
         sendall_recipient_addresses[0]: Account(balance=sendall_amount, storage={0: 1}),
     }
-
-    nonce = count()
-    tx = Transaction(
-        ty=0x0,
-        value=tx_value,
-        data=selfdestruct_contract_initcode,
-        chain_id=0x0,
-        nonce=next(nonce),
-        to=None,
-        gas_limit=100_000_000,
-        gas_price=10,
-        protected=False,
-    )
 
     state_test(env=env, pre=pre, post=post, tx=tx)
 
@@ -615,7 +510,7 @@ def test_self_destructing_initcode_create_tx(
     "sendall_recipient_addresses",
     [
         pytest.param(
-            [Address(0x1000)],
+            [PRE_DEPLOY_CONTRACT_1],
             id="selfdestruct_other_address",
         ),
         pytest.param(
@@ -623,6 +518,7 @@ def test_self_destructing_initcode_create_tx(
             id="selfdestruct_to_self",
         ),
     ],
+    indirect=["sendall_recipient_addresses"],
 )
 @pytest.mark.parametrize("selfdestruct_contract_initial_balance", [0, 100_000])
 @pytest.mark.parametrize("recreate_times", [1])
@@ -631,13 +527,11 @@ def test_self_destructing_initcode_create_tx(
 def test_recreate_self_destructed_contract_different_txs(
     blockchain_test: BlockchainTestFiller,
     env: Environment,
-    pre: Dict[Address, Account],
-    entry_code_address: Address,
-    selfdestruct_contract_initcode: Bytecode,
-    selfdestruct_contract_address: Address,
+    pre: Alloc,
+    sender: EOA,
+    selfdestruct_code: Bytecode,
     selfdestruct_contract_initial_balance: int,
     sendall_recipient_addresses: List[Address],
-    initcode_copy_from_address: Address,
     create_opcode: Op,
     recreate_times: int,  # Number of times to recreate the contract in different transactions
     call_times: int,  # Number of times to call the self-destructing contract in the same tx
@@ -650,14 +544,16 @@ def test_recreate_self_destructed_contract_different_txs(
 
     Test using:
         - Different initial balances for the self-destructing contract
-        - CREATE2 only
+        - Contract creating opcodes that are not CREATE
     """
+    selfdestruct_contract_initcode = Initcode(deploy_code=selfdestruct_code)
+    initcode_copy_from_address = pre.deploy_contract(selfdestruct_contract_initcode)
     entry_code_storage = Storage()
     sendall_amount = selfdestruct_contract_initial_balance
 
     # Bytecode used to create the contract
-    assert create_opcode == Op.CREATE2, "cannot recreate contract using CREATE opcode"
-    create_bytecode = Op.CREATE2(0, 0, len(selfdestruct_contract_initcode), 0)
+    assert create_opcode != Op.CREATE, "cannot recreate contract using CREATE opcode"
+    create_bytecode = create_opcode(size=len(selfdestruct_contract_initcode))
 
     # Entry code that will be executed, creates the contract and then calls it
     entry_code = (
@@ -668,16 +564,17 @@ def test_recreate_self_destructed_contract_different_txs(
             0,
             len(selfdestruct_contract_initcode),
         )
+        + Op.MSTORE(0, create_bytecode)
         + Op.SSTORE(
             Op.CALLDATALOAD(0),
-            create_bytecode,
+            Op.MLOAD(0),
         )
     )
 
     for i in range(call_times):
         entry_code += Op.CALL(
             Op.GASLIMIT,
-            selfdestruct_contract_address,
+            Op.MLOAD(0),
             i,
             0,
             0,
@@ -688,33 +585,32 @@ def test_recreate_self_destructed_contract_different_txs(
 
     entry_code += Op.STOP
 
+    entry_code_address = pre.deploy_contract(code=entry_code)
+    selfdestruct_contract_address = compute_create_address(
+        address=entry_code_address, initcode=selfdestruct_contract_initcode, opcode=create_opcode
+    )
+    pre.fund_address(selfdestruct_contract_address, selfdestruct_contract_initial_balance)
+    for i in range(len(sendall_recipient_addresses)):
+        if sendall_recipient_addresses[i] == SELF_ADDRESS:
+            sendall_recipient_addresses[i] = selfdestruct_contract_address
+
     txs: List[Transaction] = []
-    nonce = count()
     for i in range(recreate_times + 1):
         txs.append(
             Transaction(
-                ty=0x0,
                 data=Hash(i),
-                chain_id=0x0,
-                nonce=next(nonce),
+                sender=sender,
                 to=entry_code_address,
-                gas_limit=100_000_000,
-                gas_price=10,
-                protected=False,
+                gas_limit=500_000,
             )
         )
         entry_code_storage[i] = selfdestruct_contract_address
 
-    pre[entry_code_address] = Account(code=entry_code)
     post: Dict[Address, Account] = {
         entry_code_address: Account(
-            code=entry_code,
             storage=entry_code_storage,
         ),
         selfdestruct_contract_address: Account.NONEXISTENT,  # type: ignore
-        initcode_copy_from_address: Account(
-            code=selfdestruct_contract_initcode,
-        ),
     }
     if sendall_recipient_addresses[0] != selfdestruct_contract_address:
         post[sendall_recipient_addresses[0]] = Account(balance=sendall_amount, storage={0: 1})
@@ -727,63 +623,60 @@ def test_recreate_self_destructed_contract_different_txs(
     [
         pytest.param(
             1,
-            [Address(0x1000)],
+            [PRE_DEPLOY_CONTRACT_1],
             id="single_call",
         ),
         pytest.param(
             1,
-            [PRE_EXISTING_SELFDESTRUCT_ADDRESS],
+            [SELF_ADDRESS],
             id="single_call_self",
         ),
         pytest.param(
             2,
-            [Address(0x1000)],
+            [PRE_DEPLOY_CONTRACT_1],
             id="multiple_calls_single_sendall_recipient",
         ),
         pytest.param(
             2,
-            [PRE_EXISTING_SELFDESTRUCT_ADDRESS],
+            [SELF_ADDRESS],
             id="multiple_calls_single_self_recipient",
         ),
         pytest.param(
             3,
-            [Address(0x1000), Address(0x2000), Address(0x3000)],
+            [PRE_DEPLOY_CONTRACT_1, PRE_DEPLOY_CONTRACT_2, PRE_DEPLOY_CONTRACT_3],
             id="multiple_calls_multiple_sendall_recipients",
         ),
         pytest.param(
             3,
-            [PRE_EXISTING_SELFDESTRUCT_ADDRESS, Address(0x2000), Address(0x3000)],
+            [SELF_ADDRESS, PRE_DEPLOY_CONTRACT_2, PRE_DEPLOY_CONTRACT_3],
             id="multiple_calls_multiple_sendall_recipients_including_self",
         ),
         pytest.param(
             3,
-            [Address(0x1000), Address(0x2000), PRE_EXISTING_SELFDESTRUCT_ADDRESS],
+            [PRE_DEPLOY_CONTRACT_1, PRE_DEPLOY_CONTRACT_2, SELF_ADDRESS],
             id="multiple_calls_multiple_sendall_recipients_including_self_last",
         ),
         pytest.param(
             6,
-            [PRE_EXISTING_SELFDESTRUCT_ADDRESS, Address(0x2000), Address(0x3000)],
+            [SELF_ADDRESS, PRE_DEPLOY_CONTRACT_2, PRE_DEPLOY_CONTRACT_3],
             id="multiple_calls_multiple_repeating_sendall_recipients_including_self",
         ),
         pytest.param(
             6,
-            [Address(0x1000), Address(0x2000), PRE_EXISTING_SELFDESTRUCT_ADDRESS],
+            [PRE_DEPLOY_CONTRACT_1, PRE_DEPLOY_CONTRACT_2, SELF_ADDRESS],
             id="multiple_calls_multiple_repeating_sendall_recipients_including_self_last",
         ),
     ],
+    indirect=["sendall_recipient_addresses"],
 )
 @pytest.mark.parametrize("selfdestruct_contract_initial_balance", [0, 100_000])
-@pytest.mark.parametrize(
-    "selfdestruct_contract_address", [PRE_EXISTING_SELFDESTRUCT_ADDRESS], ids=["pre_existing"]
-)
 @pytest.mark.valid_from("Shanghai")
 def test_selfdestruct_pre_existing(
     state_test: StateTestFiller,
     eip_enabled: bool,
     env: Environment,
-    pre: Dict[Address, Account],
-    entry_code_address: Address,
-    selfdestruct_contract_address: Address,
+    pre: Alloc,
+    sender: EOA,
     selfdestruct_code: Bytecode,
     selfdestruct_contract_initial_balance: int,
     sendall_recipient_addresses: List[Address],
@@ -800,7 +693,14 @@ def test_selfdestruct_pre_existing(
         - Different send-all recipient addresses: single, multiple, including self
         - Different initial balances for the self-destructing contract
     """
+    selfdestruct_contract_address = pre.deploy_contract(selfdestruct_code)
     entry_code_storage = Storage()
+
+    for i in range(len(sendall_recipient_addresses)):
+        if sendall_recipient_addresses[i] == SELF_ADDRESS:
+            sendall_recipient_addresses[i] = selfdestruct_contract_address
+    if selfdestruct_contract_initial_balance > 0:
+        pre.fund_address(selfdestruct_contract_address, selfdestruct_contract_initial_balance)
 
     # Create a dict to record the expected final balances
     sendall_final_balances = dict(
@@ -814,6 +714,7 @@ def test_selfdestruct_pre_existing(
 
     # Call the self-destructing contract multiple times as required, increasing the wei sent each
     # time
+    entry_code_balance = 0
     for i, sendall_recipient in zip(range(call_times), cycle(sendall_recipient_addresses)):
         entry_code += Op.MSTORE(0, sendall_recipient)
         entry_code += Op.SSTORE(
@@ -828,6 +729,7 @@ def test_selfdestruct_pre_existing(
                 0,
             ),
         )
+        entry_code_balance += i
         selfdestruct_contract_current_balance += i
 
         # Balance is always sent to other contracts
@@ -859,9 +761,18 @@ def test_selfdestruct_pre_existing(
     # values for verification.
     entry_code += Op.RETURN(32, 1)
 
+    tx = Transaction(
+        value=entry_code_balance,
+        data=entry_code,
+        sender=sender,
+        to=None,
+        gas_limit=500_000,
+    )
+
+    entry_code_address = tx.created_contract
+
     post: Dict[Address, Account] = {
         entry_code_address: Account(
-            code="0x00",
             storage=entry_code_storage,
         ),
     }
@@ -875,49 +786,23 @@ def test_selfdestruct_pre_existing(
         balance = selfdestruct_contract_current_balance
         post[selfdestruct_contract_address] = Account(
             balance=balance,
-            code=selfdestruct_code,
             storage={0: call_times},
         )
     else:
         post[selfdestruct_contract_address] = Account.NONEXISTENT  # type: ignore
-
-    nonce = count()
-    tx = Transaction(
-        ty=0x0,
-        value=100_000,
-        data=entry_code,
-        chain_id=0x0,
-        nonce=next(nonce),
-        to=None,
-        gas_limit=100_000_000,
-        gas_price=10,
-        protected=False,
-    )
 
     state_test(env=env, pre=pre, post=post, tx=tx)
 
 
 @pytest.mark.parametrize("selfdestruct_contract_initial_balance", [0, 1])
 @pytest.mark.parametrize("call_times", [1, 10])
-@pytest.mark.parametrize(
-    "selfdestruct_contract_address,entry_code_address",
-    [
-        (
-            compute_create_address(address=TestAddress, nonce=0),
-            compute_create_address(address=TestAddress, nonce=1),
-        )
-    ],
-)
 @pytest.mark.valid_from("Shanghai")
 def test_selfdestruct_created_same_block_different_tx(
     blockchain_test: BlockchainTestFiller,
     eip_enabled: bool,
     env: Environment,
-    pre: Dict[Address, Account],
-    entry_code_address: Address,
-    selfdestruct_contract_address: Address,
-    selfdestruct_code: Bytecode,
-    selfdestruct_contract_initcode: Bytecode,
+    pre: Alloc,
+    sender: EOA,
     selfdestruct_contract_initial_balance: int,
     sendall_recipient_addresses: List[Address],
     call_times: int,
@@ -926,6 +811,12 @@ def test_selfdestruct_created_same_block_different_tx(
     Test that if an account created in the same block that contains a selfdestruct is
     called, its balance is sent to the send-all address, but the account is not deleted.
     """
+    selfdestruct_code = selfdestruct_code_preset(
+        sendall_recipient_addresses=sendall_recipient_addresses,
+    )
+    selfdestruct_contract_initcode = Initcode(deploy_code=selfdestruct_code)
+    selfdestruct_contract_address = compute_create_address(address=sender, nonce=0)
+    entry_code_address = compute_create_address(address=sender, nonce=1)
     entry_code_storage = Storage()
     sendall_amount = selfdestruct_contract_initial_balance
     entry_code = Bytecode()
@@ -935,6 +826,7 @@ def test_selfdestruct_created_same_block_different_tx(
 
     # Call the self-destructing contract multiple times as required, increasing the wei sent each
     # time
+    entry_code_balance = 0
     for i in range(call_times):
         entry_code += Op.SSTORE(
             entry_code_storage.store_next(1),
@@ -948,7 +840,7 @@ def test_selfdestruct_created_same_block_different_tx(
                 0,
             ),
         )
-
+        entry_code_balance += i
         sendall_amount += i
 
         entry_code += Op.SSTORE(
@@ -973,91 +865,49 @@ def test_selfdestruct_created_same_block_different_tx(
 
     post: Dict[Address, Account] = {
         entry_code_address: Account(
-            code="0x00",
             storage=entry_code_storage,
         ),
         sendall_recipient_addresses[0]: Account(balance=sendall_amount, storage={0: 1}),
     }
 
     if eip_enabled:
-        post[selfdestruct_contract_address] = Account(
-            balance=0, code=selfdestruct_code, storage={0: call_times}
-        )
+        post[selfdestruct_contract_address] = Account(balance=0, storage={0: call_times})
     else:
         post[selfdestruct_contract_address] = Account.NONEXISTENT  # type: ignore
 
-    nonce = count()
     txs = [
         Transaction(
-            ty=0x0,
-            value=0,
+            value=selfdestruct_contract_initial_balance,
             data=selfdestruct_contract_initcode,
-            chain_id=0x0,
-            nonce=next(nonce),
+            sender=sender,
             to=None,
-            gas_limit=100_000_000,
-            gas_price=10,
-            protected=False,
+            gas_limit=500_000,
         ),
         Transaction(
-            ty=0x0,
-            value=100_000,
+            value=entry_code_balance,
             data=entry_code,
-            chain_id=0x0,
-            nonce=next(nonce),
+            sender=sender,
             to=None,
-            gas_limit=100_000_000,
-            gas_price=10,
-            protected=False,
+            gas_limit=500_000,
         ),
     ]
 
     blockchain_test(genesis_environment=env, pre=pre, post=post, blocks=[Block(txs=txs)])
 
 
-@pytest.mark.parametrize(
-    "selfdestruct_code",
-    [
-        pytest.param(
-            Op.DELEGATECALL(
-                Op.GAS,
-                PRE_EXISTING_SELFDESTRUCT_ADDRESS,
-                0,
-                0,
-                0,
-                0,
-            ),
-            id="delegatecall",
-        ),
-        pytest.param(
-            Op.CALLCODE(
-                Op.GAS,
-                PRE_EXISTING_SELFDESTRUCT_ADDRESS,
-                0,
-                0,
-                0,
-                0,
-                0,
-            ),
-            id="callcode",
-        ),
-    ],
-)  # The self-destruct code is delegatecall
 @pytest.mark.parametrize("call_times", [1])
 @pytest.mark.parametrize("selfdestruct_contract_initial_balance", [0, 1])
+@pytest.mark.parametrize("call_opcode", [Op.DELEGATECALL, Op.CALLCODE])
 @pytest.mark.parametrize("create_opcode", [Op.CREATE])
 @pytest.mark.valid_from("Shanghai")
 def test_delegatecall_from_new_contract_to_pre_existing_contract(
     state_test: StateTestFiller,
     env: Environment,
-    pre: Dict[Address, Account],
-    entry_code_address: Address,
-    selfdestruct_code: Bytecode,
-    selfdestruct_contract_initcode: Bytecode,
-    selfdestruct_contract_address: Address,
+    pre: Alloc,
+    sender: EOA,
     sendall_recipient_addresses: List[Address],
-    initcode_copy_from_address: Address,
     create_opcode: Op,
+    call_opcode: Op,
     call_times: int,
     selfdestruct_contract_initial_balance: int,
 ):
@@ -1065,20 +915,27 @@ def test_delegatecall_from_new_contract_to_pre_existing_contract(
     Test that if an account created in the current transaction delegate-call a previously created
     account that executes self-destruct, the calling account is deleted.
     """
+    pre_existing_selfdestruct_address = pre.deploy_contract(
+        selfdestruct_code_preset(
+            sendall_recipient_addresses=sendall_recipient_addresses,
+        ),
+    )
     # Our entry point is an initcode that in turn creates a self-destructing contract
     entry_code_storage = Storage()
     sendall_amount = 0
 
+    entry_code_address = compute_create_address(address=sender, nonce=0)
+    selfdestruct_contract_address = compute_create_address(address=entry_code_address, nonce=1)
+
+    pre.fund_address(selfdestruct_contract_address, selfdestruct_contract_initial_balance)
+
+    # self-destructing delegate call
+    selfdestruct_code = call_opcode(address=pre_existing_selfdestruct_address)
+    selfdestruct_contract_initcode = Initcode(deploy_code=selfdestruct_code)
+    initcode_copy_from_address = pre.deploy_contract(selfdestruct_contract_initcode)
+
     # Bytecode used to create the contract, can be CREATE or CREATE2
-    create_args = [
-        0,  # Value
-        0,  # Offset
-        len(selfdestruct_contract_initcode),  # Length
-    ]
-    if create_opcode == Op.CREATE2:
-        # CREATE2 requires a salt argument
-        create_args.append(0)
-    create_bytecode = create_opcode(*create_args)
+    create_bytecode = create_opcode(size=len(selfdestruct_contract_initcode))
 
     # Entry code that will be executed, creates the contract and then calls it in the same tx
     entry_code = (
@@ -1109,6 +966,7 @@ def test_delegatecall_from_new_contract_to_pre_existing_contract(
 
     # Call the self-destructing contract multiple times as required, increasing the wei sent each
     # time
+    entry_code_balance = 0
     for i in range(call_times):
         entry_code += Op.SSTORE(
             entry_code_storage.store_next(1),
@@ -1122,7 +980,7 @@ def test_delegatecall_from_new_contract_to_pre_existing_contract(
                 0,
             ),
         )
-
+        entry_code_balance += i
         sendall_amount += i
 
         entry_code += Op.SSTORE(
@@ -1152,27 +1010,18 @@ def test_delegatecall_from_new_contract_to_pre_existing_contract(
 
     post: Dict[Address, Account] = {
         entry_code_address: Account(
-            code="0x00",
             storage=entry_code_storage,
         ),
         selfdestruct_contract_address: Account.NONEXISTENT,  # type: ignore
-        initcode_copy_from_address: Account(
-            code=selfdestruct_contract_initcode,
-        ),
         sendall_recipient_addresses[0]: Account(balance=sendall_amount, storage={0: 1}),
     }
 
-    nonce = count()
     tx = Transaction(
-        ty=0x0,
-        value=100_000,
+        value=entry_code_balance,
         data=entry_code,
-        chain_id=0x0,
-        nonce=next(nonce),
+        sender=sender,
         to=None,
-        gas_limit=100_000_000,
-        gas_price=10,
-        protected=False,
+        gas_limit=500_000,
     )
 
     state_test(env=env, pre=pre, post=post, tx=tx)
@@ -1182,58 +1031,52 @@ def test_delegatecall_from_new_contract_to_pre_existing_contract(
 @pytest.mark.parametrize("call_opcode", [Op.DELEGATECALL, Op.CALLCODE])
 @pytest.mark.parametrize("call_times", [1])
 @pytest.mark.parametrize("selfdestruct_contract_initial_balance", [0, 1])
+@pytest.mark.parametrize("pre_existing_contract_initial_balance", [0, 1])
 @pytest.mark.valid_from("Shanghai")
 def test_delegatecall_from_pre_existing_contract_to_new_contract(
     state_test: StateTestFiller,
     eip_enabled: bool,
     env: Environment,
-    pre: Dict[Address, Account],
-    entry_code_address: Address,
+    pre: Alloc,
+    sender: EOA,
     selfdestruct_code: Bytecode,
-    selfdestruct_contract_initcode: Bytecode,
-    selfdestruct_contract_address: Address,
     sendall_recipient_addresses: List[Address],
-    initcode_copy_from_address: Address,
     call_opcode: Op,
     create_opcode: Op,
     call_times: int,
     selfdestruct_contract_initial_balance: int,
+    pre_existing_contract_initial_balance: int,
 ):
     """
     Test that if an account created in the current transaction contains a self-destruct and is
     delegate-called by an account created before the current transaction, the calling account
     is not deleted.
     """
+    selfdestruct_contract_initcode = Initcode(deploy_code=selfdestruct_code)
+    initcode_copy_from_address = pre.deploy_contract(
+        selfdestruct_contract_initcode,
+    )
+
+    selfdestruct_contract_address = compute_create_address(
+        address=compute_create_address(address=sender, nonce=0),
+        nonce=1,
+        salt=0,
+        initcode=selfdestruct_contract_initcode,
+        opcode=create_opcode,
+    )
+
     # Add the contract that delegate calls to the newly created contract
-    delegate_caller_address = Address("0x2222222222222222222222222222222222222222")
-    call_args: List[int | Bytecode | Address] = [
-        Op.GAS(),
-        selfdestruct_contract_address,
-        0,
-        0,
-        0,
-        0,
-    ]
-    if call_opcode == Op.CALLCODE:
-        # CALLCODE requires `value`
-        call_args.append(0)
-    delegate_caller_code = call_opcode(*call_args)
-    pre[delegate_caller_address] = Account(code=delegate_caller_code)
+    delegate_caller_code = Op.SSTORE(1, Op.ADD(Op.SLOAD(1), 1)) + call_opcode(
+        address=selfdestruct_contract_address
+    )
+    delegate_caller_address = pre.deploy_contract(
+        delegate_caller_code,
+        balance=pre_existing_contract_initial_balance,
+    )
 
     # Our entry point is an initcode that in turn creates a self-destructing contract
     entry_code_storage = Storage()
-    sendall_amount = 0
-
-    # Bytecode used to create the contract, can be CREATE or CREATE2
-    create_args = [
-        0,  # Value
-        0,  # Offset
-        len(selfdestruct_contract_initcode),  # Length
-    ]
-    if create_opcode == Op.CREATE2:
-        # CREATE2 requires a salt argument
-        create_args.append(0)
-    create_bytecode = create_opcode(*create_args)
+    sendall_amount = pre_existing_contract_initial_balance
 
     # Entry code that will be executed, creates the contract and then calls it in the same tx
     entry_code = (
@@ -1247,7 +1090,10 @@ def test_delegatecall_from_pre_existing_contract_to_new_contract(
         # And we store the created address for verification purposes
         + Op.SSTORE(
             entry_code_storage.store_next(selfdestruct_contract_address),
-            create_bytecode,
+            create_opcode(
+                value=selfdestruct_contract_initial_balance,
+                size=len(selfdestruct_contract_initcode),
+            ),
         )
     )
 
@@ -1264,6 +1110,7 @@ def test_delegatecall_from_pre_existing_contract_to_new_contract(
 
     # Now instead of calling the newly created contract directly, we delegate call to it
     # from a pre-existing contract, and the contract must not self-destruct
+    entry_code_balance = selfdestruct_contract_initial_balance
     for i in range(call_times):
         entry_code += Op.SSTORE(
             entry_code_storage.store_next(1),
@@ -1277,7 +1124,7 @@ def test_delegatecall_from_pre_existing_contract_to_new_contract(
                 0,
             ),
         )
-
+        entry_code_balance += i
         sendall_amount += i
 
         entry_code += Op.SSTORE(
@@ -1300,74 +1147,55 @@ def test_delegatecall_from_pre_existing_contract_to_new_contract(
     # values for verification.
     entry_code += Op.RETURN(max(len(selfdestruct_contract_initcode), 32), 1)
 
+    tx = Transaction(
+        value=entry_code_balance,
+        data=entry_code,
+        sender=sender,
+        to=None,
+        gas_limit=500_000,
+    )
+
+    entry_code_address = tx.created_contract
+
     post: Dict[Address, Account] = {
         entry_code_address: Account(
-            code="0x00",
             storage=entry_code_storage,
-        ),
-        selfdestruct_contract_address: Account(
-            code=selfdestruct_code, balance=selfdestruct_contract_initial_balance
-        ),
-        initcode_copy_from_address: Account(
-            code=selfdestruct_contract_initcode,
         ),
         sendall_recipient_addresses[0]: Account(balance=sendall_amount, storage={0: 1}),
     }
 
     if eip_enabled:
-        post[delegate_caller_address] = Account(code=delegate_caller_code, balance=0)
+        post[delegate_caller_address] = Account(
+            storage={
+                0: call_times,
+                1: call_times,
+            },
+            balance=0,
+        )
     else:
         post[delegate_caller_address] = Account.NONEXISTENT  # type: ignore
-
-    nonce = count()
-    tx = Transaction(
-        ty=0x0,
-        value=100_000,
-        data=entry_code,
-        chain_id=0x0,
-        nonce=next(nonce),
-        to=None,
-        gas_limit=100_000_000,
-        gas_price=10,
-        protected=False,
-    )
 
     state_test(env=env, pre=pre, post=post, tx=tx)
 
 
-initcode = Op.RETURN(0, 1)
-
-
-@pytest.mark.parametrize(
-    "selfdestruct_pre_bytecode",
-    [
-        pytest.param(
-            Op.MSTORE(0, Op.PUSH32(bytes(initcode)))
-            + Op.POP(Op.CREATE(0, 32 - len(initcode), len(initcode))),
-            id="increase_nonce_by_create",
-        )
-    ],
-)
 @pytest.mark.parametrize("create_opcode", [Op.CREATE, Op.CREATE2])
 @pytest.mark.parametrize("selfdestruct_contract_initial_balance", [0, 100_000])
 @pytest.mark.parametrize(
     "call_times,sendall_recipient_addresses",
     [
-        pytest.param(1, [Address(0x1000)], id="single_call"),
-        pytest.param(5, [Address(0x1000)], id="multiple_calls_single beneficiary"),
+        pytest.param(1, [PRE_DEPLOY_CONTRACT_1], id="single_call"),
+        pytest.param(5, [PRE_DEPLOY_CONTRACT_1], id="multiple_calls_single beneficiary"),
     ],
+    indirect=["sendall_recipient_addresses"],
 )
 @pytest.mark.valid_from("Shanghai")
 def test_create_selfdestruct_same_tx_increased_nonce(
     state_test: StateTestFiller,
     env: Environment,
-    pre: Dict[Address, Account],
-    entry_code_address: Address,
+    pre: Alloc,
+    sender: EOA,
     selfdestruct_code: Bytecode,
-    selfdestruct_contract_initcode: Bytecode,
-    selfdestruct_contract_address: Address,
     sendall_recipient_addresses: List[Address],
-    initcode_copy_from_address: Address,
     create_opcode: Op,
     call_times: int,
     selfdestruct_contract_initial_balance: int,
@@ -1376,6 +1204,22 @@ def test_create_selfdestruct_same_tx_increased_nonce(
     Verify that a contract can self-destruct if it was created in the same transaction, even when
     its nonce has been increased due to contract creation.
     """
+    initcode = Op.RETURN(0, 1)
+    selfdestruct_pre_bytecode = Op.MSTORE(0, Op.PUSH32(bytes(initcode))) + Op.POP(
+        Op.CREATE(offset=32 - len(initcode), size=len(initcode))
+    )
+    selfdestruct_code = selfdestruct_pre_bytecode + selfdestruct_code
+    selfdestruct_contract_initcode = Initcode(deploy_code=selfdestruct_code)
+    initcode_copy_from_address = pre.deploy_contract(selfdestruct_contract_initcode)
+
+    selfdestruct_contract_address = compute_create_address(
+        address=compute_create_address(address=sender, nonce=0),
+        nonce=1,
+        initcode=selfdestruct_contract_initcode,
+        opcode=create_opcode,
+    )
+    if selfdestruct_contract_initial_balance > 0:
+        pre.fund_address(selfdestruct_contract_address, selfdestruct_contract_initial_balance)
     # Our entry point is an initcode that in turn creates a self-destructing contract
     entry_code_storage = Storage()
 
@@ -1386,15 +1230,7 @@ def test_create_selfdestruct_same_tx_increased_nonce(
     selfdestruct_contract_current_balance = selfdestruct_contract_initial_balance
 
     # Bytecode used to create the contract, can be CREATE or CREATE2
-    create_args = [
-        0,  # Value
-        0,  # Offset
-        len(selfdestruct_contract_initcode),  # Length
-    ]
-    if create_opcode == Op.CREATE2:
-        # CREATE2 requires a salt argument
-        create_args.append(0)
-    create_bytecode = create_opcode(*create_args)
+    create_bytecode = create_opcode(size=len(selfdestruct_contract_initcode))
 
     # Entry code that will be executed, creates the contract and then calls it in the same tx
     entry_code = (
@@ -1425,6 +1261,7 @@ def test_create_selfdestruct_same_tx_increased_nonce(
 
     # Call the self-destructing contract multiple times as required, increasing the wei sent each
     # time
+    entry_code_balance = 0
     for i, sendall_recipient in zip(range(call_times), cycle(sendall_recipient_addresses)):
         entry_code += Op.MSTORE(0, sendall_recipient)
         entry_code += Op.SSTORE(
@@ -1439,6 +1276,7 @@ def test_create_selfdestruct_same_tx_increased_nonce(
                 0,
             ),
         )
+        entry_code_balance += i
         selfdestruct_contract_current_balance += i
 
         # Balance is always sent to other contracts
@@ -1469,6 +1307,16 @@ def test_create_selfdestruct_same_tx_increased_nonce(
     # values for verification.
     entry_code += Op.RETURN(max(len(selfdestruct_contract_initcode), 32), 1)
 
+    tx = Transaction(
+        value=entry_code_balance,
+        data=entry_code,
+        sender=sender,
+        to=None,
+        gas_limit=1_000_000,
+    )
+
+    entry_code_address = tx.created_contract
+
     post: Dict[Address, Account] = {
         entry_code_address: Account(
             code="0x00",
@@ -1493,18 +1341,5 @@ def test_create_selfdestruct_same_tx_increased_nonce(
         )
 
     post[selfdestruct_contract_address] = Account.NONEXISTENT  # type: ignore
-
-    nonce = count()
-    tx = Transaction(
-        ty=0x0,
-        value=100_000,
-        data=entry_code,
-        chain_id=0x0,
-        nonce=next(nonce),
-        to=None,
-        gas_limit=100_000_000,
-        gas_price=10,
-        protected=False,
-    )
 
     state_test(env=env, pre=pre, post=post, tx=tx)

--- a/tests/cancun/eip6780_selfdestruct/test_selfdestruct.py
+++ b/tests/cancun/eip6780_selfdestruct/test_selfdestruct.py
@@ -1033,7 +1033,7 @@ def test_calling_from_new_contract_to_pre_existing_contract(
 @pytest.mark.parametrize("selfdestruct_contract_initial_balance", [0, 1])
 @pytest.mark.parametrize("pre_existing_contract_initial_balance", [0, 1])
 @pytest.mark.valid_from("Shanghai")
-def test_delegatecall_from_pre_existing_contract_to_new_contract(
+def test_calling_from_pre_existing_contract_to_new_contract(
     state_test: StateTestFiller,
     eip_enabled: bool,
     env: Environment,

--- a/tests/cancun/eip6780_selfdestruct/test_selfdestruct.py
+++ b/tests/cancun/eip6780_selfdestruct/test_selfdestruct.py
@@ -900,7 +900,7 @@ def test_selfdestruct_created_same_block_different_tx(
 @pytest.mark.parametrize("call_opcode", [Op.DELEGATECALL, Op.CALLCODE])
 @pytest.mark.parametrize("create_opcode", [Op.CREATE])
 @pytest.mark.valid_from("Shanghai")
-def test_delegatecall_from_new_contract_to_pre_existing_contract(
+def test_calling_from_new_contract_to_pre_existing_contract(
     state_test: StateTestFiller,
     env: Environment,
     pre: Alloc,

--- a/tests/cancun/eip6780_selfdestruct/test_selfdestruct.py
+++ b/tests/cancun/eip6780_selfdestruct/test_selfdestruct.py
@@ -929,7 +929,7 @@ def test_delegatecall_from_new_contract_to_pre_existing_contract(
 
     pre.fund_address(selfdestruct_contract_address, selfdestruct_contract_initial_balance)
 
-    # self-destructing delegate call
+    # self-destructing call
     selfdestruct_code = call_opcode(address=pre_existing_selfdestruct_address)
     selfdestruct_contract_initcode = Initcode(deploy_code=selfdestruct_code)
     initcode_copy_from_address = pre.deploy_contract(selfdestruct_contract_initcode)

--- a/tests/cancun/eip6780_selfdestruct/test_selfdestruct_revert.py
+++ b/tests/cancun/eip6780_selfdestruct/test_selfdestruct_revert.py
@@ -32,7 +32,7 @@ SELFDESTRUCT_ENABLE_FORK = Cancun
 @pytest.fixture
 def entry_code_address() -> Address:
     """Address where the entry code will run."""
-    return compute_create_address(TestAddress, 0)
+    return compute_create_address(address=TestAddress, nonce=0)
 
 
 @pytest.fixture
@@ -132,8 +132,7 @@ def recursive_revert_contract_code(
 @pytest.fixture
 def selfdestruct_with_transfer_contract_address(entry_code_address: Address) -> Address:
     """Contract address for contract that can selfdestruct and receive value"""
-    res = compute_create_address(entry_code_address, 1)
-    return res
+    return compute_create_address(address=entry_code_address, nonce=1)
 
 
 @pytest.fixture

--- a/tests/paris/security/test_selfdestruct_balance_bug.py
+++ b/tests/paris/security/test_selfdestruct_balance_bug.py
@@ -26,7 +26,6 @@ from ethereum_test_tools import (
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 
-@pytest.mark.compile_yul_with("Paris")  # Shanghai refuses to compile SELFDESTRUCT
 @pytest.mark.valid_from("Constantinople")
 def test_tx_selfdestruct_balance_bug(blockchain_test: BlockchainTestFiller, pre: Alloc):
     """

--- a/tests/paris/security/test_selfdestruct_balance_bug.py
+++ b/tests/paris/security/test_selfdestruct_balance_bug.py
@@ -14,13 +14,13 @@ import pytest
 
 from ethereum_test_tools import (
     Account,
-    Address,
+    Alloc,
     Block,
     BlockchainTestFiller,
+    CalldataCase,
     Initcode,
-    TestAddress,
+    Switch,
     Transaction,
-    YulCompiler,
     compute_create_address,
 )
 from ethereum_test_tools.vm.opcode import Opcodes as Op
@@ -28,7 +28,7 @@ from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 @pytest.mark.compile_yul_with("Paris")  # Shanghai refuses to compile SELFDESTRUCT
 @pytest.mark.valid_from("Constantinople")
-def test_tx_selfdestruct_balance_bug(blockchain_test: BlockchainTestFiller, yul: YulCompiler):
+def test_tx_selfdestruct_balance_bug(blockchain_test: BlockchainTestFiller, pre: Alloc):
     """
     Test that the vulnerability is not present by checking the balance of the
     `0xaa` contract after executing specific transactions:
@@ -52,53 +52,46 @@ def test_tx_selfdestruct_balance_bug(blockchain_test: BlockchainTestFiller, yul:
         - The balances of `0xaa` after each tx are correct.
         - During tx 2, code in `0xaa` does not execute,
             hence self-destruct mechanism does not trigger.
+
+    TODO: EOF - This test could be parametrized for EOFCREATE
     """
+    deploy_code = Switch(
+        default_action=Op.REVERT(0, 0),
+        cases=[
+            CalldataCase(
+                value=0,
+                action=Op.SELFDESTRUCT(Op.ADDRESS),
+            ),
+            CalldataCase(
+                value=1,
+                action=Op.SSTORE(0, Op.SELFBALANCE),
+            ),
+        ],
+    )
     aa_code = Initcode(
-        deploy_code=yul(
-            """
-        {
-            /* 1st entrance is self-destruct */
-            if eq(0, callvalue()) {
-                selfdestruct(0x00000000000000000000000000000000000000AA)
-            }
-
-            /* 2nd entrance is other rnd code execution */
-            if eq(1, callvalue()) {
-                let x := selfbalance()
-                sstore(0, x)
-            }
-        }
-        """
-        ),
+        deploy_code=deploy_code,
     )
-
-    aa_location = compute_create_address(address=0xCC, nonce=1)
-
     cc_code = (
-        Op.EXTCODECOPY(0xAA, 0, 0, Op.EXTCODESIZE(0xAA))
-        + Op.CREATE(
-            3,  # Initial balance of 3 wei
+        Op.CALLDATACOPY(size=Op.CALLDATASIZE)
+        + Op.MSTORE(
             0,
-            Op.EXTCODESIZE(0xAA),
+            Op.CREATE(
+                value=3,  # Initial balance of 3 wei
+                offset=0,
+                size=Op.CALLDATASIZE,
+            ),
         )
-        + Op.SSTORE(0xCA1101, Op.CALL(100000, aa_location, 0, 0, 0, 0, 0))
-        + Op.CALL(100000, aa_location, 1, 0, 0, 0, 0)
+        + Op.SSTORE(0xCA1101, Op.CALL(gas=100000, address=Op.MLOAD(0), value=0))
+        + Op.CALL(gas=100000, address=Op.MLOAD(0), value=1)
     )
 
+    cc_address = pre.deploy_contract(cc_code, balance=1000000000)
+    aa_location = compute_create_address(address=cc_address, nonce=1)
     balance_code = Op.SSTORE(0xBA1AA, Op.BALANCE(aa_location))
+    balance_address_1 = pre.deploy_contract(balance_code)
+    balance_address_2 = pre.deploy_contract(balance_code)
 
-    pre = {
-        # sender
-        TestAddress: Account(balance=1000000000),
-        # caller
-        Address(0xCC): Account(balance=1000000000, code=cc_code, nonce=1),
-        # stores balance of 0xaa after each tx 1
-        Address(0xBA11): Account(code=balance_code),
-        # stores balance of 0xaa after each tx 2
-        Address(0xBA12): Account(code=balance_code),
-        # Initcode of the self-destruct contract
-        Address(0xAA): Account(code=aa_code),
-    }
+    sender = pre.fund_eoa()
 
     blocks = [
         Block(
@@ -106,32 +99,29 @@ def test_tx_selfdestruct_balance_bug(blockchain_test: BlockchainTestFiller, yul:
                 # Sender invokes caller, caller invokes 0xaa:
                 # calling with 1 wei call
                 Transaction(
-                    nonce=0,
-                    to=Address(0xCC),
+                    sender=sender,
+                    to=cc_address,
+                    data=aa_code,
                     gas_limit=1000000,
-                    gas_price=10,
                 ),
                 # Dummy tx to store balance of 0xaa after first TX.
                 Transaction(
-                    nonce=1,
-                    to=Address(0xBA11),
+                    sender=sender,
+                    to=balance_address_1,
                     gas_limit=100000,
-                    gas_price=10,
                 ),
                 # Sender calls 0xaa with 5 wei.
                 Transaction(
-                    nonce=2,
+                    sender=sender,
                     to=aa_location,
                     gas_limit=100000,
-                    gas_price=10,
                     value=5,
                 ),
                 # Dummy tx to store balance of 0xaa after second TX.
                 Transaction(
-                    nonce=3,
-                    to=Address(0xBA12),
+                    sender=sender,
+                    to=balance_address_2,
                     gas_limit=100000,
-                    gas_price=10,
                 ),
             ],
         ),
@@ -139,13 +129,13 @@ def test_tx_selfdestruct_balance_bug(blockchain_test: BlockchainTestFiller, yul:
 
     post = {
         # Check call from caller has succeeded.
-        Address(0xCC): Account(nonce=2, storage={0xCA1101: 1}),
+        cc_address: Account(nonce=2, storage={0xCA1101: 1}),
         # Check balance of 0xaa after tx 1 is 0 wei, i.e self-destructed.
         # Vulnerable versions should return 1 wei.
-        Address(0xBA11): Account(storage={0xBA1AA: 0}),
+        balance_address_1: Account(storage={0xBA1AA: 0}),
         # Check that 0xaa exists and balance after tx 2 is 5 wei.
         # Vulnerable versions should return 6 wei.
-        Address(0xBA12): Account(storage={0xBA1AA: 5}),
+        balance_address_2: Account(storage={0xBA1AA: 5}),
         aa_location: Account(storage={0: 0}),
     }
 

--- a/tests/paris/security/test_selfdestruct_balance_bug.py
+++ b/tests/paris/security/test_selfdestruct_balance_bug.py
@@ -72,7 +72,7 @@ def test_tx_selfdestruct_balance_bug(blockchain_test: BlockchainTestFiller, yul:
         ),
     )
 
-    aa_location = compute_create_address(0xCC, 1)
+    aa_location = compute_create_address(address=0xCC, nonce=1)
 
     cc_code = (
         Op.EXTCODECOPY(0xAA, 0, 0, Op.EXTCODESIZE(0xAA))

--- a/tests/prague/eip7702_eoa_code_tx/test_eoa_code_txs.py
+++ b/tests/prague/eip7702_eoa_code_tx/test_eoa_code_txs.py
@@ -298,14 +298,9 @@ def test_set_code_to_contract_creator(
     deployed_code = Op.STOP
     initcode = Initcode(deploy_code=deployed_code)
 
-    if op == Op.CREATE:
-        deployed_contract_address = compute_create_address(auth_signer)
-    elif op == Op.CREATE2:
-        deployed_contract_address = compute_create2_address(
-            address=auth_signer,
-            salt=0,
-            initcode=initcode,
-        )
+    deployed_contract_address = compute_create_address(
+        address=auth_signer, salt=0, initcode=initcode, opcode=op
+    )
 
     set_code = Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE) + Op.SSTORE(
         storage.store_next(deployed_contract_address),


### PR DESCRIPTION
## 🗒️ Description
### `pre_alloc_modify` test marker

Used to mark tests that cannot work without making impractical (for real networks) modifications to the pre-alloc, such as deploying a contract in an address to allow a collision with another deployment.

This will help us not having to run these tests in devnets because is unfeasible.

### Update `compute_create_address`

Updates `compute_create_address` helper to take an `opcode` parameter and switch between `CREATE` or `CREATE2` (`EOFCREATE` eventually) to calculate the address.

### Convert tests to use `pre: Alloc` fixture

Converts the following tests to use the `pre` fixture to use `pre.deploy_contract`, `pre.fund_eoa` and `pre.fund_address`:

- tests/cancun/eip1153_tstore/test_tstorage*.py
- tests/cancun/eip4788_beacon_root/test_beacon_root_contract.py
- tests/cancun/eip4844_blobs/test_blob_txs*.py
- tests/cancun/eip4844_blobs/test_blobhash_opcode.py
- tests/cancun/eip4844_blobs/test_excess_blob_gas.py
- tests/cancun/eip4844_blobs/test_point_evaluation_precompile*.py
- tests/cancun/eip5656_mcopy/test_mcopy*.py
- tests/cancun/eip6780_selfdestruct/test_selfdestruct.py
- tests/cancun/eip6780_selfdestruct/test_selfdestruct_revert.py
- tests/cancun/eip7516_blobgasfee/test_blobgasfee_opcode.py
- tests/paris/security/test_selfdestruct_balance_bug.py


## 🔗 Related Issues
None

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
