### PR TITLE
new(tests): EOF - EIP-7620: migrate "embedded container" tests

### DIFF
--- a/converted-ethereum-tests.txt
+++ b/converted-ethereum-tests.txt
@@ -5,6 +5,7 @@ GeneralStateTests/stCreate2/call_then_create2_successful_then_returndatasize.jso
 ([#598](https://github.com/ethereum/execution-spec-tests/pull/598))
 EOFTests/EIP3540/validInvalid.json
 
+EOFTests/efValidation/EOF1_embedded_container_.json
 EOFTests/efValidation/EOF1_eofcreate_valid_.json
 EOFTests/efValidation/EOF1_section_order_.json
 EOFTests/efValidation/EOF1_truncated_section_.json

--- a/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
+++ b/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
@@ -29,20 +29,13 @@ returncontract_code_section = Section.Code(
     code=Op.SSTORE(slot_code_worked, value_code_worked) + Op.RETURNCONTRACT[0](0, 0),
     max_stack_height=2,
 )
-stop_sub_container = Section.Container(container=Container(sections=[Section.Code(code=Op.STOP)]))
-return_sub_container = Section.Container(
-    container=Container(sections=[Section.Code(code=Op.RETURN(0, 0), max_stack_height=2)])
-)
-revert_sub_container = Section.Container(
-    container=Container(sections=[Section.Code(code=Op.REVERT(0, 0), max_stack_height=2)])
-)
+stop_sub_container = Section.Container(Container.Code(Op.STOP))
+return_sub_container = Section.Container(Container.Code(Op.RETURN(0, 0)))
+revert_sub_container = Section.Container(Container.Code(Op.REVERT(0, 0)))
 returncontract_sub_container = Section.Container(
-    container=Container(
+    Container(
         sections=[
-            Section.Code(
-                code=Op.RETURNCONTRACT[0](0, 0),
-                max_stack_height=2,
-            ),
+            Section.Code(Op.RETURNCONTRACT[0](0, 0)),
             stop_sub_container,
         ],
     )
@@ -474,9 +467,9 @@ def test_container_both_kinds_different_sub(eof_test: EOFTestFiller):
 @pytest.mark.parametrize(
     ["deepest_container", "exception"],
     [
-        pytest.param(Container(sections=[Section.Code(code=Op.STOP)]), None, id="valid"),
+        pytest.param(Container.Code(Op.STOP), None, id="valid"),
         pytest.param(
-            Container(sections=[Section.Code(code=Op.PUSH0)]),
+            Container.Code(code=Op.PUSH0),
             EOFException.MISSING_STOP_OPCODE,
             id="code-error",
         ),
@@ -572,13 +565,71 @@ def test_wide_container(eof_test: EOFTestFiller, width: int, exception: EOFExcep
                         + Op.POP
                         + Op.STOP
                     ),
-                    Section.Container(Container(sections=[Section.Code(Op.INVALID)])),
+                    Section.Container(Container.Code(Op.INVALID)),
                 ],
                 expected_bytecode="""
                 ef0001010004020001000b0300010014040000000080000436600060ff6000ec005000ef000101000402
                 000100010400000000800000fe""",
             ),
             id="EOF1_eofcreate_valid_0",
+        ),
+        pytest.param(
+            Container(
+                sections=[
+                    Section.Code(Op.PUSH1[0] + Op.RJUMP[0] + Op.STOP),
+                    Section.Container(Container.Code(Op.INVALID)),
+                ],
+                expected_bytecode="""
+                ef00010100040200010006030001001404000000008000016000e0000000ef0001010004020001000104
+                00000000800000fe""",
+                # Originally this test was "valid" because it was created
+                # before "orphan subcontainer" rule was introduced.
+                validity_error=EOFException.ORPHAN_SUBCONTAINER,
+            ),
+            id="EOF1_embedded_container_0",
+        ),
+        pytest.param(
+            Container(
+                sections=[
+                    Section.Code(Op.PUSH1[0] + Op.RJUMP[0] + Op.STOP),
+                    Section.Container(Container.Code(Op.INVALID)),
+                    Section.Data(custom_size=2),
+                ],
+                expected_bytecode="""
+                ef00010100040200010006030001001404000200008000016000e0000000ef0001010004020001000104
+                00000000800000fe""",
+                # Originally this test was "valid" but against the current spec
+                # it contains two errors: data section truncated and orphan subcontainer.
+                validity_error=EOFException.TOPLEVEL_CONTAINER_TRUNCATED,
+            ),
+            id="EOF1_embedded_container_1",
+        ),
+        pytest.param(
+            Container(
+                sections=[
+                    Section.Code(Op.PUSH1[0] + Op.RJUMP[0] + Op.STOP),
+                    Section.Container(Container.Code(Op.INVALID)),
+                    Section.Data("aabb"),
+                ],
+                expected_bytecode="""
+                ef00010100040200010006030001001404000200008000016000e0000000ef0001010004020001000104
+                00000000800000feaabb""",
+                # Originally this test was "valid" because it was created
+                # before "orphan subcontainer" rule was introduced.
+                validity_error=EOFException.ORPHAN_SUBCONTAINER,
+            ),
+            id="EOF1_embedded_container_2",
+        ),
+        pytest.param(
+            Container(
+                sections=[
+                    Section.Code(Op.EOFCREATE[0](0, 0, 0, 0) + Op.STOP),
+                    Section.Container("aabbccddeeff"),
+                ],
+                # The original test has been modified to reference the subcontainer by EOFCREATE.
+                validity_error=EOFException.INVALID_MAGIC,
+            ),
+            id="EOF1_embedded_container_3",
         ),
         pytest.param(
             Container(
@@ -593,7 +644,7 @@ def test_wide_container(eof_test: EOFTestFiller, width: int, exception: EOFExcep
                         + Op.STOP
                     )
                 ]
-                + 2 * [Section.Container(Container(sections=[Section.Code(Op.INVALID)]))],
+                + 2 * [Section.Container(Container.Code(Op.INVALID))],
                 expected_bytecode="""
                 ef0001010004020001000b03000200140014040000000080000436600060ff6000ec015000ef00010100
                 0402000100010400000000800000feef000101000402000100010400000000800000fe""",
@@ -602,6 +653,22 @@ def test_wide_container(eof_test: EOFTestFiller, width: int, exception: EOFExcep
                 validity_error=EOFException.ORPHAN_SUBCONTAINER,
             ),
             id="EOF1_eofcreate_valid_1",
+        ),
+        pytest.param(
+            Container(
+                sections=[
+                    Section.Code(Op.PUSH1[0] + Op.RJUMP[0] + Op.STOP),
+                    Section.Container(Container.Code(Op.INVALID)),
+                    Section.Container(Container.Code(Op.PUSH0 + Op.PUSH0 + Op.RETURN)),
+                ],
+                expected_bytecode="""
+                ef000101000402000100060300020014001604000000008000016000e0000000ef000101000402000100
+                010400000000800000feef0001010004020001000304000000008000025f5ff3""",
+                # Originally this test was "valid" because it was created
+                # before "orphan subcontainer" rule was introduced.
+                validity_error=EOFException.ORPHAN_SUBCONTAINER,
+            ),
+            id="EOF1_embedded_container_4",
         ),
         pytest.param(
             Container(
@@ -616,12 +683,22 @@ def test_wide_container(eof_test: EOFTestFiller, width: int, exception: EOFExcep
                         + Op.STOP
                     )
                 ]
-                + 256 * [Section.Container(Container(sections=[Section.Code(Op.INVALID)]))],
+                + 256 * [Section.Container(Container.Code(Op.INVALID))],
                 # Originally this test was "valid" because it was created
                 # before "orphan subcontainer" rule was introduced.
                 validity_error=EOFException.ORPHAN_SUBCONTAINER,
             ),
             id="EOF1_eofcreate_valid_2",
+        ),
+        pytest.param(
+            Container(
+                sections=[Section.Code(Op.PUSH1[0] + Op.RJUMP[0] + Op.STOP)]
+                + 256 * [Section.Container(Container.Code(Op.INVALID))],
+                # Originally this test was "valid" because it was created
+                # before "orphan subcontainer" rule was introduced.
+                validity_error=EOFException.ORPHAN_SUBCONTAINER,
+            ),
+            id="EOF1_embedded_container_5",
         ),
     ],
 )

--- a/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
+++ b/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
@@ -571,7 +571,7 @@ def test_wide_container(eof_test: EOFTestFiller, width: int, exception: EOFExcep
                 ef0001010004020001000b0300010014040000000080000436600060ff6000ec005000ef000101000402
                 000100010400000000800000fe""",
             ),
-            id="EOF1_eofcreate_valid_0",
+            id="eofcreate_0",
         ),
         pytest.param(
             Container(
@@ -586,7 +586,7 @@ def test_wide_container(eof_test: EOFTestFiller, width: int, exception: EOFExcep
                 # before "orphan subcontainer" rule was introduced.
                 validity_error=EOFException.ORPHAN_SUBCONTAINER,
             ),
-            id="EOF1_embedded_container_0",
+            id="orphan_subcontainer_0",
         ),
         pytest.param(
             Container(
@@ -602,7 +602,7 @@ def test_wide_container(eof_test: EOFTestFiller, width: int, exception: EOFExcep
                 # it contains two errors: data section truncated and orphan subcontainer.
                 validity_error=EOFException.TOPLEVEL_CONTAINER_TRUNCATED,
             ),
-            id="EOF1_embedded_container_1",
+            id="orphan_subcontainer_0_and_truncated_data",
         ),
         pytest.param(
             Container(
@@ -618,7 +618,7 @@ def test_wide_container(eof_test: EOFTestFiller, width: int, exception: EOFExcep
                 # before "orphan subcontainer" rule was introduced.
                 validity_error=EOFException.ORPHAN_SUBCONTAINER,
             ),
-            id="EOF1_embedded_container_2",
+            id="orphan_subcontainer_0_and_data",
         ),
         pytest.param(
             Container(
@@ -629,7 +629,7 @@ def test_wide_container(eof_test: EOFTestFiller, width: int, exception: EOFExcep
                 # The original test has been modified to reference the subcontainer by EOFCREATE.
                 validity_error=EOFException.INVALID_MAGIC,
             ),
-            id="EOF1_embedded_container_3",
+            id="subcontainer_0_with_invalid_prefix",
         ),
         pytest.param(
             Container(
@@ -652,7 +652,7 @@ def test_wide_container(eof_test: EOFTestFiller, width: int, exception: EOFExcep
                 # before "orphan subcontainer" rule was introduced.
                 validity_error=EOFException.ORPHAN_SUBCONTAINER,
             ),
-            id="EOF1_eofcreate_valid_1",
+            id="eofcreate_1_orphan_subcontainer_0",
         ),
         pytest.param(
             Container(
@@ -668,7 +668,7 @@ def test_wide_container(eof_test: EOFTestFiller, width: int, exception: EOFExcep
                 # before "orphan subcontainer" rule was introduced.
                 validity_error=EOFException.ORPHAN_SUBCONTAINER,
             ),
-            id="EOF1_embedded_container_4",
+            id="two_orphan_subcontainers",
         ),
         pytest.param(
             Container(
@@ -688,7 +688,7 @@ def test_wide_container(eof_test: EOFTestFiller, width: int, exception: EOFExcep
                 # before "orphan subcontainer" rule was introduced.
                 validity_error=EOFException.ORPHAN_SUBCONTAINER,
             ),
-            id="EOF1_eofcreate_valid_2",
+            id="eofcreate_255_max_orphan_subcontainers",
         ),
         pytest.param(
             Container(
@@ -698,7 +698,7 @@ def test_wide_container(eof_test: EOFTestFiller, width: int, exception: EOFExcep
                 # before "orphan subcontainer" rule was introduced.
                 validity_error=EOFException.ORPHAN_SUBCONTAINER,
             ),
-            id="EOF1_embedded_container_5",
+            id="max_orphan_subcontainers",
         ),
     ],
 )


### PR DESCRIPTION
Migrate EOFTests/efValidation/EOF1_embedded_container_.json.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
