### PR TITLE
refactor(fw): `parametrize_with_defaults` -> `extend_with_defaults`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,7 +26,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - 🐞 Fixes consume genesis mismatch exception for hive based simulators ([#734](https://github.com/ethereum/execution-spec-tests/pull/734)).
 - ✨ Adds reproducible consume commands to hiveview ([#717](https://github.com/ethereum/execution-spec-tests/pull/717)).
 - ✨ Added optional parameter to all `with_all_*` markers to specify a lambda function that filters the parametrized values ([#739](https://github.com/ethereum/execution-spec-tests/pull/739)).
-- ✨ Added [`parametrize_with_defaults` decorator](https://ethereum.github.io/execution-spec-tests/main/writing_tests/writing_a_new_test/#parametrize_with_defaults-decorator), which can be used as a replacement to `@pytest.mark.parametrize` to limit the generated test combinations ([#739](https://github.com/ethereum/execution-spec-tests/pull/739)).
+- ✨ Added [`extend_with_defaults` utility function](https://ethereum.github.io/execution-spec-tests/main/writing_tests/writing_a_new_test/#ethereum_test_tools.utility.pytest.extend_with_defaults), which helps extend test case parameter sets with default values. `@pytest.mark.parametrize` ([#739](https://github.com/ethereum/execution-spec-tests/pull/739)).
 - ✨ Added `Container.Init` to `ethereum_test_types.EOF.V1` package, which allows generation of an EOF init container more easily ([#739](https://github.com/ethereum/execution-spec-tests/pull/739)).
 
 ### 🔧 EVM Tools

--- a/docs/writing_tests/writing_a_new_test.md
+++ b/docs/writing_tests/writing_a_new_test.md
@@ -274,45 +274,6 @@ Tests can also be automatically parametrized with appropriate fork covariant
 values using the `with_all_*` markers listed in the
 [Test Markers](./test_markers.md#fork-covariant-markers) page.
 
-### `parametrize_with_defaults` decorator
+### The `extend_with_defaults` Utility
 
-This decorator can be used as a replacement to `@pytest.mark.parametrize` that
-allows to provide default values for the parameters and to specify each case
-only with the parameters that are different from the default values, and
-therefore lower the amount of redundant test cases.
-
-Example:
-
-```python
-@parametrize_with_defaults(
-    signer_type=SignerType.SINGLE_SIGNER,
-    authorization_invalidity_type=AuthorizationInvalidityType.NONE,
-    authorizations_count=1,
-    chain_id_type=ChainIDType.GENERIC,
-    authorize_to_address=AddressType.EMPTY_ACCOUNT,
-    access_list_case=AccessListType.EMPTY,
-    self_sponsored=False,
-    authority_type=AddressType.EMPTY_ACCOUNT,
-    data=b"",
-    cases=[
-        dict(authorizations_count=2, id="two_authorizations", marks=[pytest.mark.valid_from("Berlin")]),
-        ...
-    ],
-)
-def test_gas(
-    blockchain_test: BlockchainTestFiller,
-    signer_type: SignerType,
-    authorization_invalidity_type: AuthorizationInvalidityType,
-    authorizations_count: int,
-    chain_id_type: ChainIDType,
-    authorize_to_address: AddressType,
-    access_list_case: AccessListType,
-    self_sponsored: bool,
-    authority_type: AddressType,
-    data: bytes,
-):
-    ... 
-```
-
-This will run the test with the default values for all parameters except for
-`authorizations_count` which will be set to `2`.
+::: ethereum_test_tools.utility.pytest.extend_with_defaults

--- a/src/ethereum_test_tools/__init__.py
+++ b/src/ethereum_test_tools/__init__.py
@@ -79,7 +79,7 @@ from .code import (
     Yul,
     YulCompiler,
 )
-from .utility.pytest import parametrize_with_defaults
+from .utility.pytest import extend_with_defaults
 
 __all__ = (
     "SPEC_TYPES",
@@ -150,6 +150,6 @@ __all__ = (
     "cost_memory_bytes",
     "eip_2028_transaction_data_cost",
     "eip_2028_transaction_data_cost",
-    "parametrize_with_defaults",
+    "extend_with_defaults",
     "vm",
 )

--- a/src/ethereum_test_tools/utility/pytest.py
+++ b/src/ethereum_test_tools/utility/pytest.py
@@ -114,9 +114,10 @@ def extend_with_defaults(
           original `cases` list is modified.
     """
     for i, case in enumerate(cases):
-        assert len(case.values) == 1 and isinstance(
-            case.values[0], dict
-        ), "each case must contain exactly one value; a dict of parameter values"
+        if not (len(case.values) == 1 and isinstance(case.values[0], dict)):
+            raise ValueError(
+                "each case must contain exactly one value; a dict of parameter values"
+            )
         if set(case.values[0].keys()) - set(defaults.keys()):
             raise UnknownParameterInCasesError()
         # Overwrite values in defaults if the parameter is present in the test case values

--- a/src/ethereum_test_tools/utility/pytest.py
+++ b/src/ethereum_test_tools/utility/pytest.py
@@ -8,6 +8,16 @@ import pytest
 from _pytest.mark.structures import ParameterSet
 
 
+class UnknownParameterInCasesError(Exception):
+    """
+    Exception raised when a test case contains parameters
+    that are not present in the defaults.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("each case must only contain parameters present in defaults")
+
+
 def extend_with_defaults(
     defaults: Dict[str, Any], cases: List[ParameterSet], **parametrize_kwargs: Any
 ) -> Dict[str, Any]:
@@ -107,6 +117,8 @@ def extend_with_defaults(
         assert len(case.values) == 1 and isinstance(
             case.values[0], dict
         ), "each case must contain exactly one value; a dict of parameter values"
+        if set(case.values[0].keys()) - set(defaults.keys()):
+            raise UnknownParameterInCasesError()
         # Overwrite values in defaults if the parameter is present in the test case values
         merged_params = {**defaults, **case.values[0]}  # type: ignore
         cases[i] = pytest.param(*merged_params.values(), id=case.id, marks=case.marks)

--- a/src/ethereum_test_tools/utility/pytest.py
+++ b/src/ethereum_test_tools/utility/pytest.py
@@ -5,43 +5,110 @@ Pytest utility functions used to write Ethereum tests.
 from typing import Any, Dict, List
 
 import pytest
-
-PARAMETRIZE_KWARG_NAMES = ["indirect", "ids", "scope"]
-PARAM_KWARG_NAMES = ["id", "marks"]
+from _pytest.mark.structures import ParameterSet
 
 
-def parametrize_with_defaults(*, cases: List[Dict[str, Any]], **argument_defaults: Any):
+def extend_with_defaults(
+    defaults: Dict[str, Any], cases: List[ParameterSet], **parametrize_kwargs: Any
+) -> Dict[str, Any]:
     """
-    `pytest.mark.parametrize` replacement that allows to specify parameter names with default
-    values for each parameter.
+    Extends test cases with default parameter values.
 
-    Example usage:
-    ```
-    @parametrize_with_defaults(
-        parameter_1=0,  # Default value for parameter_1 is zero
-        parameter_2='default',  # Default value for parameter_2 is 'default' string
-        cases=[
-            dict(parameter_1=1, id='test_1'),
-            dict(parameter_2='custom', id='test_2'),
-        ],
-    )
-    def test(parameter_1, parameter_2):
-        ...
+    This utility function extends test case parameters by adding default values
+    from the `defaults` dictionary to each case in the `cases` list. If a case
+    already specifies a value for a parameter, its default is ignored.
+
+    This function is particularly useful in scenarios where you want to define
+    a common set of default values but allow individual test cases to override
+    them as needed.
+
+    The function returns a dictionary that can be directly unpacked and passed
+    to the `@pytest.mark.parametrize` decorator.
+
+    Args:
+        defaults (Dict[str, Any]): A dictionary of default parameter names and
+            their values. These values will be added to each case unless the case
+            already defines a value for each parameter.
+        cases (List[ParameterSet]): A list of `pytest.param` objects representing
+            different test cases. Its first argument must be a dictionary defining
+            parameter names and values.
+        parametrize_kwargs (Any): Additional keyword arguments to be passed to
+            `@pytest.mark.parametrize`. These arguments are not modified by this
+            function and are passed through unchanged.
+
+    Returns:
+        Dict[str, Any]: A dictionary with the following structure:
+            `argnames`: A list of parameter names.
+            `argvalues`: A list of test cases with modified parameter values.
+            `parametrize_kwargs`: Additional keyword arguments passed through unchanged.
+
+
+    Example:
+        ```python
+        @pytest.mark.parametrize(**extend_with_defaults(
+            defaults=dict(
+                min_value=0,  # default minimum value is 0
+                max_value=100,  # default maximum value is 100
+                average=50,  # default average value is 50
+            ),
+            cases=[
+                pytest.param(
+                    dict(),  # use default values
+                    id='default_case',
+                ),
+                pytest.param(
+                    dict(min_value=10),  # override with min_value=10
+                    id='min_value_10',
+                ),
+                pytest.param(
+                    dict(max_value=200),  # override with max_value=200
+                    id='max_value_200',
+                ),
+                pytest.param(
+                    dict(min_value=-10, max_value=50),  # override both min_value
+                    # and max_value
+                    id='min_-10_max_50',
+                ),
+                pytest.param(
+                    dict(min_value=20, max_value=80, average=50),  # all defaults
+                    # are overridden
+                    id="min_20_max_80_avg_50",
+                ),
+                pytest.param(
+                    dict(min_value=100, max_value=0),  # invalid range
+                    id='invalid_range',
+                    marks=pytest.mark.xfail(reason='invalid range'),
+                )
+            ],
+        ))
+        def test_range(min_value, max_value, average):
+            assert min_value <= max_value
+            assert min_value <= average <= max_value
+        ```
+
+    The above test will execute with the following sets of parameters:
+
+    ```python
+    "default_case": {"min_value": 0, "max_value": 100, "average": 50}
+    "min_value_10": {"min_value": 10, "max_value": 100, "average": 50}
+    "max_value_200": {"min_value": 0, "max_value": 200, "average": 50}
+    "min_-10_max_50": {"min_value": -10, "max_value": 50, "average": 50}
+    "min_20_max_80_avg_50": {"min_value": 20, "max_value": 80, "average": 50}
+    "invalid_range": {"min_value": 100, "max_value": 0, "average": 50}  # expected to fail
     ```
 
-    The above test will be run with two sets of parameters:
-    - `parameter_1=1, parameter_2='default'`
-    - `parameter_1=0, parameter_2='custom'`
+    Notes:
+        - Each case in `cases` must contain exactly one value, which is a dictionary
+          of parameter values.
+        - The function performs an in-place update of the `cases` list, so the
+          original `cases` list is modified.
     """
-    parametrize_kwargs = {
-        k: argument_defaults.pop(k) for k in PARAMETRIZE_KWARG_NAMES if k in argument_defaults
-    }
-    param_cases: List[Any] = []
-    for args in cases:
-        # Remove keyword arguments that are part of the `pytest.param` signature
-        param_kwargs = {k: args.pop(k) for k in PARAM_KWARG_NAMES if k in args}
-        # Merge default arguments with the test case arguments
-        args = {**argument_defaults, **args}
-        param_cases.append(pytest.param(*args.values(), **param_kwargs))
+    for i, case in enumerate(cases):
+        assert len(case.values) == 1 and isinstance(
+            case.values[0], dict
+        ), "each case must contain exactly one value; a dict of parameter values"
+        # Overwrite values in defaults if the parameter is present in the test case values
+        merged_params = {**defaults, **case.values[0]}  # type: ignore
+        cases[i] = pytest.param(*merged_params.values(), id=case.id, marks=case.marks)
 
-    return pytest.mark.parametrize(list(argument_defaults), param_cases, **parametrize_kwargs)
+    return {"argnames": list(defaults), "argvalues": cases, **parametrize_kwargs}

--- a/src/ethereum_test_tools/utility/tests/test_pytest.py
+++ b/src/ethereum_test_tools/utility/tests/test_pytest.py
@@ -137,8 +137,29 @@ def test_extend_with_defaults(defaults, cases, parametrize_kwargs, expected):  #
     assert result == parametrize_kwargs
 
 
-def test_extend_with_defaults_raises_for_unknown_default():
+def test_extend_with_defaults_raises_for_unknown_default():  # noqa: D103
     with pytest.raises(
         UnknownParameterInCasesError, match="only contain parameters present in defaults"
     ):
         extend_with_defaults(dict(a=0, b=1), [pytest.param(dict(c=2))])
+
+
+@pytest.mark.parametrize(
+    "defaults, cases",
+    [
+        pytest.param(
+            dict(param_1="default1"),
+            [pytest.param(dict(param_1="value1"), dict(param_2="value2"))],
+            id="multiple_values",
+        ),
+        pytest.param(
+            dict(param_1="default1"),
+            [pytest.param("not_a_dict")],
+            id="non_dict_value",
+        ),
+    ],
+)
+def test_extend_with_defaults_raises_value_error(defaults, cases):  # noqa: D103
+    expected_message = "each case must contain exactly one value; a dict of parameter values"
+    with pytest.raises(ValueError, match=expected_message):
+        extend_with_defaults(defaults, cases)

--- a/src/ethereum_test_tools/utility/tests/test_pytest.py
+++ b/src/ethereum_test_tools/utility/tests/test_pytest.py
@@ -1,0 +1,136 @@
+"""
+Tests for ethereum_test_tools.utility.pytest.
+"""
+
+import pytest
+
+from ethereum_test_tools import extend_with_defaults
+
+
+# TODO: This is from the docstring in extend_with_defaults; should be tested automatically
+@pytest.mark.parametrize(
+    **extend_with_defaults(
+        defaults=dict(
+            min_value=0,  # default minimum value is 0
+            max_value=100,  # default maximum value is 100
+            average=50,  # default average value is 50
+        ),
+        cases=[
+            pytest.param(
+                dict(),  # use default values
+                id="default_case",
+            ),
+            pytest.param(
+                dict(min_value=10),  # override with min_value=10
+                id="min_value_10",
+            ),
+            pytest.param(
+                dict(max_value=200),  # override with max_value=200
+                id="max_value_200",
+            ),
+            pytest.param(
+                dict(min_value=-10, max_value=50),  # override both min_value
+                # and max_value
+                id="min_-10_max_50",
+            ),
+            pytest.param(
+                dict(min_value=20, max_value=80, average=50),  # all defaults
+                # are overridden
+                id="min_20_max_80_avg_50",
+            ),
+            pytest.param(
+                dict(min_value=100, max_value=0),  # invalid range
+                id="invalid_range",
+                marks=pytest.mark.xfail(reason="invalid range"),
+            ),
+        ],
+    )
+)
+def test_range(min_value, max_value, average):  # noqa: D103
+    assert min_value <= max_value
+    assert min_value <= average <= max_value
+
+
+@pytest.mark.parametrize(
+    "defaults,cases,parametrize_kwargs,expected",
+    [
+        pytest.param(
+            dict(min_value=0, max_value=100, average=50),
+            [
+                pytest.param(
+                    dict(),
+                    id="default_case",
+                ),
+                pytest.param(
+                    dict(min_value=10),
+                    id="min_value_10",
+                ),
+                pytest.param(
+                    dict(max_value=200),
+                    id="max_value_200",
+                ),
+                pytest.param(
+                    dict(min_value=-10, max_value=50),
+                    id="min_-10_max_50",
+                ),
+                pytest.param(
+                    dict(min_value=20, max_value=80, average=50),
+                    id="min_20_max_80_avg_50",
+                ),
+                pytest.param(
+                    dict(min_value=100, max_value=0),
+                    id="invalid_range",
+                    marks=pytest.mark.xfail(reason="invalid range"),
+                ),
+            ],
+            dict(),
+            dict(
+                argnames=["min_value", "max_value", "average"],
+                argvalues=[
+                    pytest.param(0, 100, 50, id="default_case"),
+                    pytest.param(10, 100, 50, id="min_value_10"),
+                    pytest.param(0, 200, 50, id="max_value_200"),
+                    pytest.param(-10, 50, 50, id="min_-10_max_50"),
+                    pytest.param(20, 80, 50, id="min_20_max_80_avg_50"),
+                    pytest.param(
+                        100,
+                        0,
+                        50,
+                        id="invalid_range",
+                        marks=pytest.mark.xfail(reason="invalid range"),
+                    ),
+                ],
+            ),
+            id="defaults_and_cases_empty_parametrize_kwargs",
+        ),
+        pytest.param(
+            dict(min_value=0, max_value=100, average=50),
+            [
+                pytest.param(
+                    dict(),
+                    id="default_case",
+                ),
+                pytest.param(
+                    dict(min_value=10),
+                    id="min_value_10",
+                ),
+            ],
+            dict(scope="session"),
+            dict(
+                argnames=["min_value", "max_value", "average"],
+                argvalues=[
+                    pytest.param(0, 100, 50, id="default_case"),
+                    pytest.param(10, 100, 50, id="min_value_10"),
+                ],
+            ),
+            id="defaults_and_cases_with_parametrize_kwargs",
+        ),
+    ],
+)
+def test_extend_with_defaults(defaults, cases, parametrize_kwargs, expected):  # noqa: D103
+    result = extend_with_defaults(defaults, cases, **parametrize_kwargs)
+    assert result["argnames"] == expected["argnames"]
+    assert result["argvalues"] == expected["argvalues"]
+    result.pop("argnames")
+    result.pop("argvalues")
+    assert result == parametrize_kwargs

--- a/src/ethereum_test_tools/utility/tests/test_pytest.py
+++ b/src/ethereum_test_tools/utility/tests/test_pytest.py
@@ -5,6 +5,7 @@ Tests for ethereum_test_tools.utility.pytest.
 import pytest
 
 from ethereum_test_tools import extend_with_defaults
+from ethereum_test_tools.utility.pytest import UnknownParameterInCasesError
 
 
 # TODO: This is from the docstring in extend_with_defaults; should be tested automatically
@@ -134,3 +135,10 @@ def test_extend_with_defaults(defaults, cases, parametrize_kwargs, expected):  #
     result.pop("argnames")
     result.pop("argvalues")
     assert result == parametrize_kwargs
+
+
+def test_extend_with_defaults_raises_for_unknown_default():
+    with pytest.raises(
+        UnknownParameterInCasesError, match="only contain parameters present in defaults"
+    ):
+        extend_with_defaults(dict(a=0, b=1), [pytest.param(dict(c=2))])

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -12,6 +12,8 @@ api
 apis
 arcname
 argcount
+argnames
+argvalues
 ase
 at5
 AuthorizationInvalidityType


### PR DESCRIPTION
## 🗒️ Description

This PR tries to make this parametrizing helper function a pure helper library function which doesn't obfuscate how parametrization is achieved via pytest (respectively by the test implementer in their definition of cases).

Changes:
- Don't return a `pytest.mark.parametrize` decorator, rather a list of arguments to supply to `pytest.mark.parametrize()`.
- Make each case in `cases` a `pytest.param()`. This is a bit tricky: The `argvalues` in this case must be a dictionary containing the actual names and values of the parameters to be parametrized - a `ValueError` is raised if this is not the case.
- Raise `UnknownParameterInCasesError` if a case in `cases` contains a parameter not present in `defaults` 6591eb73425cffbdb5ed2a23ec0c3879c0a807ab
- Update docs.
- Add tests.

## 🔗 Related Issues
Original PR: #739

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
