### PR TITLE
docs: add some dev docs to help using nectos/act

### DIFF
--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -5,3 +5,4 @@ This documentation is aimed at maintainers of `execution-spec-tests` but may be 
 - [generating documentation](./docs.md).
 - [coding style](./coding_style.md).
 - [enabling pre-commit checks](./precommit.md).
+- [running github actions locally](./test_actions_locally.md).

--- a/docs/dev/test_actions_locally.md
+++ b/docs/dev/test_actions_locally.md
@@ -1,0 +1,39 @@
+# Testing Github Actions Locally
+
+The Github Actions workflows can be tested locally using [nektos/act](https://github.com/nektos/act) which allows you to test Github Actions locally, without pushing changes to the remote.
+
+## Prerequisites
+
+1. Install the `act` tool, [docs](https://nektosact.com/installation/index.html).
+2. Install the Github CLI (`gh`) for authentication: [linux](https://github.com/cli/cli/blob/trunk/docs/install_linux.md), [macos](https://github.com/cli/cli/tree/trunk?tab=readme-ov-file#macos).
+3. Authenticate with the Github CLI:
+
+    ```shell
+    gh auth login
+    ```
+
+## Testing Workflows
+
+### Testing a Workflow that uses a Matrix Strategy
+
+```bash
+ act -j build --workflows .github/workflows/tox_verify.yaml -s GITHUB_TOKEN=$(gh auth token) --matrix python:3.10
+ ```
+
+### Testing Release Builds
+
+Release builds require the `ref` input to be specified. To test a release build locally:
+
+1. Create a JSON file specifying the input data required for a release build (the release tag), e.g, `event.json`:
+
+    ```json
+    {
+        "ref": "refs/tags/stable@v4.2.0"
+    }
+    ```
+
+2. Run `act` and specify the workflow file, the Github token, and the event file:
+
+    ```bash
+    act -j build --workflows .github/workflows/fixtures_feature.yaml -s GITHUB_TOKEN=$(gh auth token) -e event.json
+    ```


### PR DESCRIPTION
## 🗒️ Description
Dev docs to help getting started with https://github.com/nektos/act.

## 🔗 Related Issues
None.

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
