### PR TITLE
new(tests): EOF - EIP-7620: EOFCREATE referencing the same subcontainer twice

### DIFF
--- a/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
+++ b/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
@@ -465,26 +465,21 @@ def test_container_both_kinds_different_sub(eof_test: EOFTestFiller):
 
 
 def test_container_multiple_eofcreate_references(eof_test: EOFTestFiller):
-    """Test multiple references to the same subcontainer"""
+    """Test multiple references to the same subcontainer from an EOFCREATE operation"""
     eof_test(
         data=Container(
             sections=[
                 Section.Code(
-                    code=Op.EOFCREATE[0](0, 0, 0, 0) + Op.EOFCREATE[0](0, 0, 0, 0) + Op.JUMPF[1],
-                ),
-                Section.Code(
-                    code=Op.RETURNCONTRACT[1](0, 0),
+                    code=Op.EOFCREATE[0](0, 0, 0, 0) + Op.EOFCREATE[0](0, 0, 0, 0) + Op.STOP,
                 ),
                 returncontract_sub_container,
-                stop_sub_container,
             ],
-            kind=ContainerKind.INITCODE,
         ),
     )
 
 
 def test_container_multiple_returncontract_references(eof_test: EOFTestFiller):
-    """Test multiple references to the same subcontainer"""
+    """Test multiple references to the same subcontainer from a RETURNCONTACT operation"""
     eof_test(
         data=Container(
             sections=[
@@ -493,8 +488,7 @@ def test_container_multiple_returncontract_references(eof_test: EOFTestFiller):
                     + Op.CALLDATALOAD
                     + Op.RJUMPI[6]
                     + Op.RETURNCONTRACT[0](0, 0)
-                    + Op.RETURNCONTRACT[0](0, 0),
-                    max_stack_height=2,
+                    + Op.RETURNCONTRACT[0](0, 0)
                 ),
                 stop_sub_container,
             ],

--- a/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
+++ b/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
@@ -463,6 +463,7 @@ def test_container_both_kinds_different_sub(eof_test: EOFTestFiller):
         ),
     )
 
+
 def test_container_multiple_eofcreate_references(eof_test: EOFTestFiller):
     """Test multiple references to the same subcontainer"""
     eof_test(
@@ -475,6 +476,26 @@ def test_container_multiple_eofcreate_references(eof_test: EOFTestFiller):
                     code=Op.RETURNCONTRACT[1](0, 0),
                 ),
                 returncontract_sub_container,
+                stop_sub_container,
+            ],
+            kind=ContainerKind.INITCODE,
+        ),
+    )
+
+
+def test_container_multiple_returncontract_references(eof_test: EOFTestFiller):
+    """Test multiple references to the same subcontainer"""
+    eof_test(
+        data=Container(
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0
+                    + Op.CALLDATALOAD
+                    + Op.RJUMPI[6]
+                    + Op.RETURNCONTRACT[0](0, 0)
+                    + Op.RETURNCONTRACT[0](0, 0),
+                    max_stack_height=2,
+                ),
                 stop_sub_container,
             ],
             kind=ContainerKind.INITCODE,

--- a/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
+++ b/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
@@ -463,6 +463,24 @@ def test_container_both_kinds_different_sub(eof_test: EOFTestFiller):
         ),
     )
 
+def test_container_multiple_eofcreate_references(eof_test: EOFTestFiller):
+    """Test multiple references to the same subcontainer"""
+    eof_test(
+        data=Container(
+            sections=[
+                Section.Code(
+                    code=Op.EOFCREATE[0](0, 0, 0, 0) + Op.EOFCREATE[0](0, 0, 0, 0) + Op.JUMPF[1],
+                ),
+                Section.Code(
+                    code=Op.RETURNCONTRACT[1](0, 0),
+                ),
+                returncontract_sub_container,
+                stop_sub_container,
+            ],
+            kind=ContainerKind.INITCODE,
+        ),
+    )
+
 
 @pytest.mark.parametrize("version", [0, 255], ids=lambda x: x)
 def test_subcontainer_wrong_eof_version(


### PR DESCRIPTION
…e subcontainer twice

## 🗒️ Description
This test should test that its valid for two EOFCreates to reference the same subcontainer

## 🔗 Related Issues
@shemnon removed a superfluous case from geth that would fail with this test: https://github.com/MariusVanDerWijden/go-ethereum/pull/56

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
