### PR TITLE
new(tests): EIP-5656/7692 - use new marker to EOF-ize MCOPY test (2)

### DIFF
--- a/tests/cancun/eip5656_mcopy/test_mcopy.py
+++ b/tests/cancun/eip5656_mcopy/test_mcopy.py
@@ -175,6 +175,7 @@ def post(code_address: Address, code_storage: Storage) -> Mapping:  # noqa: D103
         "out_of_bounds_memory_extension",
     ],
 )
+@pytest.mark.with_all_evm_code_types
 @pytest.mark.valid_from("Cancun")
 def test_valid_mcopy_operations(
     state_test: StateTestFiller,
@@ -202,6 +203,7 @@ def test_valid_mcopy_operations(
 @pytest.mark.parametrize("src", [0x00, 0x20])
 @pytest.mark.parametrize("length", [0x00, 0x01])
 @pytest.mark.parametrize("initial_memory", [bytes()], ids=["empty_memory"])
+@pytest.mark.with_all_evm_code_types
 @pytest.mark.valid_from("Cancun")
 def test_mcopy_on_empty_memory(
     state_test: StateTestFiller,


### PR DESCRIPTION
This is https://github.com/ethereum/execution-spec-tests/pull/726 rebased after the EVM code type marker got merged to `main` and cleaned up. I also completed the set of EOF-MCOPY tests by applying the parameter in the remainder of existing 5656 tests.

I ran it through evmone intentionally breaking the MCOPY implementation in various ways, and the failures appear to be "in-sync" with ones which manifested in the old version of the test, as well as make sense in general.