### PR TITLE
refactor(tools,rpc): Move `ethereum_test_tools.rpc` to `ethereum_test_rpc`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -40,6 +40,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Improves consume input flags for develop and stable fixture releases, fixes `--help` flag for consume ([#745](https://github.com/ethereum/execution-spec-tests/pull/745)).
 - 🐞 Fix erroneous fork message in pytest session header with development forks ([#806](https://github.com/ethereum/execution-spec-tests/pull/806)).
 - 🐞 Fix `Conditional` code generator in EOF mode ([#821](https://github.com/ethereum/execution-spec-tests/pull/821))
+- 🔀 `ethereum_test_rpc` library has been created with was previously `ethereum_test_tools.rpc` ([#822](https://github.com/ethereum/execution-spec-tests/pull/822))
 
 ### 🔧 EVM Tools
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -40,7 +40,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Improves consume input flags for develop and stable fixture releases, fixes `--help` flag for consume ([#745](https://github.com/ethereum/execution-spec-tests/pull/745)).
 - 🐞 Fix erroneous fork message in pytest session header with development forks ([#806](https://github.com/ethereum/execution-spec-tests/pull/806)).
 - 🐞 Fix `Conditional` code generator in EOF mode ([#821](https://github.com/ethereum/execution-spec-tests/pull/821))
-- 🔀 `ethereum_test_rpc` library has been created with was previously `ethereum_test_tools.rpc` ([#822](https://github.com/ethereum/execution-spec-tests/pull/822))
+- 🔀 `ethereum_test_rpc` library has been created with what was previously `ethereum_test_tools.rpc` ([#822](https://github.com/ethereum/execution-spec-tests/pull/822))
 
 ### 🔧 EVM Tools
 

--- a/src/cli/gentest.py
+++ b/src/cli/gentest.py
@@ -60,7 +60,7 @@ from typing import Dict, List, TextIO
 import click
 
 from ethereum_test_base_types import Account, Address, Hash, ZeroPaddedHexNumber
-from ethereum_test_tools.rpc import BlockNumberType, DebugRPC, EthRPC
+from ethereum_test_rpc import BlockNumberType, DebugRPC, EthRPC
 from ethereum_test_types import Transaction
 
 

--- a/src/ethereum_test_rpc/__init__.py
+++ b/src/ethereum_test_rpc/__init__.py
@@ -1,0 +1,13 @@
+"""
+JSON-RPC methods and helper functions for EEST consume based hive simulators.
+"""
+
+from .rpc import BlockNumberType, DebugRPC, EngineRPC, EthRPC, SendTransactionException
+
+__all__ = [
+    "BlockNumberType",
+    "DebugRPC",
+    "EngineRPC",
+    "EthRPC",
+    "SendTransactionException",
+]

--- a/src/ethereum_test_rpc/types.py
+++ b/src/ethereum_test_rpc/types.py
@@ -49,7 +49,9 @@ class TransactionByHashResponse(CamelModel):
 
     ty: HexNumber = Field(..., alias="type")
     gas_limit: HexNumber = Field(..., alias="gas")
-    gas_price: HexNumber
+    gas_price: HexNumber | None = None
+    max_fee_per_gas: HexNumber | None = None
+    max_priority_fee_per_gas: HexNumber | None = None
     value: HexNumber
     data: Bytes = Field(..., alias="input")
     nonce: HexNumber

--- a/src/ethereum_test_tools/rpc/__init__.py
+++ b/src/ethereum_test_tools/rpc/__init__.py
@@ -1,7 +1,0 @@
-"""
-JSON-RPC methods and helper functions for EEST consume based hive simulators.
-"""
-
-from .rpc import BlockNumberType, DebugRPC, EngineRPC, EthRPC
-
-__all__ = ["EthRPC", "BlockNumberType", "EngineRPC", "DebugRPC"]

--- a/src/pytest_plugins/consume/hive_simulators/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/conftest.py
@@ -14,7 +14,7 @@ from hive.testing import HiveTest
 from ethereum_test_base_types import to_json
 from ethereum_test_fixtures import BlockchainFixtureCommon
 from ethereum_test_fixtures.consume import TestCaseIndexFile, TestCaseStream
-from ethereum_test_tools.rpc import EthRPC
+from ethereum_test_rpc import EthRPC
 from pytest_plugins.consume.hive_simulators.ruleset import ruleset  # TODO: generate dynamically
 
 from .timing import TimingData
@@ -41,7 +41,7 @@ def eth_rpc(client: Client) -> EthRPC:
     """
     Initialize ethereum RPC client for the execution client under test.
     """
-    return EthRPC(ip=client.ip)
+    return EthRPC(f"http://{client.ip}:8545")
 
 
 @pytest.fixture(scope="function")

--- a/src/pytest_plugins/consume/hive_simulators/engine/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/engine/conftest.py
@@ -14,7 +14,7 @@ from hive.client import Client
 from ethereum_test_fixtures import BlockchainEngineFixture
 from ethereum_test_fixtures.consume import TestCaseIndexFile, TestCaseStream
 from ethereum_test_fixtures.file import BlockchainEngineFixtures
-from ethereum_test_tools.rpc import EngineRPC
+from ethereum_test_rpc import EngineRPC
 from pytest_plugins.consume.consume import JsonSource
 
 TestCase = TestCaseIndexFile | TestCaseStream
@@ -25,7 +25,7 @@ def engine_rpc(client: Client) -> EngineRPC:
     """
     Initialize engine RPC client for the execution client under test.
     """
-    return EngineRPC(ip=client.ip)
+    return EngineRPC(f"http://{client.ip}:8551")
 
 
 @pytest.fixture(scope="module")

--- a/src/pytest_plugins/consume/hive_simulators/engine/test_via_engine.py
+++ b/src/pytest_plugins/consume/hive_simulators/engine/test_via_engine.py
@@ -6,8 +6,8 @@ Each `engine_newPayloadVX` is verified against the appropriate VALID/INVALID res
 """
 
 from ethereum_test_fixtures import BlockchainEngineFixture, FixtureFormats
-from ethereum_test_tools.rpc import EngineRPC, EthRPC
-from ethereum_test_tools.rpc.types import ForkchoiceState, PayloadStatusEnum
+from ethereum_test_rpc import EngineRPC, EthRPC
+from ethereum_test_rpc.types import ForkchoiceState, PayloadStatusEnum
 from pytest_plugins.consume.hive_simulators.exceptions import GenesisBlockMismatchException
 
 from ...decorator import fixture_format

--- a/src/pytest_plugins/consume/hive_simulators/rlp/test_via_rlp.py
+++ b/src/pytest_plugins/consume/hive_simulators/rlp/test_via_rlp.py
@@ -6,7 +6,7 @@ Clients consume the genesis and RLP-encoded blocks from input files upon start-u
 """
 
 from ethereum_test_fixtures import BlockchainFixture, FixtureFormats
-from ethereum_test_tools.rpc import EthRPC
+from ethereum_test_rpc import EthRPC
 from pytest_plugins.consume.hive_simulators.exceptions import GenesisBlockMismatchException
 
 from ...decorator import fixture_format


### PR DESCRIPTION
## 🗒️ Description
Moves all functionality included in `ethereum_test_tools.rpc` to a new library called `ethereum_test_rpc`, and also adds some other new functionality.

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
