### PR TITLE
[WIP] feat(forks,tests,github): Add EOF to Prague

### DIFF
--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -6,11 +6,3 @@ develop:
   evm-type: develop
   fill-params: --until=Prague
   solc: 0.8.21
-eip7692:
-  evm-type: eip7692
-  fill-params: --fork=CancunEIP7692 ./tests/prague
-  solc: 0.8.21
-eip7692-prague:
-  evm-type: eip7692-prague
-  fill-params: --fork=PragueEIP7692 ./tests/prague -k "not slow"
-  solc: 0.8.21

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -154,7 +154,6 @@ jobs:
           echo "$files" | while read line; do
             file=$(echo "$line" | cut -c 3-)
             fill $file --until=Cancun --evm-bin evmone-t8n || true >> filloutput.log 2>&1
-            (fill $file --fork=CancunEIP7692 --evm-bin evmone-t8n -k eof_test || true) > >(tee -a filloutput.log filloutputEOF.log) 2>&1
           done
 
           if grep -q "FAILURES" filloutput.log; then

--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -594,6 +594,44 @@ class Prague(Cancun):
         return Version.parse("1.0.0")  # set a high version; currently unknown
 
     @classmethod
+    def evm_code_types(cls, block_number: int = 0, timestamp: int = 0) -> List[EVMCodeType]:
+        """
+        EOF V1 is supported starting from this fork.
+        """
+        return super(Prague, cls,).evm_code_types(  # noqa: SC200
+            block_number,
+            timestamp,
+        ) + [EVMCodeType.EOF_V1]
+
+    @classmethod
+    def call_opcodes(
+        cls, block_number: int = 0, timestamp: int = 0
+    ) -> List[Tuple[Opcodes, EVMCodeType]]:
+        """
+        EOF V1 introduces EXTCALL, EXTSTATICCALL, EXTDELEGATECALL.
+        """
+        return [
+            (Opcodes.EXTCALL, EVMCodeType.EOF_V1),
+            (Opcodes.EXTSTATICCALL, EVMCodeType.EOF_V1),
+            (Opcodes.EXTDELEGATECALL, EVMCodeType.EOF_V1),
+        ] + super(
+            Prague, cls  # noqa: SC200
+        ).call_opcodes(
+            block_number, timestamp
+        )
+
+    @classmethod
+    def create_opcodes(
+        cls, block_number: int = 0, timestamp: int = 0
+    ) -> List[Tuple[Opcodes, EVMCodeType]]:
+        """
+        EOF V1 introduces `EOFCREATE`.
+        """
+        return [(Opcodes.EOFCREATE, EVMCodeType.EOF_V1),] + super(
+            Prague, cls  # noqa: SC200
+        ).create_opcodes(block_number, timestamp)
+
+    @classmethod
     def precompiles(cls, block_number: int = 0, timestamp: int = 0) -> List[Address]:
         """
         At Prague, pre-compile for BLS operations are added:
@@ -711,120 +749,3 @@ class Prague(Cancun):
         At Prague, version number of NewPayload and ForkchoiceUpdated diverge.
         """
         return 3
-
-
-class CancunEIP7692(  # noqa: SC200
-    Cancun,
-    transition_tool_name="Prague",  # Evmone enables (only) EOF at Prague
-    blockchain_test_network_name="Prague",  # Evmone enables (only) EOF at Prague
-    solc_name="cancun",
-):
-    """
-    Cancun + EIP-7692 (EOF) fork
-    """
-
-    @classmethod
-    def evm_code_types(cls, block_number: int = 0, timestamp: int = 0) -> List[EVMCodeType]:
-        """
-        EOF V1 is supported starting from this fork.
-        """
-        return super(CancunEIP7692, cls,).evm_code_types(  # noqa: SC200
-            block_number,
-            timestamp,
-        ) + [EVMCodeType.EOF_V1]
-
-    @classmethod
-    def call_opcodes(
-        cls, block_number: int = 0, timestamp: int = 0
-    ) -> List[Tuple[Opcodes, EVMCodeType]]:
-        """
-        EOF V1 introduces EXTCALL, EXTSTATICCALL, EXTDELEGATECALL.
-        """
-        return [
-            (Opcodes.EXTCALL, EVMCodeType.EOF_V1),
-            (Opcodes.EXTSTATICCALL, EVMCodeType.EOF_V1),
-            (Opcodes.EXTDELEGATECALL, EVMCodeType.EOF_V1),
-        ] + super(
-            CancunEIP7692, cls  # noqa: SC200
-        ).call_opcodes(
-            block_number, timestamp
-        )
-
-    @classmethod
-    def create_opcodes(
-        cls, block_number: int = 0, timestamp: int = 0
-    ) -> List[Tuple[Opcodes, EVMCodeType]]:
-        """
-        EOF V1 introduces `EOFCREATE`.
-        """
-        return [(Opcodes.EOFCREATE, EVMCodeType.EOF_V1),] + super(
-            CancunEIP7692, cls  # noqa: SC200
-        ).create_opcodes(block_number, timestamp)
-
-    @classmethod
-    def is_deployed(cls) -> bool:
-        """
-        Flags that the fork has not been deployed to mainnet; it is under active
-        development.
-        """
-        return False
-
-    @classmethod
-    def solc_min_version(cls) -> Version:
-        """
-        Returns the minimum version of solc that supports this fork.
-        """
-        return Version.parse("1.0.0")  # set a high version; currently unknown
-
-
-class PragueEIP7692(  # noqa: SC200
-    Prague,
-    transition_tool_name="Prague",  # Besu enables EOF at Prague
-    blockchain_test_network_name="Prague",  # Besu enables EOF at Prague
-    solc_name="cancun",
-):
-    """
-    Prague + EIP-7692 (EOF) fork
-    """
-
-    @classmethod
-    def evm_code_types(cls, block_number: int = 0, timestamp: int = 0) -> List[EVMCodeType]:
-        """
-        EOF V1 is supported starting from this fork.
-        """
-        return super(PragueEIP7692, cls,).evm_code_types(  # noqa: SC200
-            block_number,
-            timestamp,
-        ) + [EVMCodeType.EOF_V1]
-
-    @classmethod
-    def call_opcodes(
-        cls, block_number: int = 0, timestamp: int = 0
-    ) -> List[Tuple[Opcodes, EVMCodeType]]:
-        """
-        EOF V1 introduces EXTCALL, EXTSTATICCALL, EXTDELEGATECALL.
-        """
-        return [
-            (Opcodes.EXTCALL, EVMCodeType.EOF_V1),
-            (Opcodes.EXTSTATICCALL, EVMCodeType.EOF_V1),
-            (Opcodes.EXTDELEGATECALL, EVMCodeType.EOF_V1),
-        ] + super(
-            PragueEIP7692, cls  # noqa: SC200
-        ).call_opcodes(
-            block_number, timestamp
-        )
-
-    @classmethod
-    def is_deployed(cls) -> bool:
-        """
-        Flags that the fork has not been deployed to mainnet; it is under active
-        development.
-        """
-        return False
-
-    @classmethod
-    def solc_min_version(cls) -> Version:
-        """
-        Returns the minimum version of solc that supports this fork.
-        """
-        return Version.parse("1.0.0")  # set a high version; currently unknown

--- a/tests/prague/eip7692_eof_v1/__init__.py
+++ b/tests/prague/eip7692_eof_v1/__init__.py
@@ -2,4 +2,4 @@
 Test cases for all EIPs mentioned in the EOF V1 meta-EIP.
 """
 
-EOF_FORK_NAME = "CancunEIP7692,PragueEIP7692"
+EOF_FORK_NAME = "Prague"

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ env_list =
 
 [forks]
 develop = Prague
-eip7692 = CancunEIP7692
 
 [testenv]
 package = wheel
@@ -67,15 +66,6 @@ extras =
 
 commands =
     pytest -n auto --until={[forks]develop}  -k "not slow"
-
-[testenv:tests-eip7692]
-description = Execute test cases in tests/, including tests for EIP-7692 (EOF)
-
-extras =
-    {[testenv:tests-base]extras}
-
-commands =
-    pytest -n auto --evm-bin=evmone-t8n --fork={[forks]eip7692}  -k "not slow" ./tests/prague
 
 [testenv:docs]
 description = Run documentation checks


### PR DESCRIPTION
## 🗒️ Description
**WIP** This PR is not meant to be merged until Devnet-4 is the next devnet to be deployed.

- Adds EOF features into the Prague fork, and removes [CancunEIP7692/PragueEIP7692](https://github.com/ethereum/execution-spec-tests/commit/659b27db9eb03ddeb97ec6dbe1c282dc653964b0)
- Changes EOF tests fork to `"Prague"`
- Other required changes.

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
