### PR TITLE
new(tests): migrate "valid" EOFCREATE validation

### DIFF
--- a/converted-ethereum-tests.txt
+++ b/converted-ethereum-tests.txt
@@ -2,6 +2,8 @@
 GeneralStateTests/stCreate2/call_outsize_then_create2_successful_then_returndatasize.json
 GeneralStateTests/stCreate2/call_then_create2_successful_then_returndatasize.json
 
+EOFTests/efValidation/EOF1_eofcreate_valid_.json
+
 ([#647](https://github.com/ethereum/execution-spec-tests/pull/647))
 EOFTests/efValidation/EOF1_returncontract_invalid_.json
 EOFTests/efValidation/EOF1_returncontract_valid_.json

--- a/src/ethereum_test_types/eof/v1/__init__.py
+++ b/src/ethereum_test_types/eof/v1/__init__.py
@@ -381,6 +381,11 @@ class Container(CopyValidateModel):
     Used to have a cohesive type among all test cases, even those that do not
     resemble a valid EOF V1 container.
     """
+    expected_bytecode: Optional[Bytes] = None
+    """
+    Optional raw bytes of the expected constructed bytecode.
+    This allows confirming that raw EOF and Container() representations are identical.
+    """
 
     @cached_property
     def bytecode(self) -> bytes:
@@ -453,6 +458,10 @@ class Container(CopyValidateModel):
 
         # Add extra (garbage)
         c += self.extra
+
+        # Check if the constructed bytecode matches the expected one
+        if self.expected_bytecode is not None:
+            assert c == self.expected_bytecode
 
         return c
 

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/container.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/container.py
@@ -166,6 +166,7 @@ INVALID: List[Container] = [
         sections=[],
         auto_data_section=False,
         auto_type_section=AutoSection.NONE,
+        expected_bytecode="ef0001 00",
         validity_error=EOFException.MISSING_TYPE_HEADER,
     ),
     Container(

--- a/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
+++ b/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
@@ -556,3 +556,78 @@ def test_wide_container(eof_test: EOFTestFiller, width: int, exception: EOFExcep
         ),
         expect_exception=exception,
     )
+
+
+@pytest.mark.parametrize(
+    "container",
+    [
+        pytest.param(
+            Container(
+                sections=[
+                    Section.Code(
+                        Op.CALLDATASIZE
+                        + Op.PUSH1[0]
+                        + Op.PUSH1[255]
+                        + Op.PUSH1[0]
+                        + Op.EOFCREATE[0]
+                        + Op.POP
+                        + Op.STOP
+                    ),
+                    Section.Container(Container(sections=[Section.Code(Op.INVALID)])),
+                ],
+                expected_bytecode="""
+                ef0001010004020001000b0300010014040000000080000436600060ff6000ec005000ef000101000402
+                000100010400000000800000fe""",
+            ),
+            id="EOF1_eofcreate_valid_0",
+        ),
+        pytest.param(
+            Container(
+                sections=[
+                    Section.Code(
+                        Op.CALLDATASIZE
+                        + Op.PUSH1[0]
+                        + Op.PUSH1[255]
+                        + Op.PUSH1[0]
+                        + Op.EOFCREATE[1]
+                        + Op.POP
+                        + Op.STOP
+                    )
+                ]
+                + 2 * [Section.Container(Container(sections=[Section.Code(Op.INVALID)]))],
+                expected_bytecode="""
+                ef0001010004020001000b03000200140014040000000080000436600060ff6000ec015000ef00010100
+                0402000100010400000000800000feef000101000402000100010400000000800000fe""",
+                # Originally this test was "valid" because it was created
+                # before "orphan subcontainer" rule was introduced.
+                validity_error=EOFException.ORPHAN_SUBCONTAINER,
+            ),
+            id="EOF1_eofcreate_valid_1",
+        ),
+        pytest.param(
+            Container(
+                sections=[
+                    Section.Code(
+                        Op.CALLDATASIZE
+                        + Op.PUSH1[0]
+                        + Op.PUSH1[255]
+                        + Op.PUSH1[0]
+                        + Op.EOFCREATE[255]
+                        + Op.POP
+                        + Op.STOP
+                    )
+                ]
+                + 256 * [Section.Container(Container(sections=[Section.Code(Op.INVALID)]))],
+                # Originally this test was "valid" because it was created
+                # before "orphan subcontainer" rule was introduced.
+                validity_error=EOFException.ORPHAN_SUBCONTAINER,
+            ),
+            id="EOF1_eofcreate_valid_2",
+        ),
+    ],
+)
+def test_migrated_eofcreate(eof_test: EOFTestFiller, container: Container):
+    """
+    Tests migrated from EOFTests/efValidation/EOF1_eofcreate_valid_.json.
+    """
+    eof_test(data=container, expect_exception=container.validity_error)


### PR DESCRIPTION
## 🗒️ Description

Migrate `EOFCREATE` tests from ethereum/tests which become outdated (contain unreferenced subcontainers).

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
