### PR TITLE
fix(forks): small pytest session header fix with dev forks

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,6 +37,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - 🐞 Fix usage of multiple `@pytest.mark.with_all*` markers which shared parameters, such as `with_all_call_opcodes` and `with_all_create_opcodes` which shared `evm_code_type`, and now only parametrize compatible values ([#762](https://github.com/ethereum/execution-spec-tests/pull/762)).
 - ✨ Added `selector` and `marks` fields to all `@pytest.mark.with_all*` markers, which allows passing lambda functions to select or mark specific parametrized values (see [documentation](https://ethereum.github.io/execution-spec-tests/main/writing_tests/test_markers/#covariant-marker-keyword-arguments) for more information) ([#762](https://github.com/ethereum/execution-spec-tests/pull/762)).
 - ✨ Improves consume input flags for develop and stable fixture releases, fixes `--help` flag for consume ([#745](https://github.com/ethereum/execution-spec-tests/pull/745)).
+- 🐞 Fix erroneous fork message in pytest session header with development forks ([#806](https://github.com/ethereum/execution-spec-tests/pull/806)).
 
 ### 🔧 EVM Tools
 

--- a/src/pytest_plugins/forks/forks.py
+++ b/src/pytest_plugins/forks/forks.py
@@ -443,7 +443,9 @@ def pytest_report_header(config, start_path):
             + reset
         ),
     ]
-    if not all(fork.is_deployed() for fork in config.forks):
+    if all(fork.is_deployed() for fork in config.forks):
+        for fork in config.forks:
+            print(fork.name(), fork.is_deployed())
         header += [
             (
                 bold + warning + "Only executing tests with stable/deployed forks: "

--- a/src/pytest_plugins/forks/forks.py
+++ b/src/pytest_plugins/forks/forks.py
@@ -444,8 +444,6 @@ def pytest_report_header(config, start_path):
         ),
     ]
     if all(fork.is_deployed() for fork in config.forks):
-        for fork in config.forks:
-            print(fork.name(), fork.is_deployed())
         header += [
             (
                 bold + warning + "Only executing tests with stable/deployed forks: "

--- a/src/pytest_plugins/forks/forks.py
+++ b/src/pytest_plugins/forks/forks.py
@@ -443,7 +443,7 @@ def pytest_report_header(config, start_path):
             + reset
         ),
     ]
-    if config.getoption("forks_until") is None:
+    if not all(fork.is_deployed() for fork in config.forks):
         header += [
             (
                 bold + warning + "Only executing tests with stable/deployed forks: "

--- a/src/pytest_plugins/forks/forks.py
+++ b/src/pytest_plugins/forks/forks.py
@@ -443,7 +443,7 @@ def pytest_report_header(config, start_path):
             + reset
         ),
     ]
-    if all(fork.is_deployed() for fork in config.forks):
+    if all(fork.is_deployed() for fork in config.fork_set):
         header += [
             (
                 bold + warning + "Only executing tests with stable/deployed forks: "


### PR DESCRIPTION
## 🗒️ Description
Don't print the following if we're generating fixtures for a fork under development:

```
Only executing tests with stable/deployed forks: Specify an upcoming fork via --until=fork to add forks under development.
```

## 🔗 Related Issues
None.

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
