### PR TITLE
feat(docs): include all parameters in test parameter datatables

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -56,7 +56,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 - ✨ Feature releases can now include multiple types of fixture tarball files from different releases that start with the same prefix ([#736](https://github.com/ethereum/execution-spec-tests/pull/736)).
 - ✨ Releases for feature eip7692 now include both Cancun and Prague based tests in the same release, in files `fixtures_eip7692.tar.gz` and `fixtures_eip7692-prague.tar.gz` respectively ([#743](https://github.com/ethereum/execution-spec-tests/pull/743)).
-✨ Re-write the test case reference doc flow as a pytest plugin and add pages for test functions with a table providing an overview of their parametrized test cases ([#801](https://github.com/ethereum/execution-spec-tests/pull/801)).
+✨ Re-write the test case reference doc flow as a pytest plugin and add pages for test functions with a table providing an overview of their parametrized test cases ([#801](https://github.com/ethereum/execution-spec-tests/pull/801), [#842](https://github.com/ethereum/execution-spec-tests/pull/842)).
 - 🔀 Simplify Python project configuration and consolidate it into `pyproject.toml` ([#764](https://github.com/ethereum/execution-spec-tests/pull/764)).
 - 🔀 Created `pytest_plugins.concurrency` plugin to sync multiple `xdist` processes without using a command flag to specify the temporary working folder ([#824](https://github.com/ethereum/execution-spec-tests/pull/824))
 - 🔀 Move pytest plugin `pytest_plugins.filler.solc` to `pytest_plugins.solc.solc` ([#823](https://github.com/ethereum/execution-spec-tests/pull/823)).

--- a/docs/dev/docs.md
+++ b/docs/dev/docs.md
@@ -5,7 +5,7 @@ The `execution-spec-tests` documentation is generated via [`mkdocs`](https://www
 ## Prerequisites
 
 ```console
-uv pip install -e .[docs]
+uv sync --all-extras
 ```
 
 ## Build the Documentation

--- a/docs/gen_test_case_reference.py
+++ b/docs/gen_test_case_reference.py
@@ -15,19 +15,23 @@ from click.testing import CliRunner
 import pytest_plugins.filler.gen_test_doc.gen_test_doc as gen_test_doc
 from cli.pytest_commands.fill import fill
 
-importlib.reload(gen_test_doc)  # get changes in plugin for use with `mkdocs serve`
+importlib.reload(gen_test_doc)  # get changes in plugin to trigger an update for `mkdocs serve`
+
+TARGET_FORK = "Prague"
+GENERATE_UNTIL_FORK = "Osaka"
 
 logger = logging.getLogger("mkdocs")
-dev_fork = "Osaka"
+
 args = [
     "--override-ini",
     "filterwarnings=ignore::pytest.PytestAssertRewriteWarning",  # suppress warnings due to reload
     "-p",
     "pytest_plugins.filler.gen_test_doc.gen_test_doc",
     "--gen-docs",
+    f"--gen-docs-target-fork={TARGET_FORK}",
+    f"--until={GENERATE_UNTIL_FORK}",
     "-m",
     "(not blockchain_test_engine) and (not eip_version_check)",
-    f"--fork={dev_fork}",
     "-s",
     "tests",
     # "tests/shanghai",
@@ -36,7 +40,10 @@ args = [
 ]
 
 runner = CliRunner()
-logger.info(f"Generating documentation for {dev_fork} as fill {' '.join(args)}")
+logger.info(
+    f"Generating documentation for test cases until {GENERATE_UNTIL_FORK} as "
+    f"fill {' '.join(args)}"
+)
 result = runner.invoke(fill, args)
 for line in result.output.split("\n"):
     if "===" in line:

--- a/docs/javascripts/site.js
+++ b/docs/javascripts/site.js
@@ -1,3 +1,4 @@
+// Function to initialize DataTables
 function initializeDataTables() {
     if (!$.fn.DataTable.isDataTable('#test_table')) {
         $('#test_table').DataTable({
@@ -8,22 +9,56 @@ function initializeDataTables() {
     }
 }
 
-// Use MutationObserver to detect changes in the DOM
+// Function to attach event listeners to the selectors
+function attachFilterListeners() {
+
+    // Attach change event listeners
+    $('#fork_selector').off('change').on('change', filterTable);
+    $('#fixture_selector').off('change').on('change', filterTable);
+}
+
+// Function to filter table based on selected fork and fixture type
+function filterTable() {
+    var selectedFork = $('#fork_selector').val();
+    var selectedFixture = $('#fixture_selector').val();
+
+    $('#test_table tbody tr').each(function() {
+        var fork = $(this).attr('data-fork');
+        var fixture = $(this).attr('data-fixture');
+
+        // Show/Hide rows based on the selected fork and fixture type
+        var showRow = (selectedFork === 'all' || fork === selectedFork) &&
+                        (selectedFixture === 'all' || fixture === selectedFixture);
+
+        $(this).toggle(showRow);  // Show or hide the row
+    });
+}
+
+// Function to apply default filters on page load or navigation
+function applyDefaultFilters() {
+    // Trigger the filtering function on page load or navigation
+    filterTable();
+}
+
+// Use MutationObserver to detect changes in the DOM and reinitialize DataTables and filters
 const observer = new MutationObserver((mutationsList, observer) => {
     for (let mutation of mutationsList) {
         if (mutation.type === 'childList') {
             initializeDataTables();
+            attachFilterListeners();
+            applyDefaultFilters();
         }
     }
 });
 
-// Start observing the body element for changes in child elements, this is required to 
-// initialize the DataTables when navigating between pages
+// Start observing the body element for changes in child elements
 observer.observe(document.body, { childList: true, subtree: true });
 
 // Run on initial load
 document.addEventListener('DOMContentLoaded', function() {
     initializeDataTables();
+    attachFilterListeners();
+    applyDefaultFilters();
 });
 
 // Event delegation for copy-to-clipboard functionality

--- a/docs/javascripts/site.js
+++ b/docs/javascripts/site.js
@@ -43,6 +43,11 @@ const initDataTable = () => {
   table = new DataTable("#test_table", {
     scrollX: true,
     autoWidth: false,
+    layout: {
+      topStart: {
+          buttons: ['colvis']
+      }
+    }
   });
 };
 

--- a/docs/javascripts/site.js
+++ b/docs/javascripts/site.js
@@ -17,6 +17,9 @@ document$.subscribe(() => {
     // Listen for copy event
     listenForClipboardCopy();
   }
+
+  // Setup up select 2
+  $(`select${FILTER_INPUT_SELECTOR}`).select2();
 });
 
 const initDataTable = () => {

--- a/docs/javascripts/site.js
+++ b/docs/javascripts/site.js
@@ -1,5 +1,6 @@
 // Config
 const FILTER_INPUT_SELECTOR = ".custom_dt_filter";
+const FILTER_SEARCH_SELECTOR = "#custom_dt_search";
 let table;
 
 // This script is used both within mkdocs and in standalone html files.
@@ -19,6 +20,8 @@ document$.subscribe(() => {
   if (table) {
     // Listen for changes to filters
     $(FILTER_INPUT_SELECTOR).on("change", filterRows);
+
+    $(FILTER_SEARCH_SELECTOR).on("input", filterRows);
 
     // Apply preselected filters (if present) on page load
     filterRows();
@@ -55,9 +58,12 @@ const initDataTable = () => {
 const filterRows = () => {
   table
     .rows()
-    .search(function (a, b, index) {
+    .search(function (rowContent, b, index) {
       const row = $(table.row(index).node());
       let match = true;
+
+      const searchKeyword = $(FILTER_SEARCH_SELECTOR).val();
+      const searchHit = rowContent.includes(searchKeyword);
 
       for (let filter of $(FILTER_INPUT_SELECTOR)) {
         // Filter is ignored if set to all
@@ -67,7 +73,8 @@ const filterRows = () => {
         match =
           match && row.data($(filter).data("criteria")) === $(filter).val();
       }
-      return match;
+
+      return searchKeyword.length ? match && searchHit : match;
     })
     .draw();
 };

--- a/docs/javascripts/site.js
+++ b/docs/javascripts/site.js
@@ -53,7 +53,8 @@ const filterRows = () => {
         if ($(filter).val() == "all") continue;
 
         // Otherwise, the result of this filter applied to the previous match.
-        match = match && row.data($(filter).data(criteria)) === $(filter).val();
+        match =
+          match && row.data($(filter).data("criteria")) === $(filter).val();
       }
       return match;
     })

--- a/docs/javascripts/site.js
+++ b/docs/javascripts/site.js
@@ -2,8 +2,17 @@
 const FILTER_INPUT_SELECTOR = ".custom_dt_filter";
 let table;
 
-// Subscribe to when a page is loaded in mkdocs.
+// This script is used both within mkdocs and in standalone html files.
+// As such, a uniform listener to page load event is required.
+// The snippet below uses mkdocs subscription if present otherwise jquery is used
+// as a fallback.
 // see: https://github.com/squidfunk/mkdocs-material/issues/5816#issuecomment-1667654560
+
+if (typeof document$ == "undefined") {
+  document$ = {};
+  document$.subscribe = $(document).ready;
+}
+
 document$.subscribe(() => {
   initDataTable();
 
@@ -29,7 +38,6 @@ const initDataTable = () => {
   // Setup DataTable plugin
   // https://datatables.net/reference/api/
   table = new DataTable("#test_table", {
-    pageLength: -1,
     scrollX: true,
     autoWidth: false,
   });
@@ -48,7 +56,7 @@ const filterRows = () => {
   table
     .rows()
     .search(function (a, b, index) {
-      const row = $(table.row(index).node()).data(target);
+      const row = $(table.row(index).node());
       let match = true;
 
       for (let filter of $(FILTER_INPUT_SELECTOR)) {

--- a/docs/javascripts/site.js
+++ b/docs/javascripts/site.js
@@ -2,6 +2,8 @@
 const FILTER_INPUT_SELECTOR = ".custom_dt_filter";
 const FILTER_SEARCH_SELECTOR = "#custom_dt_search";
 let table;
+const ICON_COLUMN_FILTER =
+  '<span class="twemoji"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M17 16.88c.56 0 1 .44 1 1s-.44 1-1 1-1-.45-1-1 .44-1 1-1m0-3c2.73 0 5.06 1.66 6 4-.94 2.34-3.27 4-6 4s-5.06-1.66-6-4c.94-2.34 3.27-4 6-4m0 1.5a2.5 2.5 0 0 0 0 5 2.5 2.5 0 0 0 0-5M18 3H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h5.42c-.16-.32-.3-.66-.42-1 .12-.34.26-.68.42-1H4v-4h6v2.97c.55-.86 1.23-1.6 2-2.21V13h1.15c1.16-.64 2.47-1 3.85-1 1.06 0 2.07.21 3 .59V5c0-1.1-.9-2-2-2m-8 8H4V7h6v4m8 0h-6V7h6v4Z"></path></svg></span>';
 
 // This script is used both within mkdocs and in standalone html files.
 // As such, a uniform listener to page load event is required.
@@ -28,6 +30,10 @@ document$.subscribe(() => {
 
     // Listen for copy event
     listenForClipboardCopy();
+
+    // Style native daaTable buttons
+    $(".dt-buttons").detach().appendTo(".panel_row.filters");
+    $(".buttons-collection").prepend(ICON_COLUMN_FILTER);
   }
 
   // Setup up select 2
@@ -45,9 +51,9 @@ const initDataTable = () => {
     autoWidth: false,
     layout: {
       topStart: {
-          buttons: ['colvis']
-      }
-    }
+        buttons: ["colvis"],
+      },
+    },
   });
 };
 

--- a/docs/javascripts/site.js
+++ b/docs/javascripts/site.js
@@ -1,0 +1,27 @@
+function initializeDataTables() {
+    if (!$.fn.DataTable.isDataTable('#test_table')) {
+        $('#test_table').DataTable({
+            pageLength: -1,
+            scrollX: true,
+            autoWidth: false
+        });
+    }
+}
+
+// Use MutationObserver to detect changes in the DOM
+const observer = new MutationObserver((mutationsList, observer) => {
+    for (let mutation of mutationsList) {
+        if (mutation.type === 'childList') {
+            initializeDataTables();
+        }
+    }
+});
+
+// Start observing the body element for changes in child elements, this is required to 
+// initialize the DataTables when navigating between pages
+observer.observe(document.body, { childList: true, subtree: true });
+
+// Run on initial load
+document.addEventListener('DOMContentLoaded', function() {
+    initializeDataTables();
+});

--- a/docs/javascripts/site.js
+++ b/docs/javascripts/site.js
@@ -31,7 +31,7 @@ document$.subscribe(() => {
     // Listen for copy event
     listenForClipboardCopy();
 
-    // Style native daaTable buttons
+    // Style native dataTable buttons
     $(".dt-buttons").detach().appendTo(".panel_row.filters");
     $(".buttons-collection").prepend(ICON_COLUMN_FILTER);
   }

--- a/docs/javascripts/site.js
+++ b/docs/javascripts/site.js
@@ -47,6 +47,7 @@ const initDataTable = () => {
   // Setup DataTable plugin
   // https://datatables.net/reference/api/
   table = new DataTable("#test_table", {
+    pageLength: -1,
     scrollX: true,
     autoWidth: false,
     layout: {

--- a/docs/javascripts/site.js
+++ b/docs/javascripts/site.js
@@ -25,3 +25,33 @@ observer.observe(document.body, { childList: true, subtree: true });
 document.addEventListener('DOMContentLoaded', function() {
     initializeDataTables();
 });
+
+// Event delegation for copy-to-clipboard functionality
+document.addEventListener('click', function(event) {
+    if (event.target && event.target.classList.contains('copy-id')) {
+        const fullId = event.target.getAttribute('data-full-id');
+
+        // Copy to clipboard
+        navigator.clipboard.writeText(fullId).then(() => {
+            const originalContent = event.target.innerHTML;
+
+            // Set the sliding message with animation
+            event.target.innerHTML = '<span class="slide show">...full test id copied!</span>';
+
+            // Delay the hiding of the slide-out message
+            setTimeout(() => {
+                const slideElement = event.target.querySelector('.slide');
+                if (slideElement) {
+                    slideElement.classList.add('hide');
+                }
+            }, 1000);
+
+            // Restore the original content after the animation
+            setTimeout(() => {
+                event.target.innerHTML = originalContent;
+            }, 1500);  // Total duration before restoring original content
+        }).catch(err => {
+            console.error('Failed to copy text: ', err);
+        });
+    }
+});

--- a/docs/stylesheets/custom.css
+++ b/docs/stylesheets/custom.css
@@ -48,3 +48,7 @@
 .control_panel .select2-container--default .select2-selection--single {
   border: none;
 }
+
+#test_table_wrapper .dt-search {
+  display: none;
+}

--- a/docs/stylesheets/custom.css
+++ b/docs/stylesheets/custom.css
@@ -65,3 +65,7 @@
   max-height: 100%;
   width: var(--md-icon-size);
 }
+
+.stand_alone_container {
+  margin: 10px 15px;
+}

--- a/docs/stylesheets/custom.css
+++ b/docs/stylesheets/custom.css
@@ -1,0 +1,17 @@
+.slide {
+    display: inline-block;
+    position: relative;
+    opacity: 0;
+    left: 20px;
+    transition: all 0.5s ease;
+}
+
+.slide.show {
+    opacity: 1;
+    left: 0;
+}
+
+.slide.hide {
+    opacity: 0;
+    left: 20px;
+}

--- a/docs/stylesheets/custom.css
+++ b/docs/stylesheets/custom.css
@@ -1,17 +1,50 @@
 .slide {
-    display: inline-block;
-    position: relative;
-    opacity: 0;
-    left: 20px;
-    transition: all 0.5s ease;
+  display: inline-block;
+  position: relative;
+  opacity: 0;
+  left: 20px;
+  transition: all 0.5s ease;
 }
 
 .slide.show {
-    opacity: 1;
-    left: 0;
+  opacity: 1;
+  left: 0;
 }
 
 .slide.hide {
-    opacity: 0;
-    left: 20px;
+  opacity: 0;
+  left: 20px;
+}
+
+/* Data table control panel */
+.control_panel .search_wrapper input {
+  border: 1px solid #9e9e9e;
+  border-radius: 4px;
+  padding: 8px 15px;
+
+  font-size: 18px;
+  display: block;
+  width: 100%;
+}
+.control_panel .filters {
+  display: flex;
+}
+
+.control_panel .filters .filter_wrapper {
+  margin-right: 15px;
+  padding: 8px 14px;
+  border-radius: 4px;
+  vertical-align: middle;
+  border: 1px solid #9e9e9e;
+  margin-bottom: 10px;
+}
+
+.control_panel .filters .filter_wrapper label {
+  color: #8f8f8f;
+  font-weight: bold;
+  font-size: 14px;
+}
+
+.control_panel .select2-container--default .select2-selection--single {
+  border: none;
 }

--- a/docs/stylesheets/custom.css
+++ b/docs/stylesheets/custom.css
@@ -69,3 +69,23 @@
 .stand_alone_container {
   margin: 10px 15px;
 }
+
+.control_panel .filters .buttons-collection,
+.control_panel .filters .buttons-collection:hover {
+  background: transparent;
+  padding: 10px 15px;
+  vertical-align: middle;
+  border: 1px solid #9e9e9e;
+  margin-bottom: 10px;
+}
+
+.control_panel div.dt-buttons > .dt-button:hover:not(.disabled),
+div.dt-buttons > div.dt-button-split .dt-button:hover:not(.disabled) {
+  background: transparent;
+  border: 1px solid #9e9e9e;
+}
+
+.buttons-collection .twemoji {
+  color: #8f8f8f;
+  margin-right: 4px;
+}

--- a/docs/stylesheets/custom.css
+++ b/docs/stylesheets/custom.css
@@ -52,3 +52,16 @@
 #test_table_wrapper .dt-search {
   display: none;
 }
+
+.twemoji {
+  --md-icon-size: 1.125em;
+  display: inline-flex;
+  height: var(--md-icon-size);
+  vertical-align: text-top;
+}
+
+.twemoji svg {
+  fill: currentcolor;
+  max-height: 100%;
+  width: var(--md-icon-size);
+}

--- a/docs/templates/base.md.j2
+++ b/docs/templates/base.md.j2
@@ -6,25 +6,11 @@
 Documentation for [`{{ pytest_node_id }}@{{ short_git_ref }}`]({{ source_code_url }}).
 
 {% if title != "Spec" %}
-{% if valid_from_fork in deployed_forks %}
-!!! example "Generate fixtures for these test cases for all forks deployed to mainnet with:"
+!!! example "Generate fixtures for these test cases for {{ target_or_valid_fork }} with:"
 
     ```console
-    fill -v {{ pytest_node_id }}
+    fill -v {{ pytest_node_id }} --fork {{ target_or_valid_fork }}
     ```
-{% else %}
-!!! example "Generate fixtures for these test cases for {{ valid_from_fork.capitalize() }} with:"
-
-    {{ valid_from_fork.capitalize() }} only:
-        ```console
-        fill -v {{ pytest_node_id }} --fork={{ valid_from_fork }} --evm-bin=/path/to/evm-tool-dev-version
-        ```
-
-    For all forks up to and including {{ valid_from_fork.capitalize() }}:
-        ```console
-        fill -v {{ pytest_node_id }} --until={{ valid_from_fork }}
-        ```
-{% endif %}
 {% endif %}
 
 {% block additional_content %}

--- a/docs/templates/function.html.j2
+++ b/docs/templates/function.html.j2
@@ -6,6 +6,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
     <link rel="stylesheet" href="https://cdn.datatables.net/2.1.7/css/dataTables.dataTables.min.css">
+    <link rel="stylesheet" href="https://cdn.datatables.net/buttons/3.1.2/css/buttons.dataTables.css">
     <link rel="stylesheet" href="{{ base_url }}stylesheets/custom.css">
 </head>
 <div class="stand_alone_container">
@@ -22,4 +23,8 @@
 <script type="text/javascript" charset="utf8" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
 <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/2.1.7/js/dataTables.min.js"></script>
+<script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/buttons/3.1.2/js/dataTables.buttons.js"></script>
+<script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/buttons/3.1.2/js/buttons.dataTables.js"></script>
+<script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/buttons/3.1.2/js/buttons.colVis.min.js"></script>
+
 <script src="{{ base_url }}javascripts/site.js"></script>

--- a/docs/templates/function.html.j2
+++ b/docs/templates/function.html.j2
@@ -8,19 +8,15 @@
     <link rel="stylesheet" href="https://cdn.datatables.net/2.1.7/css/dataTables.dataTables.min.css">
     <link rel="stylesheet" href="{{ base_url }}stylesheets/custom.css">
 </head>
-<div class="container">
-  <div class="row">
-    <div class="col">
-        {% block title %}
-        <h1>Test Function: <code>{{ title }}()</code></h1>
-        {% endblock %}
-        <p>{{ docstring_one_liner }}</p>
-        {% if cases %}
-        <h2>Parametrized Test Cases</h2>
-        {% include 'function_parameter_datatable.html.j2' %}
-        {% endif %}
-    </div>  
-  </div>
+<div class="stand_alone_container">
+    {% block title %}
+    <h1>Test Function: <code>{{ title }}()</code></h1>
+    {% endblock %}
+    <p>{{ docstring_one_liner }}</p>
+    {% if cases %}
+    <h2>Parametrized Test Cases</h2>
+    {% include 'function_parameter_datatable.html.j2' %}
+    {% endif %}
 </div>
 <script type="text/javascript" charset="utf8" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>

--- a/docs/templates/function.html.j2
+++ b/docs/templates/function.html.j2
@@ -2,7 +2,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ title }}()</title>
-    <link rel="icon" href="/execution-spec-tests/img/ETH-logo-icon.svg" type="image/x-icon">
+    <link rel="icon" href="{{ base_url }}img/ETH-logo-icon.svg" type="image/x-icon">
     <link rel="stylesheet" href="https://cdn.datatables.net/1.10.21/css/jquery.dataTables.css">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
@@ -18,12 +18,4 @@
 
 <script type="text/javascript" charset="utf8" src="https://code.jquery.com/jquery-3.5.1.js"></script>
 <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/1.10.21/js/jquery.dataTables.js"></script>
-<script>
-    $(document).ready(function () {
-        $('#test_table').DataTable({
-            pageLength: -1,
-            scrollX: true,
-            autoWidth: false
-        });
-    });
-</script>
+<script src="{{ base_url }}javascripts/site.js"></script>

--- a/docs/templates/function.html.j2
+++ b/docs/templates/function.html.j2
@@ -13,6 +13,7 @@
     <h1>Test Function: <code>{{ title }}()</code></h1>
     {% endblock %}
     <p>{{ docstring_one_liner }}</p>
+    <p><a href="{{ mkdocs_function_page_target }}">Back to <code>{{ title }}()</code></a>.</p>
     {% if cases %}
     <h2>Parametrized Test Cases</h2>
     {% include 'function_parameter_datatable.html.j2' %}

--- a/docs/templates/function.html.j2
+++ b/docs/templates/function.html.j2
@@ -8,16 +8,20 @@
     <link rel="stylesheet" href="https://cdn.datatables.net/2.1.7/css/dataTables.dataTables.min.css">
     <link rel="stylesheet" href="{{ base_url }}stylesheets/custom.css">
 </head>
-
-{% block title %}
-<h1>Test Function: <code>{{ title }}()</code></h1>
-{% endblock %}
-<p>{{ docstring_one_liner }}</p>
-{% if cases %}
-<h2>Parametrized Test Cases</h2>
-{% include 'function_parameter_datatable.html.j2' %}
-{% endif %}
-
+<div class="container">
+  <div class="row">
+    <div class="col">
+        {% block title %}
+        <h1>Test Function: <code>{{ title }}()</code></h1>
+        {% endblock %}
+        <p>{{ docstring_one_liner }}</p>
+        {% if cases %}
+        <h2>Parametrized Test Cases</h2>
+        {% include 'function_parameter_datatable.html.j2' %}
+        {% endif %}
+    </div>  
+  </div>
+</div>
 <script type="text/javascript" charset="utf8" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
 <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/2.1.7/js/dataTables.min.js"></script>

--- a/docs/templates/function.html.j2
+++ b/docs/templates/function.html.j2
@@ -3,8 +3,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ title }}()</title>
     <link rel="icon" href="{{ base_url }}img/ETH-logo-icon.svg" type="image/x-icon">
-    <link rel="stylesheet" href="https://cdn.datatables.net/2.1.7/css/dataTables.dataTables.min.css">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdn.datatables.net/2.1.7/css/dataTables.dataTables.min.css">
     <link rel="stylesheet" href="{{ base_url }}stylesheets/custom.css">
 </head>
 
@@ -18,5 +19,6 @@
 {% endif %}
 
 <script type="text/javascript" charset="utf8" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
 <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/2.1.7/js/dataTables.min.js"></script>
 <script src="{{ base_url }}javascripts/site.js"></script>

--- a/docs/templates/function.html.j2
+++ b/docs/templates/function.html.j2
@@ -5,6 +5,7 @@
     <link rel="icon" href="{{ base_url }}img/ETH-logo-icon.svg" type="image/x-icon">
     <link rel="stylesheet" href="https://cdn.datatables.net/1.10.21/css/jquery.dataTables.css">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{ base_url }}stylesheets/custom.css">
 </head>
 
 {% block title %}

--- a/docs/templates/function.html.j2
+++ b/docs/templates/function.html.j2
@@ -3,7 +3,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ title }}()</title>
     <link rel="icon" href="{{ base_url }}img/ETH-logo-icon.svg" type="image/x-icon">
-    <link rel="stylesheet" href="https://cdn.datatables.net/1.10.21/css/jquery.dataTables.css">
+    <link rel="stylesheet" href="https://cdn.datatables.net/2.1.7/css/dataTables.dataTables.min.css">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="{{ base_url }}stylesheets/custom.css">
 </head>
@@ -17,6 +17,6 @@
 {% include 'function_parameter_datatable.html.j2' %}
 {% endif %}
 
-<script type="text/javascript" charset="utf8" src="https://code.jquery.com/jquery-3.5.1.js"></script>
-<script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/1.10.21/js/jquery.dataTables.js"></script>
+<script type="text/javascript" charset="utf8" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+<script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/2.1.7/js/dataTables.min.js"></script>
 <script src="{{ base_url }}javascripts/site.js"></script>

--- a/docs/templates/function.md.j2
+++ b/docs/templates/function.md.j2
@@ -8,11 +8,15 @@
     options:
         filters: ["^[tT]est*|^Spec*"]
 
-{% if cases %}
 ## Parametrized Test Cases
 
+{% if test_case_count > 1 %}
 The interactive table below is also available as a [standalone page]({{ html_static_page_target }}).
+{% elif fixture_formats | length > 1 %}
+This test case is only parametrized by fork and fixture format.
+{% else %}
+This test case is only parametrized by fork.
+{% endif %}
 
 {% include 'function_parameter_datatable.html.j2' %}
-{% endif %}
 {% endblock %}

--- a/docs/templates/function.md.j2
+++ b/docs/templates/function.md.j2
@@ -13,11 +13,6 @@
 
 The interactive table below is also available as a [standalone page]({{ html_static_page_target }}).
 
-!!! note "Skipped Parameters"
-
-    For more concise readability, the table below does not list the following parameter values: 
-    {{ test_function_parameter_table_skipped_parameters }}.
-
 {% include 'function_parameter_datatable.html.j2' %}
 {% endif %}
 {% endblock %}

--- a/docs/templates/function.md.j2
+++ b/docs/templates/function.md.j2
@@ -19,6 +19,5 @@ The interactive table below is also available as a [standalone page]({{ html_sta
     {{ test_function_parameter_table_skipped_parameters }}.
 
 {% include 'function_parameter_datatable.html.j2' %}
-<script>$(document).ready( function () { $('#test_table').DataTable({pageLength: -1, scrollX: true, autoWidth: false}); }); </script> 
 {% endif %}
 {% endblock %}

--- a/docs/templates/function_parameter_datatable.html.j2
+++ b/docs/templates/function_parameter_datatable.html.j2
@@ -1,21 +1,46 @@
-<label for="fork_selector">Filter by Fork: </label>
-<select id="fork_selector" class="custom_dt_filter" data-criteria="fork" >
-    <option value="all">All Forks</option>
-    {% set default_fork = target_fork if target_fork in cases | map(attribute='fork') | list else cases | map(attribute='fork') | list | last %}
-    {% for fork in cases | map(attribute='fork') | unique %}
-    <option value="{{ fork }}" {% if fork == default_fork %}selected{% endif %}>{{ fork }}</option>
-    {% endfor %}
-</select>
-
-<label for="fixture_selector">Filter by Fixture Type: </label>
-<select id="fixture_selector" class="custom_dt_filter" data-criteria="fixture">
-    <option value="all">All Fixture Types</option>
-    {% set default_fixture_type = "STATE_TEST" if "STATE_TEST" in cases | map(attribute='fixture_type') | list else cases[0].fixture_type %}
-    {% for fixture_type in cases | map(attribute='fixture_type') | unique %}
-    <option value="{{ fixture_type }}" {% if fixture_type == default_fixture_type %}selected{% endif %}>{{ fixture_type }}</option>
-    {% endfor %}
-</select>
-
+<div class="control_panel">
+    <div class="panel_row filters">
+    <div class="filter_wrapper">
+        <label for="fork_selector">
+         <span class="twemoji">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                <path d="M6 2a3 3 0 0 1 3 3c0 1.28-.81 2.38-1.94 2.81.09.46.33 1.02.94 1.82 1 1.29 3 3.2 4 4.54 1-1.34 3-3.25 4-4.54.61-.8.85-1.36.94-1.82A3.015 3.015 0 0 1 15 5a3 3 0 0 1 3-3 3 3 0 0 1 3 3c0 1.32-.86 2.45-2.05 2.85-.08.52-.31 1.15-.95 1.98-1 1.34-3 3.25-4 4.55-.61.79-.85 1.35-.94 1.81C14.19 16.62 15 17.72 15 19a3 3 0 0 1-3 3 3 3 0 0 1-3-3c0-1.28.81-2.38 1.94-2.81-.09-.46-.33-1.02-.94-1.81-1-1.3-3-3.21-4-4.55-.64-.83-.87-1.46-.95-1.98A3.015 3.015 0 0 1 3 5a3 3 0 0 1 3-3m0 2a1 1 0 0 0-1 1 1 1 0 0 0 1 1 1 1 0 0 0 1-1 1 1 0 0 0-1-1m12 0a1 1 0 0 0-1 1 1 1 0 0 0 1 1 1 1 0 0 0 1-1 1 1 0 0 0-1-1m-6 14a1 1 0 0 0-1 1 1 1 0 0 0 1 1 1 1 0 0 0 1-1 1 1 0 0 0-1-1Z"></path>
+            </svg>
+          </span>
+         Fork
+        </label>
+        <select id="fork_selector" class="custom_dt_filter" data-criteria="fork" >
+            <option value="all">All Forks</option>
+            {% set default_fork = target_fork if target_fork in cases | map(attribute='fork') | list else cases | map(attribute='fork') | list | last %}
+            {% for fork in cases | map(attribute='fork') | unique %}
+            <option value="{{ fork }}" {% if fork == default_fork %}selected{% endif %}>{{ fork }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div class="filter_wrapper">
+        <label for="fixture_selector">
+        <span class="twemoji">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+            <path d="M21.818 3.646H2.182C.982 3.646 0 4.483 0 5.505v3.707h2.182V5.486h19.636v13.036H2.182v-3.735H0v3.726c0 1.022.982 1.84 2.182 1.84h19.636c1.2 0 2.182-.818 2.182-1.84V5.505c0-1.032-.982-1.859-2.182-1.859Zm-10.909 12.07L15.273 12l-4.364-3.717v2.787H0v1.859h10.909v2.787Z"></path>
+            </svg>
+        </span>
+         Fixture Type
+        </label>
+        <select id="fixture_selector" class="custom_dt_filter" data-criteria="fixture">
+            <option value="all">All Fixture Types</option>
+            {% set default_fixture_type = "STATE_TEST" if "STATE_TEST" in cases | map(attribute='fixture_type') | list else cases[0].fixture_type %}
+            {% for fixture_type in cases | map(attribute='fixture_type') | unique %}
+            <option value="{{ fixture_type }}" {% if fixture_type == default_fixture_type %}selected{% endif %}>{{ fixture_type }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    </div>
+    <div class"panel_row search">
+        <div class="search_wrapper">
+            <input type="text" class="form-control" id="custom_dt_search" placeholder="🔍 Search...">
+        </div>
+    </div>
+</div>
 <table id="test_table" class="display nowrap">
     <thead>
         <tr>

--- a/docs/templates/function_parameter_datatable.html.j2
+++ b/docs/templates/function_parameter_datatable.html.j2
@@ -37,11 +37,11 @@
     </div>
     <div class"panel_row search">
         <div class="search_wrapper">
-            <input type="text" class="form-control" id="custom_dt_search" placeholder="🔍 Search...">
+            <input type="text" class="form-control" id="custom_dt_search" placeholder="🔍 Search test cases...">
         </div>
     </div>
 </div>
-<table id="test_table" class="display nowrap">
+<table id="test_table" class="display compact nowrap">
     <thead>
         <tr>
             <th>Test ID (Abbreviated)</th>

--- a/docs/templates/function_parameter_datatable.html.j2
+++ b/docs/templates/function_parameter_datatable.html.j2
@@ -35,7 +35,7 @@
         </select>
     </div>
     </div>
-    <div class"panel_row search">
+    <div class="panel_row search">
         <div class="search_wrapper">
             <input type="text" class="form-control" id="custom_dt_search" placeholder="🔍 Search test cases...">
         </div>

--- a/docs/templates/function_parameter_datatable.html.j2
+++ b/docs/templates/function_parameter_datatable.html.j2
@@ -1,5 +1,5 @@
 <label for="fork_selector">Filter by Fork: </label>
-<select id="fork_selector">
+<select id="fork_selector" class="custom_dt_filter" data-criteria="fork" >
     <option value="all">All Forks</option>
     {% set default_fork = target_fork if target_fork in cases | map(attribute='fork') | list else cases | map(attribute='fork') | list | last %}
     {% for fork in cases | map(attribute='fork') | unique %}
@@ -8,7 +8,7 @@
 </select>
 
 <label for="fixture_selector">Filter by Fixture Type: </label>
-<select id="fixture_selector">
+<select id="fixture_selector" class="custom_dt_filter" data-criteria="fixture">
     <option value="all">All Fixture Types</option>
     {% set default_fixture_type = "STATE_TEST" if "STATE_TEST" in cases | map(attribute='fixture_type') | list else cases[0].fixture_type %}
     {% for fixture_type in cases | map(attribute='fixture_type') | unique %}

--- a/docs/templates/function_parameter_datatable.html.j2
+++ b/docs/templates/function_parameter_datatable.html.j2
@@ -1,39 +1,39 @@
 <div class="control_panel">
     <div class="panel_row filters">
-    <div class="filter_wrapper">
-        <label for="fork_selector">
-         <span class="twemoji">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-                <path d="M6 2a3 3 0 0 1 3 3c0 1.28-.81 2.38-1.94 2.81.09.46.33 1.02.94 1.82 1 1.29 3 3.2 4 4.54 1-1.34 3-3.25 4-4.54.61-.8.85-1.36.94-1.82A3.015 3.015 0 0 1 15 5a3 3 0 0 1 3-3 3 3 0 0 1 3 3c0 1.32-.86 2.45-2.05 2.85-.08.52-.31 1.15-.95 1.98-1 1.34-3 3.25-4 4.55-.61.79-.85 1.35-.94 1.81C14.19 16.62 15 17.72 15 19a3 3 0 0 1-3 3 3 3 0 0 1-3-3c0-1.28.81-2.38 1.94-2.81-.09-.46-.33-1.02-.94-1.81-1-1.3-3-3.21-4-4.55-.64-.83-.87-1.46-.95-1.98A3.015 3.015 0 0 1 3 5a3 3 0 0 1 3-3m0 2a1 1 0 0 0-1 1 1 1 0 0 0 1 1 1 1 0 0 0 1-1 1 1 0 0 0-1-1m12 0a1 1 0 0 0-1 1 1 1 0 0 0 1 1 1 1 0 0 0 1-1 1 1 0 0 0-1-1m-6 14a1 1 0 0 0-1 1 1 1 0 0 0 1 1 1 1 0 0 0 1-1 1 1 0 0 0-1-1Z"></path>
-            </svg>
-          </span>
-         Fork
-        </label>
-        <select id="fork_selector" class="custom_dt_filter" data-criteria="fork" >
-            <option value="all">All Forks</option>
-            {% set default_fork = target_fork if target_fork in cases | map(attribute='fork') | list else cases | map(attribute='fork') | list | last %}
-            {% for fork in cases | map(attribute='fork') | unique %}
-            <option value="{{ fork }}" {% if fork == default_fork %}selected{% endif %}>{{ fork }}</option>
-            {% endfor %}
-        </select>
-    </div>
-    <div class="filter_wrapper">
-        <label for="fixture_selector">
-        <span class="twemoji">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-            <path d="M21.818 3.646H2.182C.982 3.646 0 4.483 0 5.505v3.707h2.182V5.486h19.636v13.036H2.182v-3.735H0v3.726c0 1.022.982 1.84 2.182 1.84h19.636c1.2 0 2.182-.818 2.182-1.84V5.505c0-1.032-.982-1.859-2.182-1.859Zm-10.909 12.07L15.273 12l-4.364-3.717v2.787H0v1.859h10.909v2.787Z"></path>
-            </svg>
-        </span>
-         Fixture Type
-        </label>
-        <select id="fixture_selector" class="custom_dt_filter" data-criteria="fixture">
-            <option value="all">All Fixture Types</option>
-            {% set default_fixture_type = "STATE_TEST" if "STATE_TEST" in cases | map(attribute='fixture_type') | list else cases[0].fixture_type %}
-            {% for fixture_type in cases | map(attribute='fixture_type') | unique %}
-            <option value="{{ fixture_type }}" {% if fixture_type == default_fixture_type %}selected{% endif %}>{{ fixture_type }}</option>
-            {% endfor %}
-        </select>
-    </div>
+        <div class="filter_wrapper">
+            <label for="fork_selector">
+            <span class="twemoji">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                    <path d="M6 2a3 3 0 0 1 3 3c0 1.28-.81 2.38-1.94 2.81.09.46.33 1.02.94 1.82 1 1.29 3 3.2 4 4.54 1-1.34 3-3.25 4-4.54.61-.8.85-1.36.94-1.82A3.015 3.015 0 0 1 15 5a3 3 0 0 1 3-3 3 3 0 0 1 3 3c0 1.32-.86 2.45-2.05 2.85-.08.52-.31 1.15-.95 1.98-1 1.34-3 3.25-4 4.55-.61.79-.85 1.35-.94 1.81C14.19 16.62 15 17.72 15 19a3 3 0 0 1-3 3 3 3 0 0 1-3-3c0-1.28.81-2.38 1.94-2.81-.09-.46-.33-1.02-.94-1.81-1-1.3-3-3.21-4-4.55-.64-.83-.87-1.46-.95-1.98A3.015 3.015 0 0 1 3 5a3 3 0 0 1 3-3m0 2a1 1 0 0 0-1 1 1 1 0 0 0 1 1 1 1 0 0 0 1-1 1 1 0 0 0-1-1m12 0a1 1 0 0 0-1 1 1 1 0 0 0 1 1 1 1 0 0 0 1-1 1 1 0 0 0-1-1m-6 14a1 1 0 0 0-1 1 1 1 0 0 0 1 1 1 1 0 0 0 1-1 1 1 0 0 0-1-1Z"></path>
+                </svg>
+            </span>
+            Fork
+            </label>
+            <select id="fork_selector" class="custom_dt_filter" data-criteria="fork" >
+                <option value="all">All Forks</option>
+                {% set default_fork = target_fork if target_fork in cases | map(attribute='fork') | list else cases | map(attribute='fork') | list | last %}
+                {% for fork in cases | map(attribute='fork') | unique %}
+                <option value="{{ fork }}" {% if fork == default_fork %}selected{% endif %}>{{ fork }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="filter_wrapper">
+            <label for="fixture_selector">
+            <span class="twemoji">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                <path d="M21.818 3.646H2.182C.982 3.646 0 4.483 0 5.505v3.707h2.182V5.486h19.636v13.036H2.182v-3.735H0v3.726c0 1.022.982 1.84 2.182 1.84h19.636c1.2 0 2.182-.818 2.182-1.84V5.505c0-1.032-.982-1.859-2.182-1.859Zm-10.909 12.07L15.273 12l-4.364-3.717v2.787H0v1.859h10.909v2.787Z"></path>
+                </svg>
+            </span>
+            Fixture Type
+            </label>
+            <select id="fixture_selector" class="custom_dt_filter" data-criteria="fixture">
+                <option value="all">All Fixture Types</option>
+                {% set default_fixture_type = "STATE_TEST" if "STATE_TEST" in cases | map(attribute='fixture_type') | list else cases[0].fixture_type %}
+                {% for fixture_type in cases | map(attribute='fixture_type') | unique %}
+                <option value="{{ fixture_type }}" {% if fixture_type == default_fixture_type %}selected{% endif %}>{{ fixture_type }}</option>
+                {% endfor %}
+            </select>
+        </div>
     </div>
     <div class="panel_row search">
         <div class="search_wrapper">

--- a/docs/templates/function_parameter_datatable.html.j2
+++ b/docs/templates/function_parameter_datatable.html.j2
@@ -1,8 +1,25 @@
+<label for="fork_selector">Filter by Fork: </label>
+<select id="fork_selector">
+    <option value="all">All Forks</option>
+    {% set default_fork = target_fork if target_fork in cases | map(attribute='fork') | list else cases | map(attribute='fork') | list | last %}
+    {% for fork in cases | map(attribute='fork') | unique %}
+    <option value="{{ fork }}" {% if fork == default_fork %}selected{% endif %}>{{ fork }}</option>
+    {% endfor %}
+</select>
+
+<label for="fixture_selector">Filter by Fixture Type: </label>
+<select id="fixture_selector">
+    <option value="all">All Fixture Types</option>
+    {% set default_fixture_type = "STATE_TEST" if "STATE_TEST" in cases | map(attribute='fixture_type') | list else cases[0].fixture_type %}
+    {% for fixture_type in cases | map(attribute='fixture_type') | unique %}
+    <option value="{{ fixture_type }}" {% if fixture_type == default_fixture_type %}selected{% endif %}>{{ fixture_type }}</option>
+    {% endfor %}
+</select>
+
 <table id="test_table" class="display nowrap">
     <thead>
         <tr>
             <th>Test ID (Abbreviated)</th>
-            <th>Hidden</th>
             {% for header in cases[0].params.keys() %}
             <th>{{ header }}</th>
             {% endfor %}
@@ -10,14 +27,13 @@
     </thead>
     <tbody>
         {% for case in cases %}
-        <tr>
+        <tr data-fork="{{ case.fork }}" data-fixture="{{ case.fixture_type }}">
             <td> 
-                <!-- Tooltip for the full nodeid -->
+                <!-- Display abbreviated pytest nodeid, but show a tooltip for the full nodeid -->
                 <abbr class="copy-id" data-full-id="{{ case.full_id }}" title="{{ case.full_id }}">
                     ...{{ case.abbreviated_id }}
                 </abbr>
             </td>
-            <td>{{ case.full_id }}</td>
             {% for value in case.params.values() %}
             <td>{{ value }}</td>
             {% endfor %}

--- a/docs/templates/function_parameter_datatable.html.j2
+++ b/docs/templates/function_parameter_datatable.html.j2
@@ -1,7 +1,8 @@
 <table id="test_table" class="display nowrap">
     <thead>
         <tr>
-            <th>Test ID</th>
+            <th>Test ID (Abbreviated)</th>
+            <th>Hidden</th>
             {% for header in cases[0].params.keys() %}
             <th>{{ header }}</th>
             {% endfor %}
@@ -10,7 +11,13 @@
     <tbody>
         {% for case in cases %}
         <tr>
-            <td>{{ case.id }}</td>
+            <td> 
+                <!-- Tooltip for the full nodeid -->
+                <abbr class="copy-id" data-full-id="{{ case.full_id }}" title="{{ case.full_id }}">
+                    ...{{ case.abbreviated_id }}
+                </abbr>
+            </td>
+            <td>{{ case.full_id }}</td>
             {% for value in case.params.values() %}
             <td>{{ value }}</td>
             {% endfor %}

--- a/docs/templates/module.md.j2
+++ b/docs/templates/module.md.j2
@@ -18,8 +18,8 @@
 {% if test_functions %}
 ## Test Functions Overview
 
-| Name | Type | Cases | Description |
-|------|------|--------|-------------|
+| Name | Type | Cases ({{ target_or_valid_fork }}) | Description |
+|------|------|-------------------------------|-------------|
 {% for test_function in test_functions %}
 | [`{{ test_function.name }}`](./{{ test_function.name }}.md) | {{ test_function.test_type }} | {{ test_function.test_case_count }} | {{ test_function.docstring_one_liner }} |
 {% endfor %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -115,6 +115,7 @@ extra:
 extra_javascript:
   - https://code.jquery.com/jquery-3.5.1.js
   - https://cdn.datatables.net/1.10.21/js/jquery.dataTables.js
+  - javascripts/site.js
 
 extra_css:
   - https://cdn.datatables.net/1.10.21/css/jquery.dataTables.css

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,9 +116,13 @@ extra_javascript:
   - https://code.jquery.com/jquery-3.7.1.min.js
   - https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js
   - https://cdn.datatables.net/2.1.7/js/dataTables.min.js
-  - javascripts/site.js
+  - https://cdn.datatables.net/buttons/3.1.2/js/dataTables.buttons.js
+  - https://cdn.datatables.net/buttons/3.1.2/js/buttons.dataTables.js
+  - https://cdn.datatables.net/buttons/3.1.2/js/buttons.colVis.min.js
+  - javascripts/site.js    
 
 extra_css:
   - https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css
   - https://cdn.datatables.net/2.1.7/css/dataTables.dataTables.min.css
+  - https://cdn.datatables.net/buttons/3.1.2/css/buttons.dataTables.css
   - stylesheets/custom.css

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,3 +119,4 @@ extra_javascript:
 
 extra_css:
   - https://cdn.datatables.net/1.10.21/css/jquery.dataTables.css
+  - stylesheets/custom.css

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@ site_url: https://ethereum.github.io/execution-spec-tests/
 repo_url: https://github.com/ethereum/execution-spec-tests
 repo_name: execution-spec-tests
 edit_uri: edit/main/docs/
-copyright: 'Copyright: 2024, Ethereum Community'
+copyright: "Copyright: 2024, Ethereum Community"
 
 plugins:
   - git-authors:
@@ -31,7 +31,7 @@ watch:
   - src/
   - tests/
 
-theme: 
+theme:
   name: material
   logo: img/Ethereum-logo-600px.png
   favicon: img/ETH-logo-icon.svg
@@ -113,10 +113,10 @@ extra:
     provider: mike
 
 extra_javascript:
-  - https://code.jquery.com/jquery-3.5.1.js
-  - https://cdn.datatables.net/1.10.21/js/jquery.dataTables.js
+  - https://code.jquery.com/jquery-3.7.1.min.js
+  - https://cdn.datatables.net/2.1.7/js/dataTables.min.js
   - javascripts/site.js
 
 extra_css:
-  - https://cdn.datatables.net/1.10.21/css/jquery.dataTables.css
+  - https://cdn.datatables.net/2.1.7/css/dataTables.dataTables.min.css
   - stylesheets/custom.css

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,9 +114,11 @@ extra:
 
 extra_javascript:
   - https://code.jquery.com/jquery-3.7.1.min.js
+  - https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js
   - https://cdn.datatables.net/2.1.7/js/dataTables.min.js
   - javascripts/site.js
 
 extra_css:
+  - https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css
   - https://cdn.datatables.net/2.1.7/css/dataTables.dataTables.min.css
   - stylesheets/custom.css

--- a/src/pytest_plugins/filler/gen_test_doc/gen_test_doc.py
+++ b/src/pytest_plugins/filler/gen_test_doc/gen_test_doc.py
@@ -496,12 +496,16 @@ class TestDocsGenerator:
                 Path(*module_path_parts[: i + 1]) for i in range(len(module_path_parts))
             )
         for directory in sub_paths:
-            fork = (
-                directory.relative_to(self.source_dir).parts[0]
+            directory_fork_name = (
+                directory.relative_to(self.source_dir).parts[0].capitalize()
                 if directory != self.source_dir
-                # set any deployed fork for tests/index.md (to avoid dev-fork in command args)
-                else "cancun"
+                else self.target_fork
             )
+            if directory_fork_name in self.deployed_forks:
+                fork = self.target_fork
+            else:
+                # TODO: This won't work for PragueEIP7692, for example, but it will for Osaka :)
+                fork = directory_fork_name
             self.page_props[str(directory)] = DirectoryPageProps(
                 title=sanitize_string_title(str(directory.name)),
                 path=directory,

--- a/src/pytest_plugins/filler/gen_test_doc/gen_test_doc.py
+++ b/src/pytest_plugins/filler/gen_test_doc/gen_test_doc.py
@@ -337,7 +337,7 @@ class TestDocsGenerator:
         """
         ci = os.getenv("CI", None)
         github_ref_name = os.getenv("GITHUB_REF_NAME", None)
-        doc_version = os.getenv("DOC_VERSION", None)
+        doc_version = os.getenv("GEN_TEST_DOC_VERSION", None)
         if ci and github_ref_name:
             return f"/execution-spec-tests/{github_ref_name}/"
         if ci and not github_ref_name:
@@ -345,8 +345,8 @@ class TestDocsGenerator:
         if ("--strict" in sys.argv or "deploy" in sys.argv) and not doc_version:
             # assume we're trying to deploy manually via mike (locally)
             raise Exception(
-                "Failed to determine target doc version during strict build (set DOC_VERSION "
-                "env var)."
+                "Failed to determine target doc version during strict build (set "
+                "GEN_TEST_DOC_VERSION env var)."
             )
         # local test build, e.g. via `uv run mkdocs serve`
         return "/execution-spec-tests/"

--- a/src/pytest_plugins/filler/gen_test_doc/gen_test_doc.py
+++ b/src/pytest_plugins/filler/gen_test_doc/gen_test_doc.py
@@ -223,7 +223,6 @@ def get_test_function_test_type(item: pytest.Item) -> str:
     for test_type in test_types:
         if test_type in fixture_names:
             return test_type
-    assert 0
     logger.warning(f"Could not determine the test function type for {item.nodeid}")
     return f"unknown ([📖🐛]({create_github_issue_url('docs(bug): unknown test function type')}))"
 

--- a/src/pytest_plugins/filler/gen_test_doc/gen_test_doc.py
+++ b/src/pytest_plugins/filler/gen_test_doc/gen_test_doc.py
@@ -432,6 +432,7 @@ class TestDocsGenerator:
                 test_type=get_test_function_test_type(items[0]),
                 docstring_one_liner=get_docstring_one_liner(items[0]),
                 html_static_page_target=f"./{get_test_function_name(items[0])}.html",
+                mkdocs_function_page_target=f"./{get_test_function_name(items[0])}/",
             )
 
     def create_module_page_props(self) -> None:

--- a/src/pytest_plugins/filler/gen_test_doc/gen_test_doc.py
+++ b/src/pytest_plugins/filler/gen_test_doc/gen_test_doc.py
@@ -254,9 +254,6 @@ class TestDocsGenerator:
         self.source_dir = Path("tests")
         self.ref = get_current_commit_hash_or_tag()
         self.top_level_nav_entry = "Test Case Reference"
-        self.skip_params = ["fork"] + [
-            spec_type.pytest_parameter_name() for spec_type in SPEC_TYPES
-        ]
         # intermediate collected pages and their properties
         self.function_page_props: FunctionPagePropsLookup = {}
         self.module_page_props: ModulePagePropsLookup = {}
@@ -361,9 +358,6 @@ class TestDocsGenerator:
             base_url=self.get_doc_site_base_url(),
             deployed_forks=deployed_forks,
             short_git_ref=get_current_commit_hash_or_tag(shorten_hash=True),
-            test_function_parameter_table_skipped_parameters=", ".join(
-                f"`{p}`" for p in self.skip_params
-            ),
         )
 
         self.jinja2_env.globals.update(global_page_props)
@@ -374,6 +368,7 @@ class TestDocsGenerator:
 
         To do: Needs refactor.
         """
+        skip_params = ["fork"] + [spec_type.pytest_parameter_name() for spec_type in SPEC_TYPES]
         for function_id, function_items in test_functions.items():
             assert all(isinstance(item, pytest.Function) for item in function_items)
             items = cast(List[pytest.Function], function_items)  # help mypy infer type
@@ -383,7 +378,7 @@ class TestDocsGenerator:
             if getattr(items[0], "callspec", None):
                 for item in items:
                     param_set = item.callspec.params
-                    keys = [key for key in param_set.keys() if key not in self.skip_params]
+                    keys = [key for key in param_set.keys() if key not in skip_params]
                     if keys:
                         values = [param_set[key] for key in keys]
                         # TODO: This formatting of bytes objects should be moved elsewhere

--- a/src/pytest_plugins/filler/gen_test_doc/gen_test_doc.py
+++ b/src/pytest_plugins/filler/gen_test_doc/gen_test_doc.py
@@ -509,7 +509,7 @@ class TestDocsGenerator:
                 source_code_url=generate_github_url(directory, branch_or_commit_or_tag=self.ref),
                 # TODO: This won't work in all cases; should be from the development fork
                 # Currently breaks for `tests/osaka/eip7692_eof_v1/index.md`  # noqa: SC100
-                target_or_valid_fork=fork,
+                target_or_valid_fork=fork.capitalize(),
                 package_name=get_import_path(directory),  # init.py will be used for docstrings
             )
 

--- a/src/pytest_plugins/filler/gen_test_doc/gen_test_doc.py
+++ b/src/pytest_plugins/filler/gen_test_doc/gen_test_doc.py
@@ -394,7 +394,11 @@ class TestDocsGenerator:
 
                     if filtered_test_id_parts:
                         test_cases.append(
-                            TestCase(id=filtered_test_id, params=dict(zip(keys, values)))
+                            TestCase(
+                                full_id=item.nodeid,
+                                abbreviated_id=filtered_test_id,
+                                params=dict(zip(keys, values)),
+                            )
                         )
 
             module_relative_path = Path(items[0].module.__file__).relative_to(Path.cwd())

--- a/src/pytest_plugins/filler/gen_test_doc/gen_test_doc.py
+++ b/src/pytest_plugins/filler/gen_test_doc/gen_test_doc.py
@@ -388,16 +388,20 @@ class TestDocsGenerator:
                         values = [param_set[key] for key in keys]
                         # TODO: This formatting of bytes objects should be moved elsewhere
                         values = [
-                            " ".join(
-                                f"<code>{chunk}</code>" for chunk in textwrap.wrap(value.hex(), 32)
+                            (
+                                " ".join(
+                                    f"<code>{chunk}</code>"
+                                    for chunk in textwrap.wrap(value.hex(), 32)
+                                )
+                                if isinstance(value, bytes)
+                                else str(value)
                             )
-                            if isinstance(value, bytes)
-                            else str(value)
                             for value in values
                         ]
                         fork = item.callspec.params.get("fork").name()  # type: ignore
                         test_type = get_test_function_test_type(item)
-                        fixture_type = item.callspec.params.get(test_type).name  # type: ignore
+                        test_type_value = item.callspec.params.get(test_type)
+                        fixture_type = test_type_value.fixture_format_name  # type: ignore
                         test_cases.append(
                             TestCase(
                                 full_id=item.nodeid,

--- a/src/pytest_plugins/filler/gen_test_doc/gen_test_doc.py
+++ b/src/pytest_plugins/filler/gen_test_doc/gen_test_doc.py
@@ -504,7 +504,6 @@ class TestDocsGenerator:
             if directory_fork_name in self.deployed_forks:
                 fork = self.target_fork
             else:
-                # TODO: This won't work for PragueEIP7692, for example, but it will for Osaka :)
                 fork = directory_fork_name
             self.page_props[str(directory)] = DirectoryPageProps(
                 title=sanitize_string_title(str(directory.name)),

--- a/src/pytest_plugins/filler/gen_test_doc/page_props.py
+++ b/src/pytest_plugins/filler/gen_test_doc/page_props.py
@@ -144,6 +144,8 @@ class TestCase:
 
     full_id: str
     abbreviated_id: str
+    fork: str
+    fixture_type: str
     params: Dict[str, Any]
 
 

--- a/src/pytest_plugins/filler/gen_test_doc/page_props.py
+++ b/src/pytest_plugins/filler/gen_test_doc/page_props.py
@@ -96,7 +96,7 @@ class PagePropsBase:
 
     title: str
     source_code_url: str
-    valid_from_fork: str
+    target_or_valid_fork: str
     path: Path
     pytest_node_id: str
     package_name: str
@@ -157,11 +157,13 @@ class FunctionPageProps(PagePropsBase):
     corresponding static HTML pages.
     """
 
+    test_case_count: int
+    fixture_formats: List[str]
     test_type: str
     docstring_one_liner: str
     html_static_page_target: str
     mkdocs_function_page_target: str
-    cases: Optional[List[TestCase]]
+    cases: List[TestCase]
 
     @property
     def template(self) -> str:

--- a/src/pytest_plugins/filler/gen_test_doc/page_props.py
+++ b/src/pytest_plugins/filler/gen_test_doc/page_props.py
@@ -14,7 +14,7 @@ import re
 from abc import abstractmethod
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 import mkdocs_gen_files  # type: ignore
 from jinja2 import Environment

--- a/src/pytest_plugins/filler/gen_test_doc/page_props.py
+++ b/src/pytest_plugins/filler/gen_test_doc/page_props.py
@@ -142,7 +142,8 @@ class TestCase:
     Properties used to define a single test case in test function parameter tables.
     """
 
-    id: str
+    full_id: str
+    abbreviated_id: str
     params: Dict[str, Any]
 
 

--- a/src/pytest_plugins/filler/gen_test_doc/page_props.py
+++ b/src/pytest_plugins/filler/gen_test_doc/page_props.py
@@ -9,6 +9,7 @@ and target output file.
 A few helpers are defined with EEST logic in order to sanitize strings from
 file paths for use in navigation menu.
 """
+
 import re
 from abc import abstractmethod
 from dataclasses import asdict, dataclass
@@ -159,6 +160,7 @@ class FunctionPageProps(PagePropsBase):
     test_type: str
     docstring_one_liner: str
     html_static_page_target: str
+    mkdocs_function_page_target: str
     cases: Optional[List[TestCase]]
 
     @property

--- a/tests/frontier/opcodes/test_dup.py
+++ b/tests/frontier/opcodes/test_dup.py
@@ -3,6 +3,7 @@ abstract: Test DUP
     Test the DUP opcodes.
 
 """
+
 import pytest
 
 from ethereum_test_forks import Frontier, Homestead
@@ -43,10 +44,8 @@ def test_dup(
     """
     Test the DUP1-DUP16 opcodes.
 
-    note: Test case ported from:
-
-        - [ethereum/tests/GeneralStateTests/VMTests/vmTests/dup.json](https://github.com/ethereum/tests/blob/develop/GeneralStateTests/VMTests/vmTests/dup.json)
-        by Ori Pomerantz.
+    Note: Test case ported from [ethereum/tests](https://github.com/ethereum/tests)
+        Test ported from [ethereum/tests/GeneralStateTests/VMTests/vmTests/dup.json](https://github.com/ethereum/tests/blob/develop/GeneralStateTests/VMTests/vmTests/dup.json) by Ori Pomerantz.
     """  # noqa: E501
     env = Environment()
     sender = pre.fund_eoa()

--- a/tox.ini
+++ b/tox.ini
@@ -89,6 +89,7 @@ extras =
 
 setenv =
     SPEC_TESTS_AUTO_GENERATE_FILES = true
+    GEN_TEST_DOC_VERSION = "tox"
     # Required for `cairosvg` so tox can find `libcairo-2`.
     # https://squidfunk.github.io/mkdocs-material/plugins/requirements/image-processing/?h=cairo#cairo-library-was-not-found
     DYLD_FALLBACK_LIBRARY_PATH = /opt/homebrew/lib

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -226,6 +226,7 @@ initcode
 inputdata
 instantiation
 io
+isidentifier
 islice
 isort
 isort's

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -546,6 +546,8 @@ verifier
 writelines
 xfail
 ZeroPaddedHexNumber
+P7692
+
 stop
 add
 mul

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -226,8 +226,6 @@ initcode
 inputdata
 instantiation
 io
-ipython
-isidentifier
 islice
 isort
 isort's

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -231,6 +231,7 @@ isort
 isort's
 ispkg
 itemName
+javascripts
 jimporter
 joinpath
 jq


### PR DESCRIPTION
## 🗒️ Description
The test function parameter tables introduced in #801 try to only show "relevant" test function parameters. It's a nice idea, but I think this obfuscates the fact that we always parametrize by fork and potentially fixture type, so I think it's better to be transparent about that but limit the number of entries displayed by using additional select elements with reasonable defaults.

Preview available at [pr-842-preview](https://ethereum.github.io/execution-spec-tests/pr-842-preview/).

Example:
![image](https://github.com/user-attachments/assets/e1b4c667-a7f5-48a5-b952-d9901b0b54d1)


## 🔗 Related Issues
- Follows-up from:
-  #801
Includes:
- #853 
- #871 

Done:
- #813 
- Generate test function parameters for all forks by running `fill` with `--until={GENERATE_UNTIL_FORK}` instead of `--fork=...`.
- Specify a target fork that can be used to display a default set of parameters (`--gen-docs-target-fork={TARGET_FORK}`.
- Tooltip upon hover on Test Case ID entry.
- Copy-paste the full test id from the table via left-click on Test Case ID entry.
- #814 (not yet, we could add a hidden table column to display make entries searchable by full nodide).
- Fix following bug (by using datables API in select elements in order to correctly update in the table entries?):
    - The selectors work and update the rows in the table, but:
        - If I search in the "Search" box, I get output like "
        Showing 1 to 20 of 20 entries (filtered from 48 total entries)", and if there's no need to paginate, the values are shown on the first page.
        - If I filter using fork or fixture type, the rows are filtered, but the output doesn't change (it stays at "Showing 1 to 20 of 20 entries" and the pagination doesn't update; in the worst case the table is empty and you have to click through the pages until you find where the values are in the table (two example screenshots attached for the same selector values).
- Arrange select elements more nicely, apply styling.

 

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
