### PR TITLE
verkle: fix balance overflow

### DIFF
--- a/tests/verkle/eip6800_verkle_tree/test_verkle_from_mpt_conversion.py
+++ b/tests/verkle/eip6800_verkle_tree/test_verkle_from_mpt_conversion.py
@@ -24,7 +24,7 @@ REFERENCE_SPEC_VERSION = "2f8299df31bb8173618901a03a8366a3183479b0"
 @pytest.fixture
 def pre() -> Mapping:  # noqa: D103
     return {
-        TestAddress: Account(balance=10**40),
+        TestAddress: Account(balance=2**127),
         code_address: Account(
             nonce=1,
             balance=1,


### PR DESCRIPTION
The current EIP-6800 defines the balance as a value of [up to 128 bits](https://eips.ethereum.org/EIPS/eip-6800#header-values). We had a test which defined a pre-state with a balance of $10^{40} > 128$ bits.