### PR TITLE
feat(hint): post state key hint [IDEA]

### DIFF
--- a/src/ethereum_test_specs/state.py
+++ b/src/ethereum_test_specs/state.py
@@ -40,6 +40,7 @@ class StateTest(BaseTest):
     pre: Alloc
     post: Alloc
     tx: Transaction
+    post_hint: Optional[Dict[int, str]] = None
     engine_api_error_code: Optional[EngineAPIError] = None
     blockchain_test_header_verify: Optional[Header] = None
     blockchain_test_rlp_modifier: Optional[Header] = None
@@ -117,6 +118,7 @@ class StateTest(BaseTest):
         t8n: TransitionTool,
         fork: Fork,
         eips: Optional[List[int]] = None,
+        post_hint: Optional[Dict[int, str]] = None,
     ) -> Fixture:
         """
         Create a fixture from the state test definition.
@@ -146,7 +148,7 @@ class StateTest(BaseTest):
         )
 
         try:
-            self.post.verify_post_alloc(transition_tool_output.alloc)
+            self.post.verify_post_alloc(transition_tool_output.alloc, post_hint)
         except Exception as e:
             print_traces(t8n.get_traces())
             raise e
@@ -183,7 +185,7 @@ class StateTest(BaseTest):
                 request=request, t8n=t8n, fork=fork, fixture_format=fixture_format, eips=eips
             )
         elif fixture_format == StateFixture:
-            return self.make_state_test_fixture(t8n, fork, eips)
+            return self.make_state_test_fixture(t8n, fork, eips, self.post_hint)
 
         raise Exception(f"Unknown fixture format: {fixture_format}")
 

--- a/src/ethereum_test_types/types.py
+++ b/src/ethereum_test_types/types.py
@@ -4,7 +4,7 @@ Useful types for generating Ethereum tests.
 
 from dataclasses import dataclass
 from functools import cached_property
-from typing import Any, ClassVar, Dict, Generic, List, Literal, Sequence, Tuple
+from typing import Any, ClassVar, Dict, Generic, List, Literal, Optional, Sequence, Tuple
 
 from coincurve.keys import PrivateKey, PublicKey
 from ethereum import rlp as eth_rlp
@@ -268,7 +268,7 @@ class Alloc(BaseAlloc):
                     )
         return state_root(state)
 
-    def verify_post_alloc(self, got_alloc: "Alloc"):
+    def verify_post_alloc(self, got_alloc: "Alloc", post_hint: Optional[Dict[int, str]] = None):
         """
         Verify that the allocation matches the expected post in the test.
         Raises exception on unexpected values.
@@ -284,7 +284,7 @@ class Alloc(BaseAlloc):
                     got_account = got_alloc.root[address]
                     assert isinstance(got_account, Account)
                     assert isinstance(account, Account)
-                    account.check_alloc(address, got_account)
+                    account.check_alloc(address, got_account, post_hint)
                 else:
                     raise Alloc.MissingAccount(address)
 


### PR DESCRIPTION
## 🗒️ Description
Add a hint dictionary for exceptions when generating the test. 
Before:
```
E   ethereum_test_base_types.composite_types.Storage.KeyValueMismatch: incorrect value in address 0x0000000000000000000000000000000000001200 (runner_contract) for key 0x0000000000000000000000000000000000000000000000000000000000000001: want 0x3 (dec:3), got 0x2 (dec:2)
```

After
```
src/ethereum_test_base_types/composite_types.py:261: in must_be_equal
    raise Storage.KeyValueMismatch(
E   ethereum_test_base_types.composite_types.Storage.KeyValueMismatch: incorrect value in address 0x0000000000000000000000000000000000001200 (runner_contract) for key SIMPLE_CALL: want 0x3 (dec:3), got 0x2 (dec:2)
```

Possible improvements:
make storage keyvalue a class like Address so it can have hint label? 
pass hint map for each address, each storage to convert sotrage keys into labels?

## 🔗 Related Issues
NONE

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
