### PR TITLE
feat(github): Allow starts-with feature building when tagging

### DIFF
--- a/.github/workflows/fixtures_feature.yaml
+++ b/.github/workflows/fixtures_feature.yaml
@@ -7,20 +7,34 @@ on:
   workflow_dispatch:
 
 jobs:
+  feature-names:
+    runs-on: ubuntu-latest
+    outputs:
+      names: ${{ steps.feature-name.outputs.names }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+      - name: Get feature names
+        id: feature-name
+        shell: bash
+        run: |
+          names=$(grep -Po "^${GITHUB_REF_NAME//@*/}[^:]*" configs/feature.yaml | jq  --raw-input .  | jq -c --slurp .)
+          echo names=${names}
+          echo names=${names} >> "$GITHUB_OUTPUT"
   build:
     runs-on: ubuntu-latest
+    needs: feature-names
+    strategy:
+      matrix:
+        feature: ${{ fromJSON(needs.feature-names.outputs.names) }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - name: Get feature name
-        id: feature-name
-        shell: bash
-        run: |
-          echo name=${GITHUB_REF_NAME//@*/} >> "$GITHUB_OUTPUT"
       - uses: ./.github/actions/build-fixtures
         with:
-          name: ${{ steps.feature-name.outputs.name }}
+          name: ${{ matrix.feature }}
   release:
     runs-on: ubuntu-latest
     needs: build

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,8 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 ### 📋 Misc
 
+- ✨ Feature releases can now include multiple types of fixture tarball files from different releases that start with the same prefix ([#736](https://github.com/ethereum/execution-spec-tests/pull/736)).
+
 ## [v3.0.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v3.0.0) - 2024-07-22
 
 ### 🧪 Test Cases


### PR DESCRIPTION
## 🗒️ Description
Allow automatic fixture building of all features that start with the given feature name included in the tag.

For example, if we create a tag called `eip7692@v123.0.0`, and there are two features named `eip7692` and `eip7692-prague`, fixtures for both features will be built and automatically included in the new release.

Test workflow run here: https://github.com/marioevz/execution-spec-tests/actions/runs/10308733453

## 🔗 Related Issues
None.

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
