### PR TITLE
 fix(fw): max stack height calculation in __add__ 

### DIFF
--- a/src/ethereum_test_vm/tests/test_vm.py
+++ b/src/ethereum_test_vm/tests/test_vm.py
@@ -383,6 +383,21 @@ def test_macros():
         pytest.param(
             Op.POP(Op.CALL(1, 2, 3, 4, 5, 6, 7)), 0, 0, 7, 0, id="POP(CALL(1, 2, 3, 4, 5, 6, 7))"
         ),
+        pytest.param(
+            Op.PUSH0 * 2 + Op.PUSH0 + Op.ADD + Op.PUSH0 + Op.POP * 2, 0, 1, 3, 0, id="parens1"
+        ),
+        pytest.param(
+            Op.PUSH0 * 2 + (Op.PUSH0 + Op.ADD + Op.PUSH0 + Op.POP * 2), 0, 1, 3, 0, id="parens2"
+        ),
+        pytest.param(
+            Op.PUSH0 * 2 + Op.PUSH0 + (Op.ADD + Op.PUSH0 + Op.POP * 2), 0, 1, 3, 0, id="parens3"
+        ),
+        pytest.param(
+            Op.PUSH0 * 2 + Op.PUSH0 + (Op.ADD + Op.PUSH0) + Op.POP * 2, 0, 1, 3, 0, id="parens4"
+        ),
+        pytest.param(
+            Op.PUSH0 * 2 + (Op.PUSH0 + Op.ADD + Op.PUSH0) + Op.POP * 2, 0, 1, 3, 0, id="parens5"
+        ),
     ],
 )
 def test_bytecode_properties(


### PR DESCRIPTION
## 🗒️ Description

Split out of #785 with a unit test added.

I've noticed that the algorithm might not handle all cases well, and I am proposing an alternative. I've left all my overly verbose comments in the code to illustrate the train of thought, as this has been quite hard to grasp the original code intentions (maybe there has been an easier fix hidden from my sight there).

## 🔗 Related Issues

n/a

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
