### PR TITLE
fix(fw,tests): Replace `ethereum.base_types` with `ethereum-types`, replace `ethereum.crypto.hash`

### DIFF
--- a/.github/actions/setup-uv/action.yaml
+++ b/.github/actions/setup-uv/action.yaml
@@ -6,6 +6,6 @@ runs:
     - name: Install UV
       shell: bash
       run: |
-        UV_VERSION="0.4.2"
+        UV_VERSION="0.4.17"
         echo "Installing UV version $UV_VERSION..."
         curl -LsSf https://astral.sh/uv/${UV_VERSION}/install.sh | sh

--- a/.github/workflows/tox_verify.yaml
+++ b/.github/workflows/tox_verify.yaml
@@ -8,10 +8,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-24.04
-            python: "3.10"
-            evm-type: "stable"
-            tox-cmd: "uvx --with=tox-uv tox"  # run-parallel --parallel-no-spinner"  # TODO: disable parallelisation for uv testing
+          # Temporarily disable
+          # - os: ubuntu-24.04
+          #   python: "3.10"
+          #   evm-type: "stable"
+          #   tox-cmd: "uvx --with=tox-uv tox"  # run-parallel --parallel-no-spinner"  # TODO: disable parallelisation for uv testing
           - os: ubuntu-24.04
             python: "3.12"
             evm-type: "stable"

--- a/.github/workflows/tox_verify.yaml
+++ b/.github/workflows/tox_verify.yaml
@@ -9,21 +9,21 @@ jobs:
       matrix:
         include:
           # Temporarily disable
-          # - os: ubuntu-24.04
+          # - os: ubuntu-latest
           #   python: "3.10"
           #   evm-type: "stable"
           #   tox-cmd: "uvx --with=tox-uv tox"  # run-parallel --parallel-no-spinner"  # TODO: disable parallelisation for uv testing
-          - os: ubuntu-24.04
+          - os: ubuntu-latest
             python: "3.12"
             evm-type: "stable"
             tox-cmd: "uvx --with=tox-uv tox"  # run-parallel --parallel-no-spinner"
           # Disabled due to unavailable evm implementation for devnet-1
-          # - os: ubuntu-24.04
+          # - os: ubuntu-latest
           #   python: '3.11'
           #   evm-type: 'develop'
           #   tox-cmd: 'tox -e tests-develop'
           # Disabled to not be gated by evmone implementation
-          # - os: ubuntu-24.04
+          # - os: ubuntu-latest
           #   python: '3.11'
           #   evm-type: 'eip7692'
           #   tox-cmd: 'tox -e tests-eip7692'

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -42,6 +42,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - 🐞 Fix `Conditional` code generator in EOF mode ([#821](https://github.com/ethereum/execution-spec-tests/pull/821))
 - 🔀 `ethereum_test_rpc` library has been created with what was previously `ethereum_test_tools.rpc` ([#822](https://github.com/ethereum/execution-spec-tests/pull/822))
 - ✨ Add `Wei` type to `ethereum_test_base_types` which allows parsing wei amounts from strings like "1 ether", "1000 wei", "10**2 gwei", etc ([#825](https://github.com/ethereum/execution-spec-tests/pull/825))
+- 🔀 Replace `ethereum.base_types` with `ethereum-types` ([#850](https://github.com/ethereum/execution-spec-tests/pull/850))
 
 ### 🔧 EVM Tools
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "rich>=13.7.0,<14",
     "solc-select>=1.0.4,<2",
     "filelock>=3.15.1,<4",
+    "ethereum-types>=0.2.1,<0.3",
 ]
 
 [project.urls]

--- a/src/ethereum_test_base_types/base_types.py
+++ b/src/ethereum_test_base_types/base_types.py
@@ -197,12 +197,12 @@ class Bytes(bytes, ToStringSchema):
             return input
         return cls(input)
 
-    def keccak256(self) -> "Bytes":
+    def keccak256(self) -> "Hash":
         """
         Return the keccak256 hash of the opcode byte representation.
         """
         k = keccak.new(digest_bits=256)
-        return Bytes(k.update(bytes(self)).digest())
+        return Hash(k.update(bytes(self)).digest())
 
 
 S = TypeVar("S", bound="FixedSizeHexNumber")

--- a/src/ethereum_test_fixtures/blockchain.py
+++ b/src/ethereum_test_fixtures/blockchain.py
@@ -6,8 +6,8 @@ from functools import cached_property
 from typing import Annotated, Any, ClassVar, List, Literal, Tuple, Union, get_args, get_type_hints
 
 from ethereum import rlp as eth_rlp
-from ethereum.base_types import Uint
 from ethereum.crypto.hash import keccak256
+from ethereum_types.numeric import Uint
 from pydantic import AliasChoices, Field, PlainSerializer, computed_field
 
 from ethereum_test_base_types import (

--- a/src/ethereum_test_fixtures/blockchain.py
+++ b/src/ethereum_test_fixtures/blockchain.py
@@ -6,7 +6,6 @@ from functools import cached_property
 from typing import Annotated, Any, ClassVar, List, Literal, Tuple, Union, get_args, get_type_hints
 
 from ethereum import rlp as eth_rlp
-from ethereum.crypto.hash import keccak256
 from ethereum_types.numeric import Uint
 from pydantic import AliasChoices, Field, PlainSerializer, computed_field
 
@@ -182,7 +181,7 @@ class FixtureHeader(CamelModel):
         """
         Compute the RLP of the header
         """
-        return Hash(keccak256(self.rlp))
+        return self.rlp.keccak256()
 
 
 class FixtureExecutionPayload(CamelModel):

--- a/src/ethereum_test_fixtures/tests/test_blockchain.py
+++ b/src/ethereum_test_fixtures/tests/test_blockchain.py
@@ -620,8 +620,7 @@ fixture_header_ones = FixtureHeader(
                 "excessBlobGas": hex(18),
                 "blockHash": "0xd90115b7fde329f64335763a446af150ab67e639281dccdb07a007d18bb80211",
                 "transactions": [
-                    "0x"
-                    + Transaction(
+                    Transaction(
                         to=0x1234,
                         data=b"\x01\x00",
                         access_list=[
@@ -735,8 +734,7 @@ fixture_header_ones = FixtureHeader(
                             "0x8eca4747db6a4b272018f2850e4208b863989ce9971bb1907467ae2204950695"
                         ),
                         "transactions": [
-                            "0x"
-                            + Transaction(
+                            Transaction(
                                 to=0x1234,
                                 data=b"\x01\x00",
                                 access_list=[
@@ -914,8 +912,7 @@ fixture_header_ones = FixtureHeader(
                             "0x78a4bf2520248e0b403d343c32b6746a43da1ebcf3cc8de14b959bc9f461fe76"
                         ),
                         "transactions": [
-                            "0x"
-                            + Transaction(
+                            Transaction(
                                 to=0x1234,
                                 data=b"\x01\x00",
                                 access_list=[
@@ -1082,8 +1079,7 @@ EngineNewPayloadParametersAdapter = TypeAdapter(EngineNewPayloadParameters)  # t
                     "blockHash": "0xd90115b7fde329f64335763a446af1"
                     "50ab67e639281dccdb07a007d18bb80211",
                     "transactions": [
-                        "0x"
-                        + Transaction(
+                        Transaction(
                             to=0x1234,
                             data=b"\x01\x00",
                             access_list=[
@@ -1193,8 +1189,7 @@ EngineNewPayloadParametersAdapter = TypeAdapter(EngineNewPayloadParameters)  # t
                     "blockHash": "0xd90115b7fde329f64335763a446af1"
                     "50ab67e639281dccdb07a007d18bb80211",
                     "transactions": [
-                        "0x"
-                        + Transaction(
+                        Transaction(
                             to=0x1234,
                             data=b"\x01\x00",
                             access_list=[

--- a/src/ethereum_test_tools/__init__.py
+++ b/src/ethereum_test_tools/__init__.py
@@ -56,6 +56,7 @@ from ethereum_test_types import (
     copy_opcode_cost,
     cost_memory_bytes,
     eip_2028_transaction_data_cost,
+    keccak256,
 )
 from ethereum_test_vm import (
     Bytecode,
@@ -151,5 +152,6 @@ __all__ = (
     "eip_2028_transaction_data_cost",
     "eip_2028_transaction_data_cost",
     "extend_with_defaults",
+    "keccak256",
     "vm",
 )

--- a/src/ethereum_test_types/__init__.py
+++ b/src/ethereum_test_types/__init__.py
@@ -29,6 +29,7 @@ from .types import (
     Transaction,
     Withdrawal,
     WithdrawalRequest,
+    keccak256,
 )
 
 __all__ = (
@@ -64,5 +65,6 @@ __all__ = (
     "copy_opcode_cost",
     "cost_memory_bytes",
     "eip_2028_transaction_data_cost",
+    "keccak256",
     "to_json",
 )

--- a/src/ethereum_test_types/helpers.py
+++ b/src/ethereum_test_types/helpers.py
@@ -5,7 +5,6 @@ Helper functions/classes used to generate Ethereum tests.
 from dataclasses import MISSING, dataclass, fields
 from typing import List, SupportsBytes
 
-from ethereum.crypto.hash import keccak256
 from ethereum.rlp import encode
 
 from ethereum_test_base_types.base_types import Address, Bytes, Hash
@@ -48,7 +47,7 @@ def compute_create_address(
         if nonce is None:
             nonce = 0
         nonce_bytes = bytes() if nonce == 0 else nonce.to_bytes(length=1, byteorder="big")
-        hash = keccak256(encode([address, nonce_bytes]))
+        hash = Bytes(encode([address, nonce_bytes])).keccak256()
         return Address(hash[-20:])
     if opcode == Op.CREATE2:
         return compute_create2_address(address, salt, initcode)
@@ -62,7 +61,7 @@ def compute_create2_address(
     Compute address of the resulting contract created using the `CREATE2`
     opcode.
     """
-    hash = keccak256(b"\xff" + Address(address) + Hash(salt) + keccak256(Bytes(initcode)))
+    hash = Bytes(b"\xff" + Address(address) + Hash(salt) + Bytes(initcode).keccak256()).keccak256()
     return Address(hash[-20:])
 
 
@@ -100,7 +99,9 @@ def compute_eofcreate_address(
     """
     Compute address of the resulting contract created using the `EOFCREATE` opcode.
     """
-    hash = keccak256(b"\xff" + Address(address) + Hash(salt) + keccak256(Bytes(init_container)))
+    hash = Bytes(
+        b"\xff" + Address(address) + Hash(salt) + Bytes(init_container).keccak256()
+    ).keccak256()
     return Address(hash[-20:])
 
 

--- a/src/ethereum_test_types/tests/test_transactions.py
+++ b/src/ethereum_test_types/tests/test_transactions.py
@@ -260,4 +260,4 @@ def test_transaction_signing(
     assert signature == expected_signature
     assert tx.sender is not None
     assert tx.sender.hex() == expected_sender
-    assert ("0x" + tx.rlp.hex()) == expected_serialized
+    assert (tx.rlp.hex()) == expected_serialized

--- a/src/ethereum_test_types/types.py
+++ b/src/ethereum_test_types/types.py
@@ -8,7 +8,6 @@ from typing import Any, ClassVar, Dict, Generic, List, Literal, Sequence, Tuple
 
 from coincurve.keys import PrivateKey, PublicKey
 from ethereum import rlp as eth_rlp
-from ethereum.crypto.hash import keccak256
 from ethereum.frontier.fork_types import Account as FrontierAccount
 from ethereum.frontier.fork_types import Address as FrontierAddress
 from ethereum.frontier.state import State, set_account, set_storage, state_root
@@ -48,6 +47,13 @@ from ethereum_test_base_types.conversions import (
 from ethereum_test_exceptions import TransactionException
 from ethereum_test_forks import Fork
 from ethereum_test_vm import EVMCodeType
+
+
+def keccak256(data: bytes) -> Hash:
+    """
+    Calculates the keccak256 hash of the given data.
+    """
+    return Bytes(data).keccak256()
 
 
 # Sentinel classes
@@ -494,16 +500,19 @@ class AuthorizationTupleGeneric(CamelModel, Generic[NumberBoundTypeVar]):
         ]
 
     @cached_property
-    def signing_bytes(self) -> bytes:
+    def signing_bytes(self) -> Bytes:
         """
         Returns the data to be signed.
         """
-        return int.to_bytes(self.magic, length=1, byteorder="big") + eth_rlp.encode(
-            [
-                Uint(self.chain_id),
-                self.address,
-                Uint(self.nonce),
-            ]
+        return Bytes(
+            int.to_bytes(self.magic, length=1, byteorder="big")
+            + eth_rlp.encode(
+                [
+                    Uint(self.chain_id),
+                    self.address,
+                    Uint(self.nonce),
+                ]
+            )
         )
 
     def signature(self, private_key: Hash) -> Tuple[int, int, int]:
@@ -552,7 +561,7 @@ class AuthorizationTuple(AuthorizationTupleGeneric[HexNumber]):
                     + bytes([self.v])
                 )
                 public_key = PublicKey.from_signature_and_message(
-                    signature_bytes, keccak256(self.signing_bytes), hasher=None
+                    signature_bytes, self.signing_bytes.keccak256(), hasher=None
                 )
                 self.signer = EOA(
                     address=Address(keccak256(public_key.format(compressed=False)[1:])[32 - 20 :])
@@ -668,7 +677,7 @@ class Transaction(TransactionGeneric[HexNumber], TransactionTransitionToolConver
     error: List[TransactionException] | TransactionException | None = Field(None, exclude=True)
 
     protected: bool = Field(True, exclude=True)
-    rlp_override: bytes | None = Field(None, exclude=True)
+    rlp_override: Bytes | None = Field(None, exclude=True)
 
     wrapped_blob_transaction: bool = Field(False, exclude=True)
     blobs: Sequence[Bytes] | None = Field(None, exclude=True)
@@ -788,7 +797,7 @@ class Transaction(TransactionGeneric[HexNumber], TransactionTransitionToolConver
                 return self
 
             public_key = PublicKey.from_signature_and_message(
-                self.signature_bytes, keccak256(self.signing_bytes), hasher=None
+                self.signature_bytes, self.signing_bytes.keccak256(), hasher=None
             )
             updated_values["sender"] = Address(
                 keccak256(public_key.format(compressed=False)[1:])[32 - 20 :]
@@ -799,7 +808,7 @@ class Transaction(TransactionGeneric[HexNumber], TransactionTransitionToolConver
             raise ValueError("secret_key must be set to sign a transaction")
 
         # Get the signing bytes
-        signing_hash = keccak256(self.signing_bytes)
+        signing_hash = self.signing_bytes.keccak256()
 
         # Sign the bytes
         signature_bytes = PrivateKey(secret=self.secret_key).sign_recoverable(
@@ -984,7 +993,7 @@ class Transaction(TransactionGeneric[HexNumber], TransactionTransitionToolConver
         return signing_envelope + [Uint(self.v), Uint(self.r), Uint(self.s)]
 
     @cached_property
-    def rlp(self) -> bytes:
+    def rlp(self) -> Bytes:
         """
         Returns bytes of the serialized representation of the transaction,
         which is almost always RLP encoding.
@@ -992,30 +1001,30 @@ class Transaction(TransactionGeneric[HexNumber], TransactionTransitionToolConver
         if self.rlp_override is not None:
             return self.rlp_override
         if self.ty > 0:
-            return bytes([self.ty]) + eth_rlp.encode(self.payload_body)
+            return Bytes(bytes([self.ty]) + eth_rlp.encode(self.payload_body))
         else:
-            return eth_rlp.encode(self.payload_body)
+            return Bytes(eth_rlp.encode(self.payload_body))
 
     @cached_property
     def hash(self) -> Hash:
         """
         Returns hash of the transaction.
         """
-        return Hash(keccak256(self.rlp))
+        return self.rlp.keccak256()
 
     @cached_property
-    def signing_bytes(self) -> bytes:
+    def signing_bytes(self) -> Bytes:
         """
         Returns the serialized bytes of the transaction used for signing.
         """
-        return (
+        return Bytes(
             bytes([self.ty]) + eth_rlp.encode(self.signing_envelope)
             if self.ty > 0
             else eth_rlp.encode(self.signing_envelope)
         )
 
     @cached_property
-    def signature_bytes(self) -> bytes:
+    def signature_bytes(self) -> Bytes:
         """
         Returns the serialized bytes of the transaction signature.
         """
@@ -1027,7 +1036,7 @@ class Transaction(TransactionGeneric[HexNumber], TransactionTransitionToolConver
                 v -= 35 + (self.chain_id * 2)
             else:
                 v -= 27
-        return (
+        return Bytes(
             self.r.to_bytes(32, byteorder="big")
             + self.s.to_bytes(32, byteorder="big")
             + bytes([v])
@@ -1074,7 +1083,7 @@ class Transaction(TransactionGeneric[HexNumber], TransactionTransitionToolConver
         )
         if self.sender is None:
             raise ValueError("sender address is None")
-        hash = keccak256(eth_rlp.encode([self.sender, nonce_bytes]))
+        hash = Bytes(eth_rlp.encode([self.sender, nonce_bytes])).keccak256()
         return Address(hash[-20:])
 
 

--- a/src/ethereum_test_types/types.py
+++ b/src/ethereum_test_types/types.py
@@ -8,11 +8,11 @@ from typing import Any, ClassVar, Dict, Generic, List, Literal, Sequence, Tuple
 
 from coincurve.keys import PrivateKey, PublicKey
 from ethereum import rlp as eth_rlp
-from ethereum.base_types import U256, Uint
 from ethereum.crypto.hash import keccak256
 from ethereum.frontier.fork_types import Account as FrontierAccount
 from ethereum.frontier.fork_types import Address as FrontierAddress
 from ethereum.frontier.state import State, set_account, set_storage, state_root
+from ethereum_types.numeric import U256, Uint
 from pydantic import (
     BaseModel,
     ConfigDict,

--- a/src/ethereum_test_vm/bytecode.py
+++ b/src/ethereum_test_vm/bytecode.py
@@ -3,7 +3,7 @@ Ethereum Virtual Machine bytecode primitives and utilities.
 """
 from typing import SupportsBytes
 
-from ethereum.crypto.hash import keccak256
+from ethereum_test_base_types import Bytes, Hash
 
 
 class Bytecode:
@@ -216,8 +216,8 @@ class Bytecode:
         """
         return bytes(self).hex()
 
-    def keccak256(self) -> bytes:
+    def keccak256(self) -> Hash:
         """
         Return the keccak256 hash of the opcode byte representation.
         """
-        return keccak256(self._bytes_)
+        return Bytes(self._bytes_).keccak256()

--- a/tests/cancun/eip4788_beacon_root/conftest.py
+++ b/tests/cancun/eip4788_beacon_root/conftest.py
@@ -6,7 +6,6 @@ from itertools import count
 from typing import Dict, Iterator, List
 
 import pytest
-from ethereum.crypto.hash import keccak256
 
 from ethereum_test_tools import (
     AccessList,
@@ -19,6 +18,7 @@ from ethereum_test_tools import (
     Storage,
     Transaction,
     add_kzg_version,
+    keccak256,
 )
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 

--- a/tests/cancun/eip5656_mcopy/test_mcopy.py
+++ b/tests/cancun/eip5656_mcopy/test_mcopy.py
@@ -3,14 +3,14 @@ abstract: Tests [EIP-5656: MCOPY - Memory copying instruction](https://eips.ethe
     Test copy operations of [EIP-5656: MCOPY - Memory copying instruction](https://eips.ethereum.org/EIPS/eip-5656)
 
 """  # noqa: E501
+
 from typing import Mapping
 
 import pytest
-from ethereum.crypto.hash import keccak256
 
 from ethereum_test_tools import Account, Address, Alloc, Bytecode, Environment, Hash
 from ethereum_test_tools import Opcodes as Op
-from ethereum_test_tools import StateTestFiller, Storage, Transaction, ceiling_division
+from ethereum_test_tools import StateTestFiller, Storage, Transaction, ceiling_division, keccak256
 
 from .common import REFERENCE_SPEC_GIT_PATH, REFERENCE_SPEC_VERSION, mcopy
 

--- a/tests/constantinople/eip1014_create2/test_create_returndata.py
+++ b/tests/constantinople/eip1014_create2/test_create_returndata.py
@@ -5,10 +5,10 @@ Port call_then_create2_successful_then_returndatasizeFiller.json test
 """
 
 import pytest
-from ethereum.crypto.hash import keccak256
 
-from ethereum_test_tools import Account, Alloc, Environment, StateTestFiller, Transaction
-from ethereum_test_tools.vm.opcode import Opcodes as Op
+from ethereum_test_tools import Account, Alloc, Environment
+from ethereum_test_tools import Opcodes as Op
+from ethereum_test_tools import StateTestFiller, Transaction, keccak256
 
 from .spec import ref_spec_1014
 
@@ -102,20 +102,22 @@ def test_create2_return_data(
                 slot_returndatacopy_before_create_2: 0,
                 #
                 # the actual bytes returned by returndatacopy opcode after create
-                slot_returndatacopy_after_create: return_data_in_create
-                if return_type_in_create == Op.REVERT
-                else 0,
+                slot_returndatacopy_after_create: (
+                    return_data_in_create if return_type_in_create == Op.REVERT else 0
+                ),
                 slot_returndatasize_before_create: call_return_size,
                 #
                 # return datasize value after create
-                slot_returndatasize_after_create: 0x20
-                if return_type_in_create == Op.REVERT
-                else 0,
+                slot_returndatasize_after_create: (
+                    0x20 if return_type_in_create == Op.REVERT else 0
+                ),
                 #
                 slot_return_data_hash_before_create: keccak256(expected_call_return_data),
-                slot_return_data_hash_after_create: keccak256(empty_data)
-                if return_type_in_create == Op.RETURN
-                else keccak256(int.to_bytes(return_data_in_create, 32, byteorder="big")),
+                slot_return_data_hash_after_create: (
+                    keccak256(empty_data)
+                    if return_type_in_create == Op.RETURN
+                    else keccak256(int.to_bytes(return_data_in_create, 32, byteorder="big"))
+                ),
                 #
                 # check that create 2 didn't mess up with initial memory space declared for return
                 slot_begin_memory_after_create: expected_returndatacopy,

--- a/tests/prague/eip2537_bls_12_381_precompiles/conftest.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/conftest.py
@@ -1,13 +1,14 @@
 """
 Shared pytest definitions local to EIP-2537 tests.
 """
+
 from typing import SupportsBytes
 
 import pytest
-from ethereum.crypto.hash import keccak256
 
-from ethereum_test_tools import EOA, Address, Alloc, Bytecode, Storage, Transaction
-from ethereum_test_tools.vm import Opcodes as Op
+from ethereum_test_tools import EOA, Address, Alloc, Bytecode
+from ethereum_test_tools import Opcodes as Op
+from ethereum_test_tools import Storage, Transaction, keccak256
 
 from .spec import GAS_CALCULATION_FUNCTION_MAP
 

--- a/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_extcode.py
+++ b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_extcode.py
@@ -1,12 +1,13 @@
 """
 test execution semantics changes
 """
-import pytest
-from ethereum.crypto.hash import keccak256
 
-from ethereum_test_tools import Account, Alloc, Environment, StateTestFiller, Storage, Transaction
+import pytest
+
+from ethereum_test_tools import Account, Alloc, Environment
+from ethereum_test_tools import Opcodes as Op
+from ethereum_test_tools import StateTestFiller, Storage, Transaction, keccak256
 from ethereum_test_tools.eof.v1 import Container, Section
-from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 from .. import EOF_FORK_NAME
 

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -9,7 +9,6 @@ from itertools import count
 from typing import List
 
 import pytest
-from ethereum.crypto.hash import keccak256
 
 from ethereum_test_tools import (
     AccessList,
@@ -38,6 +37,7 @@ from ethereum_test_tools import (
     add_kzg_version,
     call_return_code,
     compute_create_address,
+    keccak256,
 )
 from ethereum_test_tools.eof.v1 import Container, Section
 
@@ -1404,12 +1404,12 @@ def test_ext_code_on_chain_delegating_set_code(
     set_code_2 = Spec.delegation_designation(auth_signer_1)
 
     callee_storage[slot_ext_code_size_result_1] = len(set_code_2)
-    callee_storage[slot_ext_code_hash_result_1] = keccak256(set_code_2)
+    callee_storage[slot_ext_code_hash_result_1] = set_code_2.keccak256()
     callee_storage[slot_ext_code_copy_result_1] = bytes(set_code_2).ljust(32, b"\x00")[:32]
     callee_storage[slot_ext_balance_result_1] = auth_signer_1_balance
 
     callee_storage[slot_ext_code_size_result_2] = len(set_code_1)
-    callee_storage[slot_ext_code_hash_result_2] = keccak256(set_code_1)
+    callee_storage[slot_ext_code_hash_result_2] = set_code_1.keccak256()
     callee_storage[slot_ext_code_copy_result_2] = bytes(set_code_1).ljust(32, b"\x00")[:32]
     callee_storage[slot_ext_balance_result_2] = auth_signer_2_balance
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ develop = Prague
 eip7692 = CancunEIP7692
 
 [testenv]
+runner = uv-venv-lock-runner
 package = wheel
 wheel_build_env = .pkg
 

--- a/uv.lock
+++ b/uv.lock
@@ -498,9 +498,10 @@ wheels = [
 [[package]]
 name = "ethereum"
 version = "0.1.0"
-source = { git = "https://github.com/ethereum/execution-specs#51fac24740e662844446439ceeb96a460aae0ba0" }
+source = { git = "https://github.com/ethereum/execution-specs#9b95554a88d2a8485f8180254d0f6a493a593fda" }
 dependencies = [
     { name = "coincurve" },
+    { name = "ethereum-types" },
     { name = "py-ecc" },
     { name = "pycryptodome" },
     { name = "typing-extensions" },

--- a/uv.lock
+++ b/uv.lock
@@ -517,6 +517,7 @@ dependencies = [
     { name = "colorlog" },
     { name = "ethereum" },
     { name = "ethereum-spec-evm-resolver" },
+    { name = "ethereum-types" },
     { name = "filelock" },
     { name = "gitpython" },
     { name = "hive-py" },
@@ -578,6 +579,7 @@ requires-dist = [
     { name = "colorlog", specifier = ">=6.7.0,<7" },
     { name = "ethereum", git = "https://github.com/ethereum/execution-specs" },
     { name = "ethereum-spec-evm-resolver", git = "https://github.com/petertdavies/ethereum-spec-evm-resolver" },
+    { name = "ethereum-types", specifier = ">=0.2.1,<0.3" },
     { name = "filelock", specifier = ">=3.15.1,<4" },
     { name = "flake8", marker = "extra == 'lint'", specifier = ">=6.1.0,<7" },
     { name = "flake8-docstrings", marker = "extra == 'lint'", specifier = ">=1.6,<2" },
@@ -633,6 +635,18 @@ dependencies = [
     { name = "requests-unixsocket2" },
     { name = "typing-extensions" },
     { name = "urllib3" },
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/a8/053c5fcc8581fe599a87b86431a50b7df5b84a88242a6ba33ab1138a2a34/ethereum_types-0.2.1.tar.gz", hash = "sha256:2b53c5f08aff52004d7a49cdb09e70163482b55a41e274a95a8d27d194c5d146", size = 14935 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/76/3bbd13a9637287388f23c0c4094c81adf2d1467e314f8974ea0c61d2fc94/ethereum_types-0.2.1-py3-none-any.whl", hash = "sha256:6f6c51b239c231c6e33c10451b8fffb2fc168c6a7f0975cac3893d7e38e9c3e9", size = 10288 },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🗒️ Description

- Use `ethereum_types` instead of `ethereum.base_types`
- Replace uses of `ethereum.crypto.hash.keccak256` with internal function that directly uses `coincurve`
- Refactor some methods to return `Bytes` in order to use `Bytes.keccak256`

Bonus:
- Bump uv version in ci.
- Configure tox-uv (in tox.ini) to use uv.lock.
- Configure runner as ubuntu-latest (this was bumped to ubuntu-24.04 https://github.com/actions/runner-images/commit/ae99c16b0cf27c0cca7ef0b08e7bcf13c33f6cfa)
- 
## 🔗 Related Issues
- Follow-up issue: #852 
- ethereum/execution-specs#1007

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
