### PR TITLE
fix(tests): Fix Existing EOF + EIP-7702 Tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,7 +12,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Example test `tests/frontier/opcodes/test_dup.py` now includes EOF parametrization ([#610](https://github.com/ethereum/execution-spec-tests/pull/610)).
 - ✨ Convert all opcodes validation test `tests/frontier/opcodes/test_all_opcodes.py` ([#748](https://github.com/ethereum/execution-spec-tests/pull/748)).
 - ✨ Update [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) tests for Devnet-3 ([#733](https://github.com/ethereum/execution-spec-tests/pull/733))
-- 🐞 Fix [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702)+EOF tests ([#821](https://github.com/ethereum/execution-spec-tests/pull/821))
+- 🐞 Fix [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702)+EOF tests due to incorrect test expectations and faulty `Conditional` test generator in EOF mode ([#821](https://github.com/ethereum/execution-spec-tests/pull/821))
 
 ### 🛠️ Framework
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Example test `tests/frontier/opcodes/test_dup.py` now includes EOF parametrization ([#610](https://github.com/ethereum/execution-spec-tests/pull/610)).
 - ✨ Convert all opcodes validation test `tests/frontier/opcodes/test_all_opcodes.py` ([#748](https://github.com/ethereum/execution-spec-tests/pull/748)).
 - ✨ Update [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) tests for Devnet-3 ([#733](https://github.com/ethereum/execution-spec-tests/pull/733))
+- 🐞 Fix [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702)+EOF tests ([#821](https://github.com/ethereum/execution-spec-tests/pull/821))
 
 ### 🛠️ Framework
 
@@ -38,6 +39,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Added `selector` and `marks` fields to all `@pytest.mark.with_all*` markers, which allows passing lambda functions to select or mark specific parametrized values (see [documentation](https://ethereum.github.io/execution-spec-tests/main/writing_tests/test_markers/#covariant-marker-keyword-arguments) for more information) ([#762](https://github.com/ethereum/execution-spec-tests/pull/762)).
 - ✨ Improves consume input flags for develop and stable fixture releases, fixes `--help` flag for consume ([#745](https://github.com/ethereum/execution-spec-tests/pull/745)).
 - 🐞 Fix erroneous fork message in pytest session header with development forks ([#806](https://github.com/ethereum/execution-spec-tests/pull/806)).
+- 🐞 Fix `Conditional` code generator in EOF mode ([#821](https://github.com/ethereum/execution-spec-tests/pull/821))
 
 ### 🔧 EVM Tools
 

--- a/src/ethereum_test_tools/code/generators.py
+++ b/src/ethereum_test_tools/code/generators.py
@@ -217,13 +217,17 @@ class Conditional(Bytecode):
             # Then we need to do the conditional jump by skipping the false branch
             condition = Op.JUMPI(Op.ADD(Op.PC, len(if_false) + 3), condition)
 
+            # Finally we append the condition, false and true branches, plus the jumpdest at the
+            # very end
+            bytecode = condition + if_false + if_true + Op.JUMPDEST
+
         elif evm_code_type == EVMCodeType.EOF_V1:
-            if_false += Op.RJUMP[len(if_true)]
+            if not if_false.terminating:
+                if_false += Op.RJUMP[len(if_true)]
             condition = Op.RJUMPI[len(if_false)](condition)
 
-        # Finally we append the true and false branches, and the condition, plus the jumpdest at
-        # the very end
-        bytecode = condition + if_false + if_true + Op.JUMPDEST
+            # Finally we append the condition, false and true branches
+            bytecode = condition + if_false + if_true
 
         return super().__new__(cls, bytecode)
 


### PR DESCRIPTION
## 🗒️ Description
- Fixes some issues with EIP-7702 tests when parametrized to EOF variants in `PragueEIP7692` fork.
- Fixes `Conditional` code generator in EOF mode.

We should be able to release a new EOF tests release after this is merged.

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
