### PR TITLE
feat: allow dynamic evm fork definitions via pytest plugin

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -10,6 +10,7 @@ addopts =
     -p pytest_plugins.filler.pre_alloc
     -p pytest_plugins.filler.filler
     -p pytest_plugins.forks.forks
+    -p pytest_plugins.chain_selector.chain_selector
     -p pytest_plugins.spec_version_checker.spec_version_checker
     -p pytest_plugins.help.help
     -m "not eip_version_check"

--- a/src/ethereum_test_forks/__init__.py
+++ b/src/ethereum_test_forks/__init__.py
@@ -20,11 +20,15 @@ from .forks.forks import (
     Prague,
     Shanghai,
 )
+
 from .forks.transition import (
     BerlinToLondonAt5,
     ParisToShanghaiAtTime15k,
     ShanghaiToCancunAtTime15k,
 )
+
+from .fork_registry import update_fork_registry, get_fork_registry
+
 from .helpers import (
     InvalidForkError,
     forks_from,
@@ -67,10 +71,12 @@ __all__ = [
     "forks_from_until",
     "get_deployed_forks",
     "get_development_forks",
+    "get_fork_registry",
     "get_forks",
     "get_forks_with_solc_support",
     "get_forks_without_solc_support",
     "get_closest_fork_with_solc_support",
     "transition_fork_from_to",
     "transition_fork_to",
+    "update_fork_registry",
 ]

--- a/src/ethereum_test_forks/fork_registry.py
+++ b/src/ethereum_test_forks/fork_registry.py
@@ -1,0 +1,33 @@
+"""
+Define a global registry for forks that can be used in the Ethereum test
+framework.
+
+This approach allows different chains to register their fork class 
+definitions.
+"""
+
+from typing import Dict, Type
+from .base_fork import BaseFork
+from .helpers import get_forks
+
+fork_registry: Dict[str, Dict[str, Type[BaseFork]]] = {}
+
+fork_registry["ethereum-mainnet"] = {fork.name(): fork for fork in get_forks()}
+
+
+def update_fork_registry(chain_name: str, forks: Dict[str, Type[BaseFork]]):
+    """
+    Updates the global fork registry with forks from a specific chain.
+    If the chain already exists, it merges the new forks with the existing ones.
+    """
+    if chain_name in fork_registry:
+        fork_registry[chain_name].update(forks)
+    else:
+        fork_registry[chain_name] = forks
+
+
+def get_fork_registry() -> Dict[str, Dict[str, Type[BaseFork]]]:
+    """
+    Returns the current fork registry.
+    """
+    return fork_registry

--- a/src/pytest_plugins/chain_selector/chain_selector.py
+++ b/src/pytest_plugins/chain_selector/chain_selector.py
@@ -1,0 +1,41 @@
+"""
+
+"""
+
+import pytest
+from ethereum_test_forks.fork_registry import get_fork_registry
+from ethereum_test_forks.helpers import get_forks
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--chain",
+        action="store",
+        default="ethereum-mainnet",
+        help="Select the EVM chain for testing. Default: ethereum-mainnet.",
+    )
+
+
+@pytest.fixture(scope="session")
+def chain(request):
+    return request.config.getoption("--chain")
+
+
+@pytest.fixture(scope="session")
+def forks(chain):
+    fork_registry = get_fork_registry()
+    if chain not in fork_registry:
+        raise ValueError(f"No forks found for chain: {chain}")
+    return fork_registry[chain].values()
+
+
+# @pytest.hookimpl(tryfirst=True)
+# def pytest_generate_tests(metafunc):
+#     if "fork" in metafunc.fixturenames:
+#         chain = metafunc.config.getoption("chain")
+#         fork_registry = get_fork_registry()
+#         if chain in fork_registry:
+#             forks = fork_registry[chain]
+#             metafunc.parametrize(
+#                 "fork", forks.values(), ids=[fork.__name__ for fork in forks.values()]
+#             )

--- a/src/pytest_plugins/forks/forks.py
+++ b/src/pytest_plugins/forks/forks.py
@@ -16,6 +16,7 @@ from ethereum_test_forks import (
     ForkAttribute,
     get_deployed_forks,
     get_forks,
+    get_fork_registry,
     get_transition_forks,
     transition_fork_to,
 )
@@ -274,7 +275,9 @@ def pytest_configure(config: pytest.Config):
     for d in fork_covariant_descriptors:
         config.addinivalue_line("markers", f"{d.marker_name}: {d.description}")
 
-    forks = set([fork for fork in get_forks() if not fork.ignore()])
+    chain = config.getoption("chain")
+    assert chain in get_fork_registry(), f"No forks found for chain: {chain}"
+    forks = set([fork for fork in get_fork_registry()[chain].values() if not fork.ignore()])
     config.forks = forks  # type: ignore
     config.fork_names = set([fork.name() for fork in sorted(list(forks))])  # type: ignore
     config.forks_by_name = {fork.name(): fork for fork in forks}  # type: ignore
@@ -305,7 +308,7 @@ def pytest_configure(config: pytest.Config):
 
         resulting_forks = set()
 
-        for fork in get_forks():
+        for fork in get_fork_registry()[chain].values():
             if fork.name() in forks_str:
                 resulting_forks.add(fork)
 

--- a/src/pytest_plugins/optimism.py
+++ b/src/pytest_plugins/optimism.py
@@ -1,0 +1,30 @@
+"""
+Chain definition for the Optimism network.
+"""
+from typing import List
+
+import pytest
+
+from ethereum_test_forks import Cancun, get_fork_registry, update_fork_registry
+
+
+class OptimismCancun(Cancun):
+    """
+    Defines the Optimism Cancun fork, which adds the secp256r1 precompile.
+    """
+
+    @classmethod
+    def precompiles(cls, block_number: int = 0, timestamp: int = 0) -> List[int]:
+        """
+        Optimism added the secp256r1 precompile to its Cancun fork.
+        """
+        return [0x100] + super(OptimismCancun, cls).precompiles(block_number, timestamp)
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_configure(config):
+    ethereum_mainnet_forks = get_fork_registry()["ethereum-mainnet"]
+    assert "Cancun" in ethereum_mainnet_forks, "Cancun fork not found in ethereum-mainnet forks."
+    optimism_mainnet_forks = ethereum_mainnet_forks.copy()
+    optimism_mainnet_forks["Cancun"] = OptimismCancun
+    update_fork_registry("optimism", optimism_mainnet_forks)


### PR DESCRIPTION
## 🗒️ Description

This adds a new `fork_registry` and a `chain_selector` plugin (although not strictly required) that enables a pytest plugin (there's temporary and very simple example in `./src/pytest_plugins/optimism.py`) to dynamically register fork class definitions. This allows evm implementations that deviate from Ethereum mainnet to use EEST.

### Example

Register the optimism plugin (`--chain` flag likely superfluous) and execute
`test_withdrawing_to_precompiles` which uses the `with_all_precompiles` test parametrizer:
```
fill -p pytest_plugins.optimism --chain=optimism --fork=OptimismCancun tests/shanghai/eip4895_withdrawals/ -k "test_withdrawing_to_precompiles and amount_0" -m blockchain_test --collect-only -q
```
to additionally parametrize the test with the `secp256r1` precompile that's deployed at `0x100`:
```
tests/shanghai/eip4895_withdrawals/test_withdrawals.py::test_withdrawing_to_precompiles[fork_OptimismCancun-precompile_256-blockchain_test-amount_0]
tests/shanghai/eip4895_withdrawals/test_withdrawals.py::test_withdrawing_to_precompiles[fork_OptimismCancun-precompile_10-blockchain_test-amount_0]
tests/shanghai/eip4895_withdrawals/test_withdrawals.py::test_withdrawing_to_precompiles[fork_OptimismCancun-precompile_9-blockchain_test-amount_0]
tests/shanghai/eip4895_withdrawals/test_withdrawals.py::test_withdrawing_to_precompiles[fork_OptimismCancun-precompile_5-blockchain_test-amount_0]
tests/shanghai/eip4895_withdrawals/test_withdrawals.py::test_withdrawing_to_precompiles[fork_OptimismCancun-precompile_6-blockchain_test-amount_0]
tests/shanghai/eip4895_withdrawals/test_withdrawals.py::test_withdrawing_to_precompiles[fork_OptimismCancun-precompile_7-blockchain_test-amount_0]
tests/shanghai/eip4895_withdrawals/test_withdrawals.py::test_withdrawing_to_precompiles[fork_OptimismCancun-precompile_8-blockchain_test-amount_0]
tests/shanghai/eip4895_withdrawals/test_withdrawals.py::test_withdrawing_to_precompiles[fork_OptimismCancun-precompile_1-blockchain_test-amount_0]
tests/shanghai/eip4895_withdrawals/test_withdrawals.py::test_withdrawing_to_precompiles[fork_OptimismCancun-precompile_2-blockchain_test-amount_0]
tests/shanghai/eip4895_withdrawals/test_withdrawals.py::test_withdrawing_to_precompiles[fork_OptimismCancun-precompile_3-blockchain_test-amount_0]
tests/shanghai/eip4895_withdrawals/test_withdrawals.py::test_withdrawing_to_precompiles[fork_OptimismCancun-precompile_4-blockchain_test-amount_0]
```

The main magic is using the correct fork class definitions via `forks` plugin.

### TODO

This is a very rough POC and hasn't been properly tested. The `forks` plugin is probably very broken.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
