### PR TITLE
chore(ci): remove redundant tests for fixture releases.

### DIFF
--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -1,10 +1,14 @@
+legacy:
+  evm-type: stable
+  fill-params: --until=Shanghai
+  solc: 0.8.21
 stable:
   evm-type: stable
-  fill-params: ''
+  fill-params: --fork=Cancun
   solc: 0.8.21
 develop:
   evm-type: develop
-  fill-params: --until=Prague
+  fill-params: --from=Cancun --until=Prague
   solc: 0.8.21
 eip7692:
   evm-type: eip7692

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -45,11 +45,11 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Feature releases can now include multiple types of fixture tarball files from different releases that start with the same prefix ([#736](https://github.com/ethereum/execution-spec-tests/pull/736)).
 - ✨ Releases for feature eip7692 now include both Cancun and Prague based tests in the same release, in files `fixtures_eip7692.tar.gz` and `fixtures_eip7692-prague.tar.gz` respectively ([#743](https://github.com/ethereum/execution-spec-tests/pull/743)).
 - 🔀 Simplify Python project configuration and consolidate it into `pyproject.toml` ([#764](https://github.com/ethereum/execution-spec-tests/pull/764)).
-- ✨ Remove redundant tests within stable and develop fixture releases, moving them to a separate legacy release ([#788](https://github.com/ethereum/execution-spec-tests/pull/788)).
 
 ### 💥 Breaking Change
 
 - The EOF fixture format contained in `eof_tests` may now contain multiple exceptions in the `"exception"` field in the form of a pipe (`|`) separated string ([#759](https://github.com/ethereum/execution-spec-tests/pull/759)).
+- Remove redundant tests within stable and develop fixture releases, moving them to a separate legacy release ([#788](https://github.com/ethereum/execution-spec-tests/pull/788)).
 
 ## [v3.0.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v3.0.0) - 2024-07-22
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -45,6 +45,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Feature releases can now include multiple types of fixture tarball files from different releases that start with the same prefix ([#736](https://github.com/ethereum/execution-spec-tests/pull/736)).
 - ✨ Releases for feature eip7692 now include both Cancun and Prague based tests in the same release, in files `fixtures_eip7692.tar.gz` and `fixtures_eip7692-prague.tar.gz` respectively ([#743](https://github.com/ethereum/execution-spec-tests/pull/743)).
 - 🔀 Simplify Python project configuration and consolidate it into `pyproject.toml` ([#764](https://github.com/ethereum/execution-spec-tests/pull/764)).
+- ✨ Remove redundant tests within stable and develop fixture releases, moving them to a separate legacy release ([#788](https://github.com/ethereum/execution-spec-tests/pull/788)).
 
 ### 💥 Breaking Change
 


### PR DESCRIPTION
## 🗒️ Description
This PR aims to reduce the number of tests in our fixture releases. Where the new strategy includes the following:
- `fixtures_stable`: contains mainnet so only Cancun.
- `fixtures_develop`: contains mainnet plus Prague.
- `fixtures_legacy`: contains all forks pre-mainnet.

The mainnet, development and legacy fork variables within `feature.yaml` can be updated to reflect these changes in the future.

Tox should still fill all tests for all forks to assert the framework is not broken.

## 🔗 Related Issues
N/A

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
