### PR TITLE
new(test): EIP-7702 + EIP-1153: test that TransientStorage stays at correct address

### DIFF
--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -378,12 +378,9 @@ def test_set_code_to_tstore_reentry(
     )
 
 
-@pytest.mark.parametrize(
-    "call_opcode",
-    [
-        Op.CALL,
-        Op.STATICCALL,
-    ],
+@pytest.mark.with_all_call_opcodes(
+    selector=lambda call_opcode: call_opcode
+    not in [Op.DELEGATECALL, Op.CALLCODE, Op.STATICCALL, Op.EXTDELEGATECALL, Op.EXTSTATICCALL]
 )
 @pytest.mark.parametrize("call_eoa_first", [True, False])
 def test_set_code_to_tstore_available_at_correct_address(
@@ -410,13 +407,8 @@ def test_set_code_to_tstore_available_at_correct_address(
     set_code_to_address = pre.deploy_contract(tstore_check_code)
 
     def make_call(call_type: Op, call_eoa: bool) -> Bytecode:
-
         call_target = auth_signer if call_eoa else set_code_to_address
-        if call_type == Op.STATICCALL:
-            return call_type(Op.GAS(), call_target, 0, 0, 0, 0)
-        else:
-            # call_type = Op.CALL
-            return call_type(Op.GAS(), call_target, 0, 0, 0, 0, 0)
+        return call_type(address=call_target)
 
     chain_code = make_call(call_type=call_opcode, call_eoa=call_eoa_first) + make_call(
         call_type=call_opcode, call_eoa=not call_eoa_first

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -379,6 +379,81 @@ def test_set_code_to_tstore_reentry(
 
 
 @pytest.mark.parametrize(
+    "call_opcode",
+    [
+        Op.CALL,
+        Op.STATICCALL,
+    ],
+)
+@pytest.mark.parametrize("call_eoa_first", [True, False])
+def test_set_code_to_tstore_available_at_correct_address(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    call_opcode: Op,
+    call_eoa_first: bool,
+):
+    """
+    Test TLOADing from slot 2 and then SSTORE this in slot 1, then TSTORE 3 in slot 2.
+    This is done both from the EOA which is delegated to account A, and then A is called.
+    The storage should stay empty on both the EOA and the delegated account.
+    """
+    auth_signer = pre.fund_eoa(auth_account_start_balance)
+
+    storage_slot = 1
+    tload_slot = 2
+    tstore_value = 3
+
+    tstore_check_code = Op.SSTORE(storage_slot, Op.TLOAD(tload_slot)) + Op.TSTORE(
+        tload_slot, tstore_value
+    )
+
+    set_code_to_address = pre.deploy_contract(tstore_check_code)
+
+    def make_call(call_type: Op, call_eoa: bool) -> Bytecode:
+
+        call_target = auth_signer if call_eoa else set_code_to_address
+        if call_type == Op.STATICCALL:
+            return call_type(Op.GAS(), call_target, 0, 0, 0, 0)
+        else:
+            # call_type = Op.CALL
+            return call_type(Op.GAS(), call_target, 0, 0, 0, 0, 0)
+
+    chain_code = make_call(call_type=call_opcode, call_eoa=call_eoa_first) + make_call(
+        call_type=call_opcode, call_eoa=not call_eoa_first
+    )
+
+    target_call_chain_address = pre.deploy_contract(chain_code)
+
+    tx = Transaction(
+        gas_limit=100_000,
+        to=target_call_chain_address,
+        value=0,
+        authorization_list=[
+            AuthorizationTuple(
+                address=set_code_to_address,
+                nonce=0,
+                signer=auth_signer,
+            ),
+        ],
+        sender=pre.fund_eoa(),
+    )
+
+    state_test(
+        env=Environment(),
+        pre=pre,
+        tx=tx,
+        post={
+            auth_signer: Account(
+                storage={storage_slot: 0},
+            ),
+            set_code_to_address: Account(
+                storage={storage_slot: 0},
+            ),
+        },
+    )
+
+
+@pytest.mark.parametrize(
     "external_sendall_recipient",
     [False, True],
 )
@@ -659,9 +734,11 @@ def test_set_code_call_set_code(
             auth_signer_1: Account(
                 nonce=1,
                 code=Spec.delegation_designation(set_code_to_address_1),
-                storage=storage_1
-                if call_opcode in [Op.CALL, Op.STATICCALL, Op.EXTCALL, Op.EXTSTATICCALL]
-                else storage_1 + storage_2,
+                storage=(
+                    storage_1
+                    if call_opcode in [Op.CALL, Op.STATICCALL, Op.EXTCALL, Op.EXTSTATICCALL]
+                    else storage_1 + storage_2
+                ),
                 balance=(0 if call_opcode in [Op.CALL, Op.EXTCALL] else value)
                 + auth_account_start_balance,
             ),
@@ -974,9 +1051,11 @@ def test_ext_code_on_set_code(
         pre=pre,
         tx=tx,
         post={
-            set_code_to_address: Account.NONEXISTENT
-            if set_code_type == AddressType.EMPTY_ACCOUNT
-            else Account(storage={}),
+            set_code_to_address: (
+                Account.NONEXISTENT
+                if set_code_type == AddressType.EMPTY_ACCOUNT
+                else Account(storage={})
+            ),
             auth_signer: Account(
                 nonce=1,
                 code=Spec.delegation_designation(set_code_to_address),
@@ -1866,11 +1945,13 @@ def test_set_code_invalid_authorization_tuple(
         authorization_list = [
             AuthorizationTuple(
                 address=set_code_to_address,
-                nonce=1
-                if invalidity_reason == InvalidityReason.NONCE
-                else [0, 1]
-                if invalidity_reason == InvalidityReason.MULTIPLE_NONCE
-                else 0,
+                nonce=(
+                    1
+                    if invalidity_reason == InvalidityReason.NONCE
+                    else [0, 1]
+                    if invalidity_reason == InvalidityReason.MULTIPLE_NONCE
+                    else 0
+                ),
                 chain_id=2 if invalidity_reason == InvalidityReason.CHAIN_ID else 0,
                 signer=auth_signer,
             )


### PR DESCRIPTION
## 🗒️ Description
This PR tests interaction between EIP-7702 (Set EOA account code) and EIP-1153 (transient storage). 

![Diagram zonder titel drawio](https://github.com/user-attachments/assets/260c729c-da41-49b3-b2d0-b09b5c2b7844)

The call chain contract will call into the EOA, which will then SSTORE in slot 1 the TLOADed value of transient slot 2, and then TSTORE the value 3 in transient slot 2. Then, it will return to the call chain contract and it will now call into the account which the EOA is delegated to and thus re-run the same code. The transient storage should be empty, thus the storage should stay empty.

This is parametrized by:

- It will perform both CALL and STATICCALL from the chain call contract EDIT: I should remove STATICCALL since we cannot SSTORE
- The contract which is called first (EOA or the code contract) is also switched

TODO: cleanup

## 🔗 Related Issues
None

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
