### PR TITLE
chore(consume): return exit-code from consume commands

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Added optional parameter to all `with_all_*` markers to specify a lambda function that filters the parametrized values ([#739](https://github.com/ethereum/execution-spec-tests/pull/739)).
 - ✨ Added [`extend_with_defaults` utility function](https://ethereum.github.io/execution-spec-tests/main/writing_tests/writing_a_new_test/#ethereum_test_tools.utility.pytest.extend_with_defaults), which helps extend test case parameter sets with default values. `@pytest.mark.parametrize` ([#739](https://github.com/ethereum/execution-spec-tests/pull/739)).
 - ✨ Added `Container.Init` to `ethereum_test_types.EOF.V1` package, which allows generation of an EOF init container more easily ([#739](https://github.com/ethereum/execution-spec-tests/pull/739)).
+- 🐞 Fixed consume command exit code return values ([#765](https://github.com/ethereum/execution-spec-tests/pull/765)).
 
 ### 🔧 EVM Tools
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,7 +29,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Added optional parameter to all `with_all_*` markers to specify a lambda function that filters the parametrized values ([#739](https://github.com/ethereum/execution-spec-tests/pull/739)).
 - ✨ Added [`extend_with_defaults` utility function](https://ethereum.github.io/execution-spec-tests/main/writing_tests/writing_a_new_test/#ethereum_test_tools.utility.pytest.extend_with_defaults), which helps extend test case parameter sets with default values. `@pytest.mark.parametrize` ([#739](https://github.com/ethereum/execution-spec-tests/pull/739)).
 - ✨ Added `Container.Init` to `ethereum_test_types.EOF.V1` package, which allows generation of an EOF init container more easily ([#739](https://github.com/ethereum/execution-spec-tests/pull/739)).
-- 🐞 Fixed consume command exit code return values ([#765](https://github.com/ethereum/execution-spec-tests/pull/765)).
+- 🐞 Fixed `consume` exit code return values, ensuring that pytest's return value is correctly propagated to the shell. This allows the shell to accurately reflect the test results (e.g., failures) based on the pytest exit code ([#765](https://github.com/ethereum/execution-spec-tests/pull/765)).
 
 ### 🔧 EVM Tools
 

--- a/src/cli/pytest_commands/consume.py
+++ b/src/cli/pytest_commands/consume.py
@@ -101,9 +101,10 @@ def consume_command(is_hive: bool = False) -> Callable[[Callable[..., Any]], cli
             if is_hive and not any(arg.startswith("--hive-session-temp-folder") for arg in args):
                 with TemporaryDirectory() as temp_dir:
                     args.extend(["--hive-session-temp-folder", temp_dir])
-                    pytest.main(args)
+                    result = pytest.main(args)
             else:
-                pytest.main(args)
+                result = pytest.main(args)
+            sys.exit(result)
 
         command.__doc__ = func.__doc__
         return command


### PR DESCRIPTION
## 🗒️ Description
Fixes returning a 0 (pass) exit code when failing consume runs.
This cropped up in the geth verkle CI where tests would fail within consume direct but pass the CI step. @jsign

## 🔗 Related Issues
N/A

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.