### PR TITLE
refactor(tests): use extend with defaults

### DIFF
--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_section_header_body_mismatch.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_section_header_body_mismatch.py
@@ -124,13 +124,13 @@ def test_code_section_header_body_mismatch(
                 code_inputs=0,
                 code_outputs=0,
                 max_stack_height=0,
-                # weather to not mention it in code section header list
+                # whether to not mention it in code section header list
                 skip_header_listing=skip_header_listing,
-                # weather to not print it's code in containers body
+                # whether to not print its code in containers body
                 skip_body_listing=skip_body_listing,
-                # weather to not print it's input bytes in containers body
+                # whether to not print its input bytes in containers body
                 skip_types_body_listing=skip_types_body_listing,
-                # weather to not calculate it's input bytes size in types section's header
+                # whether to not calculate its input bytes size in types section's header
                 skip_types_header_listing=skip_types_header_listing,
             ),
             Section.Data("0x0bad60A7"),

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_section_header_body_mismatch.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_section_header_body_mismatch.py
@@ -7,6 +7,7 @@ import pytest
 from ethereum_test_exceptions.exceptions import EOFExceptionInstanceOrList
 from ethereum_test_tools import EOFException, EOFTestFiller
 from ethereum_test_tools import Opcodes as Op
+from ethereum_test_tools import extend_with_defaults
 from ethereum_test_tools.eof.v1 import Container, Section
 
 from .. import EOF_FORK_NAME
@@ -18,65 +19,87 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
 
 
 @pytest.mark.parametrize(
-    "skip_header_listing, skip_body_listing, skip_types_body_listing, skip_types_header_listing,"
-    "expected_code, expected_exception",
-    [
-        pytest.param(
-            True,  # second section is not in code header array
-            True,  # second section is not in container's body (it's code bytes)
-            False,  # but it's code input bytes still listed in container's body
-            False,  # but it's code input bytes size still added to types section size
-            "ef000101000802000100030400040000800001000000003050000bad60A7",
-            [EOFException.INVALID_TYPE_SECTION_SIZE, EOFException.INVALID_SECTION_BODIES_SIZE],
-            id="drop_code_section_and_header",
+    **extend_with_defaults(
+        defaults=dict(
+            skip_header_listing=False,  # second section is mentioned in code header array
+            skip_body_listing=False,  # second section code is in container's body
+            skip_types_body_listing=False,  # code input bytes not listed in container's body
+            skip_types_header_listing=False,  # code input bytes size not added to types section size  # noqa: E501
+            expected_code="",
+            expected_exception=None,
         ),
-        pytest.param(
-            True,  # second section is not in code header array
-            False,  # second section code is in container's body (3050000)
-            False,  # but it's code input bytes still listed in container's body
-            False,  # but it's code input bytes size still added to types section size
-            "ef000101000802000100030400040000800001000000003050003050000bad60A7",
-            [EOFException.INVALID_TYPE_SECTION_SIZE, EOFException.INVALID_SECTION_BODIES_SIZE],
-            id="drop_code_header",
-        ),
-        pytest.param(
-            False,  # second section is mentioned in code header array (0003)
-            True,  # second section is not in container's body (it's code bytes)
-            False,  # but it's code input bytes still listed in container's body
-            False,  # but it's code input bytes size still added to types section size
-            "ef0001010008020002000300030400040000800001000000003050000bad60A7",
-            [EOFException.UNREACHABLE_CODE_SECTIONS, EOFException.TOPLEVEL_CONTAINER_TRUNCATED],
-            id="drop_code_section",
-        ),
-        pytest.param(
-            False,  # second section is mentioned in code header array (0003)
-            False,  # second section code is in container's body (3050000)
-            False,  # but it's code input bytes still listed in container's body
-            False,  # but it's code input bytes size still added to types section size
-            "ef0001010008020002000300030400040000800001000000003050003050000bad60A7",
-            EOFException.UNREACHABLE_CODE_SECTIONS,
-            id="layout_ok_code_bad",
-        ),
-        pytest.param(
-            # Data 17 test case of valid invalid eof ori filler
-            True,  # second section is not in code header array
-            True,  # second section is not in container's body (it's code bytes)
-            True,  # it's code input bytes are not listed in container's body (00000000)
-            False,  # but it's code input bytes size still added to types section size
-            "ef0001010008020001000304000400008000013050000bad60a7",
-            [EOFException.INVALID_TYPE_SECTION_SIZE, EOFException.INVALID_SECTION_BODIES_SIZE],
-            id="drop_types_header",
-        ),
-        pytest.param(
-            True,  # second section is not in code header array
-            True,  # second section is not in container's body (it's code bytes)
-            True,  # it's code input bytes are not listed in container's body (00000000)
-            True,  # and it is bytes size is not counted in types header
-            "ef0001010004020001000304000400008000013050000bad60a7",
-            None,
-            id="drop_everything",
-        ),
-    ],
+        cases=[
+            pytest.param(
+                dict(
+                    skip_header_listing=True,
+                    skip_body_listing=True,
+                    expected_code="ef000101000802000100030400040000800001000000003050000bad60A7",
+                    expected_exception=[
+                        EOFException.INVALID_TYPE_SECTION_SIZE,
+                        EOFException.INVALID_SECTION_BODIES_SIZE,
+                    ],
+                ),
+                id="drop_code_section_and_header",
+            ),
+            pytest.param(
+                dict(
+                    skip_header_listing=True,
+                    skip_body_listing=False,
+                    expected_code="ef000101000802000100030400040000800001000000003050003050000bad60A7",  # noqa: E501
+                    expected_exception=[
+                        EOFException.INVALID_TYPE_SECTION_SIZE,
+                        EOFException.INVALID_SECTION_BODIES_SIZE,
+                    ],
+                ),
+                id="drop_code_header",
+            ),
+            pytest.param(
+                dict(
+                    skip_header_listing=False,
+                    skip_body_listing=True,
+                    expected_code="ef0001010008020002000300030400040000800001000000003050000bad60A7",  # noqa: E501
+                    expected_exception=[
+                        EOFException.UNREACHABLE_CODE_SECTIONS,
+                        EOFException.TOPLEVEL_CONTAINER_TRUNCATED,
+                    ],
+                ),
+                id="drop_code_section",
+            ),
+            pytest.param(
+                dict(
+                    skip_header_listing=False,
+                    skip_body_listing=False,
+                    expected_code="ef0001010008020002000300030400040000800001000000003050003050000bad60A7",  # noqa: E501
+                    expected_exception=EOFException.UNREACHABLE_CODE_SECTIONS,
+                ),
+                id="layout_ok_code_bad",
+            ),
+            pytest.param(
+                dict(
+                    skip_header_listing=True,
+                    skip_body_listing=True,
+                    skip_types_body_listing=True,
+                    expected_code="ef0001010008020001000304000400008000013050000bad60a7",
+                    expected_exception=[
+                        EOFException.INVALID_TYPE_SECTION_SIZE,
+                        EOFException.INVALID_SECTION_BODIES_SIZE,
+                    ],
+                ),
+                id="drop_types_header",
+            ),
+            pytest.param(
+                dict(
+                    skip_header_listing=True,
+                    skip_body_listing=True,
+                    skip_types_body_listing=True,
+                    skip_types_header_listing=True,
+                    expected_code="ef0001010004020001000304000400008000013050000bad60a7",
+                    expected_exception=None,
+                ),
+                id="drop_everything",
+            ),
+        ],
+    )
 )
 def test_code_section_header_body_mismatch(
     eof_test: EOFTestFiller,


### PR DESCRIPTION
## 🗒️ Description
Refactors the parametrization of `tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_section_header_body_mismatch.py::test_code_section_header_body_mismatch` to use
 [`extend_with_defaults`](https://ethereum.github.io/execution-spec-tests/main/writing_tests/writing_a_new_test/#the-extend_with_defaults-utility) to try and improve readability.

## 🔗 Related Issues
#731

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
