### PR TITLE
feat(fw): add optional `Container.expected_bytecode`

### DIFF
--- a/src/ethereum_test_types/eof/v1/__init__.py
+++ b/src/ethereum_test_types/eof/v1/__init__.py
@@ -381,6 +381,11 @@ class Container(CopyValidateModel):
     Used to have a cohesive type among all test cases, even those that do not
     resemble a valid EOF V1 container.
     """
+    expected_bytecode: Optional[Bytes] = None
+    """
+    Optional raw bytes of the expected constructed bytecode.
+    This allows confirming that raw EOF and Container() representations are identical.
+    """
 
     @cached_property
     def bytecode(self) -> bytes:
@@ -453,6 +458,10 @@ class Container(CopyValidateModel):
 
         # Add extra (garbage)
         c += self.extra
+
+        # Check if the constructed bytecode matches the expected one
+        if self.expected_bytecode is not None:
+            assert c == self.expected_bytecode
 
         return c
 

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/container.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/container.py
@@ -166,6 +166,7 @@ INVALID: List[Container] = [
         sections=[],
         auto_data_section=False,
         auto_type_section=AutoSection.NONE,
+        expected_bytecode="ef0001 00",
         validity_error=EOFException.MISSING_TYPE_HEADER,
     ),
     Container(


### PR DESCRIPTION
## 🗒️ Description
Add optional `Container.expected_bytecode` with raw bytes of the expected constructed bytecode.
This allows confirming that raw EOF and `Container()` representations are identical.

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
