### PR TITLE
bug(consume): genesis block hash exception

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ A metadata folder `.meta/` now stores all fixture metadata files by default ([#721](https://github.com/ethereum/execution-spec-tests/pull/721)).
 - 🐞 Fixed `fill` command index generation issue due to concurrency ([#725](https://github.com/ethereum/execution-spec-tests/pull/725)).
 - 🐞 Fixed fixture index generation on EOF tests ([#728](https://github.com/ethereum/execution-spec-tests/pull/728)).
+- 🐞 Fixes consume genesis mismatch exception for hive based simulators ([#734](https://github.com/ethereum/execution-spec-tests/pull/734)).
 
 ### 🔧 EVM Tools
 

--- a/src/pytest_plugins/consume/hive_simulators/engine/test_via_engine.py
+++ b/src/pytest_plugins/consume/hive_simulators/engine/test_via_engine.py
@@ -4,8 +4,8 @@ from the Engine API. The simulator uses the `BlockchainEngineFixtures` to test a
 
 Each `engine_newPayloadVX` is verified against the appropriate VALID/INVALID responses.
 """
+
 from ethereum_test_fixtures import BlockchainEngineFixture, FixtureFormats
-from ethereum_test_fixtures.blockchain import FixtureHeader
 from ethereum_test_tools.rpc import EngineRPC, EthRPC
 from ethereum_test_tools.rpc.types import ForkchoiceState, PayloadStatusEnum
 from pytest_plugins.consume.hive_simulators.exceptions import GenesisBlockMismatchException
@@ -45,7 +45,7 @@ def test_via_engine(
         if genesis_block["hash"] != str(blockchain_fixture.genesis.block_hash):
             raise GenesisBlockMismatchException(
                 expected_header=blockchain_fixture.genesis,
-                got_header=FixtureHeader(**genesis_block),
+                got_genesis_block=genesis_block,
             )
 
     with timing_data.time("Payloads execution") as total_payload_timing:

--- a/src/pytest_plugins/consume/hive_simulators/exceptions.py
+++ b/src/pytest_plugins/consume/hive_simulators/exceptions.py
@@ -3,6 +3,7 @@ Custom exceptions utilized within consume simulators.
 """
 
 import pprint
+from typing import Dict, List, Tuple
 
 from ethereum_test_fixtures.blockchain import FixtureHeader
 
@@ -12,17 +13,25 @@ class GenesisBlockMismatchException(Exception):
     Definers a mismatch exception between the client and fixture genesis blockhash.
     """
 
-    def __init__(self, *, expected_header: FixtureHeader, got_header: FixtureHeader):
+    def __init__(self, *, expected_header: FixtureHeader, got_genesis_block: Dict[str, str]):
         message = (
             "Genesis block hash mismatch.\n\n"
             f"Expected: {expected_header.block_hash}\n"
-            f"     Got: {got_header.block_hash}."
+            f"     Got: {got_genesis_block['hash']}."
         )
-        differences = self.compare_models(expected_header, got_header)
+        differences, unexpected_fields = self.compare_models(
+            expected_header, FixtureHeader(**got_genesis_block)
+        )
         if differences:
             message += (
                 "\n\nGenesis block header field differences:\n"
                 f"{pprint.pformat(differences, indent=4)}"
+            )
+        elif unexpected_fields:
+            message += (
+                "\n\nUn-expected genesis block header fields from client:\n"
+                f"{pprint.pformat(unexpected_fields, indent=4)}"
+                "\nIs the fork configuration correct?"
             )
         else:
             message += (
@@ -31,17 +40,20 @@ class GenesisBlockMismatchException(Exception):
         super().__init__(message)
 
     @staticmethod
-    def compare_models(expected: FixtureHeader, got: FixtureHeader) -> dict:
+    def compare_models(expected: FixtureHeader, got: FixtureHeader) -> Tuple[Dict, List]:
         """
         Compare two FixtureHeader model instances and return their differences.
         """
         differences = {}
-        for (exp_name, exp_value), (_, got_value) in zip(expected, got):
+        unexpected_fields = []
+        for (exp_name, exp_value), (got_name, got_value) in zip(expected, got):
             if "rlp" in exp_name or "fork" in exp_name:  # ignore rlp as not verbose enough
                 continue
-            if exp_value is None or got_value is None or exp_value != got_value:
+            if exp_value != got_value:
                 differences[exp_name] = {
                     "expected     ": str(exp_value),
                     "got (via rpc)": str(got_value),
                 }
-        return differences
+            if got_value is None:
+                unexpected_fields.append(got_name)
+        return differences, unexpected_fields

--- a/src/pytest_plugins/consume/hive_simulators/rlp/test_via_rlp.py
+++ b/src/pytest_plugins/consume/hive_simulators/rlp/test_via_rlp.py
@@ -4,8 +4,8 @@ A hive based simulator that executes RLP-encoded blocks against clients. The sim
 
 Clients consume the genesis and RLP-encoded blocks from input files upon start-up.
 """
+
 from ethereum_test_fixtures import BlockchainFixture, FixtureFormats
-from ethereum_test_fixtures.blockchain import FixtureHeader
 from ethereum_test_tools.rpc import EthRPC
 from pytest_plugins.consume.hive_simulators.exceptions import GenesisBlockMismatchException
 
@@ -28,7 +28,7 @@ def test_via_rlp(
         if genesis_block["hash"] != str(blockchain_fixture.genesis.block_hash):
             raise GenesisBlockMismatchException(
                 expected_header=blockchain_fixture.genesis,
-                got_header=FixtureHeader(**genesis_block),
+                got_genesis_block=genesis_block,
             )
     with timing_data.time("Get latest block"):
         block = eth_rpc.get_block_by_number("latest")


### PR DESCRIPTION
## 🗒️ Description
Fixes a bug in the consume (hive) genesis mismatch exception. For cases where the hash mismatch was present the error would overwrite the incorrect hash to the correct hash showing no mismatch within the exception. This occurred as we cast the returned genesis block from clients into the `FixtureHeader` mode, which always recalculates the block hash.

Additionally adds a further check to highlight if fields in the recieved client genesis block are unexpected. Highlighting that an incorrect fork could be enabled.

![image](https://github.com/user-attachments/assets/0dd76d8b-4518-434a-b194-dfe77d99f85c)

## 🔗 Related Issues
N/A

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
