### PR TITLE
fix(tests): EOF - Remove duplicate container tests, automatically check for duplicates

### DIFF
--- a/src/ethereum_test_specs/base.py
+++ b/src/ethereum_test_specs/base.py
@@ -9,6 +9,7 @@ from os import path
 from pathlib import Path
 from typing import Callable, ClassVar, Dict, Generator, Iterator, List, Optional
 
+import pytest
 from pydantic import BaseModel, Field
 
 from ethereum_test_base_types import to_hex
@@ -78,6 +79,7 @@ class BaseTest(BaseModel):
     def generate(
         self,
         *,
+        request: pytest.FixtureRequest,
         t8n: TransitionTool,
         fork: Fork,
         fixture_format: FixtureFormats,

--- a/src/ethereum_test_specs/blockchain.py
+++ b/src/ethereum_test_specs/blockchain.py
@@ -5,6 +5,7 @@ Ethereum blockchain test spec definition and filler.
 from pprint import pprint
 from typing import Any, Callable, ClassVar, Dict, Generator, List, Optional, Tuple, Type
 
+import pytest
 from pydantic import ConfigDict, Field, field_validator
 
 from ethereum_test_base_types import (
@@ -714,6 +715,7 @@ class BlockchainTest(BaseTest):
 
     def generate(
         self,
+        request: pytest.FixtureRequest,
         t8n: TransitionTool,
         fork: Fork,
         fixture_format: FixtureFormats,

--- a/src/ethereum_test_specs/eof.py
+++ b/src/ethereum_test_specs/eof.py
@@ -379,6 +379,10 @@ class EOFStateTest(EOFTest):
         Generate the BlockchainTest fixture.
         """
         if fixture_format == FixtureFormats.EOF_TEST:
+            if self.data in existing_tests:
+                # Gracefully skip duplicate tests because one EOFStateTest can generate multiple
+                # state fixtures with the same data.
+                pytest.skip(f"Duplicate EOF container on EOFStateTest: {request.node.nodeid}")
             return self.make_eof_test_fixture(request=request, fork=fork, eips=eips)
         elif fixture_format in (
             FixtureFormats.STATE_TEST,

--- a/src/ethereum_test_specs/eof.py
+++ b/src/ethereum_test_specs/eof.py
@@ -7,8 +7,9 @@ import warnings
 from pathlib import Path
 from shutil import which
 from subprocess import CompletedProcess
-from typing import Any, Callable, ClassVar, Generator, List, Optional, Type
+from typing import Any, Callable, ClassVar, Dict, Generator, List, Optional, Type
 
+import pytest
 from pydantic import Field, model_validator
 
 from ethereum_test_base_types import Account, Bytes
@@ -23,6 +24,8 @@ from evm_transition_tool import TransitionTool
 
 from .base import BaseTest
 from .state import StateTest
+
+existing_tests: Dict[Bytes, str] = {}
 
 
 class EOFBaseException(Exception):
@@ -186,12 +189,18 @@ class EOFTest(BaseTest):
     def make_eof_test_fixture(
         self,
         *,
+        request: pytest.FixtureRequest,
         fork: Fork,
         eips: Optional[List[int]],
     ) -> Fixture:
         """
         Generate the EOF test fixture.
         """
+        if self.data in existing_tests:
+            pytest.fail(
+                f"Duplicate EOF test: {self.data}, existing test: {existing_tests[self.data]}"
+            )
+        existing_tests[self.data] = request.node.nodeid
         vectors = [
             Vector(
                 code=self.data,
@@ -259,6 +268,7 @@ class EOFTest(BaseTest):
     def generate(
         self,
         *,
+        request: pytest.FixtureRequest,
         t8n: TransitionTool,
         fork: Fork,
         eips: Optional[List[int]] = None,
@@ -269,7 +279,7 @@ class EOFTest(BaseTest):
         Generate the BlockchainTest fixture.
         """
         if fixture_format == FixtureFormats.EOF_TEST:
-            return self.make_eof_test_fixture(fork=fork, eips=eips)
+            return self.make_eof_test_fixture(request=request, fork=fork, eips=eips)
 
         raise Exception(f"Unknown fixture format: {fixture_format}")
 
@@ -358,6 +368,7 @@ class EOFStateTest(EOFTest):
     def generate(
         self,
         *,
+        request: pytest.FixtureRequest,
         t8n: TransitionTool,
         fork: Fork,
         eips: Optional[List[int]] = None,
@@ -368,14 +379,14 @@ class EOFStateTest(EOFTest):
         Generate the BlockchainTest fixture.
         """
         if fixture_format == FixtureFormats.EOF_TEST:
-            return self.make_eof_test_fixture(fork=fork, eips=eips)
+            return self.make_eof_test_fixture(request=request, fork=fork, eips=eips)
         elif fixture_format in (
             FixtureFormats.STATE_TEST,
             FixtureFormats.BLOCKCHAIN_TEST,
             FixtureFormats.BLOCKCHAIN_TEST_ENGINE,
         ):
             return self.generate_state_test().generate(
-                t8n=t8n, fork=fork, fixture_format=fixture_format, eips=eips
+                request=request, t8n=t8n, fork=fork, fixture_format=fixture_format, eips=eips
             )
 
         raise Exception(f"Unknown fixture format: {fixture_format}")

--- a/src/ethereum_test_specs/state.py
+++ b/src/ethereum_test_specs/state.py
@@ -4,6 +4,8 @@ Ethereum state test spec definition and filler.
 
 from typing import Any, Callable, ClassVar, Dict, Generator, List, Optional, Type
 
+import pytest
+
 from ethereum_test_exceptions import EngineAPIError
 from ethereum_test_fixtures import BaseFixture, FixtureFormats
 from ethereum_test_fixtures.state import (
@@ -161,6 +163,7 @@ class StateTest(BaseTest):
 
     def generate(
         self,
+        request: pytest.FixtureRequest,
         t8n: TransitionTool,
         fork: Fork,
         fixture_format: FixtureFormats,
@@ -171,7 +174,7 @@ class StateTest(BaseTest):
         """
         if fixture_format in BlockchainTest.supported_fixture_formats:
             return self.generate_blockchain_test().generate(
-                t8n=t8n, fork=fork, fixture_format=fixture_format, eips=eips
+                request=request, t8n=t8n, fork=fork, fixture_format=fixture_format, eips=eips
             )
         elif fixture_format == FixtureFormats.STATE_TEST:
             return self.make_state_test_fixture(t8n, fork, eips)

--- a/src/ethereum_test_specs/tests/test_expect.py
+++ b/src/ethereum_test_specs/tests/test_expect.py
@@ -115,7 +115,9 @@ def test_post_storage_value_mismatch(
     Test post state `Account.storage` exceptions during state test fixture generation.
     """
     with pytest.raises(Storage.KeyValueMismatch) as e_info:
-        state_test.generate(t8n=t8n, fork=fork, fixture_format=FixtureFormats.STATE_TEST)
+        state_test.generate(
+            request=None, t8n=t8n, fork=fork, fixture_format=FixtureFormats.STATE_TEST
+        )
     assert e_info.value == expected_exception
 
 
@@ -141,10 +143,14 @@ def test_post_nonce_value_mismatch(pre: Alloc, post: Alloc, state_test, t8n, for
     pre_nonce = pre_account.nonce
     post_nonce = post_account.nonce
     if "nonce" not in post_account.model_fields_set:  # no exception
-        state_test.generate(t8n=t8n, fork=fork, fixture_format=FixtureFormats.STATE_TEST)
+        state_test.generate(
+            request=None, t8n=t8n, fork=fork, fixture_format=FixtureFormats.STATE_TEST
+        )
         return
     with pytest.raises(Account.NonceMismatch) as e_info:
-        state_test.generate(t8n=t8n, fork=fork, fixture_format=FixtureFormats.STATE_TEST)
+        state_test.generate(
+            request=None, t8n=t8n, fork=fork, fixture_format=FixtureFormats.STATE_TEST
+        )
     assert e_info.value == Account.NonceMismatch(
         address=ADDRESS_UNDER_TEST, want=post_nonce, got=pre_nonce
     )
@@ -172,10 +178,14 @@ def test_post_code_value_mismatch(pre: Alloc, post: Alloc, state_test, t8n, fork
     pre_code = pre_account.code
     post_code = post_account.code
     if "code" not in post_account.model_fields_set:  # no exception
-        state_test.generate(t8n=t8n, fork=fork, fixture_format=FixtureFormats.STATE_TEST)
+        state_test.generate(
+            request=None, t8n=t8n, fork=fork, fixture_format=FixtureFormats.STATE_TEST
+        )
         return
     with pytest.raises(Account.CodeMismatch) as e_info:
-        state_test.generate(t8n=t8n, fork=fork, fixture_format=FixtureFormats.STATE_TEST)
+        state_test.generate(
+            request=None, t8n=t8n, fork=fork, fixture_format=FixtureFormats.STATE_TEST
+        )
     assert e_info.value == Account.CodeMismatch(
         address=ADDRESS_UNDER_TEST, want=post_code, got=pre_code
     )
@@ -203,10 +213,14 @@ def test_post_balance_value_mismatch(pre: Alloc, post: Alloc, state_test, t8n, f
     pre_balance = pre_account.balance
     post_balance = post_account.balance
     if "balance" not in post_account.model_fields_set:  # no exception
-        state_test.generate(t8n=t8n, fork=fork, fixture_format=FixtureFormats.STATE_TEST)
+        state_test.generate(
+            request=None, t8n=t8n, fork=fork, fixture_format=FixtureFormats.STATE_TEST
+        )
         return
     with pytest.raises(Account.BalanceMismatch) as e_info:
-        state_test.generate(t8n=t8n, fork=fork, fixture_format=FixtureFormats.STATE_TEST)
+        state_test.generate(
+            request=None, t8n=t8n, fork=fork, fixture_format=FixtureFormats.STATE_TEST
+        )
     assert e_info.value == Account.BalanceMismatch(
         address=ADDRESS_UNDER_TEST, want=post_balance, got=pre_balance
     )
@@ -245,7 +259,11 @@ def test_post_account_mismatch(state_test, t8n, fork, exception_type: Type[Excep
     fixture generation.
     """
     if exception_type is None:
-        state_test.generate(t8n=t8n, fork=fork, fixture_format=FixtureFormats.STATE_TEST)
+        state_test.generate(
+            request=None, t8n=t8n, fork=fork, fixture_format=FixtureFormats.STATE_TEST
+        )
         return
     with pytest.raises(exception_type) as _:
-        state_test.generate(t8n=t8n, fork=fork, fixture_format=FixtureFormats.STATE_TEST)
+        state_test.generate(
+            request=None, t8n=t8n, fork=fork, fixture_format=FixtureFormats.STATE_TEST
+        )

--- a/src/ethereum_test_specs/tests/test_fixtures.py
+++ b/src/ethereum_test_specs/tests/test_fixtures.py
@@ -91,7 +91,12 @@ def test_make_genesis(fork: Fork, hash: bytes):  # noqa: D103
         post={},
         blocks=[],
         tag="some_state_test",
-    ).generate(t8n, fork, fixture_format=FixtureFormats.BLOCKCHAIN_TEST)
+    ).generate(
+        request=None,  # type: ignore
+        t8n=t8n,
+        fork=fork,
+        fixture_format=FixtureFormats.BLOCKCHAIN_TEST,
+    )
     assert isinstance(fixture, BlockchainFixture)
     assert fixture.genesis is not None
 
@@ -154,6 +159,7 @@ def test_fill_state_test(
         tx=tx,
         tag="my_chain_id_test",
     ).generate(
+        request=None,  # type: ignore
         t8n=t8n,
         fork=fork,
         fixture_format=fixture_format,
@@ -486,6 +492,7 @@ class TestFillBlockchainValidTxs:
             genesis_environment=genesis_environment,
             tag="my_blockchain_test_valid_txs",
         ).generate(
+            request=None,  # type: ignore
             t8n=t8n,
             fork=fork,
             fixture_format=fixture_format,
@@ -868,6 +875,7 @@ def test_fill_blockchain_invalid_txs(fork: Fork, check_hive: bool, expected_json
         blocks=blocks,
         genesis_environment=genesis_environment,
     ).generate(
+        request=None,  # type: ignore
         t8n=t8n,
         fork=fork,
         fixture_format=fixture_format,

--- a/src/ethereum_test_tools/tests/test_code.py
+++ b/src/ethereum_test_tools/tests/test_code.py
@@ -636,6 +636,7 @@ def test_switch(tx_data: bytes, switch_bytecode: bytes, expected_storage: Mappin
         post=post,
     )
     state_test.generate(
+        request=None,  # type: ignore
         t8n=GethTransitionTool(),
         fork=Cancun,
         fixture_format=FixtureFormats.BLOCKCHAIN_TEST,

--- a/src/pytest_plugins/filler/filler.py
+++ b/src/pytest_plugins/filler/filler.py
@@ -823,6 +823,7 @@ def base_test_parametrizer(cls: Type[BaseTest]):
                     kwargs["pre"] = pre
                 super(BaseTestWrapper, self).__init__(*args, **kwargs)
                 fixture = self.generate(
+                    request=request,
                     t8n=t8n,
                     fork=fork,
                     fixture_format=fixture_format,

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_migrated_valid_invalid.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_migrated_valid_invalid.py
@@ -45,36 +45,6 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
             id="EOF1V3540_0002_deployed_code_with_data_section",
         ),
         pytest.param(
-            # No data section contents
-            Container(
-                name="EOF1V3540_0003",
-                sections=[
-                    Section.Code(code=Op.INVALID),
-                    Section.Data(custom_size=2),
-                ],
-            ),
-            EOFException.TOPLEVEL_CONTAINER_TRUNCATED,
-            id="EOF1V3540_0003_no_data_section_contents",
-        ),
-        pytest.param(
-            # Data section contents incomplete
-            Container(
-                name="EOF1V3540_0004",
-                sections=[
-                    Section.Code(code=Op.INVALID),
-                    Section.Data("aa", custom_size=2),
-                ],
-            ),
-            EOFException.TOPLEVEL_CONTAINER_TRUNCATED,
-            id="EOF1V3540_0004_data_section_contents_incomplete",
-        ),
-        pytest.param(
-            # Type section size incomplete
-            bytes.fromhex("ef00010100"),
-            [EOFException.INCOMPLETE_SECTION_SIZE, EOFException.INVALID_TYPE_SECTION_SIZE],
-            id="EOF1I3540_0011_type_section_size_incomplete",
-        ),
-        pytest.param(
             # Empty code section with non-empty data section
             Container(
                 sections=[Section.Code(code_outputs=0), Section.Data("aabb")],
@@ -82,40 +52,6 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
             ),
             EOFException.ZERO_SECTION_SIZE,
             id="EOF1I3540_0012_empty_code_section_with_non_empty_data_section",
-        ),
-        pytest.param(
-            Container(
-                name="EOF1I3540_0014 (Invalid) Total of code sections incomplete",
-                raw_bytes="ef00010100040200",
-            ),
-            EOFException.INCOMPLETE_SECTION_NUMBER,
-            id="EOF1I3540_0014_total_of_code_sections_incomplete",
-        ),
-        pytest.param(
-            Container(
-                name="EOF1I3540_0016 (Invalid) Code section size incomplete",
-                raw_bytes="0xef000101000402000100",
-            ),
-            [EOFException.INCOMPLETE_SECTION_SIZE, EOFException.ZERO_SECTION_SIZE],
-            id="EOF1I3540_0016_code_section_size_incomplete",
-        ),
-        pytest.param(
-            # No data section after code section size
-            bytes.fromhex("ef00010100040200010001"),
-            EOFException.MISSING_HEADERS_TERMINATOR,
-            id="EOF1I3540_0017_no_data_section_after_code_section_size",
-        ),
-        pytest.param(
-            # No data size
-            bytes.fromhex("ef0001010004020001000104"),
-            [EOFException.MISSING_HEADERS_TERMINATOR, EOFException.INCOMPLETE_DATA_HEADER],
-            id="EOF1I3540_0018_no_data_size",
-        ),
-        pytest.param(
-            # Data size incomplete
-            bytes.fromhex("ef000101000402000100010400"),
-            [EOFException.INCOMPLETE_SECTION_SIZE, EOFException.INCOMPLETE_DATA_HEADER],
-            id="EOF1I3540_0019_data_size_incomplete",
         ),
         pytest.param(
             # No section terminator after data section size
@@ -310,16 +246,6 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
             [EOFException.MISSING_TERMINATOR, EOFException.UNEXPECTED_HEADER_KIND],
             id="EOF1I3540_0049_unknown_section_id_after_data_section_ff",
         ),
-        # TODO: Duplicated tests
-        # The following test cases are duplicates but added to confirm test coverage is retained.
-        pytest.param(
-            Container(
-                name="EOF1I3540_0001 (Invalid) No magic",
-                raw_bytes="ef",
-            ),
-            EOFException.INVALID_MAGIC,
-            id="EOF1I3540_0001_invalid_no_magic",
-        ),
         pytest.param(
             Container(
                 name="EOF1I3540_0002 (Invalid) Invalid magic",
@@ -343,14 +269,6 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
             ),
             EOFException.INVALID_MAGIC,
             id="EOF1I3540_0004_invalid_incorrect_magic_ff",
-        ),
-        pytest.param(
-            Container(
-                name="EOF1I3540_0005 (Invalid) No version",
-                raw_bytes="ef00",
-            ),
-            [EOFException.INVALID_VERSION, EOFException.INVALID_MAGIC],
-            id="EOF1I3540_0005_invalid_no_version",
         ),
         pytest.param(
             Container(

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_section_order.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_section_order.py
@@ -244,6 +244,9 @@ def test_container_section_order(
     This extends and follows the convention of the test_section_order()
     for the optional container section.
     """
+    if container_position == 2:
+        pytest.skip("Skip valid container section position")
+
     section_code = Section.Code(
         code=Op.EOFCREATE[0](0, 0, 0, 0)
         # TODO: Migrated tests had the following infinite loop, so it is kept here

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_section_size.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_section_size.py
@@ -53,7 +53,9 @@ class SectionSize(IntEnum):
             SectionKind.DATA, SectionSize.HUGE, EOFException.TOPLEVEL_CONTAINER_TRUNCATED
         ),
         pytest.param(SectionKind.DATA, SectionSize.MAX, EOFException.TOPLEVEL_CONTAINER_TRUNCATED),
-        pytest.param(SectionKind.CODE, SectionSize.NORMAL, None),
+        pytest.param(
+            SectionKind.CODE, SectionSize.NORMAL, None, marks=pytest.mark.skip(reason="duplicate")
+        ),
         pytest.param(SectionKind.CODE, SectionSize.ZERO, EOFException.ZERO_SECTION_SIZE),
         pytest.param(
             SectionKind.CODE, SectionSize.UNDERSIZE, EOFException.INVALID_SECTION_BODIES_SIZE
@@ -63,7 +65,9 @@ class SectionSize(IntEnum):
         ),
         pytest.param(SectionKind.CODE, SectionSize.HUGE, EOFException.INVALID_SECTION_BODIES_SIZE),
         pytest.param(SectionKind.CODE, SectionSize.MAX, EOFException.INVALID_SECTION_BODIES_SIZE),
-        pytest.param(SectionKind.TYPE, SectionSize.NORMAL, None),
+        pytest.param(
+            SectionKind.TYPE, SectionSize.NORMAL, None, marks=pytest.mark.skip(reason="duplicate")
+        ),
         pytest.param(
             SectionKind.TYPE,
             SectionSize.ZERO,
@@ -83,7 +87,12 @@ class SectionSize(IntEnum):
             [EOFException.INVALID_SECTION_BODIES_SIZE, EOFException.INVALID_TYPE_SECTION_SIZE],
             id="type_size_max",
         ),
-        pytest.param(SectionKind.CONTAINER, SectionSize.NORMAL, None),
+        pytest.param(
+            SectionKind.CONTAINER,
+            SectionSize.NORMAL,
+            None,
+            marks=pytest.mark.skip(reason="duplicate"),
+        ),
         pytest.param(SectionKind.CONTAINER, SectionSize.ZERO, EOFException.ZERO_SECTION_SIZE),
         pytest.param(
             SectionKind.CONTAINER, SectionSize.UNDERSIZE, EOFException.INVALID_SECTION_BODIES_SIZE
@@ -212,9 +221,14 @@ def test_truncated_container_with_data(
     This test takes a valid container with data and removes some bytes from its tail.
     Migrated from EOFTests/efValidation/EOF1_truncated_section_.json (cases with data section).
     """
-    container = Container(sections=[Section.Code(Op.INVALID), Section.Data("aabb")])
-    bytecode = bytes(container)
+    data = b"\xaa\xbb"
+    container = Container(
+        sections=[
+            Section.Code(Op.INVALID),
+            Section.Data(data[0 : (len(data) - truncation_len)], custom_size=2),
+        ]
+    )
     eof_test(
-        data=bytecode[: len(bytecode) - truncation_len],
+        data=container,
         expect_exception=exception,
     )

--- a/tests/prague/eip7692_eof_v1/eip4200_relative_jumps/test_rjump.py
+++ b/tests/prague/eip7692_eof_v1/eip4200_relative_jumps/test_rjump.py
@@ -41,28 +41,6 @@ def test_rjump_positive_negative(
     )
 
 
-def test_rjump_positive_negative_with_data(
-    eof_state_test: EOFStateTestFiller,
-):
-    """EOF1V4200_0001 (Valid) EOF code containing RJUMP (Positive, Negative)"""
-    eof_state_test(
-        data=Container(
-            sections=[
-                Section.Code(
-                    code=Op.PUSH0
-                    + Op.RJUMPI[3]
-                    + Op.RJUMP[7]
-                    + Op.SSTORE(slot_code_worked, value_code_worked)
-                    + Op.STOP
-                    + Op.RJUMP[-10],
-                ),
-                Section.Data(data=b"\xde\xad\xbe\xef"),
-            ],
-        ),
-        container_post=Account(storage={slot_code_worked: value_code_worked}),
-    )
-
-
 def test_rjump_zero(
     eof_state_test: EOFStateTestFiller,
 ):

--- a/tests/prague/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpi.py
+++ b/tests/prague/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpi.py
@@ -539,10 +539,10 @@ def test_rjumpi_into_push_1(
 ):
     """EOF1I4200_0024 (Invalid) EOF code containing RJUMPI with target PUSH1 immediate"""
     code = (
-        Op.PUSH1(1) + Op.RJUMPI[-4] + Op.STOP
+        Op.PUSH1[1] + Op.RJUMPI[-4]
         if jump == JumpDirection.BACKWARD
-        else Op.PUSH1(1) + Op.RJUMPI[1] + Op.STOP
-    )
+        else Op.PUSH1[1] + Op.RJUMPI[1] + Op.PUSH1[1] + Op.POP
+    ) + Op.STOP
     eof_test(
         data=Container(
             sections=[

--- a/tests/prague/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py
+++ b/tests/prague/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py
@@ -1033,7 +1033,7 @@ def test_rjumpv_into_exchange(
                     + Op.PUSH1(2)
                     + Op.PUSH1(3)
                     + Op.PUSH1(0)
-                    + Op.RJUMPV[1]
+                    + Op.RJUMPV[jump_table]
                     + Op.EXCHANGE[0x00]
                     + Op.SSTORE
                     + Op.STOP,

--- a/tests/prague/eip7692_eof_v1/eip4750_functions/test_code_validation.py
+++ b/tests/prague/eip7692_eof_v1/eip4750_functions/test_code_validation.py
@@ -159,19 +159,6 @@ INVALID: List[Container] = [
         ],
         validity_error=EOFException.TOO_MANY_CODE_SECTIONS,
     ),
-    Container(
-        name="callf_to_non_returning",
-        sections=[
-            Section.Code(
-                code=(Op.CALLF[1] + Op.STOP),
-            ),
-            Section.Code(
-                code=(Op.STOP),
-                code_outputs=0,
-            ),
-        ],
-        validity_error=EOFException.INVALID_NON_RETURNING_FLAG,
-    ),
 ]
 
 


### PR DESCRIPTION
## 🗒️ Description

### Duplicate checks

`EOFTest` spec base now automatically checks for duplicate containers during the fill process.
The simple approach is to define a global variable that contains all containers filled up until now, and fail the test in the case that the test currently being generated has already been seen.

An exception to this rule is on `EOFStateTest` specs because these tests can generate multiple state tests on the same container, but in the case of a simple EOF test, if the container has already been seen, the test is gracefully skipped.

## Removed tests

All of the following tests were detected as duplicates and only one of them is left now in code.

- tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py::test_version_validation[fork_CancunEIP7692-eof_test-version_1], tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py::test_magic_validation[fork_CancunEIP7692-eof_test-magic_1_0-magic_0_239]: Same when both valid
- tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py::test_valid_containers[fork_CancunEIP7692-eof_test-single_code_section_with_data_section]
- tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_migrated_valid_invalid.py::test_migrated_valid_invalid[fork_CancunEIP7692-eof_test-EOF1I3540_0011_type_section_size_incomplete] -> tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py::test_invalid_containers[fork_CancunEIP7692-eof_test-incomplete_type_section_size]
- tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_migrated_valid_invalid.py::test_migrated_valid_invalid[fork_CancunEIP7692-eof_test-EOF1I3540_0014_total_of_code_sections_incomplete] -> tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py::test_invalid_containers[fork_CancunEIP7692-eof_test-code_section_count_incomplete]
- tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_migrated_valid_invalid.py::test_migrated_valid_invalid[fork_CancunEIP7692-eof_test-EOF1I3540_0016_code_section_size_incomplete] -> tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py::test_invalid_containers[fork_CancunEIP7692-eof_test-code_section_size_incomplete]
- tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_migrated_valid_invalid.py::test_migrated_valid_invalid[fork_CancunEIP7692-eof_test-EOF1I3540_0017_no_data_section_after_code_section_size] -> tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py::test_invalid_containers[fork_CancunEIP7692-eof_test-truncated_header_data_section]
- tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_migrated_valid_invalid.py::test_migrated_valid_invalid[fork_CancunEIP7692-eof_test-EOF1I3540_0018_no_data_size] -> tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py::test_invalid_containers[fork_CancunEIP7692-eof_test-no_data_section_size]
- tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_migrated_valid_invalid.py::test_migrated_valid_invalid[fork_CancunEIP7692-eof_test-EOF1I3540_0019_data_size_incomplete] -> tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py::test_invalid_containers[fork_CancunEIP7692-eof_test-data_section_size_incomplete]
- tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_migrated_valid_invalid.py::test_migrated_valid_invalid[fork_CancunEIP7692-eof_test-EOF1I3540_0001_invalid_no_magic] -> tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py::test_invalid_containers[fork_CancunEIP7692-eof_test-incomplete_magic]
- tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_migrated_valid_invalid.py::test_migrated_valid_invalid[fork_CancunEIP7692-eof_test-EOF1I3540_0005_invalid_no_version] -> tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py::test_invalid_containers[fork_CancunEIP7692-eof_test-no_version]
- tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_section_order.py::test_container_section_order[fork_CancunEIP7692-eof_test-test_position_CasePosition.HEADER-container_position_2], tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_section_order.py::test_container_section_order[fork_CancunEIP7692-eof_test-test_position_CasePosition.BODY-container_position_2], tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_section_order.py::test_container_section_order[fork_CancunEIP7692-eof_test-test_position_CasePosition.BODY_AND_HEADER-container_position_2] (correct container position)
- tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_section_size.py::test_section_size[fork_CancunEIP7692-eof_test-section_kind_DATA-section_size_NORMAL-exception_None], tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_section_size.py::test_section_size[fork_CancunEIP7692-eof_test-section_kind_TYPE-section_size_NORMAL-exception_None], tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_section_size.py::test_section_size[fork_CancunEIP7692-eof_test-section_kind_CONTAINER-section_size_NORMAL-exception_None] -> tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_section_size.py::test_section_size[fork_CancunEIP7692-eof_test-section_kind_CODE-section_size_NORMAL-exception_None]
- tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_migrated_valid_invalid.py::test_migrated_valid_invalid[fork_CancunEIP7692-eof_test-EOF1V3540_0004_data_section_contents_incomplete] -> tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_section_size.py::test_truncated_container_with_data[fork_CancunEIP7692-eof_test-EOF1_truncated_section_4]
- tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_migrated_valid_invalid.py::test_migrated_valid_invalid[fork_CancunEIP7692-eof_test-EOF1V3540_0003_no_data_section_contents] -> tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_section_size.py::test_truncated_container_with_data[fork_CancunEIP7692-eof_test-EOF1_truncated_section_3]
- tests/prague/eip7692_eof_v1/eip4200_relative_jumps/test_rjump.py::test_rjump_positive_negative_with_data[fork_CancunEIP7692-eof_test] -> tests/prague/eip7692_eof_v1/eip4200_relative_jumps/test_rjump.py::test_rjump_backwards_infinite_loop[fork_CancunEIP7692-eof_test]
- tests/prague/eip7692_eof_v1/eip4750_functions/test_code_validation.py::test_eof_validity[fork_CancunEIP7692-eof_test-callf_to_non_returning] -> tests/prague/eip7692_eof_v1/eip6206_jumpf/test_nonretruning_validation.py::test_returning_section_not_returning[fork_CancunEIP7692-eof_test-stop0]
- tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py::test_invalid_containers[fork_CancunEIP7692-eof_test-code_section_output_too_large_2] -> tests/prague/eip7692_eof_v1/eip6206_jumpf/test_nonretruning_validation.py::test_retf_in_nonreturning[fork_CancunEIP7692-eof_test-PUSH0x0x80-first_False]

## Fixed Tests

The following tests were detected as duplicates but due to a parametrization error:

- tests/prague/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpi.py::test_rjumpi_into_push_1[fork_CancunEIP7692-eof_test-jump_JumpDirection.FORWARD]
- tests/prague/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py::test_rjumpv_into_exchange

Tests are now correctly generating different containers.

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
