### PR TITLE
feat(docs,filler): add info about ripemd160 & update github actions

### DIFF
--- a/docs/dev/test_actions_locally.md
+++ b/docs/dev/test_actions_locally.md
@@ -76,3 +76,13 @@ Release builds require the `ref` input to be specified. To test a release build 
     ```bash
     gh act -j build --workflows .github/workflows/fixtures_feature.yaml -s GITHUB_TOKEN=$(gh auth token) -e event.json
     ```
+
+### Manually Specifying the Docker Image
+
+It's possible to specify the Docker image used by the `act` tool for a specific platform defined in a workflow using the `-P` (`--platform`) option. For example, use map `ubuntu-latest` in the workflow to use `ubuntu-24.04`:
+
+```bash
+-P ubuntu-latest=ubuntu-24.04
+```
+
+This can be added to any `gh act` command.

--- a/docs/dev/test_actions_locally.md
+++ b/docs/dev/test_actions_locally.md
@@ -33,6 +33,7 @@ The Github Actions workflows can be tested locally using [nektos/act](https://gi
 ```bash
 gh act list
 ```
+
 will output something similar to:
 
 ```bash
@@ -51,7 +52,6 @@ Stage  Job ID                Job name              Workflow name                
 ```
 
 The `Job ID` is required to run a specific workflow and is provided to the `-j` option of `gh act`.
-
 
 ## Running Workflows Locally
 

--- a/docs/dev/test_actions_locally.md
+++ b/docs/dev/test_actions_locally.md
@@ -1,26 +1,79 @@
-# Testing Github Actions Locally
+# Running Github Actions Locally
 
-The Github Actions workflows can be tested locally using [nektos/act](https://github.com/nektos/act) which allows you to test Github Actions locally, without pushing changes to the remote.
+The Github Actions workflows can be tested locally using [nektos/act](https://github.com/nektos/act) without pushing changes to the remote. The local repository state will be used in the executed workflow.
 
 ## Prerequisites
 
-1. Install the `act` tool, [docs](https://nektosact.com/installation/index.html).
-2. Install the Github CLI (`gh`) for authentication: [linux](https://github.com/cli/cli/blob/trunk/docs/install_linux.md), [macos](https://github.com/cli/cli/tree/trunk?tab=readme-ov-file#macos).
-3. Authenticate with the Github CLI:
+1. Install the Github CLI (`gh`): [linux](https://github.com/cli/cli/blob/trunk/docs/install_linux.md), [macos](https://github.com/cli/cli/tree/trunk?tab=readme-ov-file#macos).
+2. Install the `act` tool as a Github extension ([nektos/act docs](https://nektosact.com/installation/gh.html)):
+
+    ```bash
+    gh extension install https://github.com/nektos/gh-act
+    ```
+
+    or use one of the [other available methods](https://nektosact.com/installation/index.html).
+
+3. Authenticate your Github account with the Github CLI:
 
     ```bash
     gh auth login
     ```
 
-## Testing Workflows
+    This is required to set `GITHUB_TOKEN` to the output of `gh auth token` when running the workflows.
 
-### Testing a Workflow that uses a Matrix Strategy
+!!! note "Updating nektos/act to the latest version via the Github CLI"
+    The `act` tool can be updated via the Github CLI:
+
+    ```bash
+    gh extension upgrade nektos/act
+    ```
+
+## Listing the Available Workflows
 
 ```bash
-act -j build --workflows .github/workflows/tox_verify.yaml -s GITHUB_TOKEN=$(gh auth token) --matrix python:3.10
+gh act list
+```
+will output something similar to:
+
+```bash
+INFO[0000] Using docker host 'unix:///var/run/docker.sock', and daemon socket 'unix:///var/run/docker.sock' 
+Stage  Job ID                Job name              Workflow name                             Workflow file          Events                             
+0      evmone-coverage-diff  evmone-coverage-diff  Evmone Coverage Report                    coverage.yaml          pull_request                       
+0      deploy                deploy                Deploy Docs Main                          docs_main.yaml         push                               
+0      deploy                deploy                Deploy Docs Tags                          docs_tags.yaml         push                               
+0      features              features              Build and Package Fixtures                fixtures.yaml          push,workflow_dispatch             
+0      feature-names         feature-names         Build and Package Fixtures for a feature  fixtures_feature.yaml  push,workflow_dispatch             
+0      build                 build                 Run Tox Verifications                     tox_verify.yaml        push,pull_request,workflow_dispatch
+1      build                 build                 Build and Package Fixtures                fixtures.yaml          push,workflow_dispatch             
+1      build                 build                 Build and Package Fixtures for a feature  fixtures_feature.yaml  push,workflow_dispatch             
+2      release               release               Build and Package Fixtures                fixtures.yaml          push,workflow_dispatch             
+2      release               release               Build and Package Fixtures for a feature  fixtures_feature.yaml  push,workflow_dispatch
 ```
 
-### Testing Release Builds
+The `Job ID` is required to run a specific workflow and is provided to the `-j` option of `gh act`.
+
+
+## Running Workflows Locally
+
+!!! note "Specifying the `ubuntu-24.04` docker image"
+
+    [#792](https://github.com/ethereum/execution-spec-tests/pull/792/) made EELS the default `t8n` tool. Our Github workflows were changed to use the `ubuntu-24.04` docker image which has OpenSSL 3.0.7, required by EELs to have RIPEMD160 support (used by the precompile at `0x03`). As of 2024-09-30 `ubuntu-latest` resolves to `ubuntu-22-04`.
+    
+    To run workflows that use `ubuntu-24.04` with `act` (as of version 0.2.67) the following must be added to the command-line:
+
+    ```bash
+    -P ubuntu-24.04=ghcr.io/catthehacker/ubuntu:full-24.04
+    ```
+
+    See also [Installation Troubleshooting](../getting_started/installation_troubleshooting.md#problem-valueerror-unsupported-hash-type-ripemd160) for more information.
+
+### Running Workflows Locally that use a Matrix Strategy
+
+```bash
+gh act -j build --workflows .github/workflows/tox_verify.yaml -s GITHUB_TOKEN=$(gh auth token) --matrix python:3.10 -P ubuntu-24.04=ghcr.io/catthehacker/ubuntu:full-24.04
+```
+
+### Running Release Workflows
 
 Release builds require the `ref` input to be specified. To test a release build locally:
 
@@ -35,5 +88,5 @@ Release builds require the `ref` input to be specified. To test a release build 
 2. Run `act` and specify the workflow file, the Github token, and the event file:
 
     ```bash
-    act -j build --workflows .github/workflows/fixtures_feature.yaml -s GITHUB_TOKEN=$(gh auth token) -e event.json
+    gh act -j build --workflows .github/workflows/fixtures_feature.yaml -s GITHUB_TOKEN=$(gh auth token) -e event.json -P ubuntu-24.04=ghcr.io/catthehacker/ubuntu:full-24.04
     ```

--- a/docs/dev/test_actions_locally.md
+++ b/docs/dev/test_actions_locally.md
@@ -53,24 +53,10 @@ Stage  Job ID                Job name              Workflow name                
 
 The `Job ID` is required to run a specific workflow and is provided to the `-j` option of `gh act`.
 
-## Running Workflows Locally
-
-!!! note "Specifying the `ubuntu-24.04` docker image"
-
-    [#792](https://github.com/ethereum/execution-spec-tests/pull/792/) made EELS the default `t8n` tool. Our Github workflows were changed to use the `ubuntu-24.04` docker image which has OpenSSL 3.0.7, required by EELs to have RIPEMD160 support (used by the precompile at `0x03`). As of 2024-09-30 `ubuntu-latest` resolves to `ubuntu-22-04`.
-    
-    To run workflows that use `ubuntu-24.04` with `act` (as of version 0.2.67) the following must be added to the command-line:
-
-    ```bash
-    -P ubuntu-24.04=ghcr.io/catthehacker/ubuntu:full-24.04
-    ```
-
-    See also [Installation Troubleshooting](../getting_started/installation_troubleshooting.md#problem-valueerror-unsupported-hash-type-ripemd160) for more information.
-
 ### Running Workflows Locally that use a Matrix Strategy
 
 ```bash
-gh act -j build --workflows .github/workflows/tox_verify.yaml -s GITHUB_TOKEN=$(gh auth token) --matrix python:3.10 -P ubuntu-24.04=ghcr.io/catthehacker/ubuntu:full-24.04
+gh act -j build --workflows .github/workflows/tox_verify.yaml -s GITHUB_TOKEN=$(gh auth token) --matrix python:3.12
 ```
 
 ### Running Release Workflows
@@ -88,5 +74,5 @@ Release builds require the `ref` input to be specified. To test a release build 
 2. Run `act` and specify the workflow file, the Github token, and the event file:
 
     ```bash
-    gh act -j build --workflows .github/workflows/fixtures_feature.yaml -s GITHUB_TOKEN=$(gh auth token) -e event.json -P ubuntu-24.04=ghcr.io/catthehacker/ubuntu:full-24.04
+    gh act -j build --workflows .github/workflows/fixtures_feature.yaml -s GITHUB_TOKEN=$(gh auth token) -e event.json
     ```

--- a/docs/getting_started/installation_troubleshooting.md
+++ b/docs/getting_started/installation_troubleshooting.md
@@ -62,6 +62,40 @@ This page provides guidance on how to troubleshoot common issues that may arise 
         /Applications/Python\ 3.11/Install\ Certificates.command
         ```
 
+## Problem: `ValueError: unsupported hash type ripemd160`
+
+!!! danger "Problem: `Running fill fails with tests that use the RIPEMD160 precompile (0x03)`"
+    When running `fill`, you encounter the following error:
+
+    ```python
+    ValueError: unsupported hash type ripemd160
+    # or
+    ValueError: [digital envelope routines] unsupported
+    ```
+
+    This is due to the removal of certain cryptographic primitives in OpenSSL 3. These were re-introduced in [OpenSSL v3.0.7](https://github.com/openssl/openssl/blob/master/CHANGES.md#changes-between-306-and-307-1-nov-2022).
+
+!!! success "Solution: Modify OpenSSL configuration"
+    On platforms where OpenSSL v3.0.7 is unavailable (e.g., Ubuntu 22.04), modify your OpenSSL configuration to enable RIPEMD160. Make the following changes in the OpenSSL config file:
+
+    ```ini
+    [openssl_init]
+    providers = provider_sect
+    
+    # List of providers to load
+    [provider_sect]
+    default = default_sect
+    legacy = legacy_sect
+
+    [default_sect]
+    activate = 1
+
+    [legacy_sect]
+    activate = 1
+    ```
+
+    This will enable the legacy cryptographic algorithms, including RIPEMD160. See [ethereum/execution-specs#506](https://github.com/ethereum/execution-specs/issues/506) for more information.
+
 ## Other Issues Not Listed?
 
 If you're facing an issue that's not listed here, you can easily report it on GitHub for resolution.

--- a/docs/writing_tests/verifying_changes.md
+++ b/docs/writing_tests/verifying_changes.md
@@ -7,26 +7,18 @@ The `tox` tool can be executed locally to check that local changes won't cause G
 
 ## Executing `tox`
 
-### Prerequisites
-
-```console
-python -m venv ./venv/
-source ./venv/bin/activate
-pip install tox-uv
-```
-
 ### Execution
 
-Run tox, as executed in Github Actions, with:
+Run `tox` and execute the defined environments (see `tox.ini`) in parallel with:
 
 ```console
-tox run-parallel
+uvx --with=tox-uv tox run-parallel
 ```
 
 or, with sequential test environment execution and verbose output as:
 
 ```console
-tox
+uvx --with=tox-uv tox
 ```
 
 This executes all the environments described in the next section.
@@ -51,7 +43,7 @@ For targeted tox runs locally, each environment can be ran separately as describ
 Verify:
 
 ```console
-tox -e tests
+uvx --with=tox-uv tox -e tests
 ```
 
 ### Framework Verification: `framework`
@@ -59,7 +51,7 @@ tox -e tests
 Verify:
 
 ```console
-tox -e framework
+uvx --with=tox-uv tox -e framework
 ```
 
 ### Documentation Verification: `docs`
@@ -86,7 +78,7 @@ Additional, optional prerequisites:
 Verify:
 
 ```console
-tox -e docs
+uvx --with=tox-uv tox -e docs
 ```
 
 ### Verifying Fixture Changes

--- a/src/pytest_plugins/filler/filler.py
+++ b/src/pytest_plugins/filler/filler.py
@@ -514,7 +514,7 @@ def create_properties_file(
     command_line_args = command_line_args.replace("<code>", "").replace("</code>", "")
     fixture_properties["command_line_args"] = command_line_args
 
-    config = configparser.ConfigParser()
+    config = configparser.ConfigParser(interpolation=None)
     config["fixtures"] = fixture_properties
     environment_properties = {}
     for key, val in request.config.stash[metadata_key].items():

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -270,6 +270,7 @@ namespace
 natively
 nav
 ncheck
+nektos
 nethermind
 nexternal
 nGo
@@ -288,6 +289,7 @@ ommer
 ommers
 oneliner
 oob
+OpenSSL
 opc
 oprypin
 ori


### PR DESCRIPTION
## 🗒️ Description

Docs:
- Improve "Running Github Actions Locally" developer docs section.
- Add RIPEMD160 precompile problem to "Installation Troubleshooting".
- Also snuck in: Improve tox commands in "Verifying Changes" (`tox` -> `uvx --with=tox-uv tox`).

Filler:
- Set `interpolation` to `None` in `configparser.ConfigParser(interpolation=None)` to avoid issues parsing the `GITHUB_REF` in when workflows are ran with `nektos/act`.

## 🔗 Related Issues
#792

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] ~~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~ **Skipped**
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
