### PR TITLE
fix(consume): use the session_temp_folder introduced in #824

### DIFF
--- a/src/pytest_plugins/pytest_hive/pytest_hive.py
+++ b/src/pytest_plugins/pytest_hive/pytest_hive.py
@@ -100,11 +100,6 @@ def simulator(request):  # noqa: D103
     return request.config.hive_simulator
 
 
-@pytest.fixture(scope="session")
-def session_temp_folder(request) -> Path:  # noqa: D103
-    return request.config.option.hive_session_temp_folder
-
-
 @pytest.fixture(scope="module")
 def test_suite(
     simulator: Simulation,


### PR DESCRIPTION
## 🗒️ Description
Fix a small regression that crept in when introducing the concurrency plugin, #824

We need some basic smoke testing for `consume` asap.

## 🔗 Related Issues
 #824

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] ~~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~ **skipped**
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
