### PR TITLE
fix(consume): couple of bugfixes when --input is a release tarball

### DIFF
--- a/src/cli/gen_index.py
+++ b/src/cli/gen_index.py
@@ -137,6 +137,7 @@ def generate_fixtures_index(
         total_files = count_json_files_exclude_index(input_path)
 
     output_file = Path(f"{input_path}/.meta/index.json")
+    output_file.parent.mkdir(parents=True, exist_ok=True)  # no meta dir in <=v3.0.0
     try:
         root_hash = HashableItem.from_folder(folder_path=input_path).hash()
     except (KeyError, TypeError):

--- a/src/pytest_plugins/consume/consume.py
+++ b/src/pytest_plugins/consume/consume.py
@@ -57,7 +57,7 @@ def download_and_extract(url: str, base_directory: Path) -> Path:
 
     if extract_to.exists():
         # skip download if the archive has already been downloaded
-        return extract_to
+        return extract_to / "fixtures"
 
     extract_to.mkdir(parents=True, exist_ok=False)
     response = requests.get(url)


### PR DESCRIPTION
## 🗒️ Description
This PR fixes two bugs for `consume`'s `--input` flag with remote URLs:
1. For the case that the tarball is already downloaded and extracted to `cached_downloads`.
2. And a pre-`.meta` directory release (such as v3.0.0), cf #721.

This fixes this behaviour, for example:
```
 consume direct --input https://github.com/ethereum/execution-spec-tests/releases/download/v3.0.0/fixtures_stable.tar.gz
``` 

## 🔗 Related Issues
#721

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] ~~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~ Skipping as regression has been released.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
