### PR TITLE
feat(plugins,forks,github): Allow dual-feature (Prague+Cancun) build on EOF releases

### DIFF
--- a/.github/actions/build-besu-evm/action.yaml
+++ b/.github/actions/build-besu-evm/action.yaml
@@ -37,4 +37,4 @@ runs:
       run: |
         cd $GITHUB_WORKSPACE/besu
         ./gradlew installDist
-        echo $GITHUB_WORKSPACE/besu/build/install/besu/bin/evmtool >> $GITHUB_PATH
+        echo $GITHUB_WORKSPACE/besu/build/install/besu/bin/ >> $GITHUB_PATH

--- a/.github/actions/build-evm/action.yaml
+++ b/.github/actions/build-evm/action.yaml
@@ -17,7 +17,10 @@ outputs:
     value: ${{ steps.config-evm-reader.outputs.ref }}
   evm-bin:
     description: "Binary name of the evm tool to use"
-    value: ${{ steps.config-evm-reader.outputs.evm-bin }}
+    value: ${{ steps.config-evm-impl-config-reader.outputs.evm-bin }}
+  x-dist:
+    description: "Binary name of the evm tool to use"
+    value: ${{ steps.config-evm-impl-config-reader.outputs.x-dist }}
 runs:
   using: "composite"
   steps:
@@ -27,13 +30,20 @@ runs:
       run: |
         awk "/^${{ inputs.type }}:/{flag=1; next} /^[[:alnum:]]/{flag=0} flag" ./configs/evm.yaml \
         | sed 's/ //g' | sed 's/:/=/g' >> "$GITHUB_OUTPUT"
+    - name: Get the EVM implementation configuration from configs/evm-impl-config.yaml
+      id: config-evm-impl-config-reader
+      shell: bash
+      run: |
+        awk "/^${{ steps.config-evm-reader.outputs.impl }}:/{flag=1; next} /^[[:alnum:]]/{flag=0} flag" ./configs/evm-impl.yaml \
+        | sed 's/ //g' | sed 's/:/=/g' >> "$GITHUB_OUTPUT"
     - name: Print Variables for the selected EVM type
       shell: bash
       run: |
         echo "Implementation: ${{ steps.config-evm-reader.outputs.impl }}"
         echo "Repository: ${{ steps.config-evm-reader.outputs.repo }}"
         echo "Reference: ${{ steps.config-evm-reader.outputs.ref }}"
-        echo "EVM Binary: ${{ steps.config-evm-reader.outputs.evm-bin }}"
+        echo "EVM Binary: ${{ steps.config-evm-impl-config-reader.outputs.evm-bin }}"
+        echo "X-Dist parameter: ${{ steps.config-evm-impl-config-reader.outputs.x-dist }}"
     - name: Build the EVM using Geth action
       if: steps.config-evm-reader.outputs.impl == 'geth'
       uses: ./.github/actions/build-geth-evm

--- a/.github/actions/build-fixtures/action.yaml
+++ b/.github/actions/build-fixtures/action.yaml
@@ -31,7 +31,7 @@ runs:
         source env/bin/activate
         pip install -e .
         solc-select use  ${{ steps.properties.outputs.solc }} --always-install
-        fill -n auto --evm-bin=${{ steps.evm-builder.outputs.evm-bin }} ${{ steps.properties.outputs.fill-params }} --output=fixtures_${{ inputs.name }}.tar.gz --build-name ${{ inputs.name }}
+        fill -n ${{ steps.evm-builder.outputs.x-dist }} --evm-bin=${{ steps.evm-builder.outputs.evm-bin }} ${{ steps.properties.outputs.fill-params }} --output=fixtures_${{ inputs.name }}.tar.gz --build-name ${{ inputs.name }}
     - uses: actions/upload-artifact@v4
       with:
         name: fixtures_${{ inputs.name }}

--- a/configs/evm-impl.yaml
+++ b/configs/evm-impl.yaml
@@ -1,0 +1,9 @@
+geth:
+  evm-bin: evm
+  x-dist: auto
+evmone:
+  evm-bin: evmone-t8n
+  x-dist: auto
+besu:
+  evm-bin: evmtool
+  x-dist: 0

--- a/configs/evm.yaml
+++ b/configs/evm.yaml
@@ -2,19 +2,15 @@ stable:
   impl: geth
   repo: ethereum/go-ethereum
   ref: master
-  evm-bin: evm
 develop:
   impl: geth
   repo: lightclient/go-ethereum
   ref: prague-devnet-1
-  evm-bin: evm
 eip7692:
   impl: evmone
   repo: ethereum/evmone
   ref: master
-  evm-bin: evmone-t8n
 eip7692-prague:
   impl: besu
   repo: hyperledger/besu
   ref: main
-  evm-bin: evmtool

--- a/configs/evm.yaml
+++ b/configs/evm.yaml
@@ -13,3 +13,8 @@ eip7692:
   repo: ethereum/evmone
   ref: master
   evm-bin: evmone-t8n
+eip7692-prague:
+  impl: besu
+  repo: hyperledger/besu
+  ref: main
+  evm-bin: evmtool

--- a/configs/feature.yaml
+++ b/configs/feature.yaml
@@ -12,5 +12,5 @@ eip7692:
   solc: 0.8.21
 eip7692-prague:
   evm-type: eip7692-prague
-  fill-params: --fork=PragueEIP7692 ./tests/prague
+  fill-params: --fork=PragueEIP7692 ./tests/prague/eip7692_eof_v1
   solc: 0.8.21

--- a/configs/feature.yaml
+++ b/configs/feature.yaml
@@ -12,5 +12,5 @@ eip7692:
   solc: 0.8.21
 eip7692-prague:
   evm-type: eip7692-prague
-  fill-params: --fork=PragueEIP7692 ./tests/prague
+  fill-params: --fork=PragueEIP7692 ./tests/prague -k "not slow"
   solc: 0.8.21

--- a/configs/feature.yaml
+++ b/configs/feature.yaml
@@ -10,3 +10,7 @@ eip7692:
   evm-type: eip7692
   fill-params: --fork=CancunEIP7692 ./tests/prague
   solc: 0.8.21
+eip7692-prague:
+  evm-type: eip7692-prague
+  fill-params: --fork=PragueEIP7692 ./tests/prague
+  solc: 0.8.21

--- a/configs/feature.yaml
+++ b/configs/feature.yaml
@@ -12,5 +12,5 @@ eip7692:
   solc: 0.8.21
 eip7692-prague:
   evm-type: eip7692-prague
-  fill-params: --fork=PragueEIP7692 ./tests/prague/eip7692_eof_v1
+  fill-params: --fork=PragueEIP7692 ./tests/prague
   solc: 0.8.21

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 ### 📋 Misc
 
 - ✨ Feature releases can now include multiple types of fixture tarball files from different releases that start with the same prefix ([#736](https://github.com/ethereum/execution-spec-tests/pull/736)).
+- ✨ Releases for feature eip7692 now include both Cancun and Prague based tests in the same release, in files `fixtures_eip7692.tar.gz` and `fixtures_eip7692-prague.tar.gz` respectively ([#743](https://github.com/ethereum/execution-spec-tests/pull/743)).
 
 ## [v3.0.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v3.0.0) - 2024-07-22
 

--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -709,3 +709,56 @@ class CancunEIP7692(  # noqa: SC200
         Returns the minimum version of solc that supports this fork.
         """
         return Version.parse("1.0.0")  # set a high version; currently unknown
+
+
+class PragueEIP7692(  # noqa: SC200
+    Prague,
+    transition_tool_name="Prague",  # Besu enables EOF at Prague
+    blockchain_test_network_name="Prague",  # Besu enables EOF at Prague
+    solc_name="cancun",
+):
+    """
+    Prague + EIP-7692 (EOF) fork
+    """
+
+    @classmethod
+    def evm_code_types(cls, block_number: int = 0, timestamp: int = 0) -> List[EVMCodeType]:
+        """
+        EOF V1 is supported starting from this fork.
+        """
+        return super(PragueEIP7692, cls,).evm_code_types(  # noqa: SC200
+            block_number,
+            timestamp,
+        ) + [EVMCodeType.EOF_V1]
+
+    @classmethod
+    def call_opcodes(
+        cls, block_number: int = 0, timestamp: int = 0
+    ) -> List[Tuple[Opcodes, EVMCodeType]]:
+        """
+        EOF V1 introduces EXTCALL, EXTSTATICCALL, EXTDELEGATECALL.
+        """
+        return [
+            (Opcodes.EXTCALL, EVMCodeType.EOF_V1),
+            (Opcodes.EXTSTATICCALL, EVMCodeType.EOF_V1),
+            (Opcodes.EXTDELEGATECALL, EVMCodeType.EOF_V1),
+        ] + super(
+            PragueEIP7692, cls  # noqa: SC200
+        ).call_opcodes(
+            block_number, timestamp
+        )
+
+    @classmethod
+    def is_deployed(cls) -> bool:
+        """
+        Flags that the fork has not been deployed to mainnet; it is under active
+        development.
+        """
+        return False
+
+    @classmethod
+    def solc_min_version(cls) -> Version:
+        """
+        Returns the minimum version of solc that supports this fork.
+        """
+        return Version.parse("1.0.0")  # set a high version; currently unknown

--- a/src/pytest_plugins/forks/forks.py
+++ b/src/pytest_plugins/forks/forks.py
@@ -6,7 +6,7 @@ import itertools
 import sys
 import textwrap
 from dataclasses import dataclass, field
-from typing import Any, List
+from typing import Any, List, Set
 
 import pytest
 from pytest import Metafunc
@@ -187,27 +187,68 @@ fork_covariant_descriptors = [
 ]
 
 
-def get_fork_range(forks: List[Fork], forks_from: Fork, forks_until: Fork) -> List[Fork]:
+def get_from_until_fork_set(
+    forks: Set[Fork], forks_from: Set[Fork], forks_until: Set[Fork]
+) -> Set[Fork]:
     """
     Get the fork range from forks_from to forks_until.
     """
-    return [
-        next_fork for next_fork in forks if next_fork <= forks_until and next_fork >= forks_from
-    ]
+    resulting_set = set()
+    for fork_from in forks_from:
+        for fork_until in forks_until:
+            for fork in forks:
+                if fork <= fork_until and fork >= fork_from:
+                    resulting_set.add(fork)
+    return resulting_set
 
 
-def get_last_descendant(forks: List[Fork], fork: Fork) -> Fork:
+def get_forks_with_no_parents(forks: Set[Fork]) -> Set[Fork]:
+    """
+    Get the forks with no parents in the inheritance hierarchy.
+    """
+    resulting_forks: Set[Fork] = set()
+    for fork in forks:
+        parents = False
+        for next_fork in forks - {fork}:
+            if next_fork < fork:
+                parents = True
+                break
+        if not parents:
+            resulting_forks = resulting_forks | {fork}
+    return resulting_forks
+
+
+def get_forks_with_no_descendants(forks: Set[Fork]) -> Set[Fork]:
+    """
+    Get the forks with no descendants in the inheritance hierarchy.
+    """
+    resulting_forks: Set[Fork] = set()
+    for fork in forks:
+        descendants = False
+        for next_fork in forks - {fork}:
+            if next_fork > fork:
+                descendants = True
+                break
+        if not descendants:
+            resulting_forks = resulting_forks | {fork}
+    return resulting_forks
+
+
+def get_last_descendants(forks: Set[Fork], forks_from: Set[Fork]) -> Set[Fork]:
     """
     Get the last descendant of a class in the inheritance hierarchy.
     """
-    for next_fork in reversed(forks):
-        if next_fork >= fork:
-            return next_fork
-    return fork
+    resulting_forks: Set[Fork] = set()
+    forks = get_forks_with_no_descendants(forks)
+    for fork_from in forks_from:
+        for fork in forks:
+            if fork >= fork_from:
+                resulting_forks = resulting_forks | {fork}
+    return resulting_forks
 
 
 @pytest.hookimpl(tryfirst=True)
-def pytest_configure(config):
+def pytest_configure(config: pytest.Config):
     """
     Register the plugin's custom markers and process command-line options.
 
@@ -233,13 +274,13 @@ def pytest_configure(config):
     for d in fork_covariant_descriptors:
         config.addinivalue_line("markers", f"{d.marker_name}: {d.description}")
 
-    config.forks = [fork for fork in get_forks() if not fork.ignore()]
-    config.fork_names = [fork.name() for fork in config.forks]
+    forks = set([fork for fork in get_forks() if not fork.ignore()])
+    config.forks = forks  # type: ignore
 
     available_forks_help = textwrap.dedent(
         f"""\
         Available forks:
-        {", ".join(config.fork_names)}
+        {", ".join(fork.name() for fork in forks)}
         """
     )
     available_forks_help += textwrap.dedent(
@@ -249,24 +290,34 @@ def pytest_configure(config):
         """
     )
 
-    def get_fork_option(config, option_name: str, parameter_name: str) -> Fork | None:
+    def get_fork_option(config, option_name: str, parameter_name: str) -> Set[Fork]:
         """Post-process get option to allow for external fork conditions."""
-        option = config.getoption(option_name)
-        if not option:
-            return None
-        if option == "Merge":
-            option = "Paris"
+        config_str = config.getoption(option_name)
+        if not config_str:
+            return set()
+        forks_str = config_str.split(",")
+        for i in range(len(forks_str)):
+            forks_str[i] = forks_str[i].strip()
+            if forks_str[i] == "Merge":
+                forks_str[i] = "Paris"
+
+        resulting_forks = set()
+
         for fork in get_forks():
-            if option == fork.name():
-                return fork
-        print(
-            f"Error: Unsupported fork provided to {parameter_name}:",
-            option,
-            "\n",
-            file=sys.stderr,
-        )
-        print(available_forks_help, file=sys.stderr)
-        pytest.exit("Invalid command-line options.", returncode=pytest.ExitCode.USAGE_ERROR)
+            if fork.name() in forks_str:
+                resulting_forks.add(fork)
+
+        if len(resulting_forks) != len(forks_str):
+            print(
+                f"Error: Unsupported fork provided to {parameter_name}:",
+                config_str,
+                "\n",
+                file=sys.stderr,
+            )
+            print(available_forks_help, file=sys.stderr)
+            pytest.exit("Invalid command-line options.", returncode=pytest.ExitCode.USAGE_ERROR)
+
+        return resulting_forks
 
     single_fork = get_fork_option(config, "single_fork", "--fork")
     forks_from = get_fork_option(config, "forks_from", "--from")
@@ -295,15 +346,17 @@ def pytest_configure(config):
         forks_until = single_fork
     else:
         if not forks_from:
-            forks_from = config.forks[0]
+            forks_from = get_forks_with_no_parents(forks)
         if not forks_until:
-            forks_until = get_last_descendant(get_deployed_forks(), forks_from)
+            forks_until = get_last_descendants(set(get_deployed_forks()), forks_from)
 
-    config.fork_range = get_fork_range(config.forks, forks_from, forks_until)
+    fork_set = get_from_until_fork_set(forks, forks_from, forks_until)
+    config.fork_set = fork_set  # type: ignore
 
-    if not config.fork_range:
+    if not fork_set:
         print(
-            f"Error: --from {forks_from.name()} --until {forks_until.name()} "
+            f"Error: --from {','.join(fork.name() for fork in forks_from)} "
+            f"--until {','.join(fork.name() for fork in forks_until)} "
             "creates an empty fork range.",
             file=sys.stderr,
         )
@@ -313,15 +366,15 @@ def pytest_configure(config):
         )
 
     # with --collect-only, we don't have access to these config options
+    config.unsupported_forks: Set[Fork] = set()  # type: ignore
     if config.option.collectonly:
-        config.unsupported_forks = []
         return
 
     evm_bin = config.getoption("evm_bin")
     t8n = TransitionTool.from_binary_path(binary_path=evm_bin)
-    config.unsupported_forks = [
-        fork for fork in config.fork_range if not t8n.is_fork_supported(fork)
-    ]
+    config.unsupported_forks = filter(  # type: ignore
+        lambda fork: not t8n.is_fork_supported(fork), fork_set
+    )
 
 
 @pytest.hookimpl(trylast=True)
@@ -333,7 +386,8 @@ def pytest_report_header(config, start_path):
     header = [
         (
             bold
-            + f"Executing tests for: {', '.join([f.name() for f in config.fork_range])} "
+            + "Executing tests for: "
+            + ", ".join([f.name() for f in sorted(list(config.fork_set))])
             + reset
         ),
     ]
@@ -360,7 +414,7 @@ def get_validity_marker_args(
     metafunc: Metafunc,
     validity_marker_name: str,
     test_name: str,
-) -> Fork | None:
+) -> Set[Fork]:
     """Check and return the arguments specified to validity markers.
 
     Check that the validity markers:
@@ -386,7 +440,7 @@ def get_validity_marker_args(
         marker for marker in metafunc.definition.iter_markers(validity_marker_name)
     ]
     if not validity_markers:
-        return None
+        return set()
     if len(validity_markers) > 1:
         pytest.fail(f"'{test_name}': Too many '{validity_marker_name}' markers applied to test. ")
     if len(validity_markers[0].args) == 0:
@@ -395,20 +449,24 @@ def get_validity_marker_args(
         pytest.fail(
             f"'{test_name}': Too many arguments specified to '{validity_marker_name}' marker. "
         )
-    fork_name = validity_markers[0].args[0]
-
+    fork_names_string = validity_markers[0].args[0]
+    fork_names = fork_names_string.split(",")
+    resulting_set: Set[Fork] = set()
     for fork in metafunc.config.forks:  # type: ignore
-        if fork.name() == fork_name:
-            return fork
+        if fork.name() in fork_names:
+            resulting_set.add(fork)
+
+    if resulting_set:
+        return resulting_set
 
     pytest.fail(
-        f"'{test_name}' specifies an invalid fork '{fork_name}' to the "
+        f"'{test_name}' specifies an invalid fork '{fork_names_string}' to the "
         f"'{validity_marker_name}'. "
         f"List of valid forks: {', '.join(metafunc.config.fork_names)}"  # type: ignore
     )
 
 
-def pytest_generate_tests(metafunc):
+def pytest_generate_tests(metafunc: pytest.Metafunc):
     """
     Pytest hook used to dynamically generate test cases.
     """
@@ -430,22 +488,25 @@ def pytest_generate_tests(metafunc):
             "The markers 'valid_until' and 'valid_at_transition_to' can't be combined. "
         )
 
-    intersection_range = []
+    fork_set: Set[Fork] = metafunc.config.fork_set  # type: ignore
+    forks: Set[Fork] = metafunc.config.forks  # type: ignore
 
+    intersection_set: Set[Fork] = set()
     if valid_at_transition_to:
-        if valid_at_transition_to in metafunc.config.fork_range:
-            intersection_range = transition_fork_to(valid_at_transition_to)
+        for fork in valid_at_transition_to:
+            if fork in fork_set:
+                intersection_set = intersection_set | set(transition_fork_to(fork))
 
     else:
         if not valid_from:
-            valid_from = metafunc.config.forks[0]
+            valid_from = get_forks_with_no_parents(forks)
 
         if not valid_until:
-            valid_until = get_last_descendant(metafunc.config.fork_range, valid_from)
+            valid_until = get_last_descendants(fork_set, valid_from)
 
-        test_fork_range = get_fork_range(metafunc.config.forks, valid_from, valid_until)
+        test_fork_set = get_from_until_fork_set(forks, valid_from, valid_until)
 
-        if not test_fork_range:
+        if not test_fork_set:
             pytest.fail(
                 "The test function's "
                 f"'{test_name}' fork validity markers generate "
@@ -454,11 +515,11 @@ def pytest_generate_tests(metafunc):
                 f"@pytest.mark.valid_until ({valid_until})."
             )
 
-        intersection_range = list(set(metafunc.config.fork_range) & set(test_fork_range))
-        intersection_range.sort(key=metafunc.config.fork_range.index)
+        intersection_set = fork_set & test_fork_set
 
+    pytest_params: List[Any]
     if "fork" in metafunc.fixturenames:
-        if not intersection_range:
+        if not intersection_set:
             if metafunc.config.getoption("verbose") >= 2:
                 pytest_params = [
                     pytest.param(
@@ -475,6 +536,7 @@ def pytest_generate_tests(metafunc):
                 ]
                 metafunc.parametrize("fork", pytest_params, scope="function")
         else:
+            unsupported_forks: Set[Fork] = metafunc.config.unsupported_forks  # type: ignore
             pytest_params = [
                 (
                     ForkParametrizer(
@@ -486,10 +548,10 @@ def pytest_generate_tests(metafunc):
                             )
                         ),
                     )
-                    if fork.name() in metafunc.config.unsupported_forks
+                    if fork.name() in sorted(list(unsupported_forks))
                     else ForkParametrizer(fork=fork)
                 )
-                for fork in intersection_range
+                for fork in sorted(list(intersection_set))
             ]
             add_fork_covariant_parameters(metafunc, pytest_params)
             parametrize_fork(metafunc, pytest_params)

--- a/tests/prague/eip7692_eof_v1/__init__.py
+++ b/tests/prague/eip7692_eof_v1/__init__.py
@@ -2,4 +2,4 @@
 Test cases for all EIPs mentioned in the EOF V1 meta-EIP.
 """
 
-EOF_FORK_NAME = "PragueEIP7692"
+EOF_FORK_NAME = "CancunEIP7692,PragueEIP7692"

--- a/tests/prague/eip7692_eof_v1/__init__.py
+++ b/tests/prague/eip7692_eof_v1/__init__.py
@@ -2,4 +2,4 @@
 Test cases for all EIPs mentioned in the EOF V1 meta-EIP.
 """
 
-EOF_FORK_NAME = "CancunEIP7692"
+EOF_FORK_NAME = "PragueEIP7692"


### PR DESCRIPTION
## 🗒️ Description
#736 broke feature building for `eip7692-prague` because `PragueEIP7692` does not exist in main so the simultaneous building of both `eip7692`+`eip7692-prague` would fail when the release is tagged.

This PR not only fixes the issue but also allows forks to be specified in comma-separated value, so now the EOF fork is defined as:
```python
EOF_FORK_NAME = "CancunEIP7692,PragueEIP7692"
```

Which means that the EOF tests now can be filled in either fork, and this results in the correct and automatic filling of both `eip7692` and `eip7692-prague` features in the same release.

This was achieved by a refactor of `src/pytest_plugins/forks/forks.py`, by simply using sets instead of lists, after many attempts including constructing a "fork-tree", which was unsuccessful.

This PR also adds the `configs/evm-impl.yaml` file which specifies attributes that each evm tool supports, e.g. concurrency.

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.