### PR TITLE
fix(docs,ci): add build-evm-base to docs deploy workflows

### DIFF
--- a/.github/workflows/docs_main.yaml
+++ b/.github/workflows/docs_main.yaml
@@ -16,6 +16,11 @@ jobs:
         with:
           fetch-depth: 0
           ssh-key: ${{secrets.GH_ACTIONS_DEPLOY_KEY}}
+      - name: Build transition tool
+        uses: ./.github/actions/build-evm-base
+        with:
+          id: evm-builder
+          type: stable
       - name: Set up uv
         uses: ./.github/actions/setup-uv
       - name: Set up Python

--- a/.github/workflows/docs_tags.yaml
+++ b/.github/workflows/docs_tags.yaml
@@ -16,6 +16,11 @@ jobs:
         with:
           fetch-depth: 0
           ssh-key: ${{secrets.GH_ACTIONS_DEPLOY_KEY}}
+      - name: Build transition tool
+        uses: ./.github/actions/build-evm-base
+        with:
+          id: evm-builder
+          type: stable
       - name: Set up uv
         uses: ./.github/actions/setup-uv
       - name: Set up Python


### PR DESCRIPTION
## 🗒️ Description

**#792 would also fix this; we can disregard this PR if #792 gets merged first/quickly**

#801 re-implements the "Test Case Reference" generation script as a pytest plugin (based on top of `fill`). As the forks plugin (and others; didn't check) require a `t8n` tool in the path, we need to provide one, even if it's not strictly necessary to build docs.

This is a tricky subject. I'm not a fan of requiring a t8n tool to collect tests/build doc, but if we use t8n properties in test markers or other places, it's not easy to avoid.

## 🔗 Related Issues
#801 

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] ~~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~ Skipped
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
