### PR TITLE
bug(fw): fix unsupported forks in forks plugin

### DIFF
--- a/src/pytest_plugins/forks/forks.py
+++ b/src/pytest_plugins/forks/forks.py
@@ -170,14 +170,19 @@ class CovariantDescriptor:
     def process_value(
         values: Any | List[Any] | Tuple[Any],
         selector: FunctionType,
-        marks: None
-        | pytest.Mark
-        | pytest.MarkDecorator
-        | List[pytest.Mark | pytest.MarkDecorator]
-        | Callable[
-            [Any],
-            List[pytest.Mark | pytest.MarkDecorator] | pytest.Mark | pytest.MarkDecorator | None,
-        ],
+        marks: (
+            None
+            | pytest.Mark
+            | pytest.MarkDecorator
+            | List[pytest.Mark | pytest.MarkDecorator]
+            | Callable[
+                [Any],
+                List[pytest.Mark | pytest.MarkDecorator]
+                | pytest.Mark
+                | pytest.MarkDecorator
+                | None,
+            ]
+        ),
     ) -> List[List[MarkedValue]]:
         """
         Process a value for a covariant parameter.
@@ -424,8 +429,8 @@ def pytest_configure(config: pytest.Config):
 
     evm_bin = config.getoption("evm_bin")
     t8n = TransitionTool.from_binary_path(binary_path=evm_bin)
-    config.unsupported_forks = filter(  # type: ignore
-        lambda fork: not t8n.is_fork_supported(fork), fork_set
+    config.unsupported_forks = (  # type: ignore
+        set(filter(lambda fork: not t8n.is_fork_supported(fork), fork_set))
     )
 
 
@@ -596,13 +601,13 @@ def pytest_generate_tests(metafunc: pytest.Metafunc):
                         marks=[
                             pytest.mark.skip(
                                 reason=(
-                                    f"Fork '{fork}' unsupported by "
+                                    f"Fork '{fork.name()}' unsupported by "
                                     f"'{metafunc.config.getoption('evm_bin')}'."
                                 )
                             )
                         ],
                     )
-                    if fork.name() in sorted(list(unsupported_forks))
+                    if fork in sorted(list(unsupported_forks))
                     else ForkParametrizer(fork=fork)
                 )
                 for fork in sorted(list(intersection_set))


### PR DESCRIPTION
## 🗒️ Description
Fixes how we use unsupported forks when filling tests, such that they are skipped appropriately, when a transition tool does not support a fork we try to fill for.

We were using a `filter()` which is an **iterator**, when determining the unsupported forks:
```python
config.unsupported_forks = filter(lambda fork: not t8n.is_fork_supported(fork), fork_set)
```

This essentially meant that on the 2nd call to unsupported forks, it would always be empty. This is called everytime we parameterize a test case.

The solution was to wrap the `filter()` in a `set()`, as sets are concrete collections that can be accessed multiple times.

## 🔗 Related Issues
N/A

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
