### PR TITLE
chore: update uv.lock for updated solc deps

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -640,7 +640,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13.7.0,<14" },
     { name = "semver", specifier = ">=3.0.1,<4" },
     { name = "setuptools" },
-    { name = "solc-select", specifier = ">=1.0.4" },
+    { name = "solc-select", specifier = ">=1.0.4,<2" },
     { name = "tenacity", specifier = ">8.2.0,<9" },
     { name = "trie", specifier = ">=2.0.2,<3" },
     { name = "types-requests", marker = "extra == 'lint'" },


### PR DESCRIPTION
## 🗒️ Description

Updates the `uv.lock` file. This is necessary because:
- #777 introduced a `uv.lock` file
- #772 modified dependencies for solc (added an upper bound <2.0.0), which was not taken into account for in #777.

## 🔗 Related Issues
#777, #772.

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] ~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~ Not necessary
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
