### PR TITLE
verkle: fix compute_create_address signature calls

### DIFF
--- a/tests/verkle/eip4762_verkle_gas_witness/test_codecopy_generic_initcode.py
+++ b/tests/verkle/eip4762_verkle_gas_witness/test_codecopy_generic_initcode.py
@@ -50,7 +50,7 @@ def test_generic_codecopy_initcode(blockchain_test: BlockchainTestFiller, fork: 
         TestAddress: Account(balance=1000000000000000000000),
     }
 
-    contract_address = compute_create_address(TestAddress, 0)
+    contract_address = compute_create_address(address=TestAddress, nonce=0)
     if instruction == Op.EXTCODECOPY:
         deploy_code = Op.EXTCODECOPY(contract_address, 0, 0, 100) + Op.ORIGIN * 100
         data = Initcode(deploy_code=deploy_code)

--- a/tests/verkle/eip4762_verkle_gas_witness/test_creates.py
+++ b/tests/verkle/eip4762_verkle_gas_witness/test_creates.py
@@ -65,7 +65,7 @@ def test_create(
     """
     contract_code = Op.PUSH0 * code_size
     if create_instruction is None or create_instruction == Op.CREATE:
-        contract_address = compute_create_address(TestAddress, 0)
+        contract_address = compute_create_address(address=TestAddress, nonce=0)
     else:
         contract_address = compute_create2_address(
             TestAddress, 0xDEADBEEF, Initcode(deploy_code=contract_code)
@@ -129,7 +129,7 @@ def test_create_insufficient_gas(
     """
     contract_code = Op.PUSH0 * (129 * 31 + 42)
     if create_instruction is None or create_instruction == Op.CREATE:
-        contract_address = compute_create_address(TestAddress, 0)
+        contract_address = compute_create_address(address=TestAddress, nonce=0)
     else:
         contract_address = compute_create2_address(
             TestAddress, 0xDEADBEEF, Initcode(deploy_code=contract_code)
@@ -237,7 +237,7 @@ def test_big_calldata(
     """
     contract_code = Op.PUSH0 * (1000 * 31 + 42)
     if create_instruction is None or create_instruction == Op.CREATE:
-        contract_address = compute_create_address(TestAddress, 0)
+        contract_address = compute_create_address(address=TestAddress, nonce=0)
     else:
         contract_address = compute_create2_address(
             TestAddress, 0xDEADBEEF, Initcode(deploy_code=contract_code)
@@ -291,7 +291,7 @@ def _create(
         tx_value = 0
         tx_data = deploy_code
         if generate_collision:
-            contract_address = compute_create_address(TestAddress, 0)
+            contract_address = compute_create_address(address=TestAddress, nonce=0)
             pre[contract_address] = Account(nonce=1)
     elif create_instruction is not None and create_instruction.int() == Op.CREATE2.int():
         pre[TestAddress2] = Account(
@@ -309,7 +309,7 @@ def _create(
         tx_value = value
         tx_data = deploy_code
         if generate_collision:
-            contract_address = compute_create_address(TestAddress, 0)
+            contract_address = compute_create_address(address=TestAddress, nonce=0)
             pre[contract_address] = Account(nonce=1)
 
     tx = Transaction(

--- a/tests/verkle/eip4762_verkle_gas_witness/test_extcodesize.py
+++ b/tests/verkle/eip4762_verkle_gas_witness/test_extcodesize.py
@@ -131,7 +131,7 @@ def _extcodesize(
 
     post = {}
     if not fails:
-        contract_address = compute_create_address(TestAddress, tx.nonce)
+        contract_address = compute_create_address(address=TestAddress, nonce=tx.nonce)
         post[contract_address] = Account(storage={0: len(bytecode)})
 
     # witness = Witness()

--- a/tests/verkle/eip6800_genesis_verkle_tree/test_contract_codechunking.py
+++ b/tests/verkle/eip6800_genesis_verkle_tree/test_contract_codechunking.py
@@ -77,7 +77,7 @@ def test_code_chunking(blockchain_test: BlockchainTestFiller, fork: str, bytecod
     )
     blocks = [Block(txs=[tx])]
 
-    contract_address = compute_create_address(TestAddress, tx.nonce)
+    contract_address = compute_create_address(address=TestAddress, nonce=tx.nonce)
 
     post = {
         contract_address: Account(

--- a/tests/verkle/eip6800_genesis_verkle_tree/test_contract_creation.py
+++ b/tests/verkle/eip6800_genesis_verkle_tree/test_contract_creation.py
@@ -68,7 +68,7 @@ def test_contract_creation(
     )
     blocks = [Block(txs=[tx])]
 
-    contract_address = compute_create_address(TestAddress, tx.nonce)
+    contract_address = compute_create_address(address=TestAddress, nonce=tx.nonce)
 
     post = {
         contract_address: Account(

--- a/tests/verkle/eip6800_genesis_verkle_tree/test_storage_slot_write.py
+++ b/tests/verkle/eip6800_genesis_verkle_tree/test_storage_slot_write.py
@@ -72,7 +72,7 @@ def test_storage_slot_write(blockchain_test: BlockchainTestFiller, fork: str, sl
     )
     blocks = [Block(txs=[tx])]
 
-    contract_address = compute_create_address(TestAddress, tx.nonce)
+    contract_address = compute_create_address(address=TestAddress, nonce=tx.nonce)
 
     post = {
         contract_address: Account(


### PR DESCRIPTION
The `verkle/main` branch had a recent change in the testing library which didn't allow anonymous parameters for `compute_create_address(...)`. 