### PR TITLE
new(tests): EOF - EIP-7620 EOFCREATE gas testing

### DIFF
--- a/tests/prague/eip7692_eof_v1/eip7069_extcall/helpers.py
+++ b/tests/prague/eip7692_eof_v1/eip7069_extcall/helpers.py
@@ -16,10 +16,6 @@ slot_delegate_code_worked = next(_slot)
 slot_call_status = next(_slot)
 slot_calldata_1 = next(_slot)
 slot_calldata_2 = next(_slot)
-slot_cold_gas = next(_slot)
-slot_warm_gas = next(_slot)
-slot_oog_call_result = next(_slot)
-slot_sanity_call_result = next(_slot)
 
 slot_last_slot = next(_slot)
 
@@ -28,8 +24,6 @@ value_exceptional_abort_canary = 0x1984
 
 """Storage values for common testing fields"""
 value_code_worked = 0x2015
-value_call_legacy_abort = 0
-value_call_legacy_success = 1
 
 """Memory and storage value for calldata"""
 value_calldata_1 = 0xC1C1C1C1C1C1C1C1C1C1C1C1C1C1C1C1C1C1C1C1C1C1C1C1C1C1C1C1C1C1C1C1

--- a/tests/prague/eip7692_eof_v1/eip7069_extcall/test_gas.py
+++ b/tests/prague/eip7692_eof_v1/eip7069_extcall/test_gas.py
@@ -5,21 +5,13 @@ abstract: Tests [EIP-7069: Revamped CALL instructions](https://eips.ethereum.org
 
 import pytest
 
-from ethereum_test_tools import Account, Alloc, Environment, StateTestFiller, Transaction
+from ethereum_test_tools import Alloc, Environment, StateTestFiller
 from ethereum_test_tools.eof.v1 import Container
 from ethereum_test_tools.vm.opcode import Opcodes as Op
-from ethereum_test_vm import Bytecode, EVMCodeType
 
 from .. import EOF_FORK_NAME
+from ..gas_test import gas_test
 from . import REFERENCE_SPEC_GIT_PATH, REFERENCE_SPEC_VERSION
-from .helpers import (
-    slot_cold_gas,
-    slot_oog_call_result,
-    slot_sanity_call_result,
-    slot_warm_gas,
-    value_call_legacy_abort,
-    value_call_legacy_success,
-)
 
 REFERENCE_SPEC_GIT_PATH = REFERENCE_SPEC_GIT_PATH
 REFERENCE_SPEC_VERSION = REFERENCE_SPEC_VERSION
@@ -43,112 +35,6 @@ def state_env() -> Environment:
     is not decreased by the target.
     """
     return Environment()
-
-
-def gas_test(
-    state_test: StateTestFiller,
-    env: Environment,
-    pre: Alloc,
-    setup_code: Bytecode,
-    subject_code: Bytecode,
-    tear_down_code: Bytecode,
-    cold_gas: int,
-    warm_gas: int | None = None,
-):
-    """
-    Creates a State Test to check the gas cost of a sequence of EOF code.
-
-    `setup_code` and `tear_down_code` are called multiple times during the test, and MUST NOT have
-    any side-effects which persist across message calls, and in particular, any effects on the gas
-    usage of `subject_code`.
-    """
-    if cold_gas <= 0:
-        raise ValueError(f"Target gas allocations (cold_gas) must be > 0, got {cold_gas}")
-    if warm_gas is None:
-        warm_gas = cold_gas
-
-    sender = pre.fund_eoa()
-
-    address_baseline = pre.deploy_contract(Container.Code(setup_code + tear_down_code))
-    address_subject = pre.deploy_contract(
-        Container.Code(setup_code + subject_code + tear_down_code)
-    )
-    # 2 times GAS, POP, CALL, 6 times PUSH1 - instructions charged for at every gas run
-    gas_single_gas_run = 2 * 2 + 2 + WARM_ACCOUNT_ACCESS_GAS + 6 * 3
-    address_legacy_harness = pre.deploy_contract(
-        code=(
-            # warm subject and baseline without executing
-            (Op.BALANCE(address_subject) + Op.POP + Op.BALANCE(address_baseline) + Op.POP)
-            # Baseline gas run
-            + (
-                Op.GAS
-                + Op.CALL(address=address_baseline, gas=Op.GAS)
-                + Op.POP
-                + Op.GAS
-                + Op.SWAP1
-                + Op.SUB
-            )
-            # cold gas run
-            + (
-                Op.GAS
-                + Op.CALL(address=address_subject, gas=Op.GAS)
-                + Op.POP
-                + Op.GAS
-                + Op.SWAP1
-                + Op.SUB
-            )
-            # warm gas run
-            + (
-                Op.GAS
-                + Op.CALL(address=address_subject, gas=Op.GAS)
-                + Op.POP
-                + Op.GAS
-                + Op.SWAP1
-                + Op.SUB
-            )
-            # Store warm gas: DUP3 is the gas of the baseline gas run
-            + (Op.DUP3 + Op.SWAP1 + Op.SUB + Op.PUSH2(slot_warm_gas) + Op.SSTORE)
-            # store cold gas: DUP2 is the gas of the baseline gas run
-            + (Op.DUP2 + Op.SWAP1 + Op.SUB + Op.PUSH2(slot_cold_gas) + Op.SSTORE)
-            # oog gas run:
-            # - DUP7 is the gas of the baseline gas run, after other CALL args were pushed
-            # - subtract the gas charged by the harness
-            # - add warm gas charged by the subject
-            # - subtract 1 to cause OOG exception
-            + Op.SSTORE(
-                slot_oog_call_result,
-                Op.CALL(
-                    gas=Op.ADD(warm_gas - gas_single_gas_run - 1, Op.DUP7),
-                    address=address_subject,
-                ),
-            )
-            # sanity gas run: not subtracting 1 to see if enough gas makes the call succeed
-            + Op.SSTORE(
-                slot_sanity_call_result,
-                Op.CALL(
-                    gas=Op.ADD(warm_gas - gas_single_gas_run, Op.DUP7),
-                    address=address_subject,
-                ),
-            )
-            + Op.STOP
-        ),
-        evm_code_type=EVMCodeType.LEGACY,  # Needs to be legacy to use GAS opcode
-    )
-
-    post = {
-        address_legacy_harness: Account(
-            storage={
-                slot_warm_gas: warm_gas,
-                slot_cold_gas: cold_gas,
-                slot_oog_call_result: value_call_legacy_abort,
-                slot_sanity_call_result: value_call_legacy_success,
-            },
-        ),
-    }
-
-    tx = Transaction(to=address_legacy_harness, gas_limit=env.gas_limit, sender=sender)
-
-    state_test(env=env, pre=pre, tx=tx, post=post)
 
 
 @pytest.mark.parametrize(

--- a/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_gas.py
+++ b/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_gas.py
@@ -37,19 +37,6 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
 EOFCREATE_GAS = 32000
 
 
-def make_initcode(runtime: Container):
-    """
-    Wraps a runtime container into a minimal initcontainer
-    """
-    return Container(
-        name="Initcode Subcontainer",
-        sections=[
-            Section.Code(code=Op.RETURNCONTRACT[0](0, 0)),
-            Section.Container(container=runtime),
-        ],
-    )
-
-
 def make_factory(initcode: Container):
     """
     Wraps an initcontainer into a minimal runtime container
@@ -106,7 +93,7 @@ def make_factory(initcode: Container):
             id="smallest_code",
         ),
         pytest.param(
-            make_initcode(aborting_container),
+            Container.Init(aborting_container),
             smallest_initcode_subcontainer_gas,
             aborting_container,
             id="aborting_runtime",
@@ -121,13 +108,13 @@ def make_factory(initcode: Container):
             id="expensively_reverting_initcode",
         ),
         pytest.param(
-            make_initcode(big_runtime_subcontainer),
+            Container.Init(big_runtime_subcontainer),
             smallest_initcode_subcontainer_gas,
             big_runtime_subcontainer,
             id="big_runtime",
         ),
         pytest.param(
-            make_initcode(make_factory(smallest_initcode_subcontainer)),
+            Container.Init(make_factory(smallest_initcode_subcontainer)),
             smallest_initcode_subcontainer_gas,
             make_factory(smallest_initcode_subcontainer),
             id="nested_initcode",

--- a/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_gas.py
+++ b/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_gas.py
@@ -197,7 +197,7 @@ def test_eofcreate_gas(
         + initcode_execution_cost
         + deployed_code_cost,
         subject_subcontainer=initcode,
-        subject_balance=10**18,
+        subject_balance=value * 4,
         subject_address=subject_address,
         oog_difference=initcode_execution_cost + deployed_code_cost + 1,
     )

--- a/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_gas.py
+++ b/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_gas.py
@@ -1,0 +1,208 @@
+"""
+Test good and bad EOFCREATE cases
+"""
+
+import pytest
+
+from ethereum_test_tools import Alloc, Environment, StateTestFiller, compute_eofcreate_address
+from ethereum_test_tools.eof.v1 import Container, Section
+from ethereum_test_tools.vm.opcode import Opcodes as Op
+
+from .. import EOF_FORK_NAME
+from ..gas_test import gas_test
+from .helpers import (
+    aborting_container,
+    big_runtime_subcontainer,
+    bigger_initcode_subcontainer,
+    bigger_initcode_subcontainer_gas,
+    data_appending_initcode_subcontainer,
+    data_appending_initcode_subcontainer_gas,
+    data_initcode_subcontainer,
+    data_runtime_container,
+    expensively_reverting_container,
+    expensively_reverting_container_gas,
+    reverting_container,
+    slot_counter,
+    smallest_initcode_subcontainer,
+    smallest_initcode_subcontainer_gas,
+    smallest_runtime_subcontainer,
+)
+
+REFERENCE_SPEC_GIT_PATH = "EIPS/eip-7620.md"
+REFERENCE_SPEC_VERSION = "52ddbcdddcf72dd72427c319f2beddeb468e1737"
+
+pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
+
+EOFCREATE_GAS = 32000
+
+
+def make_initcode(runtime: Container):
+    """
+    Wraps a runtime container into a minimal initcontainer
+    """
+    return Container(
+        name="Initcode Subcontainer",
+        sections=[
+            Section.Code(code=Op.RETURNCONTRACT[0](0, 0)),
+            Section.Container(container=runtime),
+        ],
+    )
+
+
+def make_factory(initcode: Container):
+    """
+    Wraps an initcontainer into a minimal runtime container
+    """
+    return Container(
+        name="Factory Subcontainer",
+        sections=[
+            Section.Code(Op.EOFCREATE[0](0, 0, 0, 0) + Op.STOP),
+            Section.Container(initcode),
+        ],
+    )
+
+
+@pytest.mark.parametrize(
+    ["cold_gas", "value", "new_account"],
+    [
+        pytest.param(
+            EOFCREATE_GAS,
+            0,
+            False,
+            id="EOFCREATE",
+        ),
+        pytest.param(
+            EOFCREATE_GAS,
+            1,
+            False,
+            id="EOFCREATE_with_value",
+        ),
+        pytest.param(
+            EOFCREATE_GAS,
+            0,
+            True,
+            id="EOFCREATE_new_acc",
+        ),
+        pytest.param(
+            EOFCREATE_GAS,
+            1,
+            True,
+            id="EOFCREATE_with_value_new_acc",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    ["mem_expansion_size", "mem_expansion_extra_gas"],
+    [
+        pytest.param(0, 0, id="no_mem_expansion"),
+        pytest.param(1, 3, id="1byte_mem_expansion"),
+        pytest.param(32, 3, id="1word_mem_expansion"),
+        pytest.param(33, 6, id="33bytes_mem_expansion"),
+    ],
+)
+@pytest.mark.parametrize(
+    ["initcode", "initcode_execution_cost", "runtime"],
+    [
+        pytest.param(
+            smallest_initcode_subcontainer,
+            smallest_initcode_subcontainer_gas,
+            smallest_runtime_subcontainer,
+            id="smallest_code",
+        ),
+        pytest.param(
+            make_initcode(aborting_container),
+            smallest_initcode_subcontainer_gas,
+            aborting_container,
+            id="aborting_runtime",
+        ),
+        pytest.param(
+            reverting_container, smallest_initcode_subcontainer_gas, None, id="reverting_initcode"
+        ),
+        pytest.param(
+            expensively_reverting_container,
+            expensively_reverting_container_gas,
+            None,
+            id="expensively_reverting_initcode",
+        ),
+        pytest.param(
+            make_initcode(big_runtime_subcontainer),
+            smallest_initcode_subcontainer_gas,
+            big_runtime_subcontainer,
+            id="big_runtime",
+        ),
+        pytest.param(
+            make_initcode(make_factory(smallest_initcode_subcontainer)),
+            smallest_initcode_subcontainer_gas,
+            make_factory(smallest_initcode_subcontainer),
+            id="nested_initcode",
+        ),
+        pytest.param(
+            bigger_initcode_subcontainer,
+            bigger_initcode_subcontainer_gas,
+            smallest_runtime_subcontainer,
+            id="bigger_initcode",
+        ),
+        pytest.param(
+            data_initcode_subcontainer,
+            smallest_initcode_subcontainer_gas,
+            data_runtime_container,
+            id="data_initcode",
+        ),
+        pytest.param(
+            data_appending_initcode_subcontainer,
+            data_appending_initcode_subcontainer_gas,
+            data_runtime_container,
+            id="data_appending_initcode",
+        ),
+    ],
+)
+def test_eofcreate_gas(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    cold_gas: int,
+    value: int,
+    new_account: bool,
+    mem_expansion_size: int,
+    mem_expansion_extra_gas: int,
+    initcode: Container,
+    initcode_execution_cost: int,
+    runtime: Container,
+):
+    """Tests variations of EOFCREATE gas"""
+    initcode_hashing_cost = 6 * ((len(initcode) + 31) // 32)
+    deployed_code_cost = 200 * len(runtime) if runtime else 0
+
+    sender = pre.fund_eoa()
+
+    salt_addresses = [compute_eofcreate_address(sender, i, initcode) for i in range(10)]
+
+    if not new_account:
+        for a in salt_addresses:
+            pre.fund_address(a, 1)
+
+    # Using `TLOAD` / `TSTORE` to work around warm/cold gas differences. We need a counter to pick
+    # a distinct salt on each `EOFCREATE` and avoid running into address conflicts.
+    code_increment_counter = (
+        Op.TLOAD(slot_counter) + Op.DUP1 + Op.TSTORE(slot_counter, Op.PUSH1(1) + Op.ADD)
+    )
+
+    gas_test(
+        state_test,
+        Environment(),
+        pre,
+        setup_code=Op.PUSH1(mem_expansion_size)
+        + Op.PUSH0
+        + code_increment_counter
+        + Op.PUSH32(value),
+        subject_code=Op.EOFCREATE[0],
+        tear_down_code=Op.STOP,
+        cold_gas=cold_gas
+        + mem_expansion_extra_gas
+        + initcode_hashing_cost
+        + initcode_execution_cost
+        + deployed_code_cost,
+        subject_subcontainer=initcode,
+        sender=sender,
+        subject_balance=10**18,
+        oog_difference=initcode_execution_cost + deployed_code_cost + 1,
+    )

--- a/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_gas.py
+++ b/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_gas.py
@@ -50,35 +50,8 @@ def make_factory(initcode: Container):
     )
 
 
-@pytest.mark.parametrize(
-    ["cold_gas", "value", "new_account"],
-    [
-        pytest.param(
-            EOFCREATE_GAS,
-            0,
-            False,
-            id="EOFCREATE",
-        ),
-        pytest.param(
-            EOFCREATE_GAS,
-            1,
-            False,
-            id="EOFCREATE_with_value",
-        ),
-        pytest.param(
-            EOFCREATE_GAS,
-            0,
-            True,
-            id="EOFCREATE_new_acc",
-        ),
-        pytest.param(
-            EOFCREATE_GAS,
-            1,
-            True,
-            id="EOFCREATE_with_value_new_acc",
-        ),
-    ],
-)
+@pytest.mark.parametrize("value", [0, 1])
+@pytest.mark.parametrize("new_account", [True, False])
 @pytest.mark.parametrize(
     "mem_expansion_bytes",
     [0, 1, 32, 33],
@@ -142,7 +115,6 @@ def make_factory(initcode: Container):
 def test_eofcreate_gas(
     state_test: StateTestFiller,
     pre: Alloc,
-    cold_gas: int,
     value: int,
     new_account: bool,
     mem_expansion_bytes: int,
@@ -178,7 +150,7 @@ def test_eofcreate_gas(
         + Op.PUSH32(value),
         subject_code=Op.EOFCREATE[0],
         tear_down_code=Op.STOP,
-        cold_gas=cold_gas
+        cold_gas=EOFCREATE_GAS
         + cost_memory_bytes(mem_expansion_bytes, 0)
         + initcode_hashing_cost
         + initcode_execution_cost

--- a/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_gas.py
+++ b/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_gas.py
@@ -167,9 +167,9 @@ def test_eofcreate_gas(
     initcode_hashing_cost = 6 * ((len(initcode) + 31) // 32)
     deployed_code_cost = 200 * len(runtime) if runtime else 0
 
-    sender = pre.fund_eoa()
+    subject_address = pre.fund_eoa(0)
 
-    salt_addresses = [compute_eofcreate_address(sender, i, initcode) for i in range(10)]
+    salt_addresses = [compute_eofcreate_address(subject_address, i, initcode) for i in range(4)]
 
     if not new_account:
         for a in salt_addresses:
@@ -197,7 +197,7 @@ def test_eofcreate_gas(
         + initcode_execution_cost
         + deployed_code_cost,
         subject_subcontainer=initcode,
-        sender=sender,
         subject_balance=10**18,
+        subject_address=subject_address,
         oog_difference=initcode_execution_cost + deployed_code_cost + 1,
     )

--- a/tests/prague/eip7692_eof_v1/gas_test.py
+++ b/tests/prague/eip7692_eof_v1/gas_test.py
@@ -4,11 +4,11 @@ Test cases for all EIPs mentioned in the EOF V1 meta-EIP.
 
 import itertools
 
+from ethereum_test_base_types.base_types import Address
 from ethereum_test_tools import Account, Alloc, Environment, StateTestFiller, Transaction
 from ethereum_test_tools.eof.v1 import Container
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 from ethereum_test_types.eof.v1 import Section
-from ethereum_test_types.types import EOA
 from ethereum_test_vm import Bytecode, EVMCodeType
 
 WARM_ACCOUNT_ACCESS_GAS = 100
@@ -33,7 +33,7 @@ def gas_test(
     cold_gas: int,
     warm_gas: int | None = None,
     subject_subcontainer: Container | None = None,
-    sender: EOA | None = None,
+    subject_address: Address | None = None,
     subject_balance: int = 0,
     oog_difference: int = 1,
 ):
@@ -49,8 +49,7 @@ def gas_test(
     if warm_gas is None:
         warm_gas = cold_gas
 
-    if not sender:
-        sender = pre.fund_eoa()
+    sender = pre.fund_eoa()
 
     address_baseline = pre.deploy_contract(Container.Code(setup_code + tear_down_code))
     code_subject = setup_code + subject_code + tear_down_code
@@ -64,6 +63,7 @@ def gas_test(
             ]
         ),
         balance=subject_balance,
+        address=subject_address,
     )
     # 2 times GAS, POP, CALL, 6 times PUSH1 - instructions charged for at every gas run
     gas_single_gas_run = 2 * 2 + 2 + WARM_ACCOUNT_ACCESS_GAS + 6 * 3

--- a/tests/prague/eip7692_eof_v1/gas_test.py
+++ b/tests/prague/eip7692_eof_v1/gas_test.py
@@ -1,0 +1,143 @@
+"""
+Test cases for all EIPs mentioned in the EOF V1 meta-EIP.
+"""
+
+import itertools
+
+from ethereum_test_tools import Account, Alloc, Environment, StateTestFiller, Transaction
+from ethereum_test_tools.eof.v1 import Container
+from ethereum_test_tools.vm.opcode import Opcodes as Op
+from ethereum_test_types.eof.v1 import Section
+from ethereum_test_types.types import EOA
+from ethereum_test_vm import Bytecode, EVMCodeType
+
+WARM_ACCOUNT_ACCESS_GAS = 100
+
+"""Storage addresses for common testing fields"""
+_slot = itertools.count()
+slot_cold_gas = next(_slot)
+slot_warm_gas = next(_slot)
+slot_oog_call_result = next(_slot)
+slot_sanity_call_result = next(_slot)
+value_call_legacy_abort = 0
+value_call_legacy_success = 1
+
+
+def gas_test(
+    state_test: StateTestFiller,
+    env: Environment,
+    pre: Alloc,
+    setup_code: Bytecode,
+    subject_code: Bytecode,
+    tear_down_code: Bytecode,
+    cold_gas: int,
+    warm_gas: int | None = None,
+    subject_subcontainer: Container | None = None,
+    sender: EOA | None = None,
+    subject_balance: int = 0,
+    oog_difference: int = 1,
+):
+    """
+    Creates a State Test to check the gas cost of a sequence of EOF code.
+
+    `setup_code` and `tear_down_code` are called multiple times during the test, and MUST NOT have
+    any side-effects which persist across message calls, and in particular, any effects on the gas
+    usage of `subject_code`.
+    """
+    if cold_gas <= 0:
+        raise ValueError(f"Target gas allocations (cold_gas) must be > 0, got {cold_gas}")
+    if warm_gas is None:
+        warm_gas = cold_gas
+
+    if not sender:
+        sender = pre.fund_eoa()
+
+    address_baseline = pre.deploy_contract(Container.Code(setup_code + tear_down_code))
+    code_subject = setup_code + subject_code + tear_down_code
+    address_subject = pre.deploy_contract(
+        Container.Code(code_subject)
+        if not subject_subcontainer
+        else Container(
+            sections=[
+                Section.Code(code_subject),
+                Section.Container(subject_subcontainer),
+            ]
+        ),
+        balance=subject_balance,
+    )
+    # 2 times GAS, POP, CALL, 6 times PUSH1 - instructions charged for at every gas run
+    gas_single_gas_run = 2 * 2 + 2 + WARM_ACCOUNT_ACCESS_GAS + 6 * 3
+    address_legacy_harness = pre.deploy_contract(
+        code=(
+            # warm subject and baseline without executing
+            (Op.BALANCE(address_subject) + Op.POP + Op.BALANCE(address_baseline) + Op.POP)
+            # Baseline gas run
+            + (
+                Op.GAS
+                + Op.CALL(address=address_baseline, gas=Op.GAS)
+                + Op.POP
+                + Op.GAS
+                + Op.SWAP1
+                + Op.SUB
+            )
+            # cold gas run
+            + (
+                Op.GAS
+                + Op.CALL(address=address_subject, gas=Op.GAS)
+                + Op.POP
+                + Op.GAS
+                + Op.SWAP1
+                + Op.SUB
+            )
+            # warm gas run
+            + (
+                Op.GAS
+                + Op.CALL(address=address_subject, gas=Op.GAS)
+                + Op.POP
+                + Op.GAS
+                + Op.SWAP1
+                + Op.SUB
+            )
+            # Store warm gas: DUP3 is the gas of the baseline gas run
+            + (Op.DUP3 + Op.SWAP1 + Op.SUB + Op.PUSH2(slot_warm_gas) + Op.SSTORE)
+            # store cold gas: DUP2 is the gas of the baseline gas run
+            + (Op.DUP2 + Op.SWAP1 + Op.SUB + Op.PUSH2(slot_cold_gas) + Op.SSTORE)
+            # oog gas run:
+            # - DUP7 is the gas of the baseline gas run, after other CALL args were pushed
+            # - subtract the gas charged by the harness
+            # - add warm gas charged by the subject
+            # - subtract `oog_difference` to cause OOG exception (1 by default)
+            + Op.SSTORE(
+                slot_oog_call_result,
+                Op.CALL(
+                    gas=Op.ADD(warm_gas - gas_single_gas_run - oog_difference, Op.DUP7),
+                    address=address_subject,
+                ),
+            )
+            # sanity gas run: not subtracting 1 to see if enough gas makes the call succeed
+            + Op.SSTORE(
+                slot_sanity_call_result,
+                Op.CALL(
+                    gas=Op.ADD(warm_gas - gas_single_gas_run, Op.DUP7),
+                    address=address_subject,
+                ),
+            )
+            + Op.STOP
+        ),
+        evm_code_type=EVMCodeType.LEGACY,  # Needs to be legacy to use GAS opcode
+    )
+
+    post = {
+        address_legacy_harness: Account(
+            storage={
+                slot_warm_gas: warm_gas,
+                slot_cold_gas: cold_gas,
+                slot_oog_call_result: value_call_legacy_abort,
+                slot_sanity_call_result: value_call_legacy_success,
+            },
+        ),
+    }
+
+    tx = Transaction(to=address_legacy_harness, gas_limit=env.gas_limit, sender=sender)
+
+    state_test(env=env, pre=pre, tx=tx, post=post)

--- a/tests/prague/eip7692_eof_v1/gas_test.py
+++ b/tests/prague/eip7692_eof_v1/gas_test.py
@@ -1,5 +1,5 @@
 """
-Test cases for all EIPs mentioned in the EOF V1 meta-EIP.
+Utility to generate gas usage related state tests automatically.
 """
 
 import itertools


### PR DESCRIPTION
## 🗒️ Description

EOFCREATE gas testing using the "Op.GAS harness" used in #771.

~I'm pushing early to signal the [fix(fw): max stack height calculation in `__add__`](https://github.com/ethereum/execution-spec-tests/commit/acee5dab6abac2c8293d3951b5a8613ecf0e0729). The new bytecodes used in the new tests didn't have the correct autocalculated max stack height. After some digging, I've noticed that the algorithm might not handle all cases well, and I am proposing an alternative. I've left all my overly verbose comments in the code to illustrate the train of thought, as this has been quite hard to grasp the original code intentions (maybe there has been an easier fix hidden from my sight there).~ EDIT: the max stack height fix split out to https://github.com/ethereum/execution-spec-tests/pull/810, merge 810 first

Apart from that the EOFCREATE test reveals some difficulties related to the harness, and how the harness needs to be generalized to test such instructions. However, since the difficulties are related to satisfying the requirements of subject code (the EOFCREATE in question here has many), I suppose these difficulties would be present in all gas testing approaches.

## 🔗 Related Issues

Addresses the last remaining item off of the list https://github.com/ipsilon/eof/pull/138.

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
