### PR TITLE
fix(tests): fix TSTORE EOF variant test

### DIFF
--- a/tests/cancun/eip1153_tstore/test_tstorage_clear_after_tx.py
+++ b/tests/cancun/eip1153_tstore/test_tstorage_clear_after_tx.py
@@ -47,7 +47,7 @@ def test_tstore_clear_after_deployment_tx(
     code: Optional[Container | Initcode] = None
     if evm_code_type == EVMCodeType.EOF_V1:
         code = Container.Init(
-            deploy_container=Container.Code(deploy_code), initcode_prefix=init_code
+            deploy_container=Container.Code(deploy_code + Op.STOP), initcode_prefix=init_code
         )
     else:
         code = Initcode(deploy_code=deploy_code, initcode_prefix=init_code)


### PR DESCRIPTION

## 🗒️ Description
The runtime code of the TSTORE test is not valid EOF, it requires a
terminating instruction.


## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
