### PR TITLE
feat(coverage): Enable coverage on any test change (rebased with uv)

### DIFF
--- a/.github/actions/build-evm-client/evmone/action.yaml
+++ b/.github/actions/build-evm-client/evmone/action.yaml
@@ -9,6 +9,10 @@ inputs:
     description: 'Reference to branch, commit, or tag to use to build the EVM binary'
     required: true
     default: 'master'
+  targets:
+    description: 'Which targets to build from evmone repo'
+    required: false
+    default: 'all'
 runs:
   using: "composite"
   steps:
@@ -27,5 +31,5 @@ runs:
         mkdir -p $GITHUB_WORKSPACE/bin
         cd $GITHUB_WORKSPACE/evmone
         cmake -S . -B build -DEVMONE_TESTING=ON
-        cmake --build build --parallel
+        cmake --build build --parallel --target ${{ inputs.targets }}
         echo $GITHUB_WORKSPACE/evmone/build/bin/ >> $GITHUB_PATH

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -8,9 +8,6 @@ on:
 jobs:
   evmone-coverage-diff:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        driver: [retesteth, native]
 
     steps:
       - name: Checkout code
@@ -28,6 +25,8 @@ jobs:
         with:
           # TODO: non-test modules such as __init__.py or spec.py could effect coverage - in this case we should
           # fill all applicable tests (i.e., all the test_*.py files in or under the changed module's directory)
+          include_all_old_new_renamed_files: true
+          output_renamed_files_as_deleted_and_added: true
           files_yaml: |
             tests:
               - tests/**/test_*.py
@@ -43,7 +42,8 @@ jobs:
       - name: Report changed python test moudules
         if: steps.changed-tests.outputs.tests_any_changed == 'true'
         run: |
-          echo "Changed python test modules: ${{ steps.changed-tests.outputs.tests_all_changed_files }}"
+          echo "${{ toJson(steps.changed-tests.outputs) }}"
+          echo "Changed python test modules: ${{ steps.changed-tests.outputs.tests_all_modified_files }}"
 
       - name: Debug GitHub context
         run: |
@@ -159,7 +159,7 @@ jobs:
 
       # This command diffs the .py scripts introduced by a PR
       - name: Parse and fill introduced test sources
-        if: steps.changed-tests.outputs.tests_any_changed == 'true'      
+        if: steps.changed-tests.outputs.tests_any_changed == 'true'
         env:
           CHANGED_TEST_FILES: ${{ steps.changed-tests.outputs.tests_all_changed_files }}
         run: |
@@ -171,23 +171,12 @@ jobs:
           mkdir -p fixtures/state_tests
           mkdir -p fixtures/eof_tests
 
-          # Use a while loop with a here-string to avoid subshell issues
-          while IFS= read -r file; do
-            echo "Fill: $file"
-            uv run fill "$file" --until=Cancun --evm-bin evmone-t8n || true >> filloutput.log 2>&1
-            (uv run fill "$file" --fork=CancunEIP7692 --evm-bin evmone-t8n -k eof_test || true) > >(tee -a filloutput.log filloutputEOF.log) 2>&1
-          done <<< "$files"
+          uv run fill $files --until=Cancun --evm-bin evmone-t8n || true >> filloutput.log 2>&1
+          (uv run fill $files --fork=PragueEIP7692 --evm-bin evmone-t8n || true) > >(tee -a filloutput.log filloutputEOF.log) 2>&1
 
           if grep -q "FAILURES" filloutput.log; then
               echo "Error: failed to generate .py tests."
               exit 1
-          fi
-          if [ "${{ matrix.driver }}" = "retesteth" ] && grep -q "passed" filloutputEOF.log; then
-              echo "Disabling retesteth coverage check as EOF tests detected!"
-              echo "retesteth_skip=true" >> $GITHUB_ENV
-              exit 0
-          else
-              echo "retesteth_skip=false" >> $GITHUB_ENV
           fi
 
           filesState=$(find fixtures/state_tests -type f -name "*.json")
@@ -207,18 +196,29 @@ jobs:
           find fixtures/eof_tests -type f -name "*.json" -exec cp {} $PATCH_TEST_PATH \;
 
       - name: Parse and fill introduced test sources from before the PR
-        if: ${{ steps.changed-tests.outputs.tests_any_changed == 'true' && (env.retesteth_skip == 'false' || matrix.driver == 'native') && env.converted_skip == 'true' }}
+        if: ${{ steps.changed-tests.outputs.tests_any_changed == 'true' && env.converted_skip == 'true' }}
+        env:
+          CHANGED_TEST_FILES: ${{ steps.changed-tests.outputs.tests_all_modified_files }}
         run: |
             echo "--------------------"
             echo "converted-ethereum-tests.txt seem untouched, try to fill pre-patched version of .py files:"
 
-            # load introduces .py files
             source $GITHUB_ENV
-            files=$(echo "$NEW_TESTS" | tr ',' '\n')
+            files=$(echo "$CHANGED_TEST_FILES" | tr ',' '\n')
 
             git checkout main
             PREV_COMMIT=$(git rev-parse HEAD)
             echo "Checkout head $PREV_COMMIT"
+
+            # Take only those files that exist in the filesystem (ignore newly created files)
+            files_fixed=$(echo "$files" | tr ' ' '\n' | while read file; do
+              if [ -f "$file" ]; then
+                echo "$file"
+              fi
+            done | tr '\n' ' ')
+
+            echo "Select files that were changed and exist on the main branch:"
+            echo $files_fixed
 
             rm -r fixtures
             rm filloutput.log
@@ -226,14 +226,15 @@ jobs:
             mkdir -p fixtures/state_tests
             mkdir -p fixtures/eof_tests
 
-            # Use a while loop with a here-string to avoid subshell issues
-            while IFS= read -r file; do
-            echo "Fill: $files"
-            uv run fill "$files" --until=Cancun --evm-bin evmone-t8n || true >> filloutput.log 2>&1
-            (uv run fill "$files" --fork=CancunEIP7692 --evm-bin evmone-t8n -k eof_test || true) >> (tee -a filloutput.log filloutputEOF.log) 2>&1
-            done <<< "$files"
+            uv run fill $files_fixed --until=Cancun --evm-bin evmone-t8n || true >> filloutput.log 2>&1
+            (uv run fill $files_fixed --fork=PragueEIP7692 --evm-bin evmone-t8n || true) > >(tee -a filloutput.log filloutputEOF.log) 2>&1
 
             if grep -q "FAILURES" filloutput.log; then
+              echo "Error: failed to generate .py tests from before the PR."
+              exit 1
+            fi
+
+            if grep -q "ERROR collecting test session" filloutput.log; then
               echo "Error: failed to generate .py tests from before the PR."
               exit 1
             fi
@@ -253,7 +254,7 @@ jobs:
 
 
       - name: Print tests that will be covered
-        if: ${{ steps.changed-tests.outputs.tests_any_changed == 'true' && (env.retesteth_skip == 'false' || matrix.driver == 'native') }}
+        if: ${{ steps.changed-tests.outputs.tests_any_changed == 'true' }}
         run: |
           echo "Original BASE tests:"
           ls ${{ github.workspace }}/evmtest_coverage/coverage/BASE_TESTS
@@ -263,44 +264,44 @@ jobs:
 
       - name: Run coverage of the BASE tests
         uses: addnab/docker-run-action@v3
-        if: ${{ steps.changed-tests.outputs.tests_any_changed == 'true' && (env.retesteth_skip == 'false' || matrix.driver == 'native') }}
+        if: ${{ steps.changed-tests.outputs.tests_any_changed == 'true' }}
         with:
           image: winsvega/evmone-coverage-script:latest
           options: -v ${{ github.workspace }}/evmtest_coverage/coverage:/tests
-          run: /entrypoint.sh --mode=cover --driver=${{ matrix.driver }} --testpath=/tests/BASE_TESTS --outputname=BASE
+          run: /entrypoint.sh --mode=cover --driver=native --testpath=/tests/BASE_TESTS --outputname=BASE
 
       - name: Run coverage of the PATCH tests
         uses: addnab/docker-run-action@v3
-        if: ${{ steps.changed-tests.outputs.tests_any_changed == 'true' && (env.retesteth_skip == 'false' || matrix.driver == 'native') }}
+        if: ${{ steps.changed-tests.outputs.tests_any_changed == 'true' }}
         with:
           image: winsvega/evmone-coverage-script:latest
           options: -v ${{ github.workspace }}/evmtest_coverage/coverage:/tests
-          run: /entrypoint.sh --mode=cover --driver=${{ matrix.driver }} --testpath=/tests/PATCH_TESTS --outputname=PATCH
+          run: /entrypoint.sh --mode=cover --driver=native --testpath=/tests/PATCH_TESTS --outputname=PATCH
 
       - name: Run coverage DIFF of the PATCH tests compared to BASE tests
         uses: addnab/docker-run-action@v3
-        if: ${{  steps.changed-tests.outputs.tests_any_changed == 'true' && (env.retesteth_skip == 'false' || matrix.driver == 'native') }}
+        if: ${{  steps.changed-tests.outputs.tests_any_changed == 'true' }}
         with:
           image: winsvega/evmone-coverage-script:latest
           options: -v ${{ github.workspace }}/evmtest_coverage/coverage:/tests
           run: /entrypoint.sh --mode=diff --basefile=coverage_BASE.lcov --patchfile=coverage_PATCH.lcov
 
       - name: Chmod coverage results
-        if: ${{ steps.changed-tests.outputs.tests_any_changed == 'true' && (env.retesteth_skip == 'false' || matrix.driver == 'native') }}
+        if: ${{ steps.changed-tests.outputs.tests_any_changed == 'true' }}
         run: |
           user=$(whoami)
           sudo chown -R $user:$user ${{ github.workspace }}/evmtest_coverage/coverage
 
       - name: Upload coverage results
         uses: actions/upload-artifact@v3
-        if: ${{ steps.changed-tests.outputs.tests_any_changed == 'true' && (env.retesteth_skip == 'false' || matrix.driver == 'native') }}
+        if: ${{ steps.changed-tests.outputs.tests_any_changed == 'true' }}
         with:
-          name: coverage-diff-${{ matrix.driver }}
+          name: coverage-diff-native
           path: ${{ github.workspace }}/evmtest_coverage/coverage
 
       - name: Verify coverage results
         uses: addnab/docker-run-action@v3
-        if: ${{ steps.changed-tests.outputs.tests_any_changed == 'true' && (env.retesteth_skip == 'false' || matrix.driver == 'native') }}
+        if: ${{ steps.changed-tests.outputs.tests_any_changed == 'true' }}
         with:
           image: winsvega/evmone-coverage-script:latest
           options: -v ${{ github.workspace }}/evmtest_coverage/coverage:/tests

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -158,9 +158,6 @@ jobs:
           source $GITHUB_ENV
           files=$(echo "$NEW_TESTS" | tr ',' '\n')
 
-          python3 -m venv ./venv/
-          source ./venv/bin/activate
-
           # fill new tests
           # using `|| true` here because if no tests found, pyspec fill returns error code
           mkdir -p fixtures/state_tests
@@ -169,8 +166,8 @@ jobs:
           # Use a while loop with a here-string to avoid subshell issues
           while IFS= read -r file; do
             echo "Fill: $file"
-            fill "$file" --until=Cancun --evm-bin evmone-t8n || true >> filloutput.log 2>&1
-            (fill "$file" --fork=CancunEIP7692 --evm-bin evmone-t8n -k eof_test || true) > >(tee -a filloutput.log filloutputEOF.log) 2>&1
+            uv run fill "$file" --until=Cancun --evm-bin evmone-t8n || true >> filloutput.log 2>&1
+            (uv run fill "$file" --fork=CancunEIP7692 --evm-bin evmone-t8n -k eof_test || true) > >(tee -a filloutput.log filloutputEOF.log) 2>&1
           done <<< "$files"
 
           if grep -q "FAILURES" filloutput.log; then
@@ -194,7 +191,7 @@ jobs:
 
           # Include basic evm operations into coverage by default
           # As when we translate from yul/solidity some dup/push opcodes could become untouched
-          fill tests/homestead/coverage/test_coverage.py --until=Cancun --evm-bin evmone-t8n
+          uv run fill tests/homestead/coverage/test_coverage.py --until=Cancun --evm-bin evmone-t8n
 
           PATCH_TEST_PATH=${{ github.workspace }}/evmtest_coverage/coverage/PATCH_TESTS
           mkdir -p $PATCH_TEST_PATH
@@ -215,9 +212,6 @@ jobs:
             PREV_COMMIT=$(git rev-parse HEAD)
             echo "Checkout head $PREV_COMMIT"
 
-            python3 -m venv ./venv/
-            source ./venv/bin/activate
-
             rm -r fixtures
             rm filloutput.log
             rm filloutputEOF.log
@@ -227,8 +221,8 @@ jobs:
             # Use a while loop with a here-string to avoid subshell issues
             while IFS= read -r file; do
              echo "Fill: $file"
-              fill "$file" --until=Cancun --evm-bin evmone-t8n || true >> filloutput.log 2>&1
-              (fill "$file" --fork=CancunEIP7692 --evm-bin evmone-t8n -k eof_test || true) > >(tee -a filloutput.log filloutputEOF.log) 2>&1
+              uv run fill "$file" --until=Cancun --evm-bin evmone-t8n || true >> filloutput.log 2>&1
+              (uv run fill "$file" --fork=CancunEIP7692 --evm-bin evmone-t8n -k eof_test || true) > >(tee -a filloutput.log filloutputEOF.log) 2>&1
             done <<< "$files"
 
             if grep -q "FAILURES" filloutput.log; then

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -20,6 +20,9 @@ jobs:
           echo "Git reference: ${{ github.ref }}"
           echo "Git head ref: ${{ github.head_ref }}"
           echo "Git base ref: ${{ github.base_ref }}"
+          echo "Node Version: $(node -v)"
+          echo "NPM Version: $(npm -v)"
+
 
       - name: Get all changed python files in tests/ and changes to coverted-ethereum-tests.txt
         id: changed-tests
@@ -88,7 +91,7 @@ jobs:
         if: steps.changed-tests.outputs.tests_any_changed == 'true'
         id: evm-builder2
         with:
-          type: "main"
+          targets: "evmone-t8n"
 
       - name: Checkout ethereum/tests
         uses: actions/checkout@v4
@@ -175,7 +178,9 @@ jobs:
           mkdir -p fixtures/state_tests
           mkdir -p fixtures/eof_tests
 
-          uv run fill $files -n auto --until=Cancun --evm-bin evmone-t8n || true >> filloutput.log 2>&1
+          echo "uv run fill $files --until=Cancun --evm-bin evmone-t8n >> filloutput.log 2>&1"
+          uv run fill $files --until=Cancun --evm-bin evmone-t8n >> filloutput.log 2>&1
+          cat filloutput.log
 
           if grep -q "FAILURES" filloutput.log; then
               echo "Error: failed to generate .py tests."
@@ -229,7 +234,9 @@ jobs:
             mkdir -p fixtures/eof_tests
 
             if [ -n "$files_fixed" ]; then
-                uv run fill $files_fixed -n auto --until=Cancun --evm-bin evmone-t8n || true >> filloutput.log 2>&1
+                echo "uv run fill $files_fixed --until=Cancun --evm-bin evmone-t8n >> filloutput.log 2>&1"
+                uv run fill $files_fixed --until=Cancun --evm-bin evmone-t8n >> filloutput.log 2>&1
+                cat filloutput.log
 
                 if grep -q "FAILURES" filloutput.log; then
                   echo "Error: failed to generate .py tests from before the PR."
@@ -240,20 +247,22 @@ jobs:
                   echo "Error: failed to generate .py tests from before the PR."
                   exit 1
                 fi
-
-                filesState=$(find fixtures/state_tests -type f -name "*.json")
-                filesEOF=$(find fixtures/eof_tests -type f -name "*.json")
-
-                BASE_TEST_PATH=${{ github.workspace }}/evmtest_coverage/coverage/BASE_TESTS
-                mkdir -p $BASE_TEST_PATH
-                find fixtures/state_tests -type f -name "*.json" -exec cp {} $BASE_TEST_PATH \;
-                find fixtures/eof_tests -type f -name "*.json" -exec cp {} $BASE_TEST_PATH \;
-                for file in $BASE_TEST_PATH/*.json; do
-                    if [ -e "$file" ]; then
-                        mv "$file" "${file%.json}_$PREV_COMMIT.json"
-                    fi
-                done
+            else
+                echo "No tests affected from before patch!"
             fi
+
+            filesState=$(find fixtures/state_tests -type f -name "*.json")
+            filesEOF=$(find fixtures/eof_tests -type f -name "*.json")
+
+            BASE_TEST_PATH=${{ github.workspace }}/evmtest_coverage/coverage/BASE_TESTS
+            mkdir -p $BASE_TEST_PATH
+            find fixtures/state_tests -type f -name "*.json" -exec cp {} $BASE_TEST_PATH \;
+            find fixtures/eof_tests -type f -name "*.json" -exec cp {} $BASE_TEST_PATH \;
+            for file in $BASE_TEST_PATH/*.json; do
+                if [ -e "$file" ]; then
+                    mv "$file" "${file%.json}_$PREV_COMMIT.json"
+                fi
+            done
 
       - name: Print tests that will be covered
         if: ${{ steps.changed-tests.outputs.tests_any_changed == 'true' }}

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -115,7 +115,7 @@ jobs:
                 echo "Error: Failed to find the test file $file in test repo"
                 exit 1
               fi
-          done          
+          done
 
       # This command diffs the .py scripts introduced by a PR
       - name: Parse and fill introduced test sources
@@ -146,32 +146,15 @@ jobs:
 
           # fill new tests
           # using `|| true` here because if no tests found, pyspec fill returns error code
-          FOUND_TEST=false
           mkdir -p fixtures/state_tests
           mkdir -p fixtures/eof_tests
 
           # Use a while loop with a here-string to avoid subshell issues
           while IFS= read -r line; do
             file=$(echo "$line" | cut -c 3-)
-            if grep -q "def test_" "$file"; then
-              FOUND_TEST=true
-              fill "$file" --until=Cancun --evm-bin evmone-t8n || true >> filloutput.log 2>&1
-              (fill "$file" --fork=CancunEIP7692 --evm-bin evmone-t8n -k eof_test || true) > >(tee -a filloutput.log filloutputEOF.log) 2>&1
-            fi
+            fill "$file" --until=Cancun --evm-bin evmone-t8n || true >> filloutput.log 2>&1
+            (fill "$file" --fork=CancunEIP7692 --evm-bin evmone-t8n -k eof_test || true) > >(tee -a filloutput.log filloutputEOF.log) 2>&1
           done <<< "$files"
-
-          echo "Tests found: $FOUND_TEST"
-          if [[ "$FOUND_TEST" == "false" ]]; then
-              if [ "${{ env.converted_skip }}" == 'false' ]; then
-                  echo "Error converted-ethereum-tests.txt has new lines, but no test in .py files were found"
-                  exit 1
-              fi
-              echo "No test detected in changed .py files, exiting the script"
-              echo "coverage_skip=true" >> $GITHUB_ENV
-              exit 0
-          else
-              echo "coverage_skip=false" >> $GITHUB_ENV
-          fi
 
           if grep -q "FAILURES" filloutput.log; then
              echo "Error: failed to generate .py tests."
@@ -185,13 +168,8 @@ jobs:
               echo "retesteth_skip=false" >> $GITHUB_ENV
           fi
 
-
           filesState=$(find fixtures/state_tests -type f -name "*.json")
           filesEOF=$(find fixtures/eof_tests -type f -name "*.json")
-          if [ -z "$filesState" ] && [ -z "$filesEOF" ]; then
-              echo "Error: No filled JSON fixtures found in fixtures."
-              exit 1
-          fi
 
           PATCH_TEST_PATH=${{ github.workspace }}/evmtest_coverage/coverage/PATCH_TESTS
           mkdir -p $PATCH_TEST_PATH
@@ -199,7 +177,7 @@ jobs:
           find fixtures/eof_tests -type f -name "*.json" -exec cp {} $PATCH_TEST_PATH \;
 
       - name: Parse and fill introduced test sources from before the PR
-        if: ${{ (env.retesteth_skip == 'false' || matrix.driver == 'native') && env.converted_skip == 'true' && env.coverage_skip == 'false'}}
+        if: ${{ (env.retesteth_skip == 'false' || matrix.driver == 'native') && env.converted_skip == 'true' }}
         run: |
             echo "--------------------"
             echo "converted-ethereum-tests.txt seem untouched, try to fill pre-patched version of .py files:"
@@ -229,22 +207,11 @@ jobs:
             mkdir -p fixtures/state_tests
             mkdir -p fixtures/eof_tests
 
-            FOUND_TEST=false
             while IFS= read -r line; do
               file=$(echo "$line" | cut -c 3-)
-              if grep -q "def test_" "$file"; then
-                 FOUND_TEST=true
-                 fill "$file" --until=Cancun --evm-bin evmone-t8n || true >> filloutput.log 2>&1
-                 (fill "$file" --fork=CancunEIP7692 --evm-bin evmone-t8n -k eof_test || true) > >(tee -a filloutput.log filloutputEOF.log) 2>&1
-              fi
+              fill "$file" --until=Cancun --evm-bin evmone-t8n || true >> filloutput.log 2>&1
+              (fill "$file" --fork=CancunEIP7692 --evm-bin evmone-t8n -k eof_test || true) > >(tee -a filloutput.log filloutputEOF.log) 2>&1
             done <<< "$files"
-
-            echo "Tests found: $FOUND_TEST"
-            if [[ "$FOUND_TEST" == "false" ]]; then
-                echo "No test detected in .py files from before the PR, exiting the script"
-                echo "coverage_skip=true" >> $GITHUB_ENV
-                exit 0
-            fi
 
             if grep -q "FAILURES" filloutput.log; then
              echo "Error: failed to generate .py tests from before the PR."
@@ -268,7 +235,7 @@ jobs:
 
 
       - name: Print tests that will be covered
-        if: ${{ (env.retesteth_skip == 'false' || matrix.driver == 'native') && env.coverage_skip == 'false' }}
+        if: ${{ (env.retesteth_skip == 'false' || matrix.driver == 'native') }}
         run: |
           echo "Original BASE tests:"
           ls ${{ github.workspace }}/evmtest_coverage/coverage/BASE_TESTS
@@ -278,7 +245,7 @@ jobs:
 
       - name: Run coverage of the BASE tests
         uses: addnab/docker-run-action@v3
-        if: ${{ (env.retesteth_skip == 'false' || matrix.driver == 'native') && env.coverage_skip == 'false' }}
+        if: ${{ (env.retesteth_skip == 'false' || matrix.driver == 'native') }}
         with:
           image: winsvega/evmone-coverage-script:latest
           options: -v ${{ github.workspace }}/evmtest_coverage/coverage:/tests
@@ -286,7 +253,7 @@ jobs:
 
       - name: Run coverage of the PATCH tests
         uses: addnab/docker-run-action@v3
-        if: ${{ (env.retesteth_skip == 'false' || matrix.driver == 'native') && env.coverage_skip == 'false' }}
+        if: ${{ (env.retesteth_skip == 'false' || matrix.driver == 'native') }}
         with:
           image: winsvega/evmone-coverage-script:latest
           options: -v ${{ github.workspace }}/evmtest_coverage/coverage:/tests
@@ -294,28 +261,28 @@ jobs:
 
       - name: Run coverage DIFF of the PATCH tests compared to BASE tests
         uses: addnab/docker-run-action@v3
-        if: ${{ (env.retesteth_skip == 'false' || matrix.driver == 'native') && env.coverage_skip == 'false' }}
+        if: ${{ (env.retesteth_skip == 'false' || matrix.driver == 'native') }}
         with:
           image: winsvega/evmone-coverage-script:latest
           options: -v ${{ github.workspace }}/evmtest_coverage/coverage:/tests
           run: /entrypoint.sh --mode=diff --basefile=coverage_BASE.lcov --patchfile=coverage_PATCH.lcov
 
       - name: Chmod coverage results
-        if: ${{ (env.retesteth_skip == 'false' || matrix.driver == 'native') && env.coverage_skip == 'false' }}
+        if: ${{ (env.retesteth_skip == 'false' || matrix.driver == 'native') }}
         run: |
           user=$(whoami)
           sudo chown -R $user:$user ${{ github.workspace }}/evmtest_coverage/coverage
 
       - name: Upload coverage results
         uses: actions/upload-artifact@v3
-        if: ${{ (env.retesteth_skip == 'false' || matrix.driver == 'native') && env.coverage_skip == 'false' }}
+        if: ${{ (env.retesteth_skip == 'false' || matrix.driver == 'native') }}
         with:
           name: coverage-diff-${{ matrix.driver }}
           path: ${{ github.workspace }}/evmtest_coverage/coverage
 
       - name: Verify coverage results
         uses: addnab/docker-run-action@v3
-        if: ${{ (env.retesteth_skip == 'false' || matrix.driver == 'native') && env.coverage_skip == 'false' }}
+        if: ${{ (env.retesteth_skip == 'false' || matrix.driver == 'native') }}
         with:
           image: winsvega/evmone-coverage-script:latest
           options: -v ${{ github.workspace }}/evmtest_coverage/coverage:/tests

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -3,7 +3,7 @@ name: Evmone Coverage Report
 on:
   pull_request:
     paths:
-      - "converted-ethereum-tests.txt" # This triggers the workflow only for changes in file.txt
+      - 'tests/**' # This triggers the workflow for any changes in the tests folder
 
 jobs:
   evmone-coverage-diff:
@@ -43,12 +43,6 @@ jobs:
           uv run python --version
 
       # Required to fill .py tests
-      - name: Build GO EVM
-        uses: ./.github/actions/build-evm-client/geth
-        id: evm-builder
-        with:
-          type: "main"
-
       - name: Build EVMONE EVM
         uses: ./.github/actions/build-evm-client/evmone
         id: evm-builder2
@@ -76,14 +70,16 @@ jobs:
       - name: Parse converted tests from converted-ethereum-tests.txt
         run: |
           echo "New lines introduced in converted-ethereum-tests.txt:"
-          lines=$(git diff origin/${{ github.base_ref }} HEAD -- converted-ethereum-tests.txt | grep "^+" | grep -v "^+++")
-          files=$(echo "$lines" | grep -oP '(?<=\+).+\.json')
-
-          if [ -z "$files" ]; then
-              echo "Error: No new JSON files found in converted-ethereum-tests.txt"
-              exit 1
+          lines=$(git diff origin/${{ github.base_ref }} HEAD -- converted-ethereum-tests.txt | grep "^+" | grep -v "^+++" || true)
+          if [ -z "$lines" ]; then
+              echo "No new lines in converted-ethereum-tests.txt, check updates instead:"
+              echo "converted_skip=true" >> $GITHUB_ENV
+              exit 0
+          else
+              echo "converted_skip=false" >> $GITHUB_ENV
           fi
 
+          files=$(echo "$lines" | grep -oP '(?<=\+).+\.json')
           for file in $files; do
               echo $file
           done
@@ -119,7 +115,7 @@ jobs:
                 echo "Error: Failed to find the test file $file in test repo"
                 exit 1
               fi
-          done
+          done          
 
       # This command diffs the .py scripts introduced by a PR
       - name: Parse and fill introduced test sources
@@ -150,17 +146,36 @@ jobs:
 
           # fill new tests
           # using `|| true` here because if no tests found, pyspec fill returns error code
+          FOUND_TEST=false
           mkdir -p fixtures/state_tests
           mkdir -p fixtures/eof_tests
-          echo "$files" | while read line; do
+
+          # Use a while loop with a here-string to avoid subshell issues
+          while IFS= read -r line; do
             file=$(echo "$line" | cut -c 3-)
-            uv run fill $file --until=Cancun --evm-bin evmone-t8n --solc-version=0.8.25 || true >> filloutput.log 2>&1
-            (uv run fill $file --fork=CancunEIP7692 --evm-bin evmone-t8n --solc-version=0.8.25 -k eof_test || true) > >(tee -a filloutput.log filloutputEOF.log) 2>&1
-          done
+            if grep -q "def test_" "$file"; then
+              FOUND_TEST=true
+              fill "$file" --until=Cancun --evm-bin evmone-t8n || true >> filloutput.log 2>&1
+              (fill "$file" --fork=CancunEIP7692 --evm-bin evmone-t8n -k eof_test || true) > >(tee -a filloutput.log filloutputEOF.log) 2>&1
+            fi
+          done <<< "$files"
+
+          echo "Tests found: $FOUND_TEST"
+          if [[ "$FOUND_TEST" == "false" ]]; then
+              if [ "${{ env.converted_skip }}" == 'false' ]; then
+                  echo "Error converted-ethereum-tests.txt has new lines, but no test in .py files were found"
+                  exit 1
+              fi
+              echo "No test detected in changed .py files, exiting the script"
+              echo "coverage_skip=true" >> $GITHUB_ENV
+              exit 0
+          else
+              echo "coverage_skip=false" >> $GITHUB_ENV
+          fi
 
           if grep -q "FAILURES" filloutput.log; then
-              echo "Error: failed to generate .py tests."
-              exit 1
+             echo "Error: failed to generate .py tests."
+             exit 1
           fi
           if [ "${{ matrix.driver }}" = "retesteth" ] && grep -q "passed" filloutputEOF.log; then
               echo "Disabling retesteth coverage check as EOF tests detected!"
@@ -183,8 +198,77 @@ jobs:
           find fixtures/state_tests -type f -name "*.json" -exec cp {} $PATCH_TEST_PATH \;
           find fixtures/eof_tests -type f -name "*.json" -exec cp {} $PATCH_TEST_PATH \;
 
+      - name: Parse and fill introduced test sources from before the PR
+        if: ${{ (env.retesteth_skip == 'false' || matrix.driver == 'native') && env.converted_skip == 'true' && env.coverage_skip == 'false'}}
+        run: |
+            echo "--------------------"
+            echo "converted-ethereum-tests.txt seem untouched, try to fill pre-patched version of .py files:"
+
+            if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+               files=$(git diff --name-status origin/${{ github.base_ref }}...origin/PR-${{ github.event.pull_request.number }} -- tests/ | grep -E '^[AM]' | grep '\.py$')
+            else
+               files=$(git diff --name-status origin/${{ github.base_ref }}...origin/${{ github.head_ref }} -- tests/ | grep -E '^[AM]' | grep '\.py$')
+            fi
+
+            echo "Modified or new .py files in tests folder:"
+            echo "$files" | while read line; do
+              file=$(echo "$line" | cut -c 3-)
+              echo $file
+            done
+
+            git checkout main
+            PREV_COMMIT=$(git rev-parse HEAD)
+            echo "Checkout head $PREV_COMMIT"
+
+            python3 -m venv ./venv/
+            source ./venv/bin/activate
+
+            rm -r fixtures
+            rm filloutput.log
+            rm filloutputEOF.log
+            mkdir -p fixtures/state_tests
+            mkdir -p fixtures/eof_tests
+
+            FOUND_TEST=false
+            while IFS= read -r line; do
+              file=$(echo "$line" | cut -c 3-)
+              if grep -q "def test_" "$file"; then
+                 FOUND_TEST=true
+                 fill "$file" --until=Cancun --evm-bin evmone-t8n || true >> filloutput.log 2>&1
+                 (fill "$file" --fork=CancunEIP7692 --evm-bin evmone-t8n -k eof_test || true) > >(tee -a filloutput.log filloutputEOF.log) 2>&1
+              fi
+            done <<< "$files"
+
+            echo "Tests found: $FOUND_TEST"
+            if [[ "$FOUND_TEST" == "false" ]]; then
+                echo "No test detected in .py files from before the PR, exiting the script"
+                echo "coverage_skip=true" >> $GITHUB_ENV
+                exit 0
+            fi
+
+            if grep -q "FAILURES" filloutput.log; then
+             echo "Error: failed to generate .py tests from before the PR."
+              exit 1
+            fi
+
+            filesState=$(find fixtures/state_tests -type f -name "*.json")
+            filesEOF=$(find fixtures/eof_tests -type f -name "*.json")
+            if [ -z "$filesState" ] && [ -z "$filesEOF" ]; then
+              echo "Error: No filled JSON fixtures found in fixtures from before the PR."
+               exit 1
+            fi
+
+            BASE_TEST_PATH=${{ github.workspace }}/evmtest_coverage/coverage/BASE_TESTS
+            mkdir -p $BASE_TEST_PATH
+            find fixtures/state_tests -type f -name "*.json" -exec cp {} $BASE_TEST_PATH \;
+            find fixtures/eof_tests -type f -name "*.json" -exec cp {} $BASE_TEST_PATH \;
+            for file in $BASE_TEST_PATH/*.json; do
+              mv "$file" "${file%.json}_$PREV_COMMIT.json"
+            done
+
+
       - name: Print tests that will be covered
-        if: ${{ env.retesteth_skip == 'false' || matrix.driver == 'native' }}
+        if: ${{ (env.retesteth_skip == 'false' || matrix.driver == 'native') && env.coverage_skip == 'false' }}
         run: |
           echo "Original BASE tests:"
           ls ${{ github.workspace }}/evmtest_coverage/coverage/BASE_TESTS
@@ -194,7 +278,7 @@ jobs:
 
       - name: Run coverage of the BASE tests
         uses: addnab/docker-run-action@v3
-        if: ${{ env.retesteth_skip == 'false' || matrix.driver == 'native' }}
+        if: ${{ (env.retesteth_skip == 'false' || matrix.driver == 'native') && env.coverage_skip == 'false' }}
         with:
           image: winsvega/evmone-coverage-script:latest
           options: -v ${{ github.workspace }}/evmtest_coverage/coverage:/tests
@@ -202,7 +286,7 @@ jobs:
 
       - name: Run coverage of the PATCH tests
         uses: addnab/docker-run-action@v3
-        if: ${{ env.retesteth_skip == 'false' || matrix.driver == 'native' }}
+        if: ${{ (env.retesteth_skip == 'false' || matrix.driver == 'native') && env.coverage_skip == 'false' }}
         with:
           image: winsvega/evmone-coverage-script:latest
           options: -v ${{ github.workspace }}/evmtest_coverage/coverage:/tests
@@ -210,28 +294,28 @@ jobs:
 
       - name: Run coverage DIFF of the PATCH tests compared to BASE tests
         uses: addnab/docker-run-action@v3
-        if: ${{ env.retesteth_skip == 'false' || matrix.driver == 'native' }}
+        if: ${{ (env.retesteth_skip == 'false' || matrix.driver == 'native') && env.coverage_skip == 'false' }}
         with:
           image: winsvega/evmone-coverage-script:latest
           options: -v ${{ github.workspace }}/evmtest_coverage/coverage:/tests
           run: /entrypoint.sh --mode=diff --basefile=coverage_BASE.lcov --patchfile=coverage_PATCH.lcov
 
       - name: Chmod coverage results
-        if: ${{ env.retesteth_skip == 'false' || matrix.driver == 'native' }}
+        if: ${{ (env.retesteth_skip == 'false' || matrix.driver == 'native') && env.coverage_skip == 'false' }}
         run: |
           user=$(whoami)
           sudo chown -R $user:$user ${{ github.workspace }}/evmtest_coverage/coverage
 
       - name: Upload coverage results
         uses: actions/upload-artifact@v3
-        if: ${{ env.retesteth_skip == 'false' || matrix.driver == 'native' }}
+        if: ${{ (env.retesteth_skip == 'false' || matrix.driver == 'native') && env.coverage_skip == 'false' }}
         with:
-          name: coverage-diff
+          name: coverage-diff-${{ matrix.driver }}
           path: ${{ github.workspace }}/evmtest_coverage/coverage
 
       - name: Verify coverage results
         uses: addnab/docker-run-action@v3
-        if: ${{ env.retesteth_skip == 'false' || matrix.driver == 'native' }}
+        if: ${{ (env.retesteth_skip == 'false' || matrix.driver == 'native') && env.coverage_skip == 'false' }}
         with:
           image: winsvega/evmone-coverage-script:latest
           options: -v ${{ github.workspace }}/evmtest_coverage/coverage:/tests

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -4,7 +4,8 @@ on:
   pull_request:
     paths:
       - 'tests/**' # This triggers the workflow for any changes in the tests folder
-      - '!tests/prague/**'  # This excludes changes in 'tests/prague'
+      - '!tests/prague/**'  # exclude changes in 'tests/prague'
+      - '!tests/osaka/**'   # exclude changes in 'tests/osaka'
 
 jobs:
   evmone-coverage-diff:
@@ -32,6 +33,7 @@ jobs:
             tests:
               - tests/**/test_*.py
               - '!tests/prague/**'
+              - '!tests/osaka/**'
             converted_tests:
               - converted-ethereum-tests.txt
 
@@ -173,8 +175,7 @@ jobs:
           mkdir -p fixtures/state_tests
           mkdir -p fixtures/eof_tests
 
-          uv run fill $files --until=Cancun --evm-bin evmone-t8n || true >> filloutput.log 2>&1
-          (uv run fill $files --fork=PragueEIP7692 --evm-bin evmone-t8n || true) > >(tee -a filloutput.log filloutputEOF.log) 2>&1
+          uv run fill $files -n auto --until=Cancun --evm-bin evmone-t8n || true >> filloutput.log 2>&1
 
           if grep -q "FAILURES" filloutput.log; then
               echo "Error: failed to generate .py tests."
@@ -224,36 +225,35 @@ jobs:
 
             rm -r fixtures
             rm filloutput.log
-            rm filloutputEOF.log
             mkdir -p fixtures/state_tests
             mkdir -p fixtures/eof_tests
 
-            uv run fill $files_fixed --until=Cancun --evm-bin evmone-t8n || true >> filloutput.log 2>&1
-            (uv run fill $files_fixed --fork=PragueEIP7692 --evm-bin evmone-t8n || true) > >(tee -a filloutput.log filloutputEOF.log) 2>&1
+            if [ -n "$files_fixed" ]; then
+                uv run fill $files_fixed -n auto --until=Cancun --evm-bin evmone-t8n || true >> filloutput.log 2>&1
 
-            if grep -q "FAILURES" filloutput.log; then
-              echo "Error: failed to generate .py tests from before the PR."
-              exit 1
-            fi
-
-            if grep -q "ERROR collecting test session" filloutput.log; then
-              echo "Error: failed to generate .py tests from before the PR."
-              exit 1
-            fi
-
-            filesState=$(find fixtures/state_tests -type f -name "*.json")
-            filesEOF=$(find fixtures/eof_tests -type f -name "*.json")
-
-            BASE_TEST_PATH=${{ github.workspace }}/evmtest_coverage/coverage/BASE_TESTS
-            mkdir -p $BASE_TEST_PATH
-            find fixtures/state_tests -type f -name "*.json" -exec cp {} $BASE_TEST_PATH \;
-            find fixtures/eof_tests -type f -name "*.json" -exec cp {} $BASE_TEST_PATH \;
-            for file in $BASE_TEST_PATH/*.json; do
-                if [ -e "$file" ]; then
-                    mv "$file" "${file%.json}_$PREV_COMMIT.json"
+                if grep -q "FAILURES" filloutput.log; then
+                  echo "Error: failed to generate .py tests from before the PR."
+                  exit 1
                 fi
-            done
 
+                if grep -q "ERROR collecting test session" filloutput.log; then
+                  echo "Error: failed to generate .py tests from before the PR."
+                  exit 1
+                fi
+
+                filesState=$(find fixtures/state_tests -type f -name "*.json")
+                filesEOF=$(find fixtures/eof_tests -type f -name "*.json")
+
+                BASE_TEST_PATH=${{ github.workspace }}/evmtest_coverage/coverage/BASE_TESTS
+                mkdir -p $BASE_TEST_PATH
+                find fixtures/state_tests -type f -name "*.json" -exec cp {} $BASE_TEST_PATH \;
+                find fixtures/eof_tests -type f -name "*.json" -exec cp {} $BASE_TEST_PATH \;
+                for file in $BASE_TEST_PATH/*.json; do
+                    if [ -e "$file" ]; then
+                        mv "$file" "${file%.json}_$PREV_COMMIT.json"
+                    fi
+                done
+            fi
 
       - name: Print tests that will be covered
         if: ${{ steps.changed-tests.outputs.tests_any_changed == 'true' }}

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -14,65 +14,66 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Fetch github branches and detect introduces .py files
+      - name: Debug GitHub context
         run: |
-          py_files=()
-          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
-              # Fetch changes when PR comes from remote repo
-              git fetch origin +refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
-              git fetch origin +refs/pull/${{ github.event.pull_request.number }}/head:refs/remotes/origin/PR-${{ github.event.pull_request.number }}
-              gitdiff=$(git diff --name-status origin/${{ github.base_ref }}...origin/PR-${{ github.event.pull_request.number }} -- tests/)
-          else
-              # Fetch the base branch and the head branch
-              git fetch origin ${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
-              git fetch origin ${{ github.head_ref }}:refs/remotes/origin/${{ github.head_ref }}
+          echo "Git reference: ${{ github.ref }}"
+          echo "Git head ref: ${{ github.head_ref }}"
+          echo "Git base ref: ${{ github.base_ref }}"
 
-              gitdiff=$(git diff --name-status origin/${{ github.base_ref }}...origin/${{ github.head_ref }} -- tests/)
-          fi
+      - name: Get all changed python files in tests/ and changes to coverted-ethereum-tests.txt
+        id: changed-tests
+        uses: tj-actions/changed-files@v45
+        with:
+          # TODO: non-test modules such as __init__.py or spec.py could effect coverage - in this case we should
+          # fill all applicable tests (i.e., all the test_*.py files in or under the changed module's directory)
+          files_yaml: |
+            tests:
+              - tests/**/test_*.py
+            converted_tests:
+              - converted-ethereum-tests.txt
 
-          echo "git diff:"
-          echo "$gitdiff"
-          paths=$(echo "$gitdiff" | grep -oE '/[^[:space:]]+')
-          while IFS= read -r line; do
-            py_files+=("tests$line")
-          done <<< "$paths"
-          echo "Extracted file paths:"
-          for path in "${py_files[@]}"; do
-            echo "$path"
-          done
+      - name: Exit workflow if there are no changed python files
+        if: steps.changed-tests.outputs.tests_any_changed != 'true'
+        run: |
+          echo "No python files were changed in ./tests/ - no action necessary"
+          exit 0
 
-          echo "Prepare the NEW_TESTS variable"
-          py_files_str=$(IFS=,; echo "${py_files[*]}")
-          echo "NEW_TESTS=$py_files_str" >> $GITHUB_ENV
+      - name: Report changed python test moudules
+        if: steps.changed-tests.outputs.tests_any_changed == 'true'
+        run: |
+          echo "Changed python test modules: ${{ steps.changed-tests.outputs.tests_all_changed_files }}"
 
-          echo "Detected new/changed .py files:"
-          source $GITHUB_ENV
-          files2=$(echo "$NEW_TESTS" | tr ',' '\n')
-          while IFS= read -r file; do
-            echo $file
-          done <<< "$files2"
+      - name: Debug GitHub context
+        run: |
+          echo "Git reference: ${{ github.ref }}"
+          echo "Git head ref: ${{ github.head_ref }}"
+          echo "Git base ref: ${{ github.base_ref }}"
 
       - name: Log in to Docker Hub
+        if: ${{  steps.changed-tests.outputs.tests_any_changed == 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/login-action@v3
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         with:
           username: winsvega
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Install deps
+        if: steps.changed-tests.outputs.tests_any_changed == 'true'
         run: |
           echo $(pwd)
           echo ${{ github.workspace }}
 
       - name: Set up uv
+        if: steps.changed-tests.outputs.tests_any_changed == 'true'
         uses: ./.github/actions/setup-uv
 
       - name: Set up Python
+        if: steps.changed-tests.outputs.tests_any_changed == 'true'
         run: uv python install 3.10
 
       - name: Install EEST
+        if: steps.changed-tests.outputs.tests_any_changed == 'true'
         run: |
           uv sync --no-progress
           uv run python --version
@@ -80,12 +81,14 @@ jobs:
       # Required to fill .py tests
       - name: Build EVMONE EVM
         uses: ./.github/actions/build-evm-client/evmone
+        if: steps.changed-tests.outputs.tests_any_changed == 'true'
         id: evm-builder2
         with:
           type: "main"
 
       - name: Checkout ethereum/tests
         uses: actions/checkout@v4
+        if: steps.changed-tests.outputs.tests_any_changed == 'true'
         with:
           repository: ethereum/tests
           path: testpath
@@ -95,6 +98,7 @@ jobs:
 
       - name: Checkout ethereum/legacytests
         uses: actions/checkout@v4
+        if: steps.changed-tests.outputs.tests_any_changed == 'true'      
         with:
           repository: ethereum/legacytests
           path: legacytestpath
@@ -103,6 +107,7 @@ jobs:
 
       # This command diffs the file and filters in new lines
       - name: Parse converted tests from converted-ethereum-tests.txt
+        if: steps.changed-tests.outputs.tests_any_changed == 'true'
         run: |
           echo "New lines introduced in converted-ethereum-tests.txt:"
           lines=$(git diff origin/${{ github.base_ref }} HEAD -- converted-ethereum-tests.txt | grep "^+" | grep -v "^+++" || true)
@@ -154,9 +159,12 @@ jobs:
 
       # This command diffs the .py scripts introduced by a PR
       - name: Parse and fill introduced test sources
+        if: steps.changed-tests.outputs.tests_any_changed == 'true'      
+        env:
+          CHANGED_TEST_FILES: ${{ steps.changed-tests.outputs.tests_all_changed_files }}
         run: |
           source $GITHUB_ENV
-          files=$(echo "$NEW_TESTS" | tr ',' '\n')
+          files=$(echo "$CHANGED_TEST_FILES" | tr ',' '\n')
 
           # fill new tests
           # using `|| true` here because if no tests found, pyspec fill returns error code
@@ -171,8 +179,8 @@ jobs:
           done <<< "$files"
 
           if grep -q "FAILURES" filloutput.log; then
-             echo "Error: failed to generate .py tests."
-             exit 1
+              echo "Error: failed to generate .py tests."
+              exit 1
           fi
           if [ "${{ matrix.driver }}" = "retesteth" ] && grep -q "passed" filloutputEOF.log; then
               echo "Disabling retesteth coverage check as EOF tests detected!"
@@ -186,7 +194,7 @@ jobs:
           filesEOF=$(find fixtures/eof_tests -type f -name "*.json")
           if [ -z "$filesState" ] && [ -z "$filesEOF" ]; then
               echo "Error: No filled JSON fixtures found in fixtures."
-               exit 1
+              exit 1
           fi
 
           # Include basic evm operations into coverage by default
@@ -199,7 +207,7 @@ jobs:
           find fixtures/eof_tests -type f -name "*.json" -exec cp {} $PATCH_TEST_PATH \;
 
       - name: Parse and fill introduced test sources from before the PR
-        if: ${{ (env.retesteth_skip == 'false' || matrix.driver == 'native') && env.converted_skip == 'true' }}
+        if: ${{ steps.changed-tests.outputs.tests_any_changed == 'true' && (env.retesteth_skip == 'false' || matrix.driver == 'native') && env.converted_skip == 'true' }}
         run: |
             echo "--------------------"
             echo "converted-ethereum-tests.txt seem untouched, try to fill pre-patched version of .py files:"
@@ -220,13 +228,13 @@ jobs:
 
             # Use a while loop with a here-string to avoid subshell issues
             while IFS= read -r file; do
-             echo "Fill: $file"
-              uv run fill "$file" --until=Cancun --evm-bin evmone-t8n || true >> filloutput.log 2>&1
-              (uv run fill "$file" --fork=CancunEIP7692 --evm-bin evmone-t8n -k eof_test || true) > >(tee -a filloutput.log filloutputEOF.log) 2>&1
+            echo "Fill: $files"
+            uv run fill "$files" --until=Cancun --evm-bin evmone-t8n || true >> filloutput.log 2>&1
+            (uv run fill "$files" --fork=CancunEIP7692 --evm-bin evmone-t8n -k eof_test || true) >> (tee -a filloutput.log filloutputEOF.log) 2>&1
             done <<< "$files"
 
             if grep -q "FAILURES" filloutput.log; then
-             echo "Error: failed to generate .py tests from before the PR."
+              echo "Error: failed to generate .py tests from before the PR."
               exit 1
             fi
 
@@ -245,7 +253,7 @@ jobs:
 
 
       - name: Print tests that will be covered
-        if: ${{ (env.retesteth_skip == 'false' || matrix.driver == 'native') }}
+        if: ${{ steps.changed-tests.outputs.tests_any_changed == 'true' && (env.retesteth_skip == 'false' || matrix.driver == 'native') }}
         run: |
           echo "Original BASE tests:"
           ls ${{ github.workspace }}/evmtest_coverage/coverage/BASE_TESTS
@@ -255,7 +263,7 @@ jobs:
 
       - name: Run coverage of the BASE tests
         uses: addnab/docker-run-action@v3
-        if: ${{ (env.retesteth_skip == 'false' || matrix.driver == 'native') }}
+        if: ${{ steps.changed-tests.outputs.tests_any_changed == 'true' && (env.retesteth_skip == 'false' || matrix.driver == 'native') }}
         with:
           image: winsvega/evmone-coverage-script:latest
           options: -v ${{ github.workspace }}/evmtest_coverage/coverage:/tests
@@ -263,7 +271,7 @@ jobs:
 
       - name: Run coverage of the PATCH tests
         uses: addnab/docker-run-action@v3
-        if: ${{ (env.retesteth_skip == 'false' || matrix.driver == 'native') }}
+        if: ${{ steps.changed-tests.outputs.tests_any_changed == 'true' && (env.retesteth_skip == 'false' || matrix.driver == 'native') }}
         with:
           image: winsvega/evmone-coverage-script:latest
           options: -v ${{ github.workspace }}/evmtest_coverage/coverage:/tests
@@ -271,28 +279,28 @@ jobs:
 
       - name: Run coverage DIFF of the PATCH tests compared to BASE tests
         uses: addnab/docker-run-action@v3
-        if: ${{ (env.retesteth_skip == 'false' || matrix.driver == 'native') }}
+        if: ${{  steps.changed-tests.outputs.tests_any_changed == 'true' && (env.retesteth_skip == 'false' || matrix.driver == 'native') }}
         with:
           image: winsvega/evmone-coverage-script:latest
           options: -v ${{ github.workspace }}/evmtest_coverage/coverage:/tests
           run: /entrypoint.sh --mode=diff --basefile=coverage_BASE.lcov --patchfile=coverage_PATCH.lcov
 
       - name: Chmod coverage results
-        if: ${{ (env.retesteth_skip == 'false' || matrix.driver == 'native') }}
+        if: ${{ steps.changed-tests.outputs.tests_any_changed == 'true' && (env.retesteth_skip == 'false' || matrix.driver == 'native') }}
         run: |
           user=$(whoami)
           sudo chown -R $user:$user ${{ github.workspace }}/evmtest_coverage/coverage
 
       - name: Upload coverage results
         uses: actions/upload-artifact@v3
-        if: ${{ (env.retesteth_skip == 'false' || matrix.driver == 'native') }}
+        if: ${{ steps.changed-tests.outputs.tests_any_changed == 'true' && (env.retesteth_skip == 'false' || matrix.driver == 'native') }}
         with:
           name: coverage-diff-${{ matrix.driver }}
           path: ${{ github.workspace }}/evmtest_coverage/coverage
 
       - name: Verify coverage results
         uses: addnab/docker-run-action@v3
-        if: ${{ (env.retesteth_skip == 'false' || matrix.driver == 'native') }}
+        if: ${{ steps.changed-tests.outputs.tests_any_changed == 'true' && (env.retesteth_skip == 'false' || matrix.driver == 'native') }}
         with:
           image: winsvega/evmone-coverage-script:latest
           options: -v ${{ github.workspace }}/evmtest_coverage/coverage:/tests

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -16,8 +16,38 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Fetch target branch
-        run: git fetch origin ${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
+      - name: Fetch github branches and detect introduces .py files
+        run: |
+          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+              # Fetch changes when PR comes from remote repo
+              git fetch origin +refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
+              git fetch origin +refs/pull/${{ github.event.pull_request.number }}/head:refs/remotes/origin/PR-${{ github.event.pull_request.number }}
+              files=$(git diff --name-status origin/${{ github.base_ref }}...origin/PR-${{ github.event.pull_request.number }} -- tests/ | grep -E '^[AM]' | grep '\.py$')
+          else
+              # Fetch the base branch and the head branch
+              git fetch origin ${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
+              git fetch origin ${{ github.head_ref }}:refs/remotes/origin/${{ github.head_ref }}
+              files=$(git diff --name-status origin/${{ github.base_ref }}...origin/${{ github.head_ref }} -- tests/ | grep -E '^[AM]' | grep '\.py$')
+          fi
+
+          # Eliminate git diff chars, select only .py paths
+          echo "Collect the changed .py files"
+          py_files=()
+          while read -r line; do
+              file_fixed=$(echo "$line" | cut -c 3-)
+              py_files+=("$file_fixed")
+          done <<< "$files"
+
+          echo "Prepare the NEW_TESTS variable"
+          py_files_str=$(IFS=,; echo "${py_files[*]}")
+          echo "NEW_TESTS=$py_files_str" >> $GITHUB_ENV
+
+          echo "Detected new/changed .py files:"
+          source $GITHUB_ENV
+          files2=$(echo "$NEW_TESTS" | tr ',' '\n')
+          while IFS= read -r file; do
+            echo $file
+          done <<< "$files2"
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -120,29 +150,11 @@ jobs:
       # This command diffs the .py scripts introduced by a PR
       - name: Parse and fill introduced test sources
         run: |
+          source $GITHUB_ENV
+          files=$(echo "$NEW_TESTS" | tr ',' '\n')
+
           python3 -m venv ./venv/
           source ./venv/bin/activate
-
-          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
-              # Fetch changes when PR comes from remote repo
-              git fetch origin +refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
-              git fetch origin +refs/pull/${{ github.event.pull_request.number }}/head:refs/remotes/origin/PR-${{ github.event.pull_request.number }}
-              files=$(git diff --name-status origin/${{ github.base_ref }}...origin/PR-${{ github.event.pull_request.number }} -- tests/ | grep -E '^[AM]' | grep '\.py$')
-          else
-              # Fetch the base branch and the head branch
-              git fetch origin ${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
-              git fetch origin ${{ github.head_ref }}:refs/remotes/origin/${{ github.head_ref }}
-
-              # Perform the diff
-              files=$(git diff --name-status origin/${{ github.base_ref }}...origin/${{ github.head_ref }} -- tests/ | grep -E '^[AM]' | grep '\.py$')
-          fi
-
-
-          echo "Modified or new .py files in tests folder:"
-          echo "$files" | while read line; do
-            file=$(echo "$line" | cut -c 3-)
-            echo $file
-          done
 
           # fill new tests
           # using `|| true` here because if no tests found, pyspec fill returns error code
@@ -150,8 +162,8 @@ jobs:
           mkdir -p fixtures/eof_tests
 
           # Use a while loop with a here-string to avoid subshell issues
-          while IFS= read -r line; do
-            file=$(echo "$line" | cut -c 3-)
+          while IFS= read -r file; do
+            echo "Fill: $file"
             fill "$file" --until=Cancun --evm-bin evmone-t8n || true >> filloutput.log 2>&1
             (fill "$file" --fork=CancunEIP7692 --evm-bin evmone-t8n -k eof_test || true) > >(tee -a filloutput.log filloutputEOF.log) 2>&1
           done <<< "$files"
@@ -170,6 +182,14 @@ jobs:
 
           filesState=$(find fixtures/state_tests -type f -name "*.json")
           filesEOF=$(find fixtures/eof_tests -type f -name "*.json")
+          if [ -z "$filesState" ] && [ -z "$filesEOF" ]; then
+              echo "Error: No filled JSON fixtures found in fixtures."
+               exit 1
+          fi
+
+          # Include basic evm operations into coverage by default
+          # As when we translate from yul/solidity some dup/push opcodes could become untouched
+          fill tests/homestead/coverage/test_coverage.py --until=Cancun --evm-bin evmone-t8n
 
           PATCH_TEST_PATH=${{ github.workspace }}/evmtest_coverage/coverage/PATCH_TESTS
           mkdir -p $PATCH_TEST_PATH
@@ -182,17 +202,9 @@ jobs:
             echo "--------------------"
             echo "converted-ethereum-tests.txt seem untouched, try to fill pre-patched version of .py files:"
 
-            if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
-               files=$(git diff --name-status origin/${{ github.base_ref }}...origin/PR-${{ github.event.pull_request.number }} -- tests/ | grep -E '^[AM]' | grep '\.py$')
-            else
-               files=$(git diff --name-status origin/${{ github.base_ref }}...origin/${{ github.head_ref }} -- tests/ | grep -E '^[AM]' | grep '\.py$')
-            fi
-
-            echo "Modified or new .py files in tests folder:"
-            echo "$files" | while read line; do
-              file=$(echo "$line" | cut -c 3-)
-              echo $file
-            done
+            # load introduces .py files
+            source $GITHUB_ENV
+            files=$(echo "$NEW_TESTS" | tr ',' '\n')
 
             git checkout main
             PREV_COMMIT=$(git rev-parse HEAD)
@@ -207,8 +219,9 @@ jobs:
             mkdir -p fixtures/state_tests
             mkdir -p fixtures/eof_tests
 
-            while IFS= read -r line; do
-              file=$(echo "$line" | cut -c 3-)
+            # Use a while loop with a here-string to avoid subshell issues
+            while IFS= read -r file; do
+             echo "Fill: $file"
               fill "$file" --until=Cancun --evm-bin evmone-t8n || true >> filloutput.log 2>&1
               (fill "$file" --fork=CancunEIP7692 --evm-bin evmone-t8n -k eof_test || true) > >(tee -a filloutput.log filloutputEOF.log) 2>&1
             done <<< "$files"
@@ -220,17 +233,15 @@ jobs:
 
             filesState=$(find fixtures/state_tests -type f -name "*.json")
             filesEOF=$(find fixtures/eof_tests -type f -name "*.json")
-            if [ -z "$filesState" ] && [ -z "$filesEOF" ]; then
-              echo "Error: No filled JSON fixtures found in fixtures from before the PR."
-               exit 1
-            fi
 
             BASE_TEST_PATH=${{ github.workspace }}/evmtest_coverage/coverage/BASE_TESTS
             mkdir -p $BASE_TEST_PATH
             find fixtures/state_tests -type f -name "*.json" -exec cp {} $BASE_TEST_PATH \;
             find fixtures/eof_tests -type f -name "*.json" -exec cp {} $BASE_TEST_PATH \;
             for file in $BASE_TEST_PATH/*.json; do
-              mv "$file" "${file%.json}_$PREV_COMMIT.json"
+                if [ -e "$file" ]; then
+                    mv "$file" "${file%.json}_$PREV_COMMIT.json"
+                fi
             done
 
 

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -18,25 +18,30 @@ jobs:
 
       - name: Fetch github branches and detect introduces .py files
         run: |
+          py_files=()
           if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
               # Fetch changes when PR comes from remote repo
               git fetch origin +refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
               git fetch origin +refs/pull/${{ github.event.pull_request.number }}/head:refs/remotes/origin/PR-${{ github.event.pull_request.number }}
-              files=$(git diff --name-status origin/${{ github.base_ref }}...origin/PR-${{ github.event.pull_request.number }} -- tests/ | grep -E '^[AM]' | grep '\.py$')
+              gitdiff=$(git diff --name-status origin/${{ github.base_ref }}...origin/PR-${{ github.event.pull_request.number }} -- tests/)
           else
               # Fetch the base branch and the head branch
               git fetch origin ${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
               git fetch origin ${{ github.head_ref }}:refs/remotes/origin/${{ github.head_ref }}
-              files=$(git diff --name-status origin/${{ github.base_ref }}...origin/${{ github.head_ref }} -- tests/ | grep -E '^[AM]' | grep '\.py$')
+
+              gitdiff=$(git diff --name-status origin/${{ github.base_ref }}...origin/${{ github.head_ref }} -- tests/)
           fi
 
-          # Eliminate git diff chars, select only .py paths
-          echo "Collect the changed .py files"
-          py_files=()
-          while read -r line; do
-              file_fixed=$(echo "$line" | cut -c 3-)
-              py_files+=("$file_fixed")
-          done <<< "$files"
+          echo "git diff:"
+          echo "$gitdiff"
+          paths=$(echo "$gitdiff" | grep -oE '/[^[:space:]]+')
+          while IFS= read -r line; do
+            py_files+=("tests$line")
+          done <<< "$paths"
+          echo "Extracted file paths:"
+          for path in "${py_files[@]}"; do
+            echo "$path"
+          done
 
           echo "Prepare the NEW_TESTS variable"
           py_files_str=$(IFS=,; echo "${py_files[*]}")

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'tests/**' # This triggers the workflow for any changes in the tests folder
+      - '!tests/prague/**'  # This excludes changes in 'tests/prague'
 
 jobs:
   evmone-coverage-diff:
@@ -30,6 +31,7 @@ jobs:
           files_yaml: |
             tests:
               - tests/**/test_*.py
+              - '!tests/prague/**'
             converted_tests:
               - converted-ethereum-tests.txt
 


### PR DESCRIPTION
## 🗒️ Description
Enable coverage script on any test .py files changes:

if no new lines in converted-ethereum-tests.txt, then seek for .py files with tests and compare the coverage
from before and after PR, otherwise it compares the coverage from test repo and .py produced tests as before.

Script is reworked. use uv to run fill correctly
remove retesteth to simplify the script
use changed files github macro to detect changed files

## 🔗 Related Issues
Demo: https://github.com/ethereum/execution-spec-tests/pull/841
Rebase of: https://github.com/ethereum/execution-spec-tests/pull/707

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
