### PR TITLE
feat(plugins): Features plug-in, EIP-7702 mode

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -7,6 +7,7 @@ markers =
     slow
     pre_alloc_modify
 addopts = 
+    -p pytest_plugins.features.features
     -p pytest_plugins.filler.pre_alloc
     -p pytest_plugins.filler.solc
     -p pytest_plugins.filler.filler

--- a/src/cli/tests/test_pytest_fill_command.py
+++ b/src/cli/tests/test_pytest_fill_command.py
@@ -29,6 +29,7 @@ def test_fill_help(runner):
     assert "[--evm-bin EVM_BIN]" in result.output
     assert "[--traces]" in result.output
     assert "[--evm-code-type EVM_CODE_TYPE]" in result.output
+    assert "--feature" in result.output
     assert "--help" in result.output
     assert "Arguments defining evm executable behavior:" in result.output
 

--- a/src/pytest_plugins/features/__init__.py
+++ b/src/pytest_plugins/features/__init__.py
@@ -1,0 +1,7 @@
+"""
+Pytest plug-in to enable feature-based modification during test filling/execution.
+"""
+
+from .features import Features
+
+__all__ = ["Features"]

--- a/src/pytest_plugins/features/features.py
+++ b/src/pytest_plugins/features/features.py
@@ -1,0 +1,72 @@
+"""
+Enable feature-specific functionality on all tests during filling/execution.
+"""
+
+from enum import Flag, auto
+
+import pytest
+
+from ethereum_test_vm import EVMCodeType
+
+
+class Features(Flag):
+    """
+    Enumerates the available features.
+    """
+
+    NONE = 0
+    EIP_7702 = auto()
+    EOF_V1 = auto()
+
+    def __str__(self):
+        """
+        Returns the string representation of the feature.
+        """
+        return self.name
+
+
+def pytest_addoption(parser: pytest.Parser):
+    """
+    Adds command-line options to pytest.
+    """
+    features_group = parser.getgroup(
+        "features", "Arguments related to enabling specific testing of features"
+    )
+
+    features_group.addoption(
+        "--feature",
+        action="append",
+        default=[],
+        help="Enable a feature (repeat for multiple features). Supported features: "
+        + ", ".join(str(feature).lower() for feature in Features),
+    )
+
+
+@pytest.fixture(scope="session")
+def features(request):
+    """
+    Returns the enabled features.
+    """
+    features_str_list = request.config.getoption("feature")
+    features = Features.NONE
+    for feature_str in features_str_list:
+        features |= Features[feature_str.upper()]
+    return features
+
+
+@pytest.fixture(scope="session")
+def eip_7702_feature(features: Features) -> bool:
+    """
+    Returns whether the EIP-7702 mode is enabled.
+    """
+    return Features.EIP_7702 in features
+
+
+@pytest.fixture(autouse=True, scope="session")
+def evm_code_type(features: Features) -> EVMCodeType | None:
+    """
+    Returns the default EVM code type for all tests.
+    """
+    if Features.EOF_V1 in features:
+        return EVMCodeType.EOF_V1
+    return None

--- a/src/pytest_plugins/filler/pre_alloc.py
+++ b/src/pytest_plugins/filler/pre_alloc.py
@@ -39,15 +39,10 @@ def pytest_addoption(parser: pytest.Parser):
     """
     Adds command-line options to pytest.
     """
-    pre_alloc_group = parser.getgroup("pre_alloc", "Arguments defining pre-allocation behavior.")
-
-    pre_alloc_group.addoption(
-        "--strict-alloc",
-        action="store_true",
-        dest="strict_alloc",
-        default=False,
-        help=("[DEBUG ONLY] Disallows deploying a contract in a predefined address."),
+    pre_alloc_group = parser.getgroup(
+        "pre_alloc", "Arguments defining pre-allocation behavior during test filling"
     )
+
     pre_alloc_group.addoption(
         "--ca-start",
         "--contract-address-start",
@@ -67,13 +62,11 @@ def pytest_addoption(parser: pytest.Parser):
         help="The address increment value to each deployed contract by a test.",
     )
     pre_alloc_group.addoption(
-        "--evm-code-type",
-        action="store",
-        dest="evm_code_type",
-        default=None,
-        type=EVMCodeType,
-        choices=list(EVMCodeType),
-        help="Type of EVM code to deploy in each test by default.",
+        "--strict-alloc",
+        action="store_true",
+        dest="strict_alloc",
+        default=False,
+        help=("[DEBUG ONLY] Disallows deploying a contract in a predefined address."),
     )
 
 
@@ -86,6 +79,9 @@ class AllocMode(IntEnum):
     STRICT = 1
 
 
+SET_CODE_DELEGATION_DESIGNATION = b"\xef\x01\x00"
+
+
 class Alloc(BaseAlloc):
     """
     Allocation of accounts in the state, pre and post test execution.
@@ -95,6 +91,7 @@ class Alloc(BaseAlloc):
     _contract_address_iterator: Iterator[Address] = PrivateAttr(...)
     _eoa_iterator: Iterator[EOA] = PrivateAttr(...)
     _evm_code_type: EVMCodeType | None = PrivateAttr(None)
+    _eip_7702_mode: bool = PrivateAttr(False)
 
     def __init__(
         self,
@@ -103,6 +100,7 @@ class Alloc(BaseAlloc):
         contract_address_iterator: Iterator[Address],
         eoa_iterator: Iterator[EOA],
         evm_code_type: EVMCodeType | None = None,
+        eip_7702_feature: bool = False,
         **kwargs,
     ):
         """
@@ -113,6 +111,7 @@ class Alloc(BaseAlloc):
         self._contract_address_iterator = contract_address_iterator
         self._eoa_iterator = eoa_iterator
         self._evm_code_type = evm_code_type
+        self._eip_7702_mode = eip_7702_feature
 
     def __setitem__(self, address: Address | FixedSizeBytesConvertible, account: Account | None):
         """
@@ -164,15 +163,37 @@ class Alloc(BaseAlloc):
         if self._alloc_mode == AllocMode.STRICT:
             assert Number(nonce) >= 1, "impossible to deploy contract with nonce lower than one"
 
-        super().__setitem__(
-            contract_address,
-            Account(
+        if self._eip_7702_mode:
+            super().__setitem__(
+                contract_address,
+                Account(
+                    nonce=nonce,
+                    balance=0,
+                    code=self.code_pre_processor(code, evm_code_type=evm_code_type),
+                    storage={},
+                ),
+            )
+
+            eoa_set_code_proxy = next(self._eoa_iterator)
+            account = Account(
                 nonce=nonce,
                 balance=balance,
-                code=self.code_pre_processor(code, evm_code_type=evm_code_type),
+                code=SET_CODE_DELEGATION_DESIGNATION + bytes(contract_address),
                 storage=storage,
-            ),
-        )
+            )
+            super().__setitem__(eoa_set_code_proxy, account)
+            contract_address = eoa_set_code_proxy
+        else:
+            super().__setitem__(
+                contract_address,
+                Account(
+                    nonce=nonce,
+                    balance=balance,
+                    code=self.code_pre_processor(code, evm_code_type=evm_code_type),
+                    storage=storage,
+                ),
+            )
+
         if label is None:
             # Try to deduce the label from the code
             frame = inspect.currentframe()
@@ -212,7 +233,7 @@ class Alloc(BaseAlloc):
                 account = Account(
                     nonce=1,
                     balance=amount,
-                    storage=storage,
+                    storage=storage if storage is not None else {},
                 )
                 eoa.nonce = Number(1)
 
@@ -290,31 +311,22 @@ def eoa_iterator() -> Iterator[EOA]:
     return iter(eoa_by_index(i).copy() for i in count())
 
 
-@pytest.fixture(autouse=True)
-def evm_code_type(request: pytest.FixtureRequest) -> EVMCodeType:
-    """
-    Returns the default EVM code type for all tests (LEGACY).
-    """
-    parameter_evm_code_type = request.config.getoption("evm_code_type")
-    if parameter_evm_code_type is not None:
-        assert type(parameter_evm_code_type) is EVMCodeType, "Invalid EVM code type"
-        return parameter_evm_code_type
-    return EVMCodeType.LEGACY
-
-
 @pytest.fixture(scope="function")
 def pre(
     alloc_mode: AllocMode,
     contract_address_iterator: Iterator[Address],
     eoa_iterator: Iterator[EOA],
-    evm_code_type: EVMCodeType,
+    evm_code_type: EVMCodeType | None,
+    eip_7702_feature: bool,
 ) -> Alloc:
     """
     Returns the default pre allocation for all tests (Empty alloc).
     """
+    # TODO: Compare `eip_7702_feature` against the current fork.
     return Alloc(
         alloc_mode=alloc_mode,
         contract_address_iterator=contract_address_iterator,
         eoa_iterator=eoa_iterator,
         evm_code_type=evm_code_type,
+        eip_7702_feature=eip_7702_feature,
     )

--- a/src/pytest_plugins/help/help.py
+++ b/src/pytest_plugins/help/help.py
@@ -51,6 +51,7 @@ def show_test_help(config):
             "filler location",
             "defining debug",
             "pre-allocation behavior",
+            "testing of features",
         ]
     elif pytest_ini.name in [
         "pytest-consume.ini",


### PR DESCRIPTION
## 🗒️ Description
Introduces a new pytest plugin called "features" which allows enabling a specific feature globally for all tests.

### EIP-7702 Mode

Fills all tests with each deployed contract being a set-code-delegated account instead of an actual contract, i.e. the behavior of `pre.deploy_contract` changes to the following:

1) Deploy the requested code at some location `A`
2) Generate an EOA account `B`
3) Set storage of `B` to the requested initial storage (In case of normal allocation during filling, the storage is simply set in the dictionary, but if the test was to be executed on a live network, there would need to be a first authorization transaction to a contract which only purpose is to set the storage)
4) Create an authorization to set-code of `B` to `A`
5) Return address `B`

### EOF V1 Mode

Fill all tests with each deployed contract (with unspecified EVM code type) set to EOF V1 code type, i.e. `pre.deploy_contract` now first checks if the parameter `evm_code_type` is unset, and if the provided deployment code is not already `ethereum_test_tools.eof.v1.Container`, and if so then wraps the code in an EOF container before setting/deploying the code.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
