### PR TITLE
feat(fill): add solc plugin and automatic installation of solc

### DIFF
--- a/.github/actions/build-fixtures/action.yaml
+++ b/.github/actions/build-fixtures/action.yaml
@@ -30,8 +30,7 @@ runs:
         python -m venv env
         source env/bin/activate
         pip install -e .
-        solc-select use  ${{ steps.properties.outputs.solc }} --always-install
-        fill -n ${{ steps.evm-builder.outputs.x-dist }} --evm-bin=${{ steps.evm-builder.outputs.evm-bin }} ${{ steps.properties.outputs.fill-params }} --output=fixtures_${{ inputs.name }}.tar.gz --build-name ${{ inputs.name }}
+        fill -n ${{ steps.evm-builder.outputs.x-dist }} --evm-bin=${{ steps.evm-builder.outputs.evm-bin }} --solc-version=${{ steps.properties.outputs.solc }} ${{ steps.properties.outputs.fill-params }} --output=fixtures_${{ inputs.name }}.tar.gz --build-name ${{ inputs.name }}
     - uses: actions/upload-artifact@v4
       with:
         name: fixtures_${{ inputs.name }}

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -3,7 +3,7 @@ name: Evmone Coverage Report
 on:
   pull_request:
     paths:
-      - 'converted-ethereum-tests.txt' # This triggers the workflow only for changes in file.txt
+      - "converted-ethereum-tests.txt" # This triggers the workflow only for changes in file.txt
 
 jobs:
   evmone-coverage-diff:
@@ -37,20 +37,19 @@ jobs:
           python3 -m venv ./venv/
           source ./venv/bin/activate
           pip install -e .
-          solc-select use 0.8.25 --always-install
 
       # Required to fill .py tests
       - name: Build GO EVM
         uses: ./.github/actions/build-evm-client/geth
         id: evm-builder
         with:
-          type: 'main'
+          type: "main"
 
       - name: Build EVMONE EVM
         uses: ./.github/actions/build-evm-client/evmone
         id: evm-builder2
         with:
-          type: 'main'
+          type: "main"
 
       - name: Checkout ethereum/tests
         uses: actions/checkout@v4
@@ -69,7 +68,6 @@ jobs:
           sparse-checkout: |
             Cancun/GeneralStateTests
 
-
       # This command diffs the file and filters in new lines
       - name: Parse converted tests from converted-ethereum-tests.txt
         run: |
@@ -78,7 +76,7 @@ jobs:
           files=$(echo "$lines" | grep -oP '(?<=\+).+\.json')
 
           if [ -z "$files" ]; then
-             echo "Error: No new JSON files found in converted-ethereum-tests.txt"
+              echo "Error: No new JSON files found in converted-ethereum-tests.txt"
               exit 1
           fi
 
@@ -114,13 +112,13 @@ jobs:
               fi
 
               if [ $file_found -eq 0 ]; then
-               echo "Error: Failed to find the test file $file in test repo"
+                echo "Error: Failed to find the test file $file in test repo"
                 exit 1
               fi
           done
           
 
-     # This command diffs the .py scripts introduced by a PR
+      # This command diffs the .py scripts introduced by a PR
       - name: Parse and fill introduced test sources
         run: |
           python3 -m venv ./venv/
@@ -153,12 +151,12 @@ jobs:
           mkdir -p fixtures/eof_tests
           echo "$files" | while read line; do
             file=$(echo "$line" | cut -c 3-)
-            fill $file --until=Cancun --evm-bin evmone-t8n || true >> filloutput.log 2>&1
-            (fill $file --fork=CancunEIP7692 --evm-bin evmone-t8n -k eof_test || true) > >(tee -a filloutput.log filloutputEOF.log) 2>&1
+            fill $file --until=Cancun --evm-bin evmone-t8n --solc-version=0.8.25 || true >> filloutput.log 2>&1
+            (fill $file --fork=CancunEIP7692 --evm-bin evmone-t8n --solc-version=0.8.25 -k eof_test || true) > >(tee -a filloutput.log filloutputEOF.log) 2>&1
           done
 
           if grep -q "FAILURES" filloutput.log; then
-             echo "Error: failed to generate .py tests."
+              echo "Error: failed to generate .py tests."
               exit 1
           fi
           if [ "${{ matrix.driver }}" = "retesteth" ] && grep -q "passed" filloutputEOF.log; then
@@ -174,7 +172,7 @@ jobs:
           filesEOF=$(find fixtures/eof_tests -type f -name "*.json")
           if [ -z "$filesState" ] && [ -z "$filesEOF" ]; then
               echo "Error: No filled JSON fixtures found in fixtures."
-               exit 1
+              exit 1
           fi
 
           PATCH_TEST_PATH=${{ github.workspace }}/evmtest_coverage/coverage/PATCH_TESTS

--- a/README.md
+++ b/README.md
@@ -82,20 +82,19 @@ The following requires a Python 3.10, 3.11 or 3.12 installation.
 
 ### Quick Start
 
-This guide installs stable versions of the required external (go-ethereum) `evm` and `solc` executables and will only enable generation of test fixtures for features deployed to mainnet. In order to generate fixtures for features under active development, you can follow the steps below and then follow the [additional steps in the online doc](https://ethereum.github.io/execution-spec-tests/getting_started/executing_tests_dev_fork/).
+This guide installs stable versions of the external (go-ethereum) `evm` executable and will only enable generation of test fixtures for features deployed to mainnet. In order to generate fixtures for features under active development, you can follow the steps below and then follow the [additional steps in the online doc](https://ethereum.github.io/execution-spec-tests/getting_started/executing_tests_dev_fork/).
 
-1. Ensure go-ethereum's `evm` tool and `solc` ([0.8.20](https://github.com/ethereum/solidity/releases/tag/v0.8.20), [0.8.21](https://github.com/ethereum/solidity/releases/tag/v0.8.21), [0.8.22](https://github.com/ethereum/solidity/releases/tag/v0.8.22), [0.8.23](https://github.com/ethereum/solidity/releases/tag/v0.8.23)  supported) are in your path. Either build the required versions, or alternatively:
+1. Ensure go-ethereum's `evm` tool is in your path. Either build the required version, or alternatively:
 
     ```console
     sudo add-apt-repository -y ppa:ethereum/ethereum
     sudo apt-get update
-    sudo apt-get install ethereum solc
+    sudo apt-get install ethereum
     ```
 
     More help:
 
     - [geth installation doc](https://geth.ethereum.org/docs/getting-started/installing-geth#ubuntu-via-ppas).
-    - [solc installation doc](https://docs.soliditylang.org/en/latest/installing-solidity.html#linux-packages).
 
     Help for other platforms is available in the [online doc](https://ethereum.github.io/execution-spec-tests/getting_started/quick_start/).
 
@@ -129,7 +128,7 @@ This guide installs stable versions of the required external (go-ethereum) `evm`
           ![Screenshot of pytest test collection console output](docs/getting_started/img/pytest_run_example.png)
         Check:
 
-        1. The versions of the `evm` and `solc` tools are as expected (your versions may differ from those in the highlighted box).
+        1. The versions of the `evm` tool is as expected (your versions may differ from those in the highlighted box).
         2. The corresponding fixture file has been generated:
 
            ```console

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Added `Container.Init` to `ethereum_test_types.EOF.V1` package, which allows generation of an EOF init container more easily ([#739](https://github.com/ethereum/execution-spec-tests/pull/739)).
 - ✨ Introduce method valid_opcodes() to the fork class ([#748](https://github.com/ethereum/execution-spec-tests/pull/748)).
 - 🐞 Fixed `consume` exit code return values, ensuring that pytest's return value is correctly propagated to the shell. This allows the shell to accurately reflect the test results (e.g., failures) based on the pytest exit code ([#765](https://github.com/ethereum/execution-spec-tests/pull/765)).
+- ✨ Added a new flag `--solc-version` to the `fill` command, which allows the user to specify the version of the Solidity compiler to use when compiling Yul source code; this version will now be automatically downloaded by `fill` via [`solc-select`](https://github.com/crytic/solc-select) ([#772](https://github.com/ethereum/execution-spec-tests/pull/772).
 
 ### 🔧 EVM Tools
 

--- a/docs/getting_started/executing_tests_command_line.md
+++ b/docs/getting_started/executing_tests_command_line.md
@@ -114,16 +114,35 @@ fill --help
 Output:
 
 ```text
-usage: fill [-h] [--evm-bin EVM_BIN] [--traces] [--verify-fixtures]
-            [--verify-fixtures-bin VERIFY_FIXTURES_BIN] [--solc-bin SOLC_BIN]
+usage: fill [-h] [--strict-alloc] [--ca-start CA_START] [--ca-incr CA_INCR]
+            [--evm-code-type EVM_CODE_TYPE] [--solc-bin SOLC_BIN]
+            [--solc-version SOLC_VERSION] [--evm-bin EVM_BIN] [--traces]
+            [--verify-fixtures] [--verify-fixtures-bin VERIFY_FIXTURES_BIN]
             [--filler-path FILLER_PATH] [--output OUTPUT] [--flat-output]
-            [--single-fixture-per-file] [--no-html] [--strict-alloc]
-            [--ca-start CA_START] [--ca-incr CA_INCR] [--build-name BUILD_NAME]
-            [--evm-dump-dir EVM_DUMP_DIR] [--forks] [--fork FORK] [--from FROM]
-            [--until UNTIL] [--test-help]
+            [--single-fixture-per-file] [--no-html] [--build-name BUILD_NAME]
+            [--index] [--evm-dump-dir EVM_DUMP_DIR] [--forks] [--fork FORK]
+            [--from FROM] [--until UNTIL] [--test-help]
 
 options:
   -h, --help            show this help message and exit
+
+Arguments defining pre-allocation behavior.:
+  --strict-alloc        [DEBUG ONLY] Disallows deploying a contract in a
+                        predefined address.
+  --ca-start CA_START, --contract-address-start CA_START
+                        The starting address from which tests will deploy
+                        contracts.
+  --ca-incr CA_INCR, --contract-address-increment CA_INCR
+                        The address increment value to each deployed contract by
+                        a test.
+  --evm-code-type EVM_CODE_TYPE
+                        Type of EVM code to deploy in each test by default.
+
+Arguments defining the solc executable:
+  --solc-bin SOLC_BIN   Path to a solc executable (for Yul source compilation).
+                        No default; if unspecified `--solc-version` is used.
+  --solc-version SOLC_VERSION
+                        Version of the solc compiler to use. Default: 0.8.24.
 
 Arguments defining evm executable behavior:
   --evm-bin EVM_BIN     Path to an evm executable that provides `t8n`. Default:
@@ -140,18 +159,14 @@ Arguments defining evm executable behavior:
                         Path to an evm executable that provides the `blocktest`
                         command. Default: The first (geth) 'evm' entry in PATH.
 
-Arguments defining the solc executable:
-  --solc-bin SOLC_BIN   Path to a solc executable (for Yul source compilation).
-                        Default: First 'solc' entry in PATH.
-
 Arguments defining filler location and output:
   --filler-path FILLER_PATH
                         Path to filler directives
-  --output OUTPUT       Directory path to store the generated test fixtures. Can
-                        be deleted. If the specified path ends in '.tar.gz', then
-                        the specified tarball is additionally created (the
-                        fixtures are still written to the specified path without
-                        '.tar.gz' suffix). Default: './fixtures'.
+  --output OUTPUT       Directory path to store the generated test fixtures. If
+                        the specified path ends in '.tar.gz', then the specified
+                        tarball is additionally created (the fixtures are still
+                        written to the specified path without the '.tar.gz'
+                        suffix). Can be deleted. Default: './fixtures'.
   --flat-output         Output each test case in the directory without the folder
                         structure.
   --single-fixture-per-file
@@ -161,17 +176,10 @@ Arguments defining filler location and output:
   --no-html             Don't generate an HTML test report (in the output
                         directory). The --html flag can be used to specify a
                         different path.
-  --strict-alloc        [DEBUG ONLY] Disallows deploying a contract in a
-                        predefined address.
-  --ca-start CA_START, --contract-address-start CA_START
-                        The starting address from which tests will deploy
-                        contracts.
-  --ca-incr CA_INCR, --contract-address-increment CA_INCR
-                        The address increment value to each deployed contract by
-                        a test.
   --build-name BUILD_NAME
                         Specify a build name for the fixtures.ini file, e.g.,
                         'stable'.
+  --index               Generate an index file for all produced fixtures.
 
 Arguments defining debug behavior:
   --evm-dump-dir EVM_DUMP_DIR, --t8n-dump-dir EVM_DUMP_DIR

--- a/docs/getting_started/quick_start.md
+++ b/docs/getting_started/quick_start.md
@@ -1,25 +1,24 @@
 # Quick Start
 
 !!! info "Testing features under active development"
-    The EVM features under test must be implemented in the `evm` tool and `solc` executables that are used by the execution-spec-tests framework. The following guide installs stable versions of these tools.
+    The EVM features under test must be implemented in the `evm` tool and `solc` executables that are used by the execution-spec-tests framework. The following guide installs the stable version of the geth `evm`; `solc` will be installed by the `fill` command.
 
     To test features under active development, start with this base configuration and then follow the steps in [executing tests for features under development](./executing_tests_dev_fork.md). 
 
 The following requires a Python 3.10, 3.11 or 3.12 installation.
 
-1. Ensure `go-ethereum`'s `evm` tool and `solc` ([0.8.20](https://github.com/ethereum/solidity/releases/tag/v0.8.20), [0.8.21](https://github.com/ethereum/solidity/releases/tag/v0.8.21), [0.8.22](https://github.com/ethereum/solidity/releases/tag/v0.8.22), [0.8.23](https://github.com/ethereum/solidity/releases/tag/v0.8.23)  supported) are in your path. Either build the required versions, or alternatively:
+1. Ensure `go-ethereum`'s `evm` tool is in your path. Either build the required version, or alternatively:
 
     === "Ubuntu"
 
           ```console
           sudo add-apt-repository -y ppa:ethereum/ethereum
           sudo apt-get update
-          sudo apt-get install ethereum solc
+          sudo apt-get install ethereum
           ```
           More help:
 
           - [geth installation doc](https://geth.ethereum.org/docs/getting-started/installing-geth#ubuntu-via-ppas).
-          - [solc installation doc](https://docs.soliditylang.org/en/latest/installing-solidity.html#linux-packages).
 
     === "macOS"
 
@@ -32,7 +31,6 @@ The following requires a Python 3.10, 3.11 or 3.12 installation.
           More help:
 
           - [geth installation doc](https://geth.ethereum.org/docs/getting-started/installing-geth#macos-via-homebrew).
-          - [solc installation doc](https://docs.soliditylang.org/en/latest/installing-solidity.html#macos-packages).
 
     === "Windows"
 
@@ -44,7 +42,6 @@ The following requires a Python 3.10, 3.11 or 3.12 installation.
           More help:
 
           - [geth installation doc](https://geth.ethereum.org/docs/getting-started/installing-geth#windows).
-          - [solc static binaries doc](https://docs.soliditylang.org/en/latest/installing-solidity.html#static-binaries).
 
 2. Clone the [execution-spec-tests](https://github.com/ethereum/execution-spec-tests) repo and install its dependencies (it's recommended to use a virtual environment for the installation):
 
@@ -80,7 +77,7 @@ The following requires a Python 3.10, 3.11 or 3.12 installation.
         </figure>
         Check:
 
-        1. The versions of the `evm` and `solc` tools are as expected (your versions may differ from those in the highlighted box).
+        1. The versions of the `evm` tool is as expected (your versions may differ from those in the highlighted box).
         2. The generated HTML test report by clicking the link at the bottom of the console output.
         3. The corresponding fixture file has been generated:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "semver>=3.0.1,<4",
     "pydantic>=2.8.0,<2.9",
     "rich>=13.7.0,<14",
-    "solc-select>=1.0.4",
+    "solc-select>=1.0.4,<2",
     "filelock>=3.15.1,<4",
 ]
 

--- a/pytest-framework.ini
+++ b/pytest-framework.ini
@@ -5,6 +5,8 @@ python_files=
     test_*.py
 testpaths =
     src
+markers =
+    run_in_serial
 addopts = 
     -p pytester
     --ignore=src/pytest_plugins/consume/direct/test_via_direct.py

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,6 +8,7 @@ markers =
     pre_alloc_modify
 addopts = 
     -p pytest_plugins.filler.pre_alloc
+    -p pytest_plugins.filler.solc
     -p pytest_plugins.filler.filler
     -p pytest_plugins.forks.forks
     -p pytest_plugins.spec_version_checker.spec_version_checker

--- a/src/pytest_plugins/filler/solc.py
+++ b/src/pytest_plugins/filler/solc.py
@@ -13,7 +13,7 @@ from semver import Version
 from ethereum_test_forks import Frontier
 from ethereum_test_tools.code import Solc
 
-SOLC_VERSION = "0.8.24"
+DEFAULT_SOLC_VERSION = "0.8.24"
 
 
 def pytest_addoption(parser: pytest.Parser):
@@ -37,7 +37,7 @@ def pytest_addoption(parser: pytest.Parser):
         action="store",
         dest="solc_version",
         default=None,
-        help=f"Version of the solc compiler to use. Default: {SOLC_VERSION}.",
+        help=f"Version of the solc compiler to use. Default: {DEFAULT_SOLC_VERSION}.",
     )
 
 
@@ -61,7 +61,7 @@ def pytest_configure(config: pytest.Config):
         solc_version_semver = Solc(config.getoption("solc_bin")).version
     else:
         # if no solc binary is specified, use solc-select
-        solc_version = solc_version or SOLC_VERSION
+        solc_version = solc_version or DEFAULT_SOLC_VERSION
         try:
             version, _ = solc_select.current_version()
         except ArgumentTypeError:

--- a/src/pytest_plugins/filler/solc.py
+++ b/src/pytest_plugins/filler/solc.py
@@ -1,0 +1,103 @@
+"""
+Pytest plugin for configuring and installing the solc compiler.
+"""
+
+from argparse import ArgumentTypeError
+from shutil import which
+
+import pytest
+import solc_select.solc_select as solc_select  # type: ignore
+from pytest_metadata.plugin import metadata_key  # type: ignore
+from semver import Version
+
+from ethereum_test_forks import Frontier
+from ethereum_test_tools.code import Solc
+
+SOLC_VERSION = "0.8.24"
+
+
+def pytest_addoption(parser: pytest.Parser):
+    """
+    Adds command-line options to pytest.
+    """
+    solc_group = parser.getgroup("solc", "Arguments defining the solc executable")
+    solc_group.addoption(
+        "--solc-bin",
+        action="store",
+        dest="solc_bin",
+        type=str,
+        default=None,
+        help=(
+            "Path to a solc executable (for Yul source compilation). "
+            "No default; if unspecified `--solc-version` is used."
+        ),
+    )
+    solc_group.addoption(
+        "--solc-version",
+        action="store",
+        dest="solc_version",
+        default=None,
+        help=f"Version of the solc compiler to use. Default: {SOLC_VERSION}.",
+    )
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_configure(config: pytest.Config):
+    """
+    Ensure that the specified solc version is:
+    - available if --solc_bin has been specified,
+    - installed via solc_select if --solc_version has been specified.
+    """
+    solc_bin = config.getoption("solc_bin")
+    solc_version = config.getoption("solc_version")
+
+    if solc_bin and solc_version:
+        raise pytest.UsageError(
+            "You cannot specify both --solc-bin and --solc-version. Please choose one."
+        )
+
+    if solc_bin:
+        # will raise an error if the solc binary is not found.
+        solc_version_semver = Solc(config.getoption("solc_bin")).version
+    else:
+        # if no solc binary is specified, use solc-select
+        solc_version = solc_version or SOLC_VERSION
+        try:
+            version, _ = solc_select.current_version()
+        except ArgumentTypeError:
+            version = None
+        if version != solc_version:
+            if config.getoption("verbose") > 0:
+                print(f"Setting solc version {solc_version} via solc-select...")
+            try:
+                solc_select.switch_global_version(solc_version, always_install=True)
+            except Exception as e:
+                message = f"Failed to install solc version {solc_version}: {e}. "
+                if isinstance(e, ArgumentTypeError):
+                    message += "\nList available versions using `uv run solc-select install`."
+                pytest.exit(message, returncode=pytest.ExitCode.USAGE_ERROR)
+        solc_version_semver = Version.parse(solc_version)
+        config.option.solc_bin = which("solc")  # save for fixture
+
+    if "Tools" not in config.stash[metadata_key]:
+        config.stash[metadata_key]["Tools"] = {
+            "solc": str(solc_version_semver),
+        }
+    else:
+        config.stash[metadata_key]["Tools"]["solc"] = str(solc_version_semver)
+
+    if solc_version_semver < Frontier.solc_min_version():
+        pytest.exit(
+            f"Unsupported solc version: {solc_version}. Minimum required version is "
+            f"{Frontier.solc_min_version()}",
+            returncode=pytest.ExitCode.USAGE_ERROR,
+        )
+    config.solc_version = solc_version_semver  # type: ignore
+
+
+@pytest.fixture(autouse=True, scope="session")
+def solc_bin(request: pytest.FixtureRequest):
+    """
+    Returns the configured solc binary path.
+    """
+    return request.config.getoption("solc_bin")

--- a/src/pytest_plugins/filler/tests/conftest.py
+++ b/src/pytest_plugins/filler/tests/conftest.py
@@ -1,0 +1,15 @@
+"""
+Local configuration for filler tests.
+"""
+
+import os
+
+import pytest
+
+
+def pytest_runtest_setup(item):
+    """Hook to skip tests if running with pytest-xdist in parallel."""
+    marker = item.get_closest_marker(name="run_in_serial")
+    if marker is not None:
+        if os.getenv("PYTEST_XDIST_WORKER_COUNT") not in [None, "1"]:
+            pytest.skip("Skipping test because pytest-xdist is running with more than one worker.")

--- a/src/pytest_plugins/filler/tests/test_solc.py
+++ b/src/pytest_plugins/filler/tests/test_solc.py
@@ -1,0 +1,201 @@
+"""
+Tests for the solc plugin.
+"""
+
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+import solc_select.constants  # type: ignore
+import solc_select.solc_select  # type: ignore
+
+pytestmark = [pytest.mark.run_in_serial]
+
+
+@pytest.fixture(scope="module")
+def create_clean_solc_select_environment(request):
+    """
+    Setup: Copies solc artifacts to a temporary location before starting tests
+    Teardown: Restores the artifacts after tests are done.
+    """
+    try:
+        test_session_solc_version, _ = solc_select.solc_select.current_version()
+    except Exception as e:
+        raise Exception(
+            "Error in setup: ensure you've called `solc-select use <version>` before running the "
+            f"framework tests (exception: {e})"
+        )
+
+    artifacts_dir = solc_select.constants.ARTIFACTS_DIR
+    global_version_file = solc_select.constants.SOLC_SELECT_DIR.joinpath("global-version")
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_dir_path = Path(temp_dir)
+
+        # Copy global-version and artifacts to a temporary directory and delete them
+        if global_version_file.exists():
+            shutil.copy(global_version_file, temp_dir_path / "global-version")
+            os.remove(global_version_file)
+        if artifacts_dir.exists():
+            shutil.copytree(artifacts_dir, temp_dir_path / "artifacts", dirs_exist_ok=True)
+            shutil.rmtree(artifacts_dir)
+
+        os.makedirs(artifacts_dir, exist_ok=True)  # this won't get recreated by solc-select
+
+        yield
+        print("Running teardown")
+        # Teardown: Restore the original files and directory from the temporary location
+        if global_version_file.exists():
+            os.remove(global_version_file)
+        if artifacts_dir.exists():
+            shutil.rmtree(artifacts_dir)
+
+        # Restore the global-version file and artifacts
+        if (temp_dir_path / "global-version").exists():
+            shutil.copy(temp_dir_path / "global-version", global_version_file)
+        if (temp_dir_path / "artifacts").exists():
+            shutil.copytree(temp_dir_path / "artifacts", artifacts_dir, dirs_exist_ok=True)
+
+        # Restore the solc version
+        solc_select.solc_select.switch_global_version(
+            str(test_session_solc_version), always_install=True
+        )
+
+
+@pytest.mark.usefixtures("create_clean_solc_select_environment")
+@pytest.mark.parametrize("solc_version", ["0.8.21", "0.8.26"])
+class TestSolcVersion:  # noqa: D101
+    def test_solc_versions_flag(self, pytester, solc_version):
+        """
+        Ensure that the version specified by the `--solc-version` gets installed and is used.
+        """
+        pytester.makeconftest(
+            f"""
+            import pytest
+            from ethereum_test_tools.code import Solc
+
+            @pytest.fixture(autouse=True)
+            def check_solc_version(request):
+                assert request.config.getoption("solc_version") == "{solc_version}"
+                #solc_bin_version = Solc(request.config.getoption("solc_bin")).version
+                #assert request.config.getoption("solc_version") == solc_bin_version
+            """
+        )
+        pytester.copy_example(name="pytest.ini")
+        pytester.copy_example(name="tests/homestead/yul/test_yul_example.py")
+        result = pytester.runpytest(
+            "-v",
+            "--fork=Homestead",
+            "--flat-output",  # required as copy_example doesn't copy to "tests/"" sub-folder
+            "-m",
+            "state_test",
+            f"--solc-version={solc_version}",
+        )
+
+        result.assert_outcomes(
+            passed=1,
+            failed=0,
+            skipped=0,
+            errors=0,
+        )
+
+
+def test_solc_version_too_old(pytester):
+    """
+    Test the plugin exits with a UsageError if a version prior to Frontier is specified.
+    """
+    old_solc_version = "0.8.19"
+    pytester.copy_example(name="pytest.ini")
+    test_path = pytester.copy_example(name="tests/homestead/yul/test_yul_example.py")
+    result = pytester.runpytest(
+        "-v", "--fork=Frontier", "--solc-version", old_solc_version, test_path
+    )
+    assert result.ret == pytest.ExitCode.USAGE_ERROR
+    assert "Unsupported solc version" in "\n".join(result.stderr.lines)
+
+
+def test_unknown_solc_version(pytester):
+    """
+    Test the plugin exits with a UsageError if a version unknown to solc-select is specified.
+    """
+    unknown_solc_version = "420.69.0"
+    pytester.copy_example(name="pytest.ini")
+    test_path = pytester.copy_example(name="tests/homestead/yul/test_yul_example.py")
+    result = pytester.runpytest(
+        "-v", "--fork=Frontier", "--solc-version", unknown_solc_version, test_path
+    )
+    assert result.ret == pytest.ExitCode.USAGE_ERROR
+    stderr = "\n".join(result.stderr.lines)
+    assert f"Unknown version '{unknown_solc_version}'" in stderr
+    assert "List available versions using" in stderr
+
+
+def test_bad_solc_flag_combination(pytester):
+    """
+    Test the plugin exits with a UsageError if both `--solc-bin` and `--solc-version` are
+    specified.
+    """
+    pytester.copy_example(name="pytest.ini")
+    test_path = pytester.copy_example(name="tests/homestead/yul/test_yul_example.py")
+    result = pytester.runpytest(
+        "-v", "--fork=Frontier", "--solc-version=0.8.24", "--solc-bin=solc", test_path
+    )
+    assert result.ret == pytest.ExitCode.USAGE_ERROR
+    assert "You cannot specify both --solc-bin and --solc-version" in "\n".join(
+        result.stderr.lines
+    )
+
+
+@pytest.mark.usefixtures("create_clean_solc_select_environment")
+class TestSolcBin:
+    """
+    Test the `--solc-bin` flag.
+    """
+
+    @pytest.fixture()
+    def solc_version(self):  # noqa: D102
+        return "0.8.25"
+
+    @pytest.fixture()
+    def solc_bin(self, solc_version):
+        """
+        Returns an available solc binary.
+        """
+        solc_select.solc_select.switch_global_version(solc_version, always_install=True)
+        bin_path = Path(f"solc-{solc_version}") / f"solc-{solc_version}"
+        return solc_select.constants.ARTIFACTS_DIR.joinpath(bin_path)
+
+    def test_solc_bin(self, pytester, solc_version, solc_bin):
+        """
+        Ensure that the version specified by the `--solc-version` gets installed and is used.
+        """
+        pytester.makeconftest(
+            f"""
+            import pytest
+            from ethereum_test_tools.code import Solc
+
+            @pytest.fixture(autouse=True)
+            def check_solc_version(request, solc_bin):
+                # test via solc_bin fixture
+                assert Solc(solc_bin).version == "{solc_version}"
+            """
+        )
+        pytester.copy_example(name="pytest.ini")
+        pytester.copy_example(name="tests/homestead/yul/test_yul_example.py")
+        result = pytester.runpytest(
+            "-v",
+            "--fork=Homestead",
+            "-m",
+            "state_test",
+            "--flat-output",  # required as copy_example doesn't copy to "tests/"" sub-folder,
+            f"--solc-bin={solc_bin}",
+        )
+
+        result.assert_outcomes(
+            passed=1,
+            failed=0,
+            skipped=0,
+            errors=0,
+        )

--- a/src/pytest_plugins/filler/tests/test_solc.py
+++ b/src/pytest_plugins/filler/tests/test_solc.py
@@ -45,7 +45,6 @@ def create_clean_solc_select_environment(request):
         os.makedirs(artifacts_dir, exist_ok=True)  # this won't get recreated by solc-select
 
         yield
-        print("Running teardown")
         # Teardown: Restore the original files and directory from the temporary location
         if global_version_file.exists():
             os.remove(global_version_file)
@@ -77,10 +76,9 @@ class TestSolcVersion:  # noqa: D101
             from ethereum_test_tools.code import Solc
 
             @pytest.fixture(autouse=True)
-            def check_solc_version(request):
+            def check_solc_version(request, solc_bin):
                 assert request.config.getoption("solc_version") == "{solc_version}"
-                #solc_bin_version = Solc(request.config.getoption("solc_bin")).version
-                #assert request.config.getoption("solc_version") == solc_bin_version
+                assert Solc(solc_bin).version == "{solc_version}"
             """
         )
         pytester.copy_example(name="pytest.ini")

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ env_list =
     framework
     tests
     docs
-
+recreate = True
 [forks]
 develop = Prague
 eip7692 = CancunEIP7692
@@ -30,6 +30,7 @@ commands =
     flake8 {[testenv:framework]src}
     mypy {[testenv:framework]src}
     pytest -c ./pytest-framework.ini -n auto
+    pytest -c ./pytest-framework.ini -m run_in_serial
 
 [testenv:py3]
 description = An alias for the 'framework' tox environment

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,8 @@ extras =
 
 src = src
 
+commands_pre = solc-select use 0.8.24 --always-install
+
 commands =
     fname8 {[testenv:framework]src}
     isort {[testenv:framework]src} --check --diff

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@ eip7692 = CancunEIP7692
 [testenv]
 package = wheel
 wheel_build_env = .pkg
-commands_pre = solc-select use 0.8.24 --always-install
 
 [testenv:framework]
 description = Run checks on helper libraries and test framework
@@ -83,8 +82,6 @@ description = Run documentation checks
 extras =
     lint
     docs
-
-commands_pre =  # Override commands pre to not run solc-select install
 
 setenv =
     SPEC_TESTS_AUTO_GENERATE_FILES = true

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ env_list =
     framework
     tests
     docs
-recreate = True
+
 [forks]
 develop = Prague
 eip7692 = CancunEIP7692

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -222,6 +222,7 @@ isort's
 ispkg
 itemName
 jimporter
+joinpath
 jq
 js
 json
@@ -240,7 +241,9 @@ lllc
 london
 macOS
 mainnet
+makefiles
 makereport
+makeconftest
 marioevz
 markdownlint
 md


### PR DESCRIPTION
## 🗒️ Description
- Adds a new plugin `solc` (most logic is refactored from `fill` to this plugin).
- Adds a new command-line flag `--solc-version=x.y.z` to `fill`
- Adds logic to install the version specified by the flag via `solc-select` automatically when `fill` is called.
- If `--solc-bin` is specified, `solc-select` is not used; old behavior remains.

The only difference is that by default (if neither of the solc flags are specified), the first solc in the path is no longer taken; rather the default version of solc as currently specified by the plugin is used via `solc-select` (0.8.24).

`solc-select` has proven to be reliable if configured correctly. Unfortunately, the config is lost when switching venv; this avoids this pitfall.

## 🔗 Related Issues
#604 #618 

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
