### PR TITLE
new(tests): EOF - EIP-7620: tests for msg.depth and static flag

### DIFF
--- a/tests/prague/eip7692_eof_v1/eip7069_extcall/test_calls.py
+++ b/tests/prague/eip7692_eof_v1/eip7069_extcall/test_calls.py
@@ -871,6 +871,11 @@ def test_eof_calls_msg_depth(
     #     code value is actually coming from the `Op.DUP1`
     # When unwinding the msg call stack, the intermediate frames return whatever the deeper callee
     # returned with the `RETURNDATACOPY` instruction.
+
+    # Memory offsets layout:
+    # - 0  - input - msg depth
+    # - 32 - output - msg depth
+    # - 64 - output - call result
     returndatacopy_block = Op.RETURNDATACOPY(32, 0, 64) + Op.RETURN(32, 64)
     deep_most_result_block = (
         Op.MSTORE(32, Op.ADD(Op.CALLDATALOAD(0), 1)) + Op.MSTORE(64, Op.NOOP) + Op.RETURN(32, 64)

--- a/tests/prague/eip7692_eof_v1/eip7620_eof_create/helpers.py
+++ b/tests/prague/eip7692_eof_v1/eip7620_eof_create/helpers.py
@@ -16,6 +16,8 @@ slot_calldata = next(_slot)
 slot_call_result = next(_slot)
 slot_returndata = next(_slot)
 slot_returndata_size = next(_slot)
+slot_max_depth = next(_slot)
+slot_call_or_create = next(_slot)
 
 slot_last_slot = next(_slot)
 
@@ -25,6 +27,7 @@ value_canary_to_be_overwritten = 0x2009
 value_create_failed = 0
 value_legacy_call_result_failed = 0
 value_eof_call_result_success = 0
+value_eof_call_result_reverted = 1
 value_eof_call_result_failed = 2
 
 smallest_runtime_subcontainer = Container(

--- a/tests/prague/eip7692_eof_v1/eip7620_eof_create/helpers.py
+++ b/tests/prague/eip7692_eof_v1/eip7620_eof_create/helpers.py
@@ -23,7 +23,9 @@ value_code_worked = 0x2015
 value_canary_should_not_change = 0x2019
 value_canary_to_be_overwritten = 0x2009
 value_create_failed = 0
-value_call_result_success = 0
+value_legacy_call_result_failed = 0
+value_eof_call_result_success = 0
+value_eof_call_result_failed = 2
 
 smallest_runtime_subcontainer = Container(
     name="Runtime Subcontainer",
@@ -39,3 +41,5 @@ smallest_initcode_subcontainer = Container(
         Section.Container(container=smallest_runtime_subcontainer),
     ],
 )
+
+aborting_code = Container.Code(Op.INVALID)

--- a/tests/prague/eip7692_eof_v1/eip7620_eof_create/helpers.py
+++ b/tests/prague/eip7692_eof_v1/eip7620_eof_create/helpers.py
@@ -45,4 +45,4 @@ smallest_initcode_subcontainer = Container(
     ],
 )
 
-aborting_code = Container.Code(Op.INVALID)
+aborting_container = Container.Code(Op.INVALID)

--- a/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_eofcreate.py
+++ b/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_eofcreate.py
@@ -25,10 +25,10 @@ from .helpers import (
     slot_returndata_size,
     smallest_initcode_subcontainer,
     smallest_runtime_subcontainer,
-    value_call_result_success,
     value_canary_to_be_overwritten,
     value_code_worked,
     value_create_failed,
+    value_eof_call_result_success,
 )
 
 REFERENCE_SPEC_GIT_PATH = "EIPS/eip-7620.md"
@@ -431,7 +431,7 @@ def test_return_data_cleared(
     post = {
         contract_address: Account(
             storage={
-                slot_call_result: value_call_result_success,
+                slot_call_result: value_eof_call_result_success,
                 slot_returndata_size: value_return_canary_size,
                 slot_create_address: new_contract_address,
                 slot_returndata_size_2: 0,

--- a/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_eofcreate_failures.py
+++ b/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_eofcreate_failures.py
@@ -4,6 +4,7 @@ Test good and bad EOFCREATE cases
 
 import pytest
 
+from ethereum_test_base_types.base_types import Address
 from ethereum_test_tools import (
     Account,
     Alloc,
@@ -19,10 +20,12 @@ from ethereum_test_tools.vm.opcode import Opcodes as Op
 from .. import EOF_FORK_NAME
 from .helpers import (
     aborting_code,
+    slot_call_or_create,
     slot_call_result,
     slot_code_should_fail,
     slot_code_worked,
     slot_create_address,
+    slot_max_depth,
     slot_returndata,
     slot_returndata_size,
     smallest_initcode_subcontainer,
@@ -31,6 +34,7 @@ from .helpers import (
     value_code_worked,
     value_create_failed,
     value_eof_call_result_failed,
+    value_eof_call_result_reverted,
     value_legacy_call_result_failed,
 )
 
@@ -645,3 +649,125 @@ def test_static_flag_eofcreate(
     )
 
     state_test(env=env, pre=pre, post=post, tx=tx)
+
+
+magic_value_call = 0xCA11
+magic_value_create = 0xCC12EA7E
+
+
+@pytest.mark.parametrize(
+    "opcode",
+    [
+        Op.EXTCALL,
+        Op.EXTDELEGATECALL,
+    ],
+)
+@pytest.mark.parametrize(
+    "who_fails",
+    [magic_value_call, magic_value_create],
+    ids=["call_fails", "create_fails"],
+)
+def test_eof_eofcreate_msg_depth(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    opcode: Op,
+    who_fails: int,
+):
+    """
+    Test EOFCREATE handles msg depth limit correctly (1024).
+    NOTE: due to block gas limit and the 63/64th rule this limit is unlikely to be hit
+          on mainnet.
+    NOTE: See `tests/prague/eip7692_eof_v1/eip7069_extcall/test_calls.py::test_eof_calls_msg_depth`
+          for more explanations and comments. Most notable deviation from that test is that here
+          calls and `EOFCREATE`s alternate in order to reach the max depth. `who_fails` decides
+          whether the failing depth 1024 will be on a call or on an `EOFCREATE` to happen.
+    """
+    # Not a precise gas_limit formula, but enough to exclude risk of gas causing the failure.
+    gas_limit = int(20000000 * (64 / 63) ** 1024)
+    env = Environment(gas_limit=gas_limit)
+    sender = pre.fund_eoa()
+
+    callee_address = Address(0x5000)
+
+    returndatacopy_block = Op.RETURNDATACOPY(64, 0, 96) + Op.REVERT(64, 96)
+    deep_most_result_block = (
+        Op.MSTORE(64, Op.ADD(Op.CALLDATALOAD(0), 1)) + Op.MSTORE(96, Op.NOOP) + Op.REVERT(64, 96)
+    )
+    rjump_offset = len(returndatacopy_block)
+
+    callee_code = Container(
+        sections=[
+            Section.Code(
+                Op.MSTORE(0, Op.ADD(Op.CALLDATALOAD(0), 1))
+                + Op.MSTORE(128, magic_value_create)
+                + Op.EOFCREATE[0](0, Op.CALLDATALOAD(0), 0, 64)
+                + Op.RETURNDATASIZE
+                + Op.ISZERO
+                + Op.RJUMPI[rjump_offset]
+                + returndatacopy_block
+                + deep_most_result_block
+            ),
+            Section.Container(
+                Container.Code(
+                    Op.MSTORE(0, Op.ADD(Op.CALLDATALOAD(0), 1))
+                    + Op.MSTORE(128, magic_value_call)
+                    + opcode(address=callee_address, args_size=64)
+                    + Op.RETURNDATASIZE
+                    + Op.ISZERO
+                    + Op.RJUMPI[rjump_offset]
+                    + returndatacopy_block
+                    + deep_most_result_block
+                )
+            ),
+        ]
+    )
+
+    pre.deploy_contract(callee_code, address=callee_address)
+
+    calling_contract_address = pre.deploy_contract(
+        Container.Code(
+            Op.MSTORE(0, Op.CALLDATALOAD(0))
+            + Op.MSTORE(32, magic_value_create)
+            + opcode(address=callee_address, args_size=64)
+            + Op.SSTORE(slot_max_depth, Op.RETURNDATALOAD(0))
+            + Op.SSTORE(slot_call_result, Op.RETURNDATALOAD(32))
+            + Op.SSTORE(slot_call_or_create, Op.RETURNDATALOAD(64))
+            + Op.SSTORE(slot_code_worked, value_code_worked)
+            + Op.STOP
+        )
+    )
+
+    # Only bumps the msg call depth "register" and forwards to the `calling_contract_address`.
+    # If it is used it makes the "failing" depth of 1024 to happen on EOFCREATE, instead of CALL.
+    passthrough_address = pre.deploy_contract(
+        Container.Code(
+            Op.MSTORE(0, 1) + Op.EXTCALL(address=calling_contract_address, args_size=32) + Op.STOP
+        )
+    )
+
+    tx = Transaction(
+        sender=sender,
+        to=calling_contract_address if who_fails == magic_value_call else passthrough_address,
+        gas_limit=gas_limit,
+        data="",
+    )
+
+    calling_storage = {
+        slot_max_depth: 1024,
+        slot_code_worked: value_code_worked,
+        slot_call_result: value_eof_call_result_reverted
+        if who_fails == magic_value_call
+        else value_create_failed,
+        slot_call_or_create: who_fails,
+    }
+
+    post = {
+        calling_contract_address: Account(storage=calling_storage),
+    }
+
+    state_test(
+        env=env,
+        pre=pre,
+        post=post,
+        tx=tx,
+    )

--- a/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_eofcreate_failures.py
+++ b/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_eofcreate_failures.py
@@ -19,7 +19,7 @@ from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 from .. import EOF_FORK_NAME
 from .helpers import (
-    aborting_code,
+    aborting_container,
     slot_call_or_create,
     slot_call_result,
     slot_code_should_fail,
@@ -122,7 +122,7 @@ def test_initcode_aborts(
                     + Op.SSTORE(slot_code_worked, value_code_worked)
                     + Op.STOP,
                 ),
-                Section.Container(container=aborting_code),
+                Section.Container(container=aborting_container),
             ]
         )
     )
@@ -597,7 +597,7 @@ def test_insufficient_returncontract_auxdata_gas(
 @pytest.mark.parametrize("endowment", [0, 1])  # included to verify static flag check comes first
 @pytest.mark.parametrize(
     "initcode",
-    [smallest_initcode_subcontainer, aborting_code],
+    [smallest_initcode_subcontainer, aborting_container],
     ids=["working_initcode", "aborting_code"],
 )
 def test_static_flag_eofcreate(
@@ -616,7 +616,7 @@ def test_static_flag_eofcreate(
         code=Container(
             sections=[
                 Section.Code(
-                    code=Op.EOFCREATE[0](endowment, 0, 0, 0) + Op.STOP,
+                    code=Op.EOFCREATE[0](value=endowment) + Op.STOP,
                 ),
                 Section.Container(container=initcode),
             ]
@@ -700,7 +700,7 @@ def test_eof_eofcreate_msg_depth(
             Section.Code(
                 Op.MSTORE(0, Op.ADD(Op.CALLDATALOAD(0), 1))
                 + Op.MSTORE(128, magic_value_create)
-                + Op.EOFCREATE[0](0, Op.CALLDATALOAD(0), 0, 64)
+                + Op.EOFCREATE[0](salt=Op.CALLDATALOAD(0), input_size=64)
                 + Op.RETURNDATASIZE
                 + Op.ISZERO
                 + Op.RJUMPI[rjump_offset]

--- a/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_eofcreate_failures.py
+++ b/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_eofcreate_failures.py
@@ -667,6 +667,7 @@ magic_value_create = 0xCC12EA7E
     [magic_value_call, magic_value_create],
     ids=["call_fails", "create_fails"],
 )
+@pytest.mark.pre_alloc_modify
 def test_eof_eofcreate_msg_depth(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -266,6 +266,7 @@ ori
 P1
 P2
 parseable
+passthrough
 pathlib
 pdb
 perf


### PR DESCRIPTION
Mainly inspired by https://github.com/ipsilon/eof/pull/138 and evmone state_transition tests. Following the conventions used in #730, in particular the test `test_eof_eofcreate_msg_depth` is an extension of the `test_eof_calls_msg_depth`, just even more complex and magic. I'm not sure if this isn't too much, WDYT? It would however be good to have this (exotic) condition covered (and we decided we do want this `msg.depth` rule applied for various reasons).
