### PR TITLE
new(tests): EOF - EIP-3540: Test types with 128 inputs

### DIFF
--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/container.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/container.py
@@ -626,6 +626,23 @@ INVALID += [
         validity_error=EOFException.INPUTS_OUTPUTS_NUM_ABOVE_LIMIT,
     ),
     Container(
+        name="invalid_inputs_to_non_returning_code_section_2",
+        sections=[
+            Section.Code(
+                code=Op.PUSH1(0) * 128 + Op.CALLF[1] + Op.STOP,
+                max_stack_height=128,
+            ),
+            Section.Code(
+                Op.STOP,
+                code_inputs=128,
+                code_outputs=0,
+                max_stack_height=128,
+            ),
+        ],
+        # TODO auto types section generation probably failed. the exception must be about code
+        validity_error=EOFException.INPUTS_OUTPUTS_NUM_ABOVE_LIMIT,
+    ),
+    Container(
         name="single_code_section_output_too_large",
         sections=[
             Section.Code(


### PR DESCRIPTION
## 🗒️ Description
Upstreaming tests from specs implementation. Test 1 - 128 inputs in section 2.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
