### PR TITLE
feat(docs): re-write test gen doc flow with pytest plugin

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -45,6 +45,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Feature releases can now include multiple types of fixture tarball files from different releases that start with the same prefix ([#736](https://github.com/ethereum/execution-spec-tests/pull/736)).
 - ✨ Releases for feature eip7692 now include both Cancun and Prague based tests in the same release, in files `fixtures_eip7692.tar.gz` and `fixtures_eip7692-prague.tar.gz` respectively ([#743](https://github.com/ethereum/execution-spec-tests/pull/743)).
 - 🔀 Simplify Python project configuration and consolidate it into `pyproject.toml` ([#764](https://github.com/ethereum/execution-spec-tests/pull/764)).
+✨ Re-write the test case reference doc flow as a pytest plugin and add pages for test functions with a table providing an overview of their parametrized test cases ([#801](https://github.com/ethereum/execution-spec-tests/pull/801)).
 
 ### 💥 Breaking Change
 

--- a/docs/templates/base.md.j2
+++ b/docs/templates/base.md.j2
@@ -1,0 +1,32 @@
+{% block title %}
+# {{ title }}
+{# templates inheriting from this base template can re-define the title block #}
+{% endblock %}
+
+Documentation for [`{{ pytest_node_id }}@{{ short_git_ref }}`]({{ source_code_url }}).
+
+{% if title != "Spec" %}
+{% if valid_from_fork in deployed_forks %}
+!!! example "Generate fixtures for these test cases for all forks deployed to mainnet with:"
+
+    ```console
+    fill -v {{ pytest_node_id }}
+    ```
+{% else %}
+!!! example "Generate fixtures for these test cases for {{ valid_from_fork.capitalize() }} with:"
+
+    {{ valid_from_fork.capitalize() }} only:
+        ```console
+        fill -v {{ pytest_node_id }} --fork={{ valid_from_fork }} --evm-bin=/path/to/evm-tool-dev-version
+        ```
+
+    For all forks up to and including {{ valid_from_fork.capitalize() }}:
+        ```console
+        fill -v {{ pytest_node_id }} --until={{ valid_from_fork }}
+        ```
+{% endif %}
+{% endif %}
+
+{% block additional_content %}
+{# templates that inherit from base can add an additional_content block here #}
+{% endblock %}

--- a/docs/templates/directory.md.j2
+++ b/docs/templates/directory.md.j2
@@ -1,0 +1,9 @@
+{% extends "base.md.j2" %}
+{% block title %}
+# {{ title }}
+{% endblock %}
+{% block additional_content %}
+::: {{ package_name }}
+    options:
+        members: no
+{% endblock %}

--- a/docs/templates/function.html.j2
+++ b/docs/templates/function.html.j2
@@ -1,0 +1,17 @@
+{% block title %}
+<h1>Test Function: <code>{{ title }}()</code></h1>
+{% endblock %}
+{% if cases %}
+<h2>Parametrized Test Cases</h2>
+{% include 'function_parameter_datatable.html.j2' %}
+{% endif %}
+
+<script type="text/javascript" charset="utf8" src="https://code.jquery.com/jquery-3.5.1.js"></script>
+<script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/1.10.21/js/jquery.dataTables.js"></script>
+<script>
+    $(document).ready(function () {
+        $('#test_table').DataTable({
+            "pageLength": 100
+        });
+    });
+</script>

--- a/docs/templates/function.html.j2
+++ b/docs/templates/function.html.j2
@@ -1,8 +1,16 @@
-<link rel="stylesheet" href="https://cdn.datatables.net/1.10.21/css/jquery.dataTables.css">
-<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ title }}()</title>
+    <link rel="icon" href="/execution-spec-tests/img/ETH-logo-icon.svg" type="image/x-icon">
+    <link rel="stylesheet" href="https://cdn.datatables.net/1.10.21/css/jquery.dataTables.css">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+
 {% block title %}
 <h1>Test Function: <code>{{ title }}()</code></h1>
 {% endblock %}
+<p>{{ docstring_one_liner }}</p>
 {% if cases %}
 <h2>Parametrized Test Cases</h2>
 {% include 'function_parameter_datatable.html.j2' %}

--- a/docs/templates/function.html.j2
+++ b/docs/templates/function.html.j2
@@ -1,3 +1,5 @@
+<link rel="stylesheet" href="https://cdn.datatables.net/1.10.21/css/jquery.dataTables.css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
 {% block title %}
 <h1>Test Function: <code>{{ title }}()</code></h1>
 {% endblock %}
@@ -11,8 +13,9 @@
 <script>
     $(document).ready(function () {
         $('#test_table').DataTable({
-            "pageLength": 100,
+            pageLength: -1,
             scrollX: true,
+            autoWidth: false
         });
     });
 </script>

--- a/docs/templates/function.html.j2
+++ b/docs/templates/function.html.j2
@@ -11,7 +11,8 @@
 <script>
     $(document).ready(function () {
         $('#test_table').DataTable({
-            "pageLength": 100
+            "pageLength": 100,
+            scrollX: true,
         });
     });
 </script>

--- a/docs/templates/function.md.j2
+++ b/docs/templates/function.md.j2
@@ -19,6 +19,6 @@ The interactive table below is also available as a [standalone page]({{ html_sta
     {{ test_function_parameter_table_skipped_parameters }}.
 
 {% include 'function_parameter_datatable.html.j2' %}
-<script> $(document).ready( function () { $('#test_table').DataTable({"pageLength": -1}); } ); </script> 
+<script>$(document).ready( function () { $('#test_table').DataTable({pageLength: -1, scrollX: true}); }); </script> 
 {% endif %}
 {% endblock %}

--- a/docs/templates/function.md.j2
+++ b/docs/templates/function.md.j2
@@ -19,6 +19,6 @@ The interactive table below is also available as a [standalone page]({{ html_sta
     {{ test_function_parameter_table_skipped_parameters }}.
 
 {% include 'function_parameter_datatable.html.j2' %}
-<script>$(document).ready( function () { $('#test_table').DataTable({pageLength: -1, scrollX: true}); }); </script> 
+<script>$(document).ready( function () { $('#test_table').DataTable({pageLength: -1, scrollX: true, autoWidth: false}); }); </script> 
 {% endif %}
 {% endblock %}

--- a/docs/templates/function.md.j2
+++ b/docs/templates/function.md.j2
@@ -1,0 +1,24 @@
+{% extends "base.md.j2" %}
+{% block title %}
+# `{{ title }}()`
+{% endblock %}
+{% block additional_content %}
+
+::: {{ package_name }}
+    options:
+        filters: ["^[tT]est*|^Spec*"]
+
+{% if cases %}
+## Parametrized Test Cases
+
+The interactive table below is also available as a [standalone page]({{ html_static_page_target }}).
+
+!!! note "Skipped Parameters"
+
+    For more concise readability, the table below does not list the following parameter values: 
+    {{ test_function_parameter_table_skipped_parameters }}.
+
+{% include 'function_parameter_datatable.html.j2' %}
+<script> $(document).ready( function () { $('#test_table').DataTable({"pageLength": -1}); } ); </script> 
+{% endif %}
+{% endblock %}

--- a/docs/templates/function_parameter_datatable.html.j2
+++ b/docs/templates/function_parameter_datatable.html.j2
@@ -1,4 +1,4 @@
-<table id="test_table" class="display">
+<table id="test_table" class="display nowrap">
     <thead>
         <tr>
             <th>Test ID</th>

--- a/docs/templates/function_parameter_datatable.html.j2
+++ b/docs/templates/function_parameter_datatable.html.j2
@@ -1,0 +1,20 @@
+<table id="test_table" class="display">
+    <thead>
+        <tr>
+            <th>Test ID</th>
+            {% for header in cases[0].params.keys() %}
+            <th>{{ header }}</th>
+            {% endfor %}
+        </tr>
+    </thead>
+    <tbody>
+        {% for case in cases %}
+        <tr>
+            <td>{{ case.id }}</td>
+            {% for value in case.params.values() %}
+            <td>{{ value }}</td>
+            {% endfor %}
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>

--- a/docs/templates/markdown_header.md.j2
+++ b/docs/templates/markdown_header.md.j2
@@ -1,0 +1,4 @@
+!!! note "Markdown Content"
+    Below is the verbatim markdown content from [`{{ pytest_node_id }}@{{ short_git_ref }}`]({{ source_code_url }}).
+
+{# intentional additional newlines to force md file header/content to a newline #}

--- a/docs/templates/module.md.j2
+++ b/docs/templates/module.md.j2
@@ -1,0 +1,28 @@
+{% extends "base.md.j2" %}
+
+{% block title %}
+# {{ title }}
+{% endblock %}
+
+{% block additional_content %}
+
+::: {{ package_name }}
+{% if "Spec" in title %}
+    options:
+        filters: ["^Spec*"]
+{% else %}
+    options:
+        members: no
+{% endif %}
+
+{% if test_functions %}
+## Test Functions Overview
+
+| Name | Type | Cases | Description |
+|------|------|--------|-------------|
+{% for test_function in test_functions %}
+| [`{{ test_function.name }}`](./{{ test_function.name }}.md) | {{ test_function.test_type }} | {{ test_function.test_case_count }} | {{ test_function.docstring_one_liner }} |
+{% endfor %}
+{% endif %}
+
+{% endblock %}

--- a/docs/writing_tests/exception_tests.md
+++ b/docs/writing_tests/exception_tests.md
@@ -8,11 +8,11 @@ To test for an exception, the test can use either of the following types from `e
 
 1. [`TransactionException`](../consuming_tests/exceptions.md#transactionexception): To be added to the `error` field of the `Transaction` object, and to the `exception` field of the `Block` object that includes the transaction; this exception type is used when a transaction is invalid, and therefore when included in a block, the block is expected to be invalid too. This is different from valid transactions where an exception during EVM execution is expected (e.g. a revert, or out-of-gas), which can be included in valid blocks.
 
-    For an example, see [`eip3860_initcode.test_initcode.test_contract_creating_tx`](../tests/shanghai/eip3860_initcode/test_initcode/index.md#tests.shanghai.eip3860_initcode.test_initcode.test_contract_creating_tx) which raises `TransactionException.INITCODE_SIZE_EXCEEDED` in the case that the initcode size exceeds the maximum allowed size.
+    For an example, see [`eip3860_initcode.test_initcode.test_contract_creating_tx`](../tests/shanghai/eip3860_initcode/test_initcode/test_contract_creating_tx.md) which raises `TransactionException.INITCODE_SIZE_EXCEEDED` in the case that the initcode size exceeds the maximum allowed size.
 
 2. [`BlockException`](../consuming_tests/exceptions.md#blockexception): To be added to the `exception` field of the `Block` object; this exception type is used when a block is expected to be invalid, but the exception is related to a block property, e.g. an invalid value of the block header.
 
-    For an example, see [`eip4844_blobs.test_excess_blob_gas.test_invalid_static_excess_blob_gas`](../tests/cancun/eip4844_blobs/test_excess_blob_gas/index.md#tests.cancun.eip4844_blobs.test_excess_blob_gas.test_invalid_static_excess_blob_gas) which raises `BlockException.INCORRECT_EXCESS_BLOB_GAS` in the case that the `excessBlobGas` remains unchanged
+    For an example, see [`eip4844_blobs.test_excess_blob_gas.test_invalid_static_excess_blob_gas`](../tests/cancun/eip4844_blobs/test_excess_blob_gas/test_invalid_static_excess_blob_gas.md) which raises `BlockException.INCORRECT_EXCESS_BLOB_GAS` in the case that the `excessBlobGas` remains unchanged
     but the parent blobs included are not `TARGET_BLOBS_PER_BLOCK`.
 
 Although exceptions can be combined with the `|` operator to indicate that a test vector can throw either one of multiple exceptions, ideally the tester should aim to use only one exception per test vector, and only use multiple exceptions on the rare instance when it is not possible to know which exception will be thrown because it depends on client implementation.

--- a/docs/writing_tests/index.md
+++ b/docs/writing_tests/index.md
@@ -1,5 +1,5 @@
 # Writing Tests
 
-The best way to get started is to use one of the existing test modules for inspiration. A good simple example is [tests.berlin.eip2930_access_list.test_acl.test_access_list](../tests/berlin/eip2930_access_list/test_acl/index.md#tests.berlin.eip2930_access_list.test_acl.test_access_list).
+The best way to get started is to use one of the existing test modules for inspiration. A good simple example is [tests.berlin.eip2930_access_list.test_acl.test_access_list](../tests/berlin/eip2930_access_list/test_acl/test_access_list.md).
 
 Please check that your code adheres to the repo's [Coding Standards](./code_standards.md) and read the other pages in this section for more background and an explanation of how to implement state transition and blockchain tests.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,3 +110,10 @@ markdown_extensions:
 extra:
   version:
     provider: mike
+
+extra_javascript:
+  - https://code.jquery.com/jquery-3.5.1.js
+  - https://cdn.datatables.net/1.10.21/js/jquery.dataTables.js
+
+extra_css:
+  - https://cdn.datatables.net/1.10.21/css/jquery.dataTables.css

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,24 +44,25 @@ theme:
     - navigation.indexes
     - navigation.instant
     - navigation.tabs
-  palette:
-    # Palette toggle for automatic mode
-    - media: "(prefers-color-scheme)"
-      toggle:
-        icon: material/brightness-auto
-        name: Switch to light mode
-    # Palette toggle for light mode
-    - media: "(prefers-color-scheme: light)"
-      scheme: default 
-      toggle:
-        icon: material/brightness-7
-        name: Switch to dark mode
-    # Palette toggle for dark mode
-    - media: "(prefers-color-scheme: dark)"
-      scheme: slate
-      toggle:
-        icon: material/brightness-4
-        name: Switch to system preference
+  # disabled due to https://github.com/ethereum/execution-spec-tests/issues/816
+  # palette:
+  #   # Palette toggle for automatic mode
+  #   - media: "(prefers-color-scheme)"
+  #     toggle:
+  #       icon: material/brightness-auto
+  #       name: Switch to light mode
+  #   Palette toggle for light mode
+  #   - media: "(prefers-color-scheme: light)"
+  #    scheme: default
+  #    toggle:
+  #      icon: material/brightness-7
+  #      name: Switch to dark mode
+  #   # Palette toggle for dark mode
+  #   - media: "(prefers-color-scheme: dark)"
+  #     scheme: slate
+  #     toggle:
+  #       icon: material/brightness-4
+  #       name: Switch to system preference
 
 markdown_extensions:
   - abbr

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@ site_url: https://ethereum.github.io/execution-spec-tests/
 repo_url: https://github.com/ethereum/execution-spec-tests
 repo_name: execution-spec-tests
 edit_uri: edit/main/docs/
-copyright: 'Copyright: 2023, Ethereum Community'
+copyright: 'Copyright: 2024, Ethereum Community'
 
 plugins:
   - git-authors:

--- a/src/pytest_plugins/filler/gen_test_doc/__init__.py
+++ b/src/pytest_plugins/filler/gen_test_doc/__init__.py
@@ -1,0 +1,3 @@
+"""
+A pytest plugin to generate test case documentation for mkdocs.
+"""

--- a/src/pytest_plugins/filler/gen_test_doc/gen_test_doc.py
+++ b/src/pytest_plugins/filler/gen_test_doc/gen_test_doc.py
@@ -52,6 +52,7 @@ from jinja2 import Environment, FileSystemLoader, StrictUndefined
 from pytest import Item
 
 from ethereum_test_forks import get_forks
+from ethereum_test_specs import SPEC_TYPES
 from ethereum_test_tools.utility.versioning import (
     generate_github_url,
     get_current_commit_hash_or_tag,
@@ -72,6 +73,8 @@ from .page_props import (
 )
 
 logger = logging.getLogger("mkdocs")
+
+docstring_test_function_history: Dict[str, str] = {}
 
 
 def pytest_addoption(parser):  # noqa: D103
@@ -183,7 +186,7 @@ def get_docstring_one_liner(item: pytest.Item) -> str:
         docstring in docstring_test_function_history
         and docstring_test_function_history[docstring] != test_function_id
     ):
-        logger.warning(
+        logger.info(
             f"Duplicate docstring for {test_function_id}: "
             f"{docstring_test_function_history[docstring]} and {test_function_id}"
         )

--- a/src/pytest_plugins/filler/gen_test_doc/gen_test_doc.py
+++ b/src/pytest_plugins/filler/gen_test_doc/gen_test_doc.py
@@ -1,0 +1,543 @@
+"""
+A pytest plugin that generates test case documentation for use in mkdocs.
+
+It generates the top-level "Test Case Reference" section in EEST's mkdocs
+site.
+
+Note:
+-----
+- No output directory is specified for the generated output; file IO occurs
+    via the `mkdocs-gen-files` plugin. `mkdocs serve` writes intermediate files
+    to our local `docs/` directory and then copies it to the site directory.
+    We modify `docs/navigation.md` and write all other output underneath
+    `docs/tests`. If mkdocs is interrupted, these intermediate artifacts are
+    left in `docs/`.
+
+Usage:
+------
+
+!!! note "Ensuring a clean build"
+
+    In case mkdocs has polluted the `docs/` directory with intermediate files, run:
+
+    ```console
+    git restore docs/navigation.md  # Careful if you have local modifications!
+    rm -rf docs/tests docs/docs site
+    ```
+
+To test doc generation, run the plugin without mkdocs:
+
+```console
+uv run fill -p pytest_plugins.filler.gen_test_doc.gen_test_doc --gen-docs --fork=<fork> tests
+```
+
+Or to build and view the site:
+
+```console
+uv run mkdocs serve
+```
+"""
+
+import glob
+import logging
+import sys
+import textwrap
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Dict, List, Set, Tuple, cast
+
+import mkdocs_gen_files  # type: ignore
+import pytest
+from jinja2 import Environment, FileSystemLoader, StrictUndefined
+from pytest import Item
+
+from ethereum_test_forks import get_forks
+from ethereum_test_tools.utility.versioning import (
+    generate_github_url,
+    get_current_commit_hash_or_tag,
+)
+
+from .page_props import (
+    DirectoryPageProps,
+    FunctionPageProps,
+    FunctionPagePropsLookup,
+    MarkdownPageProps,
+    ModulePageProps,
+    ModulePagePropsLookup,
+    PageProps,
+    PagePropsLookup,
+    TestCase,
+    TestFunction,
+    sanitize_string_title,
+)
+
+logger = logging.getLogger("mkdocs")
+
+
+def pytest_addoption(parser):  # noqa: D103
+    gen_docs = parser.getgroup(
+        "gen_docs", "Arguments related to generating test case documentation"
+    )
+    gen_docs.addoption(
+        "--gen-docs",
+        action="store_true",
+        dest="generate_docs",
+        default=False,
+        help="Generate documentation for all collected tests for use in for mkdocs",
+    )
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_configure(config):  # noqa: D103
+    if config.getoption("--gen-docs"):
+        config.option.disable_html = True
+        config.pluginmanager.register(TestDocsGenerator(config), "test-case-doc-generator")
+
+
+def get_test_function_id(item: Item) -> str:
+    """
+    Get the test function's ID from the item.
+    """
+    return item.nodeid.split("[")[0]
+
+
+def get_test_function_name(item: Item) -> str:
+    """
+    Get the test function's name from the item.
+    """
+    return item.name.split("[")[0]
+
+
+def get_test_case_id(item: Item) -> str:
+    """
+    Get the test case's ID from the item.
+    """
+    return item.nodeid.split("[")[-1].rstrip("]")
+
+
+def get_test_function_import_path(item: pytest.Item) -> str:
+    """
+    Retrieve the fully qualified import path for an item's test function.
+
+    This is used in jinja2 templates to get the test function, respectively
+    the test function's class, documentation with mkdocstrings.
+    """
+    item = cast(pytest.Function, item)  # help mypy infer type
+    module_name = item.module.__name__
+    if hasattr(item.obj, "__self__"):
+        # it's a method bound to a class
+        test_class = item.obj.__self__.__class__.__name__
+        test_function = item.obj.__name__
+        full_path = f"{module_name}.{test_class}"
+    else:
+        # it's a standalone function, no class
+        test_function = item.obj.__name__
+        full_path = f"{module_name}.{test_function}"
+    return full_path
+
+
+def get_import_path(path: Path) -> str:
+    """
+    Get the import path for a given path.
+
+    - For modules, strip the file extension.
+    - For directories (i.e., packages such as `tests.berlin`), `with_suffix()` is ignored.
+
+    To do:
+    ------
+
+    - This should be combined with `get_test_function_import_path`.
+    """
+    return str(path.with_suffix("")).replace("/", ".")
+
+
+def create_github_issue_url(title: str) -> str:
+    """
+    Create a GitHub issue URL for the given title.
+    """
+    url_base = "https://github.com/ethereum/execution-spec-tests/issues/new?"
+    title = title.replace(" ", "%20")
+    labels = "scope:docs,type:bug"
+    return f"{url_base}title={title}&labels={labels}"
+
+
+def get_docstring_one_liner(item: pytest.Item) -> str:
+    """
+    Extracts either the first 100 characters or the first line of the docstring
+    from the function associated with the given pytest.Item.
+    """
+    item = cast(pytest.Function, item)  # help mypy infer type
+    func_obj = item.obj
+    docstring = func_obj.__doc__
+    test_function_name = get_test_function_name(item)
+
+    if not docstring:
+        github_issue_url = create_github_issue_url(
+            f"docs(bug): No docstring available for `{test_function_name}`"
+        )
+        logger.warning(f"No docstring available for `{test_function_name}`.")
+        return f"[📖🐛 No docstring available]({github_issue_url})"
+    docstring = docstring.strip()
+    lines = docstring.splitlines()
+
+    bad_oneliner_issue_url = create_github_issue_url(
+        f"docs(bug): Bad docstring oneliner for `{test_function_name}`"
+    )
+    report_bad_oneliner_link = f"([📖🐛?]({bad_oneliner_issue_url}))"
+    if lines:
+        first_line = lines[0].strip()
+        if len(first_line) <= 100:
+            return (
+                first_line
+                if not first_line.endswith(":")
+                else first_line + report_bad_oneliner_link
+            )
+        else:
+            return first_line[:100] + f"... {report_bad_oneliner_link}"
+    else:
+        return docstring[:100] + f"... {report_bad_oneliner_link}"
+
+
+def get_test_function_test_type(item: pytest.Item) -> str:
+    """
+    Get the test type for the test function based on its fixtures.
+    """
+    test_types: List[str] = [
+        "state_test",
+        "state_test_only",
+        "blockchain_test",
+        "eof_test",
+        "eof_state_test",
+    ]
+    item = cast(pytest.Function, item)  # help mypy infer type
+    fixture_names = item.fixturenames
+    for test_type in test_types:
+        if test_type in fixture_names:
+            return test_type
+    assert 0
+    logger.warning(f"Could not determine the test function type for {item.nodeid}")
+    return f"unknown ([📖🐛]({create_github_issue_url('docs(bug): unknown test function type')}))"
+
+
+class TestDocsGenerator:
+    """
+    Pytest plugin class for generating test case documentation.
+    """
+
+    def __init__(self, config) -> None:
+        self.config = config
+        self._setup_logger()
+        self.jinja2_env = Environment(
+            loader=FileSystemLoader("docs/templates"),
+            trim_blocks=True,
+            undefined=StrictUndefined,
+        )
+        self.source_dir = Path("tests")
+        self.ref = get_current_commit_hash_or_tag()
+        self.top_level_nav_entry = "Test Case Reference"
+        self.skip_params = ["blockchain_test", "state_test", "eof_test", "fork"]
+        # intermediate collected pages and their properties
+        self.function_page_props: FunctionPagePropsLookup = {}
+        self.module_page_props: ModulePagePropsLookup = {}
+        # the complete set of pages and their properties
+        self.page_props: PagePropsLookup = {}
+
+    @pytest.hookimpl(hookwrapper=True, trylast=True)
+    def pytest_collection_modifyitems(self, session, config, items):
+        """
+        Generate html doc for each test item that pytest has collected.
+        """
+        yield
+
+        self.add_global_page_props_to_env()
+
+        functions = defaultdict(list)
+        for item in items:  # group test case by test function
+            functions[get_test_function_id(item)].append(item)
+
+        # the heavy work
+        self.create_function_page_props(functions)
+        self.create_module_page_props()
+        # add the pages to the page_props dict
+        self.page_props = {**self.function_page_props, **self.module_page_props}
+        # this adds pages for the intermediate directory structure (tests, tests/berlin)
+        self.add_directory_page_props()
+        # add other interesting pages
+        self.add_spec_page_props()
+        self.add_markdown_page_props()
+        # write pages and navigation menu
+        self.write_pages()
+        self.update_mkdocs_nav()
+
+    @pytest.hookimpl(tryfirst=True)
+    def pytest_runtestloop(self, session):
+        """
+        Skip test execution, only generate docs.
+        """
+        session.testscollected = 0
+        return True
+
+    def pytest_terminal_summary(self, terminalreporter, exitstatus, config):
+        """
+        Add a summary line for the docs.
+        """
+        terminalreporter.write_sep("=", f"{len(self.page_props)} doc pages generated", bold=True)
+
+    def _setup_logger(self):
+        """
+        Configures the mkdocs logger and adds a StreamHandler if outside mkdocs.
+
+        We use the mkdocs logger to report warnings if conditions are invalid -
+        this will inform the user and fail the build with `mkdocs build --strict`.
+        """
+        if not logger.hasHandlers() or logger.level == logging.NOTSET:
+            stream_handler = logging.StreamHandler(sys.stdout)
+            stream_handler.setLevel(logging.INFO)
+            logger.addHandler(stream_handler)
+            logger.setLevel(logging.INFO)
+
+    def add_global_page_props_to_env(self):
+        """
+        Populate global page properties used in j2 templates.
+        """
+        global_page_props = dict(
+            deployed_forks=[fork.name().lower() for fork in get_forks() if fork.is_deployed()],
+            short_git_ref=get_current_commit_hash_or_tag(shorten_hash=True),
+            test_function_parameter_table_skipped_parameters=", ".join(
+                f"`{p}`" for p in self.skip_params
+            ),
+        )
+
+        self.jinja2_env.globals.update(global_page_props)
+
+    def create_function_page_props(self, test_functions: Dict["str", List[Item]]) -> None:
+        """
+        Traverse all test items and create a lookup of doc pages & required props
+
+        To do: Needs refactor.
+        """
+        for function_id, function_items in test_functions.items():
+            assert all(isinstance(item, pytest.Function) for item in function_items)
+            items = cast(List[pytest.Function], function_items)  # help mypy infer type
+            # extract parametrized test cases for each test function
+            test_cases = []
+            if getattr(items[0], "callspec", None):
+                for item in items:
+                    param_set = item.callspec.params
+                    # Filter out unwanted parameters from the param set
+                    keys = [key for key in param_set.keys() if key not in self.skip_params]
+                    values = [param_set[key] for key in keys]
+                    values = [
+                        # " ".join(f"<code>{byte:02x}</code>" for byte in value)  # noqa: SC100
+                        " ".join(
+                            f"<code>{chunk}</code>" for chunk in textwrap.wrap(value.hex(), 32)
+                        )
+                        if isinstance(value, bytes)
+                        else str(value)
+                        for value in values
+                    ]
+
+                    # Create the filtered test ID
+                    original_test_id = item.nodeid.split("[")[-1].rstrip("]")
+                    filtered_test_id_parts = []
+                    for part in original_test_id.split("-"):
+                        param_name = part.split("_")[0] if "_" in part else None
+                        if (param_name not in self.skip_params) and (part not in self.skip_params):
+                            filtered_test_id_parts.append(part)
+                    filtered_test_id = "-".join(filtered_test_id_parts)
+
+                    if filtered_test_id_parts:
+                        test_cases.append(
+                            TestCase(id=filtered_test_id, params=dict(zip(keys, values)))
+                        )
+
+            module_relative_path = Path(items[0].module.__file__).relative_to(Path.cwd())
+            source_url = generate_github_url(
+                module_relative_path,
+                branch_or_commit_or_tag=self.ref,
+                line_number=items[0].function.__code__.co_firstlineno,
+            )
+            valid_from_marker = items[0].get_closest_marker("valid_from")
+            if not valid_from_marker:
+                valid_from_fork = "Frontier"
+            else:
+                # NOTE: The EOF tests cases contain two fork names in their valid_from marker,
+                # separated by a comma. Take the last.
+                valid_from_fork = valid_from_marker.args[0].split(",")[-1]
+
+            self.function_page_props[function_id] = FunctionPageProps(
+                title=get_test_function_name(items[0]),
+                source_code_url=source_url,
+                valid_from_fork=valid_from_fork,
+                path=module_relative_path,
+                pytest_node_id=function_id,
+                package_name=get_test_function_import_path(items[0]),
+                cases=test_cases,
+                test_type=get_test_function_test_type(items[0]),
+                docstring_one_liner=get_docstring_one_liner(items[0]),
+                html_static_page_target=f"./{get_test_function_name(items[0])}.html",
+            )
+
+    def create_module_page_props(self) -> None:
+        """
+        Discover the test module doc pages and extract their properties.
+        """
+        for function_id, function_page in self.function_page_props.items():
+            if str(function_page.path) not in self.module_page_props:
+                module_path = function_page.path
+                self.module_page_props[str(function_page.path)] = ModulePageProps(
+                    title=sanitize_string_title(function_page.path.stem),
+                    source_code_url=function_page.source_code_url,
+                    valid_from_fork=function_page.valid_from_fork,
+                    path=module_path,
+                    pytest_node_id=str(module_path),
+                    package_name=get_import_path(module_path),
+                    test_functions=[
+                        TestFunction(
+                            name=function_page.title,
+                            test_type=function_page.test_type,
+                            test_case_count=len(function_page.cases) if function_page.cases else 1,
+                            docstring_one_liner=function_page.docstring_one_liner,
+                        )
+                    ],
+                )
+            else:
+                existing_module_page = self.module_page_props[str(function_page.path)]
+                existing_module_page.test_functions.append(
+                    TestFunction(
+                        name=function_page.title,
+                        test_type=function_page.test_type,
+                        test_case_count=len(function_page.cases) if function_page.cases else 1,
+                        docstring_one_liner=function_page.docstring_one_liner,
+                    )
+                )
+
+    def add_directory_page_props(self) -> None:
+        """
+        Discover the intermediate directory pages and extract their properties.
+
+        These directories may not have any test modules within them, e.g., tests/berlin/.
+        """
+        sub_paths: Set[Path] = set()
+        for module_page in self.module_page_props.values():
+            module_path_parts = module_page.path.parent.parts
+            sub_paths.update(
+                Path(*module_path_parts[: i + 1]) for i in range(len(module_path_parts))
+            )
+        for directory in sub_paths:
+            fork = (
+                directory.relative_to(self.source_dir).parts[0]
+                if directory != self.source_dir
+                # set any deployed fork for tests/index.md (to avoid dev-fork in command args)
+                else "cancun"
+            )
+            self.page_props[str(directory)] = DirectoryPageProps(
+                title=sanitize_string_title(str(directory.name)),
+                path=directory,
+                pytest_node_id=str(directory),
+                source_code_url=generate_github_url(directory, branch_or_commit_or_tag=self.ref),
+                # TODO: This won't work in all cases; should be from the development fork
+                # Currently breaks for `test/prague/eip7692_eof_v1/index.md`  # noqa: SC100
+                valid_from_fork=fork,
+                package_name=get_import_path(directory),  # init.py will be used for docstrings
+            )
+
+    def find_files_within_collection_scope(self, file_pattern: str) -> List[Path]:
+        """
+        Find all files that match the scope of the collected test modules
+
+        This to avoid adding matching files in uncollected test directories.
+
+        Note: could be optimized!
+        """
+        files = []
+        for module_page in self.module_page_props.values():
+            # all files found in and under the modules' directory
+            files += glob.glob(f"{module_page.path.parent}/**/{file_pattern}", recursive=True)
+            for parent in module_page.path.parent.parents:
+                if parent == self.source_dir:
+                    break
+                # add files in a module's parent directory
+                files += glob.glob(f"{parent}/{file_pattern}")
+        return [Path(file) for file in set(files)]
+
+    def add_spec_page_props(self) -> None:
+        """
+        Add page path properties for spec files discovered in the collection scope.
+        """
+        for spec_path in self.find_files_within_collection_scope("spec.py"):
+            self.page_props[str(spec_path)] = ModulePageProps(
+                title="Spec",
+                path=spec_path,
+                source_code_url=generate_github_url(spec_path, branch_or_commit_or_tag=self.ref),
+                pytest_node_id=str(spec_path),
+                package_name=get_import_path(spec_path),
+                valid_from_fork="",
+                test_functions=[],
+            )
+
+    def add_markdown_page_props(self) -> None:
+        """
+        Add page path properties for markdown files discovered in the collection scope.
+        """
+        for md_path in self.find_files_within_collection_scope("*.md"):
+            self.page_props[str(md_path)] = MarkdownPageProps(
+                title=md_path.stem,
+                path=md_path,
+                source_code_url=generate_github_url(md_path, branch_or_commit_or_tag=self.ref),
+                pytest_node_id=str(md_path),  # abuse: not a test, but used in source code link
+                valid_from_fork="",
+                package_name="",
+            )
+
+    def update_mkdocs_nav(self) -> None:
+        """
+        Add the generated 'Test Case Reference' entries to the mkdocs navigation menu.
+        """
+        fork_order = {fork.name().lower(): i for i, fork in enumerate(reversed(get_forks()))}
+
+        def sort_by_fork_deployment_and_path(x: PageProps) -> Tuple[Any, ...]:
+            """
+            Key function used to sort navigation menu entries for test case ref docs.
+
+            Nav entries / output files contain special cases such as:
+
+            - ("Test Case Reference",) -> tests/index.md
+            - ("Test Case Reference", "Berlin") -> tests/berlin/index.md
+            - ("Test Case Reference", "Prague", "EIP-7692 EOF V1", tracker.md")
+                tests/prague/eip7692_eof_v1/tracker.md
+            - ("Test Case Reference", "Shanghai", "EIP-3855 PUSH0", "Spec") ->
+                tests/shanghai/eip3855_push0/spec.py
+
+            This function provides and ordering to sort nav men entries as follows:
+
+            1. Forks are listed in the chronological order that they were deployed.
+            2. Special files listed first (before test pages): "*.md" and `Spec.py`,
+            3. The page's corresponding file path under `./tests/`.
+            """
+            length = len(x.path.parts)
+            if length > 1:
+                fork = str(x.path.parts[1]).lower()  # the fork folder from the relative path
+            if length == 1:
+                return (0,)
+            elif length == 2:
+                return (1, fork_order[fork])
+            elif x.path.name == "spec.py":
+                return (2, fork_order[fork], length, 0, x.path)
+            elif x.path.suffix == ".md":
+                return (2, fork_order[fork], length, 1, x.path)
+            else:
+                return (2, fork_order[fork], length, 2, x.path)
+
+        nav = mkdocs_gen_files.Nav()
+        for page in sorted(self.page_props.values(), key=sort_by_fork_deployment_and_path):
+            nav[page.nav_entry(self.top_level_nav_entry)] = str(page.target_output_file)
+        with mkdocs_gen_files.open("navigation.md", "a") as nav_file:
+            nav_file.writelines(nav.build_literate_nav())
+
+    def write_pages(self) -> None:
+        """
+        Write all pages to the target directory.
+        """
+        for page in self.page_props.values():
+            page.write_page(self.jinja2_env)

--- a/src/pytest_plugins/filler/gen_test_doc/gen_test_doc.py
+++ b/src/pytest_plugins/filler/gen_test_doc/gen_test_doc.py
@@ -344,7 +344,7 @@ class TestDocsGenerator:
                         param_name = part.split("_")[0] if "_" in part else None
                         if (param_name not in self.skip_params) and (part not in self.skip_params):
                             filtered_test_id_parts.append(part)
-                    filtered_test_id = "-".join(filtered_test_id_parts)
+                    filtered_test_id = "-".join(filtered_test_id_parts).strip("-")
 
                     if filtered_test_id_parts:
                         test_cases.append(

--- a/src/pytest_plugins/filler/gen_test_doc/page_props.py
+++ b/src/pytest_plugins/filler/gen_test_doc/page_props.py
@@ -1,0 +1,276 @@
+"""
+Classes and helpers used for templates, navigation menus and file output.
+
+The dataclass fields are used to define the page properties fields which
+are used in the jinja2 templates when generating site content (located in
+docs/templates). The classes also define each page's navigation menu entry
+and target output file.
+
+A few helpers are defined with EEST logic in order to sanitize strings from
+file paths for use in navigation menu.
+"""
+import re
+from abc import abstractmethod
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import mkdocs_gen_files  # type: ignore
+from jinja2 import Environment
+
+from ethereum_test_tools import Opcodes
+
+
+def apply_name_filters(input_string: str):
+    """
+    Apply a list of capitalizations/regexes to names used in titles & nav menus.
+
+    Note: As of PragueEIP7692 With 634 doc pages, this function constitutes ~2.0s
+    of the total runtime (~5.5s). This seems to be insignificant with the time
+    taken by mkdocstrings to include the docstrings in the final output (which)
+    is a separate mkdocs "build-step" occurs outside the scope of this plugin.
+    """
+    word_replacements = {
+        "acl": "ACL",
+        "bls 12": "BLS12",
+        "bls12 g1add": "BLS12_G1ADD",
+        "bls12 g1msm": "BLS12_G1MSM",
+        "bls12 g1mul": "BLS12_G1MUL",
+        "bls12 g2add": "BLS12_G2ADD",
+        "bls12 g2msm": "BLS12_G2MSM",
+        "bls12 g2mul": "BLS12_G2MUL",
+        "bls12 map fp2 to g2": "BLS12_MAP_FP2_TO_G2",
+        "bls12 map fp to g1": "BLS12_MAP_FP_TO_G1",
+        "bls12 pairing": "BLS12_PAIRING_CHECK",
+        "eips": "EIPs",
+        "eof": "EOF",
+        "vm": "VM",
+    }
+    # adding these is the expensive part
+    opcode_replacements = {str(opcode): str(opcode) for opcode in Opcodes if str(opcode) != "GAS"}
+    all_replacements = {**word_replacements, **opcode_replacements}
+    for word, replacement in all_replacements.items():
+        input_string = re.sub(rf"(?i)\b{re.escape(word)}\b", replacement, input_string)
+
+    regex_patterns = [
+        (r"eip-?([1-9]{1,5})", r"EIP-\1"),  # Matches "eip-123" or "eip123"
+    ]
+    for pattern, replacement in regex_patterns:
+        input_string = re.sub(pattern, replacement, input_string, flags=re.IGNORECASE)
+
+    return input_string
+
+
+def snake_to_capitalize(string: str) -> str:  # noqa: D103
+    """
+    Converts valid identifiers to a capitalized string, otherwise leave as-is.
+    """
+    if string.isidentifier():
+        return " ".join(word.capitalize() for word in string.split("_"))
+    return string
+
+
+def sanitize_string_title(string: str) -> str:
+    """
+    Sanitize a string to be used as a title.
+    """
+    return apply_name_filters(snake_to_capitalize(string))
+
+
+def nav_path_to_sanitized_str_tuple(nav_path: Path) -> tuple:
+    """
+    Convert a nav path to a tuple of sanitized strings for use in mkdocs navigation.
+    """
+    return tuple(sanitize_string_title(part) for part in nav_path.parts)
+
+
+@dataclass
+class PagePropsBase:
+    """
+    Common test reference doc page properties and definitions.
+
+    The dataclass attributes are made directly available in the jinja2
+    found in `docs/templates/*.j2`.
+    """
+
+    title: str
+    source_code_url: str
+    valid_from_fork: str
+    path: Path
+    pytest_node_id: str
+    package_name: str
+
+    def get_template(self) -> str:
+        """
+        Return the template name based on the class type.
+        """
+        if isinstance(self, FunctionPageProps):
+            return "function.md.j2"
+        elif isinstance(self, ModulePageProps):
+            return "module.md.j2"
+        elif isinstance(self, DirectoryPageProps):
+            return "directory.md.j2"
+        elif isinstance(self, MarkdownPageProps):
+            return "markdown_header.md.j2"
+        else:
+            raise ValueError(f"Unknown page type: {self.__class__.__name__}")
+
+    @property
+    @abstractmethod
+    def target_output_file(self) -> Path:
+        """
+        Get the target output file for this page.
+        """
+        raise NotImplementedError
+
+    def nav_entry(self, top_level_nav_entry: str) -> tuple:
+        """
+        Get the mkdocs navigation entry for this page.
+        """
+        if len(self.path.parts) == 1:
+            return (top_level_nav_entry,)
+        path = top_level_nav_entry / Path(*self.path.parts[1:]).with_suffix("")
+        return nav_path_to_sanitized_str_tuple(path)
+
+    def write_page(self, jinja2_env: Environment):
+        """
+        Write the page to the target directory.
+        """
+        template = jinja2_env.get_template(self.get_template())
+        rendered_content = template.render(**asdict(self))
+        with mkdocs_gen_files.open(self.target_output_file, "w") as destination:
+            for line in rendered_content.splitlines(keepends=True):
+                destination.write(line)
+
+
+@dataclass
+class TestCase:
+    """
+    Properties used to define a single test case in test function parameter tables.
+    """
+
+    id: str
+    params: Dict[str, Any]
+
+
+@dataclass
+class FunctionPageProps(PagePropsBase):
+    """
+    Definitions used for to generate test function (markdown) pages and their
+    corresponding static HTML pages.
+    """
+
+    test_type: str
+    docstring_one_liner: str
+    html_static_page_target: str
+    cases: Optional[List[TestCase]]
+
+    @property
+    def target_output_file(self) -> Path:
+        """
+        Get the target output file for this page.
+        """
+        return self.path.with_suffix("") / f"{self.title}.md"
+
+    def nav_entry(self, top_level_nav_entry) -> tuple:
+        """
+        Get the mkdocs navigation entry for this page.
+        """
+        nav_path_prefix = super().nav_entry(top_level_nav_entry)  # already sanitized
+        return tuple([*nav_path_prefix, f"<code>{self.title}</code>"])
+
+    def write_page(self, jinja2_env: Environment):
+        """
+        Test functions also get a static HTML page with parametrized test cases.
+
+        This is intended for easier viewing (without mkdocs styling) of the data-table
+        that documents the parametrized test cases.
+        """
+        super().write_page(jinja2_env)
+        if not self.cases:
+            return
+        html_template = jinja2_env.get_template("function.html.j2")
+        rendered_html_content = html_template.render(**asdict(self))
+        html_output_file = self.target_output_file.with_suffix(".html")
+        with mkdocs_gen_files.open(html_output_file, "w") as destination:
+            for line in rendered_html_content.splitlines(keepends=True):
+                destination.write(line)
+
+
+@dataclass
+class TestFunction:
+    """
+    Properties used to build the test function overview table in test module pages.
+    """
+
+    name: str
+    test_type: str
+    test_case_count: int
+    docstring_one_liner: str
+
+
+@dataclass
+class ModulePageProps(PagePropsBase):
+    """
+    Definitions used for test modules, e.g., `tests/berlin/eip2930_access_list/test_acl.py`.
+    """
+
+    test_functions: List[TestFunction]
+
+    @property
+    def target_output_file(self) -> Path:
+        """
+        Get the target output file for this page.
+        """
+        if self.path.suffix == "spec.py":
+            return self.path.with_suffix(".md")
+        return self.path.with_suffix("") / "index.md"
+
+
+@dataclass
+class DirectoryPageProps(PagePropsBase):
+    """
+    Definitions used for parent directories in test paths, e.g., `tests/berlin`.
+    """
+
+    @property
+    def target_output_file(self) -> Path:
+        """
+        Get the target output file for this page.
+        """
+        return self.path / "index.md"
+
+
+@dataclass
+class MarkdownPageProps(PagePropsBase):
+    """
+    Definitions used to verbatim include markdown files included in test paths.
+    """
+
+    @property
+    def target_output_file(self) -> Path:
+        """
+        Get the target output file for this page.
+        """
+        return self.path
+
+    def write_page(self, jinja2_env: Environment):
+        """
+        Write the page to the target directory.
+
+        We read the md file and write it with `mkdocs_gen_files`.
+        """
+        template = jinja2_env.get_template(self.get_template())
+        rendered_content = template.render(**asdict(self))
+        with open(self.path, "r") as md_source:
+            with mkdocs_gen_files.open(self.target_output_file, "w") as destination:
+                for line in rendered_content.splitlines(keepends=True):
+                    destination.write(line)
+                for line in md_source:
+                    destination.write(line)
+
+
+PageProps = DirectoryPageProps | ModulePageProps | FunctionPageProps | MarkdownPageProps
+PagePropsLookup = Dict[str, PageProps]
+ModulePagePropsLookup = Dict[str, ModulePageProps]
+FunctionPagePropsLookup = Dict[str, FunctionPageProps]

--- a/src/pytest_plugins/filler/gen_test_doc/page_props.py
+++ b/src/pytest_plugins/filler/gen_test_doc/page_props.py
@@ -163,7 +163,7 @@ class FunctionPageProps(PagePropsBase):
         """
         Get the filename of the jinja2 template used to render this page.
         """
-        return "function.html.j2"
+        return "function.md.j2"
 
     @property
     def target_output_file(self) -> Path:

--- a/src/pytest_plugins/filler/gen_test_doc/page_props.py
+++ b/src/pytest_plugins/filler/gen_test_doc/page_props.py
@@ -103,20 +103,10 @@ class PagePropsBase:
     @property
     @abstractmethod
     def template(self) -> str:
-      pass
         """
-        Return the template name based on the class type.
+        Get the jinja2 template used to render this page.
         """
-        if isinstance(self, FunctionPageProps):
-            return "function.md.j2"
-        elif isinstance(self, ModulePageProps):
-            return "module.md.j2"
-        elif isinstance(self, DirectoryPageProps):
-            return "directory.md.j2"
-        elif isinstance(self, MarkdownPageProps):
-            return "markdown_header.md.j2"
-        else:
-            raise ValueError(f"Unknown page type: {self.__class__.__name__}")
+        raise NotImplementedError
 
     @property
     @abstractmethod
@@ -139,7 +129,7 @@ class PagePropsBase:
         """
         Write the page to the target directory.
         """
-        template = jinja2_env.get_template(self.get_template())
+        template = jinja2_env.get_template(self.template)
         rendered_content = template.render(**asdict(self))
         with mkdocs_gen_files.open(self.target_output_file, "w") as destination:
             for line in rendered_content.splitlines(keepends=True):
@@ -167,6 +157,13 @@ class FunctionPageProps(PagePropsBase):
     docstring_one_liner: str
     html_static_page_target: str
     cases: Optional[List[TestCase]]
+
+    @property
+    def template(self) -> str:
+        """
+        Get the filename of the jinja2 template used to render this page.
+        """
+        return "function.html.j2"
 
     @property
     def target_output_file(self) -> Path:
@@ -221,6 +218,13 @@ class ModulePageProps(PagePropsBase):
     test_functions: List[TestFunction]
 
     @property
+    def template(self) -> str:
+        """
+        Get the filename of the jinja2 template used to render this page.
+        """
+        return "module.md.j2"
+
+    @property
     def target_output_file(self) -> Path:
         """
         Get the target output file for this page.
@@ -237,6 +241,13 @@ class DirectoryPageProps(PagePropsBase):
     """
 
     @property
+    def template(self) -> str:
+        """
+        Get the filename of the jinja2 template used to render this page.
+        """
+        return "directory.md.j2"
+
+    @property
     def target_output_file(self) -> Path:
         """
         Get the target output file for this page.
@@ -251,6 +262,13 @@ class MarkdownPageProps(PagePropsBase):
     """
 
     @property
+    def template(self) -> str:
+        """
+        Get the filename of the jinja2 template used to render this page.
+        """
+        return "markdown_header.md.j2"
+
+    @property
     def target_output_file(self) -> Path:
         """
         Get the target output file for this page.
@@ -263,7 +281,7 @@ class MarkdownPageProps(PagePropsBase):
 
         We read the md file and write it with `mkdocs_gen_files`.
         """
-        template = jinja2_env.get_template(self.get_template())
+        template = jinja2_env.get_template(self.template)
         rendered_content = template.render(**asdict(self))
         with open(self.path, "r") as md_source:
             with mkdocs_gen_files.open(self.target_output_file, "w") as destination:

--- a/src/pytest_plugins/filler/gen_test_doc/page_props.py
+++ b/src/pytest_plugins/filler/gen_test_doc/page_props.py
@@ -100,7 +100,10 @@ class PagePropsBase:
     pytest_node_id: str
     package_name: str
 
-    def get_template(self) -> str:
+    @property
+    @abstractmethod
+    def template(self) -> str:
+      pass
         """
         Return the template name based on the class type.
         """

--- a/tests/prague/__init__.py
+++ b/tests/prague/__init__.py
@@ -1,3 +1,10 @@
 """
-Test cases for EVM functionality introduced in Prague.
-"""
+Test cases for EVM functionality introduced in Prague, [EIP-7600: Hardfork Meta - Pectra](https://eip.directory/eips/eip-7600).
+
+Devnet Specifications:
+
+- [ethpandaops/pectra-devnet-4](https://notes.ethereum.org/@ethpandaops/pectra-devnet-4).
+- [ethpandaops/pectra-devnet-3](https://notes.ethereum.org/@ethpandaops/pectra-devnet-3).
+- [ethpandaops/pectra-devnet-2](https://notes.ethereum.org/@ethpandaops/pectra-devnet-2).
+- [ethpandaops/pectra-devnet-1](https://notes.ethereum.org/@ethpandaops/pectra-devnet-1).
+"""  # noqa: E501

--- a/tox.ini
+++ b/tox.ini
@@ -100,6 +100,6 @@ commands =
     black {[testenv:docs]src} --check --diff
     flake8 {[testenv:docs]src}
     mypy {[testenv:docs]src}
-    mkdocs build --strict
     python -c "import src.cli.tox_helpers; src.cli.tox_helpers.pyspelling()"
     python -c "import src.cli.tox_helpers; src.cli.tox_helpers.markdownlint()"
+    mkdocs build --strict

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -112,6 +112,7 @@ dunder
 dup
 EEST
 eip
+eip123
 eip3540
 eip4844
 eip6110
@@ -145,6 +146,7 @@ executables
 extcodecopy
 extcodehash
 extcodesize
+exitstatus
 F00
 fcu
 filelock
@@ -218,6 +220,7 @@ initcode
 inputdata
 instantiation
 io
+isidentifier
 islice
 isort
 isort's
@@ -231,6 +234,7 @@ json
 JSON
 keccak
 keccak256
+keepends
 key2
 kzg
 kzgs
@@ -271,10 +275,12 @@ NOPs
 nPython
 nSHA
 t8ntool
+NOTSET
 num
 number
 ommer
 ommers
+oneliner
 oob
 opc
 oprypin
@@ -290,6 +296,7 @@ perf
 permalink
 petersburg
 pformat
+pluginmanager
 png
 Pomerantz
 POS
@@ -334,6 +341,7 @@ rlp
 rootdir
 rpc
 ruleset
+runtestloop
 runtime
 sandboxed
 secp256k1
@@ -375,8 +383,10 @@ substring
 sudo
 t8n
 tamasfe
+terminalreporter
 testability
 TestAddress
+testscollected
 TestContractCreationGasUsage
 TestMultipleWithdrawalsSameAddress
 textwrap


### PR DESCRIPTION
## 🗒️ Description

This is a rewrite of the automatic test case doc generation as a pytest plugin (as apposed to a standalone script). A preview is available at https://ethereum.github.io/execution-spec-tests/pr-801-preview.

### Doc Improvements
1. Test module pages: Added a table that provides and overview of its test functions, e.g., [tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1add](https://ethereum.github.io/execution-spec-tests/pr-801-preview/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1add/).
2. Added test function pages which include a table which tries to give an overview of its parametrized test cases, e.g., [tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1add::test_valid](https://ethereum.github.io/execution-spec-tests/pr-801-preview/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1add/test_valid/).
3. Added static html files for the tables of the function parameters overview, as they often don't play well within mkdocs styling. 
4. Markdown pages: Added a header with a path and ref link for the markdown file, e.g., [tests/prague/eip7692_eof_v1/tracker.md](https://ethereum.github.io/execution-spec-tests/pr-801-preview/tests/prague/eip7692_eof_v1/tracker/)

### Technical Improvements

1. Doc build fails if no function docstring is available or the test type (e.g. `state_test`) can not be determined (both used in the function overview tables on test module pages).
2. Using a pytest plugin allows us to lever all the usual pytest flags for test item filtering and fork specification (great for debugging) and to introspect test items to easily grab test metadata.
3. [jinja2](https://jinja.palletsprojects.com/en/3.1.x/) is used for templating, which helps separate the content from its formatting. Jinja is a very powerful templating library which helps save a lot of boilerplate code. 

## 🔗 Related Issues
Perhaps solved, plz check whether the styling is acceptable, e.g., [test_bls12_g1add/test_valid.html](https://ethereum.github.io/execution-spec-tests/pr-801-preview/tests/prague/eip7702_set_code_tx/test_gas/test_gas_cost.html).
- #804.

Current issues:
- #803.

Ideas for future improvements:
- #802 (not a problem now, but we can only gen docs using one dev fork).
- #805.
- #813.
- #814.
- #815.
- #816.

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
