### PR TITLE
fix(fw): DATALOAD pushed_stack_items

### DIFF
--- a/src/ethereum_test_vm/opcode.py
+++ b/src/ethereum_test_vm/opcode.py
@@ -4704,7 +4704,7 @@ class Opcodes(Opcode, Enum):
     Source: [eips.ethereum.org/EIPS/eip-4200](https://eips.ethereum.org/EIPS/eip-4200)
     """
 
-    DATALOAD = Opcode(0xD0, popped_stack_items=1, kwargs=["offset"])
+    DATALOAD = Opcode(0xD0, popped_stack_items=1, pushed_stack_items=1, kwargs=["offset"])
     """
     !!! Note: This opcode is under development
 


### PR DESCRIPTION
## 🗒️ Description

DATALOAD pushes an item, same as RETURNDATALOAD and CALLDATALOAD, not sure why I missed this when doing the recent DATALOADN fix. I think now the 4 data opcodes are ok

I noticed this after getting deep into the `Bytecode.__add__` algorithm for calculating max stack height. I have a case which it seems to be mishandling (no jumps or callfs!), but I have so far been unable to fix the algorithm. If I give up, I'll just post an issue to reproduce the problematic case.

## 🔗 Related Issues

NA 

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
