### PR TITLE
feat(specs): EOF: `eof_test` generates state tests, and `execute` in live devnets

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Blockchain and Blockchain-Engine tests now have a marker to specify that they were generated from a state test, which can be used with `-m blockchain_test_from_state_test` and `-m blockchain_test_engine_from_state_test` respectively ([#1220](https://github.com/ethereum/execution-spec-tests/pull/1220)).
 - ✨ Blockchain and Blockchain-Engine tests that were generated from a state test now have `blockchain_test_from_state_test` or `blockchain_test_engine_from_state_test` as part of their test IDs ([#1220](https://github.com/ethereum/execution-spec-tests/pull/1220)).
 - 🔀 Refactor `ethereum_test_fixtures` and `ethereum_clis` to create `FixtureConsumer` and `FixtureConsumerTool` classes which abstract away the consumption process used by `consume direct` ([#935](https://github.com/ethereum/execution-spec-tests/pull/935)).
+- ✨ EOF Container validation tests (`eof_test`) now generate container deployment state tests, by wrapping the EOF container in an init-container and sending a deploy transaction ([#783](https://github.com/ethereum/execution-spec-tests/pull/783)).
 
 ### 📋 Misc
 

--- a/src/ethereum_test_specs/eof.py
+++ b/src/ethereum_test_specs/eof.py
@@ -5,10 +5,10 @@ import warnings
 from pathlib import Path
 from shutil import which
 from subprocess import CompletedProcess
-from typing import Any, Callable, ClassVar, Dict, Generator, List, Optional, Sequence, Type
+from typing import Callable, ClassVar, Dict, Generator, List, Optional, Sequence, Type
 
 import pytest
-from pydantic import Field, model_validator
+from pydantic import Field
 
 from ethereum_clis import EvmoneExceptionMapper, TransitionTool
 from ethereum_test_base_types import Account, Bytes, HexNumber
@@ -27,8 +27,9 @@ from ethereum_test_fixtures import (
 )
 from ethereum_test_fixtures.eof import Result, Vector
 from ethereum_test_forks import Fork
-from ethereum_test_types import Alloc, Environment, Transaction
-from ethereum_test_types.eof.v1 import Container, ContainerKind
+from ethereum_test_types import EOA, Alloc, Environment, Transaction
+from ethereum_test_types.eof.v1 import Container, ContainerKind, Section, SectionKind
+from ethereum_test_vm import Opcodes as Op
 
 from .base import BaseTest
 from .state import StateTest
@@ -142,50 +143,162 @@ class EOFParse:
 
 
 class EOFTest(BaseTest):
-    """Filler type that tests EOF containers."""
+    """
+    Filler type that generates a test for EOF container validation.
 
-    container: Bytes
+    A state test is also automatically generated where the container is wrapped in a
+    contract-creating transaction to test deployment/validation on the instantiated blockchain.
+    """
+
+    container: Container
+    """
+    EOF container that will be tested for validity.
+
+    The only supported type at the moment is `ethereum_test_types.eof.v1.Container`.
+
+    If an invalid container needs to be tested, and it cannot be generated using the
+    Container class features, the `raw_bytes` field can be used to provide the raw
+    container bytes.
+    """
     expect_exception: EOFExceptionInstanceOrList | None = None
-    container_kind: ContainerKind | None = None
+    """
+    Expected exception that the container should raise when parsed by an EOF parser.
+
+    Can be a single exception or a list of exceptions that the container is expected to raise,
+    in which case the test will pass if any of the exceptions are raised.
+
+    The list of supported exceptions can be found in the `ethereum_test_exceptions.EOFException`
+    class.
+    """
+    container_kind: ContainerKind = ContainerKind.RUNTIME
+    """
+    Container kind type that the container should be treated as.
+
+    The container kind can be one of the following:
+    - `ContainerKind.INITCODE`: The container is an initcode container.
+    - `ContainerKind.RUNTIME`: The container is a runtime container.
+
+    The default value is `ContainerKind.RUNTIME`.
+    """
+    deployed_container: Container | None = None
+    """
+    To be used when the container is an initcode container and the expected deployed container is
+    known.
+
+    The value is only used when a State Test is generated from this EOF test to set the expected
+    deployed container that should be found in the post state.
+
+    If this field is not set, and the container is valid:
+      - If the container kind is `ContainerKind.RUNTIME`, the deployed container is assumed to be
+        the container itself, and an initcode container that wraps the container is generated
+        automatically.
+      - If the container kind is `ContainerKind.INITCODE`, `model_post_init` will attempt to infer
+        the deployed container from the sections of the init-container, and the first
+        container-type section will be used. An error will be raised if the deployed container
+        cannot be inferred.
+
+    If the value is set to `None`, it is assumed that the container is invalid and the test will
+    expect that no contract is created.
+
+    It is considered an error if:
+      - The `deployed_container` field is set and the `container_kind` field is not set to
+        `ContainerKind.INITCODE`.
+      - The `deployed_container` field is set and the `expect_exception` is not `None`.
+
+    The deployed container is **not** executed at any point during the EOF validation test nor
+    the generated State Test. For container runtime testing use the `EOFStateTest` class.
+    """
+    pre: Alloc | None = None
+    """
+    Pre alloc object that is used during State Test generation.
+
+    This field is automatically set by the test filler when generating a State Test from this EOF
+    test and should otherwise be left unset.
+    """
+    post: Alloc | None = None
+    """
+    Post alloc object that is used during State Test generation.
+
+    This field is automatically set by the test filler when generating a State Test from this EOF
+    test and is normally not set by the user.
+    """
+    sender: EOA | None = None
+    """
+    Sender EOA object that is used during State Test generation.
+
+    This field is automatically set by the `model_post_init` method and should otherwise be left
+    unset.
+    """
 
     supported_fixture_formats: ClassVar[Sequence[FixtureFormat | LabeledFixtureFormat]] = [
-        EOFFixture,
+        EOFFixture
+    ] + [
+        LabeledFixtureFormat(
+            fixture_format,
+            f"{fixture_format.format_name}_from_eof_test",
+        )
+        for fixture_format in StateTest.supported_fixture_formats
     ]
 
-    @model_validator(mode="before")
+    supported_execute_formats: ClassVar[Sequence[ExecuteFormat | LabeledExecuteFormat]] = [
+        LabeledExecuteFormat(
+            execute_format,
+            f"{execute_format.format_name}_from_eof_test",
+        )
+        for execute_format in StateTest.supported_execute_formats
+    ]
+
+    supported_markers: ClassVar[Dict[str, str]] = {
+        "eof_test_only": "Only generate an EOF test fixture",
+    }
+
     @classmethod
-    def check_container_exception(cls, data: Any) -> Any:
-        """Check if the container exception matches the expected exception."""
-        if isinstance(data, dict):
-            container = data.get("container")
-            expect_exception = data.get("expect_exception")
-            container_kind = data.get("container_kind")
-            if container is not None and isinstance(container, Container):
-                if (
-                    "validity_error" in container.model_fields_set
-                    and container.validity_error is not None
-                ):
-                    if expect_exception is not None:
-                        assert container.validity_error == expect_exception, (
-                            f"Container validity error {container.validity_error} "
-                            f"does not match expected exception {expect_exception}."
-                        )
-                    if expect_exception is None:
-                        data["expect_exception"] = container.validity_error
-                if "kind" in container.model_fields_set:
-                    if container_kind is not None:
-                        assert container.kind == container_kind, (
-                            f"Container kind type {str(container.kind)} "
-                            f"does not match test {container_kind}."
-                        )
-                    if container.kind != ContainerKind.RUNTIME:
-                        data["container_kind"] = container.kind
-        return data
+    def discard_fixture_format_by_marks(
+        cls,
+        fixture_format: FixtureFormat,
+        fork: Fork,
+        markers: List[pytest.Mark],
+    ) -> bool:
+        """Discard a fixture format from filling if the appropriate marker is used."""
+        if "eof_test_only" in [m.name for m in markers]:
+            return fixture_format != EOFFixture
+        return False
 
     @classmethod
     def pytest_parameter_name(cls) -> str:
         """Workaround for pytest parameter name."""
         return "eof_test"
+
+    def model_post_init(self, __context):
+        """Prepare the test exception based on the container."""
+        if self.container.validity_error is not None:
+            if self.expect_exception is not None:
+                assert self.expect_exception == self.container.validity_error, (
+                    f"Container validity error {self.container.validity_error} "
+                    f"does not match expected exception {self.expect_exception}."
+                )
+            self.expect_exception = self.container.validity_error
+            assert self.deployed_container is None, (
+                "deployed_container must be None for invalid containers."
+            )
+        if "kind" in self.container.model_fields_set or "container_kind" in self.model_fields_set:
+            if (
+                "kind" in self.container.model_fields_set
+                and "container_kind" in self.model_fields_set
+            ):
+                assert self.container.kind == self.container_kind, (
+                    f"Container kind type {str(self.container.kind)} "
+                    f"does not match test {self.container_kind}."
+                )
+            elif "kind" in self.container.model_fields_set:
+                self.container_kind = self.container.kind
+            elif "container_kind" in self.model_fields_set:
+                self.container.kind = self.container_kind
+
+        assert self.pre is not None, "pre must be set to generate a StateTest."
+        self.sender = self.pre.fund_eoa()
+        if self.post is None:
+            self.post = Alloc()
 
     def make_eof_test_fixture(
         self,
@@ -195,15 +308,16 @@ class EOFTest(BaseTest):
         eips: Optional[List[int]],
     ) -> EOFFixture:
         """Generate the EOF test fixture."""
-        if self.container in existing_tests:
+        container_bytes = Bytes(self.container)
+        if container_bytes in existing_tests:
             pytest.fail(
-                f"Duplicate EOF test: {self.container}, "
-                f"existing test: {existing_tests[self.container]}"
+                f"Duplicate EOF test: {container_bytes}, "
+                f"existing test: {existing_tests[container_bytes]}"
             )
-        existing_tests[self.container] = request.node.nodeid
+        existing_tests[container_bytes] = request.node.nodeid
         vectors = [
             Vector(
-                code=self.container,
+                code=container_bytes,
                 container_kind=self.container_kind,
                 results={
                     fork.blockchain_test_network_name(): Result(
@@ -265,6 +379,71 @@ class EOFTest(BaseTest):
                     got=f"{actual_exception} ({actual_message})",
                 )
 
+    def generate_eof_contract_create_transaction(self) -> Transaction:
+        """Generate a transaction that creates a contract."""
+        assert self.sender is not None, "sender must be set to generate a StateTest."
+        assert self.post is not None, "post must be set to generate a StateTest."
+
+        initcode: Container
+        deployed_container: Container | Bytes | None = None
+        if self.container_kind == ContainerKind.INITCODE:
+            initcode = self.container
+            if "deployed_container" in self.model_fields_set:
+                # In the case of an initcontainer where we know the deployed container,
+                # we can use the initcontainer as-is.
+                deployed_container = self.deployed_container
+            elif self.expect_exception is None:
+                # We have a valid init-container, but we don't know the deployed container.
+                # Try to infer the deployed container from the sections of the init-container.
+                assert self.container.raw_bytes is None, (
+                    "deployed_container must be set for initcode containers with raw_bytes."
+                )
+                for section in self.container.sections:
+                    if section.kind == SectionKind.CONTAINER:
+                        deployed_container = section.data
+                        break
+
+                assert deployed_container is not None, (
+                    "Unable to infer deployed container for init-container. "
+                    "Use field `deployed_container` to set the expected deployed container."
+                )
+        else:
+            assert self.deployed_container is None, (
+                "deployed_container must be None for runtime containers."
+            )
+            initcode = Container(
+                sections=[
+                    Section.Code(Op.RETURNCONTRACT[0](0, 0)),
+                    Section.Container(self.container),
+                ]
+            )
+            deployed_container = self.container
+
+        tx = Transaction(
+            sender=self.sender,
+            to=None,
+            gas_limit=10_000_000,
+            data=initcode,
+        )
+
+        if self.expect_exception is not None or deployed_container is None:
+            self.post[tx.created_contract] = None
+        else:
+            self.post[tx.created_contract] = Account(
+                code=deployed_container,
+            )
+        return tx
+
+    def generate_state_test(self, fork: Fork) -> StateTest:
+        """Generate the StateTest filler."""
+        return StateTest(
+            pre=self.pre,
+            tx=self.generate_eof_contract_create_transaction(),
+            env=Environment(),
+            post=self.post,
+            t8n_dump_dir=self.t8n_dump_dir,
+        )
+
     def generate(
         self,
         *,
@@ -278,10 +457,25 @@ class EOFTest(BaseTest):
         """Generate the BlockchainTest fixture."""
         if fixture_format == EOFFixture:
             return self.make_eof_test_fixture(request=request, fork=fork, eips=eips)
-
+        elif fixture_format in StateTest.supported_fixture_formats:
+            return self.generate_state_test(fork).generate(
+                request=request, t8n=t8n, fork=fork, fixture_format=fixture_format, eips=eips
+            )
         raise Exception(f"Unknown fixture format: {fixture_format}")
 
-    # TODO: Implement execute method for EOF tests
+    def execute(
+        self,
+        *,
+        fork: Fork,
+        execute_format: ExecuteFormat,
+        eips: Optional[List[int]] = None,
+    ) -> BaseExecute:
+        """Generate the list of test fixtures."""
+        if execute_format == TransactionPost:
+            return self.generate_state_test(fork).execute(
+                fork=fork, execute_format=execute_format, eips=eips
+            )
+        raise Exception(f"Unsupported execute format: {execute_format}")
 
 
 EOFTestSpec = Callable[[str], Generator[EOFTest, None, None]]
@@ -289,15 +483,35 @@ EOFTestFiller = Type[EOFTest]
 
 
 class EOFStateTest(EOFTest, Transaction):
-    """Filler type that tests EOF containers and also generates a state/blockchain test."""
+    """
+    Filler type that generates an EOF test for container validation, and also tests the container
+    during runtime using a state test (and blockchain test).
 
-    deploy_tx: bool = False
+    In the state or blockchain test, the container is first deployed to the pre-allocation and
+    then a transaction is sent to the deployed container.
+
+    Container deployment/validation is **not** tested like in the `EOFTest` unless the container
+    under test is an initcode container.
+
+    All fields from `ethereum_test_types.Transaction` are available for use in the test.
+    """
+
     gas_limit: HexNumber = Field(HexNumber(10_000_000), serialization_alias="gas")
+    """
+    Gas limit for the transaction that deploys the container.
+    """
     tx_sender_funding_amount: int = 1_000_000_000_000_000_000_000
+    """
+    Amount of funds to send to the sender EOA before the transaction.
+    """
     env: Environment = Field(default_factory=Environment)
+    """
+    Environment object that is used during State Test generation.
+    """
     container_post: Account = Field(default_factory=Account)
-    pre: Alloc | None = None
-    post: Alloc | None = None
+    """
+    Account object used to verify the container post state.
+    """
 
     supported_fixture_formats: ClassVar[Sequence[FixtureFormat | LabeledFixtureFormat]] = [
         EOFFixture
@@ -317,24 +531,6 @@ class EOFStateTest(EOFTest, Transaction):
         for execute_format in StateTest.supported_execute_formats
     ]
 
-    @model_validator(mode="before")
-    @classmethod
-    def check_container_type(cls, data: Any) -> Any:
-        """Check if the container exception matches the expected exception."""
-        if isinstance(data, dict):
-            container = data.get("container")
-            deploy_tx = data.get("deploy_tx")
-            container_kind = data.get("container_kind")
-            if deploy_tx is None:
-                if (
-                    container is not None
-                    and isinstance(container, Container)
-                    and "kind" in container.model_fields_set
-                    and container.kind == ContainerKind.INITCODE
-                ) or (container_kind is not None and container_kind == ContainerKind.INITCODE):
-                    data["deploy_tx"] = True
-        return data
-
     @classmethod
     def pytest_parameter_name(cls) -> str:
         """Workaround for pytest parameter name."""
@@ -344,6 +540,8 @@ class EOFStateTest(EOFTest, Transaction):
         """Prepare the transaction parameters required to fill the test."""
         assert self.pre is not None, "pre must be set to generate a StateTest."
 
+        EOFTest.model_post_init(self, __context)
+
         self.sender = self.pre.fund_eoa(amount=self.tx_sender_funding_amount)
         if self.post is None:
             self.post = Alloc()
@@ -351,17 +549,17 @@ class EOFStateTest(EOFTest, Transaction):
         if self.expect_exception is not None:  # Invalid EOF
             self.to = None  # Make EIP-7698 create transaction
             self.data = Bytes(
-                self.container + self.data
+                bytes(self.container) + self.data
             )  # by concatenating container and tx data.
 
             # Run transaction model validation
             Transaction.model_post_init(self, __context)
 
             self.post[self.created_contract] = None  # Expect failure.
-        elif self.deploy_tx:
+        elif self.container_kind == ContainerKind.INITCODE:
             self.to = None  # Make EIP-7698 create transaction
             self.data = Bytes(
-                self.container + self.data
+                bytes(self.container) + self.data
             )  # by concatenating container and tx data.
 
             # Run transaction model validation
@@ -376,7 +574,7 @@ class EOFStateTest(EOFTest, Transaction):
 
             self.post[self.to] = self.container_post
 
-    def generate_state_test(self) -> StateTest:
+    def generate_state_test(self, fork: Fork) -> StateTest:
         """Generate the StateTest filler."""
         assert self.pre is not None, "pre must be set to generate a StateTest."
         assert self.post is not None, "post must be set to generate a StateTest."
@@ -401,31 +599,17 @@ class EOFStateTest(EOFTest, Transaction):
     ) -> BaseFixture:
         """Generate the BlockchainTest fixture."""
         if fixture_format == EOFFixture:
-            if self.container in existing_tests:
+            if Bytes(self.container) in existing_tests:
                 # Gracefully skip duplicate tests because one EOFStateTest can generate multiple
                 # state fixtures with the same data.
                 pytest.skip(f"Duplicate EOF container on EOFStateTest: {request.node.nodeid}")
             return self.make_eof_test_fixture(request=request, fork=fork, eips=eips)
         elif fixture_format in StateTest.supported_fixture_formats:
-            return self.generate_state_test().generate(
+            return self.generate_state_test(fork).generate(
                 request=request, t8n=t8n, fork=fork, fixture_format=fixture_format, eips=eips
             )
 
         raise Exception(f"Unknown fixture format: {fixture_format}")
-
-    def execute(
-        self,
-        *,
-        fork: Fork,
-        execute_format: ExecuteFormat,
-        eips: Optional[List[int]] = None,
-    ) -> BaseExecute:
-        """Generate the list of test fixtures."""
-        if execute_format == TransactionPost:
-            return self.generate_state_test().execute(
-                fork=fork, execute_format=execute_format, eips=eips
-            )
-        raise Exception(f"Unsupported execute format: {execute_format}")
 
 
 EOFStateTestSpec = Callable[[str], Generator[EOFStateTest, None, None]]

--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_container_size.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_container_size.py
@@ -21,6 +21,7 @@ VALID_CONTAINER = Container(sections=[Section.Code(code=Op.STOP)])
     "over_limit",
     [0, 1, 2, 2**16 - MAX_INITCODE_SIZE],
 )
+@pytest.mark.eof_test_only
 def test_max_size(
     eof_test: EOFTestFiller,
     over_limit: int,
@@ -37,7 +38,7 @@ def test_max_size(
     )
     assert len(code) == MAX_INITCODE_SIZE + over_limit
     eof_test(
-        container=bytes(code),
+        container=code,
         expect_exception=None if over_limit == 0 else EOFException.CONTAINER_SIZE_ABOVE_LIMIT,
     )
 
@@ -46,6 +47,7 @@ def test_max_size(
     "size",
     [MAX_INITCODE_SIZE + 1, MAX_INITCODE_SIZE * 2],
 )
+@pytest.mark.eof_test_only
 def test_above_max_size_raw(
     eof_test: EOFTestFiller,
     size: int,
@@ -53,7 +55,7 @@ def test_above_max_size_raw(
     """Verify EOF container invalid above maximum size, regardless of header contents."""
     code = Op.INVALID * size
     eof_test(
-        container=bytes(code),
+        container=Container(raw_bytes=code),
         expect_exception=EOFException.CONTAINER_SIZE_ABOVE_LIMIT,
     )
 
@@ -101,6 +103,6 @@ def test_section_after_end_of_container(
 ):
     """Verify EOF container is invalid if any of sections declares above container size."""
     eof_test(
-        container=bytes(code),
+        container=code,
         expect_exception=EOFException.INVALID_SECTION_BODIES_SIZE,
     )

--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py
@@ -142,9 +142,7 @@ def test_valid_containers(
     assert container.validity_error is None, (
         f"Valid container with validity error: {container.validity_error}"
     )
-    eof_test(
-        container=bytes(container),
-    )
+    eof_test(container=container)
 
 
 @pytest.mark.parametrize(
@@ -259,19 +257,25 @@ def test_valid_containers(
             raw_bytes=bytes([0xEF, 0x00, 0x01, 0x01, 0x00, 0x04, 0x02, 0xFF, 0xFF]),
             validity_error=EOFException.TOO_MANY_CODE_SECTIONS,
         ),
-        Container(
-            name="code_section_count_0x8000",
-            raw_bytes=bytes(
-                [0xEF, 0x00, 0x01, 0x01, 0x00, 0x04, 0x02, 0x80, 0x00] + [0x00, 0x01] * 0x8000
+        pytest.param(
+            Container(
+                name="code_section_count_0x8000",
+                raw_bytes=bytes(
+                    [0xEF, 0x00, 0x01, 0x01, 0x00, 0x04, 0x02, 0x80, 0x00] + [0x00, 0x01] * 0x8000
+                ),
+                validity_error=EOFException.CONTAINER_SIZE_ABOVE_LIMIT,
             ),
-            validity_error=EOFException.CONTAINER_SIZE_ABOVE_LIMIT,
+            marks=pytest.mark.eof_test_only(reason="initcode too large"),
         ),
-        Container(
-            name="code_section_count_0xFFFF",
-            raw_bytes=bytes(
-                [0xEF, 0x00, 0x01, 0x01, 0x00, 0x04, 0x02, 0xFF, 0xFF] + [0x00, 0x01] * 0xFFFF
+        pytest.param(
+            Container(
+                name="code_section_count_0xFFFF",
+                raw_bytes=bytes(
+                    [0xEF, 0x00, 0x01, 0x01, 0x00, 0x04, 0x02, 0xFF, 0xFF] + [0x00, 0x01] * 0xFFFF
+                ),
+                validity_error=EOFException.CONTAINER_SIZE_ABOVE_LIMIT,
             ),
-            validity_error=EOFException.CONTAINER_SIZE_ABOVE_LIMIT,
+            marks=pytest.mark.eof_test_only(reason="initcode too large"),
         ),
         Container(
             name="code_section_size_0x8000_truncated",
@@ -1188,7 +1192,7 @@ def test_invalid_containers(
     """Test invalid containers."""
     assert container.validity_error is not None, "Invalid container without validity error"
     eof_test(
-        container=bytes(container),
+        container=container,
         expect_exception=container.validity_error,
     )
 
@@ -1206,7 +1210,7 @@ def test_magic_validation(
     code = bytearray(bytes(VALID_CONTAINER))
     code[0:2] = magic
     eof_test(
-        container=bytes(code),
+        container=Container(raw_bytes=bytes(code)),
         expect_exception=EOFException.INVALID_MAGIC,
     )
 
@@ -1220,7 +1224,7 @@ def test_version_validation(
     code = bytearray(bytes(VALID_CONTAINER))
     code[2] = version
     eof_test(
-        container=bytes(code),
+        container=Container(raw_bytes=bytes(code)),
         expect_exception=EOFException.INVALID_VERSION,
     )
 

--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_migrated_valid_invalid.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_migrated_valid_invalid.py
@@ -55,91 +55,95 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
         ),
         pytest.param(
             # No section terminator after data section size
-            bytes.fromhex("ef00010100040200010001040002"),
+            Container(raw_bytes=bytes.fromhex("ef00010100040200010001040002")),
             EOFException.MISSING_HEADERS_TERMINATOR,
             id="EOF1I3540_0020_no_section_terminator_after_data_section_size",
         ),
         pytest.param(
             # No type section contents
-            bytes.fromhex("ef0001010004020001000104000200"),
+            Container(raw_bytes=bytes.fromhex("ef0001010004020001000104000200")),
             EOFException.INVALID_SECTION_BODIES_SIZE,
             id="EOF1I3540_0021_no_type_section_contents",
         ),
         pytest.param(
             # Type section contents (no outputs and max stack)
-            bytes.fromhex("ef000101000402000100010400020000"),
+            Container(raw_bytes=bytes.fromhex("ef000101000402000100010400020000")),
             EOFException.INVALID_SECTION_BODIES_SIZE,
             id="EOF1I3540_0022_invalid_type_section_no_outputs_and_max_stack",
         ),
         pytest.param(
             # Type section contents (no max stack)
-            bytes.fromhex("ef00010100040200010001040002000000"),
+            Container(raw_bytes=bytes.fromhex("ef00010100040200010001040002000000")),
             EOFException.INVALID_SECTION_BODIES_SIZE,
             id="EOF1I3540_0023_invalid_type_section_no_max_stack",
         ),
         pytest.param(
             # Type section contents (max stack incomplete)
-            bytes.fromhex("ef0001010004020001000104000200000000"),
+            Container(raw_bytes=bytes.fromhex("ef0001010004020001000104000200000000")),
             EOFException.INVALID_SECTION_BODIES_SIZE,
             id="EOF1I3540_0024_invalid_type_section_max_stack_incomplete",
         ),
         pytest.param(
             # No code section contents
-            bytes.fromhex("ef000101000402000100010400020000000000"),
+            Container(raw_bytes=bytes.fromhex("ef000101000402000100010400020000000000")),
             EOFException.INVALID_SECTION_BODIES_SIZE,
             id="EOF1I3540_0025_no_code_section_contents",
         ),
         pytest.param(
             # Code section contents incomplete
-            bytes.fromhex("ef0001010004020001002904000000000000027f"),
+            Container(raw_bytes=bytes.fromhex("ef0001010004020001002904000000000000027f")),
             EOFException.INVALID_SECTION_BODIES_SIZE,
             id="EOF1I3540_0026_code_section_contents_incomplete",
         ),
         pytest.param(
             # Trailing bytes after code section
-            bytes.fromhex("ef0001 010004 0200010001 040000 00 00800000 fe aabbcc"),
+            Container(
+                raw_bytes=bytes.fromhex("ef0001 010004 0200010001 040000 00 00800000 fe aabbcc")
+            ),
             EOFException.INVALID_SECTION_BODIES_SIZE,
             id="EOF1I3540_0027_trailing_bytes_after_code_section",
         ),
         pytest.param(
             # Trailing bytes after code section with wrong first section type
-            bytes.fromhex("ef0001 010004 0200010001 040000 00 00000000 fe aabbcc"),
+            Container(
+                raw_bytes=bytes.fromhex("ef0001 010004 0200010001 040000 00 00000000 fe aabbcc")
+            ),
             [EOFException.INVALID_FIRST_SECTION_TYPE, EOFException.INVALID_SECTION_BODIES_SIZE],
             id="EOF1I3540_0027_trailing_bytes_after_code_section_with_wrong_first_section_type",
         ),
         pytest.param(
             # Empty code section
-            bytes.fromhex("ef000101000402000100000400000000000000"),
+            Container(raw_bytes=bytes.fromhex("ef000101000402000100000400000000000000")),
             EOFException.ZERO_SECTION_SIZE,
             id="EOF1I3540_0028_empty_code_section",
         ),
         pytest.param(
             # Code section preceding type section
-            bytes.fromhex("ef000102000100010100040400020000000000feaabb"),
+            Container(raw_bytes=bytes.fromhex("ef000102000100010100040400020000000000feaabb")),
             [EOFException.MISSING_TYPE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
             id="EOF1I3540_0030_code_section_preceding_type_section",
         ),
         pytest.param(
             # Data section preceding type section
-            bytes.fromhex("ef000104000201000402000100010000000000feaabb"),
+            Container(raw_bytes=bytes.fromhex("ef000104000201000402000100010000000000feaabb")),
             [EOFException.MISSING_TYPE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
             id="EOF1I3540_0031_data_section_preceding_type_section",
         ),
         pytest.param(
             # Data section preceding code section
-            bytes.fromhex("ef000101000404000202000100010000000000feaabb"),
+            Container(raw_bytes=bytes.fromhex("ef000101000404000202000100010000000000feaabb")),
             [EOFException.MISSING_CODE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
             id="EOF1I3540_0032_data_section_preceding_code_section",
         ),
         pytest.param(
             # Data section without code section
-            bytes.fromhex("ef00010100040400020000000000aabb"),
+            Container(raw_bytes=bytes.fromhex("ef00010100040400020000000000aabb")),
             [EOFException.MISSING_CODE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
             id="EOF1I3540_0033_data_section_without_code_section",
         ),
         pytest.param(
             # No data section
-            bytes.fromhex("ef000101000402000100010000000000fe"),
+            Container(raw_bytes=bytes.fromhex("ef000101000402000100010000000000fe")),
             [EOFException.MISSING_DATA_SECTION, EOFException.UNEXPECTED_HEADER_KIND],
             id="EOF1I3540_0034_no_data_section",
         ),
@@ -158,91 +162,99 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
         ),
         pytest.param(
             # Trailing bytes after data section with wrong first section type
-            bytes.fromhex("ef0001 010004 0200010001 040002 00 00000000 fe aabbccdd"),
+            Container(
+                raw_bytes=bytes.fromhex("ef0001 010004 0200010001 040002 00 00000000 fe aabbccdd")
+            ),
             [EOFException.INVALID_FIRST_SECTION_TYPE, EOFException.INVALID_SECTION_BODIES_SIZE],
             id="EOF1I3540_0035_trailing_bytes_after_data_section_with_wrong_first_section_type",
         ),
         pytest.param(
             # Multiple data sections
-            bytes.fromhex("ef000101000402000100010400020400020000000000feaabbaabb"),
+            Container(
+                raw_bytes=bytes.fromhex("ef000101000402000100010400020400020000000000feaabbaabb")
+            ),
             [EOFException.MISSING_TERMINATOR, EOFException.UNEXPECTED_HEADER_KIND],
             id="EOF1I3540_0036_multiple_data_sections",
         ),
         pytest.param(
             # Multiple code and data sections
-            bytes.fromhex("ef000101000802000200010001040002040002000000000000000000fefeaabbaabb"),
+            Container(
+                raw_bytes=bytes.fromhex(
+                    "ef000101000802000200010001040002040002000000000000000000fefeaabbaabb"
+                )
+            ),
             [EOFException.MISSING_TERMINATOR, EOFException.UNEXPECTED_HEADER_KIND],
             id="EOF1I3540_0037_multiple_code_and_data_sections",
         ),
         pytest.param(
             # Unknown section ID (at the beginning)
-            bytes.fromhex("ef000105000101000402000100010400000000000000fe"),
+            Container(raw_bytes=bytes.fromhex("ef000105000101000402000100010400000000000000fe")),
             [EOFException.MISSING_TYPE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
             id="EOF1I3540_0038_unknown_section_id_at_the_beginning_05",
         ),
         pytest.param(
             # Unknown section ID (at the beginning)
-            bytes.fromhex("ef000106000101000402000100010400000000000000fe"),
+            Container(raw_bytes=bytes.fromhex("ef000106000101000402000100010400000000000000fe")),
             [EOFException.MISSING_TYPE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
             id="EOF1I3540_0039_unknown_section_id_at_the_beginning_06",
         ),
         pytest.param(
             # Unknown section ID (at the beginning)
-            bytes.fromhex("ef0001ff000101000402000100010400000000000000fe"),
+            Container(raw_bytes=bytes.fromhex("ef0001ff000101000402000100010400000000000000fe")),
             [EOFException.MISSING_TYPE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
             id="EOF1I3540_0040_unknown_section_id_at_the_beginning_ff",
         ),
         pytest.param(
             # Unknown section ID (after types section)
-            bytes.fromhex("ef000101000405000102000100010400000000000000fe"),
+            Container(raw_bytes=bytes.fromhex("ef000101000405000102000100010400000000000000fe")),
             [EOFException.MISSING_CODE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
             id="EOF1I3540_0041_unknown_section_id_after_types_section_05",
         ),
         pytest.param(
             # Unknown section ID (after types section)
-            bytes.fromhex("ef000101000406000102000100010400000000000000fe"),
+            Container(raw_bytes=bytes.fromhex("ef000101000406000102000100010400000000000000fe")),
             [EOFException.MISSING_CODE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
             id="EOF1I3540_0042_unknown_section_id_after_types_section_06",
         ),
         pytest.param(
             # Unknown section ID (after types section)
-            bytes.fromhex("ef0001010004ff000102000100010400000000000000fe"),
+            Container(raw_bytes=bytes.fromhex("ef0001010004ff000102000100010400000000000000fe")),
             [EOFException.MISSING_CODE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
             id="EOF1I3540_0043_unknown_section_id_after_types_section_ff",
         ),
         pytest.param(
             # Unknown section ID (after code section)
-            bytes.fromhex("ef000101000402000100010500010400000000000000fe"),
+            Container(raw_bytes=bytes.fromhex("ef000101000402000100010500010400000000000000fe")),
             [EOFException.MISSING_DATA_SECTION, EOFException.UNEXPECTED_HEADER_KIND],
             id="EOF1I3540_0044_unknown_section_id_after_code_section_05",
         ),
         pytest.param(
             # Unknown section ID (after code section)
-            bytes.fromhex("ef000101000402000100010600010400000000000000fe"),
+            Container(raw_bytes=bytes.fromhex("ef000101000402000100010600010400000000000000fe")),
             [EOFException.MISSING_DATA_SECTION, EOFException.UNEXPECTED_HEADER_KIND],
             id="EOF1I3540_0045_unknown_section_id_after_code_section_06",
         ),
         pytest.param(
             # Unknown section ID (after code section)
-            bytes.fromhex("ef00010100040200010001ff00010400000000000000fe"),
+            Container(raw_bytes=bytes.fromhex("ef00010100040200010001ff00010400000000000000fe")),
             [EOFException.MISSING_DATA_SECTION, EOFException.UNEXPECTED_HEADER_KIND],
             id="EOF1I3540_0046_unknown_section_id_after_code_section_ff",
         ),
         pytest.param(
             # Unknown section ID (after data section)
-            bytes.fromhex("ef000101000402000100010400000500010000000000fe"),
+            Container(raw_bytes=bytes.fromhex("ef000101000402000100010400000500010000000000fe")),
             [EOFException.MISSING_TERMINATOR, EOFException.UNEXPECTED_HEADER_KIND],
             id="EOF1I3540_0047_unknown_section_id_after_data_section_05",
         ),
         pytest.param(
             # Unknown section ID (after data section)
-            bytes.fromhex("ef000101000402000100010400000600010000000000fe"),
+            Container(raw_bytes=bytes.fromhex("ef000101000402000100010400000600010000000000fe")),
             [EOFException.MISSING_TERMINATOR, EOFException.UNEXPECTED_HEADER_KIND],
             id="EOF1I3540_0048_unknown_section_id_after_data_section_06",
         ),
         pytest.param(
             # Unknown section ID (after data section)
-            bytes.fromhex("ef00010100040200010001040000ff00010000000000fe"),
+            Container(raw_bytes=bytes.fromhex("ef00010100040200010001040000ff00010000000000fe")),
             [EOFException.MISSING_TERMINATOR, EOFException.UNEXPECTED_HEADER_KIND],
             id="EOF1I3540_0049_unknown_section_id_after_data_section_ff",
         ),
@@ -298,7 +310,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
 )
 def test_migrated_valid_invalid(
     eof_test: EOFTestFiller,
-    eof_code: Container | bytes,
+    eof_code: Container,
     exception: EOFExceptionInstanceOrList | None,
 ):
     """Verify EOF container construction and exception."""

--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_section_size.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_section_size.py
@@ -191,7 +191,7 @@ def test_truncated_container_without_data(
     container = Container(sections=[Section.Code(Op.INVALID + Op.INVALID)])
     bytecode = bytes(container)
     eof_test(
-        container=bytecode[: len(bytecode) - truncation_len],
+        container=Container(raw_bytes=bytecode[: len(bytecode) - truncation_len]),
         expect_exception=exception,
     )
 


### PR DESCRIPTION
## 🗒️ Description

~~REQUIRES #1220~~ Merged

### - `eof_test` produces state tests (and blockchain tests) 

Create a state test out of an `eof_test` by:

1) in the case of a run-time container, wrapping the container under test within an init container and sending a contract-creating transaction
2) in the case of an init container, the container is wrapped in a factory container (which would execute the initcode to create a contract) and the factory container is wrapped within an init container, which is finally sent as a contract-creating transaction

### - State test generated from EOF tests have extra markers

All state tests generated automatically from the `eof_test` spec now have a different test ID, along with an extra marker applied.

The test ID will show `state_test_from_eof_test` instead of simply `state_test`, e.g.:
`test_swapn_on_max_stack[fork_Osaka-state_test_from_eof_test-swapn_operand_0]`
intead of:
`test_swapn_on_max_stack[fork_Osaka-state_test-swapn_operand_0]`

Also, all tests will have the extra markers `state_test_from_eof_test` or `blockchain_test_from_eof_test` or `blockchain_test_engine_from_eof_test` in order to be able to fill only these specific tests.

E.g. using `-m state_test` will select all tests, including `state_test_from_eof_test` tests:

```
collected 28 items / 22 deselected / 6 selected

<Package eip663_dupn_swapn_exchange>
  <Module test_swapn.py>
    <Function test_swapn_all_valid_immediates[fork_Osaka-state_test]>
    <Function test_swapn_on_max_stack[fork_Osaka-state_test_from_eof_test-swapn_operand_0]>
    <Function test_swapn_on_max_stack[fork_Osaka-state_test_from_eof_test-swapn_operand_255]>
    <Function test_swapn_stack_underflow[fork_Osaka-state_test_from_eof_test-stack_height_0]>
    <Function test_swapn_stack_underflow[fork_Osaka-state_test_from_eof_test-stack_height_1]>
    <Function test_swapn_stack_underflow[fork_Osaka-state_test_from_eof_test-stack_height_21]>
    <Function test_swapn_stack_underflow[fork_Osaka-state_test_from_eof_test-stack_height_255]>
```

But using `-m state_test_from_eof_test` will only select state tests that have been automatically generated from an EOF test:

```
collected 28 items / 23 deselected / 5 selected

<Package eip663_dupn_swapn_exchange>
  <Module test_swapn.py>
    <Function test_swapn_on_max_stack[fork_Osaka-state_test_from_eof_test-swapn_operand_0]>
    <Function test_swapn_on_max_stack[fork_Osaka-state_test_from_eof_test-swapn_operand_255]>
    <Function test_swapn_stack_underflow[fork_Osaka-state_test_from_eof_test-stack_height_0]>
    <Function test_swapn_stack_underflow[fork_Osaka-state_test_from_eof_test-stack_height_1]>
    <Function test_swapn_stack_underflow[fork_Osaka-state_test_from_eof_test-stack_height_21]>
    <Function test_swapn_stack_underflow[fork_Osaka-state_test_from_eof_test-stack_height_255]>
```

Using `-m eof_test` will still produce the exact same tests as before.

### - `eof_test` executable in live networks

This change allows the `uv run execute` command to send EOF initcode transactions to live networks by using the same methodology described in the previous section.

The marker `transaction_post_from_eof_test` will in this case send only EOF container validation tests to the live network:

```
collected 7 items / 2 deselected / 5 selected

<Package eip663_dupn_swapn_exchange>
  <Module test_swapn.py>
    <Function test_swapn_on_max_stack[fork_Osaka-transaction_post_from_eof_test-swapn_operand_0]>
    <Function test_swapn_on_max_stack[fork_Osaka-transaction_post_from_eof_test-swapn_operand_255]>
    <Function test_swapn_stack_underflow[fork_Osaka-transaction_post_from_eof_test-stack_height_0]>
    <Function test_swapn_stack_underflow[fork_Osaka-transaction_post_from_eof_test-stack_height_1]>
    <Function test_swapn_stack_underflow[fork_Osaka-transaction_post_from_eof_test-stack_height_21]>
    <Function test_swapn_stack_underflow[fork_Osaka-transaction_post_from_eof_test-stack_height_255]>
```

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
