### PR TITLE
fix(fw): EOF - Fix EXCHANGE's data_portion_length

### DIFF
--- a/src/ethereum_test_vm/opcode.py
+++ b/src/ethereum_test_vm/opcode.py
@@ -5066,6 +5066,7 @@ class Opcodes(Opcode, Enum):
 
     EXCHANGE = Opcode(
         0xE8,
+        data_portion_length=1,
         data_portion_formatter=_exchange_encoder,
         stack_properties_modifier=_exchange_stack_properties_modifier,
     )


### PR DESCRIPTION
## 🗒️ Description

Just a minor issue I've noticed. It didn't affect any bytecode generation, but fixing anyway

## 🔗 Related Issues

NA

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
