### PR TITLE
new(tests): EOF - EIP-7620: Dangling data in subcontainer test

### DIFF
--- a/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
+++ b/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
@@ -758,27 +758,6 @@ def test_migrated_eofcreate(eof_test: EOFTestFiller, container: Container):
     eof_test(data=container, expect_exception=container.validity_error)
 
 
-def test_dangling_subcontainer_bytes(
-    eof_test: EOFTestFiller,
-):
-    """EOF Subcontainer test with subcontainer containing dangling bytes."""
-    eof_test(
-        data=Container(
-            sections=[
-                returncontract_code_section,
-                Section.Container(
-                    custom_size=len(stop_sub_container.data),
-                    container=Container(
-                        raw_bytes=stop_sub_container.data + b"\x99",
-                    ),
-                ),
-            ],
-            kind=ContainerKind.INITCODE,
-        ),
-        expect_exception=EOFException.INVALID_SECTION_BODIES_SIZE,
-    )
-
-
 def test_dangling_initcode_subcontainer_bytes(
     eof_test: EOFTestFiller,
 ):

--- a/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
+++ b/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
@@ -756,3 +756,66 @@ def test_migrated_eofcreate(eof_test: EOFTestFiller, container: Container):
     Tests migrated from EOFTests/efValidation/EOF1_eofcreate_valid_.json.
     """
     eof_test(data=container, expect_exception=container.validity_error)
+
+
+def test_dangling_subcontainer_bytes(
+    eof_test: EOFTestFiller,
+):
+    """EOF Subcontainer test with subcontainer containing dangling bytes."""
+    eof_test(
+        data=Container(
+            sections=[
+                returncontract_code_section,
+                Section.Container(
+                    custom_size=len(stop_sub_container.data),
+                    container=Container(
+                        raw_bytes=stop_sub_container.data + b"\x99",
+                    ),
+                ),
+            ],
+            kind=ContainerKind.INITCODE,
+        ),
+        expect_exception=EOFException.INVALID_SECTION_BODIES_SIZE,
+    )
+
+
+def test_dangling_initcode_subcontainer_bytes(
+    eof_test: EOFTestFiller,
+):
+    """Initcode mode EOF Subcontainer test with subcontainer containing dangling bytes."""
+    eof_test(
+        data=Container(
+            sections=[
+                returncontract_code_section,
+                Section.Container(
+                    custom_size=len(stop_sub_container.data),
+                    container=Container(
+                        raw_bytes=stop_sub_container.data + b"\x99",
+                    ),
+                ),
+            ],
+            kind=ContainerKind.INITCODE,
+        ),
+        expect_exception=EOFException.INVALID_SECTION_BODIES_SIZE,
+    )
+
+
+def test_dangling_runtime_subcontainer_bytes(
+    eof_test: EOFTestFiller,
+):
+    """runtime mode EOF Subcontainer test with subcontainer containing dangling bytes."""
+    """Simple EOF creation from a deployed EOF container"""
+    eof_test(
+        data=Container(
+            sections=[
+                eofcreate_code_section,
+                Section.Container(
+                    custom_size=len(returncontract_sub_container.data),
+                    container=Container(
+                        raw_bytes=returncontract_sub_container.data + b"\x99",
+                    ),
+                ),
+            ],
+        ),
+        expect_exception=EOFException.INVALID_SECTION_BODIES_SIZE,
+    )

--- a/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
+++ b/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
@@ -803,8 +803,7 @@ def test_dangling_initcode_subcontainer_bytes(
 def test_dangling_runtime_subcontainer_bytes(
     eof_test: EOFTestFiller,
 ):
-    """runtime mode EOF Subcontainer test with subcontainer containing dangling bytes."""
-    """Simple EOF creation from a deployed EOF container"""
+    """Runtime mode EOF Subcontainer test with subcontainer containing dangling bytes."""
     eof_test(
         data=Container(
             sections=[

--- a/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
+++ b/tests/prague/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
@@ -767,7 +767,6 @@ def test_dangling_initcode_subcontainer_bytes(
             sections=[
                 returncontract_code_section,
                 Section.Container(
-                    custom_size=len(stop_sub_container.data),
                     container=Container(
                         raw_bytes=stop_sub_container.data + b"\x99",
                     ),
@@ -788,7 +787,6 @@ def test_dangling_runtime_subcontainer_bytes(
             sections=[
                 eofcreate_code_section,
                 Section.Container(
-                    custom_size=len(returncontract_sub_container.data),
                     container=Container(
                         raw_bytes=returncontract_sub_container.data + b"\x99",
                     ),


### PR DESCRIPTION
Signed-off-by: Danno Ferrin <danno@numisight.com>

## 🗒️ Description
Test dangling data inside a subcontainer

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
