### PR TITLE
🐞 fix: Datatable custom filter and other goodies

### DIFF
--- a/docs/javascripts/site.js
+++ b/docs/javascripts/site.js
@@ -17,6 +17,9 @@ document$.subscribe(() => {
     // Listen for copy event
     listenForClipboardCopy();
   }
+
+  // Setup up select 2
+  $(`select${FILTER_INPUT_SELECTOR}`).select2();
 });
 
 const initDataTable = () => {

--- a/docs/javascripts/site.js
+++ b/docs/javascripts/site.js
@@ -1,5 +1,6 @@
 // Config
 const FILTER_INPUT_SELECTOR = ".custom_dt_filter";
+const FILTER_SEARCH_SELECTOR = "#custom_dt_search";
 let table;
 
 // This script is used both within mkdocs and in standalone html files.
@@ -19,6 +20,8 @@ document$.subscribe(() => {
   if (table) {
     // Listen for changes to filters
     $(FILTER_INPUT_SELECTOR).on("change", filterRows);
+
+    $(FILTER_SEARCH_SELECTOR).on("input", filterRows);
 
     // Apply preselected filters (if present) on page load
     filterRows();
@@ -55,9 +58,12 @@ const initDataTable = () => {
 const filterRows = () => {
   table
     .rows()
-    .search(function (a, b, index) {
+    .search(function (rowContent, b, index) {
       const row = $(table.row(index).node());
       let match = true;
+
+      const searchKeyword = $(FILTER_SEARCH_SELECTOR).val();
+      const searchHit = rowContent.includes(searchKeyword);
 
       for (let filter of $(FILTER_INPUT_SELECTOR)) {
         // Filter is ignored if set to all
@@ -67,7 +73,8 @@ const filterRows = () => {
         match =
           match && row.data($(filter).data("criteria")) === $(filter).val();
       }
-      return match;
+
+      return searchKeyword.length ? match && searchHit : match;
     })
     .draw();
 };

--- a/docs/javascripts/site.js
+++ b/docs/javascripts/site.js
@@ -53,7 +53,8 @@ const filterRows = () => {
         if ($(filter).val() == "all") continue;
 
         // Otherwise, the result of this filter applied to the previous match.
-        match = match && row.data($(filter).data(criteria)) === $(filter).val();
+        match =
+          match && row.data($(filter).data("criteria")) === $(filter).val();
       }
       return match;
     })

--- a/docs/javascripts/site.js
+++ b/docs/javascripts/site.js
@@ -2,8 +2,17 @@
 const FILTER_INPUT_SELECTOR = ".custom_dt_filter";
 let table;
 
-// Subscribe to when a page is loaded in mkdocs.
+// This script is used both within mkdocs and in standalone html files.
+// As such, a uniform listener to page load event is required.
+// The snippet below uses mkdocs subscription if present otherwise jquery is used
+// as a fallback.
 // see: https://github.com/squidfunk/mkdocs-material/issues/5816#issuecomment-1667654560
+
+if (typeof document$ == "undefined") {
+  document$ = {};
+  document$.subscribe = $(document).ready;
+}
+
 document$.subscribe(() => {
   initDataTable();
 
@@ -29,7 +38,6 @@ const initDataTable = () => {
   // Setup DataTable plugin
   // https://datatables.net/reference/api/
   table = new DataTable("#test_table", {
-    pageLength: -1,
     scrollX: true,
     autoWidth: false,
   });
@@ -48,7 +56,7 @@ const filterRows = () => {
   table
     .rows()
     .search(function (a, b, index) {
-      const row = $(table.row(index).node()).data(target);
+      const row = $(table.row(index).node());
       let match = true;
 
       for (let filter of $(FILTER_INPUT_SELECTOR)) {

--- a/docs/stylesheets/custom.css
+++ b/docs/stylesheets/custom.css
@@ -48,3 +48,7 @@
 .control_panel .select2-container--default .select2-selection--single {
   border: none;
 }
+
+#test_table_wrapper .dt-search {
+  display: none;
+}

--- a/docs/stylesheets/custom.css
+++ b/docs/stylesheets/custom.css
@@ -65,3 +65,7 @@
   max-height: 100%;
   width: var(--md-icon-size);
 }
+
+.stand_alone_container {
+  margin: 10px 15px;
+}

--- a/docs/stylesheets/custom.css
+++ b/docs/stylesheets/custom.css
@@ -1,17 +1,50 @@
 .slide {
-    display: inline-block;
-    position: relative;
-    opacity: 0;
-    left: 20px;
-    transition: all 0.5s ease;
+  display: inline-block;
+  position: relative;
+  opacity: 0;
+  left: 20px;
+  transition: all 0.5s ease;
 }
 
 .slide.show {
-    opacity: 1;
-    left: 0;
+  opacity: 1;
+  left: 0;
 }
 
 .slide.hide {
-    opacity: 0;
-    left: 20px;
+  opacity: 0;
+  left: 20px;
+}
+
+/* Data table control panel */
+.control_panel .search_wrapper input {
+  border: 1px solid #9e9e9e;
+  border-radius: 4px;
+  padding: 8px 15px;
+
+  font-size: 18px;
+  display: block;
+  width: 100%;
+}
+.control_panel .filters {
+  display: flex;
+}
+
+.control_panel .filters .filter_wrapper {
+  margin-right: 15px;
+  padding: 8px 14px;
+  border-radius: 4px;
+  vertical-align: middle;
+  border: 1px solid #9e9e9e;
+  margin-bottom: 10px;
+}
+
+.control_panel .filters .filter_wrapper label {
+  color: #8f8f8f;
+  font-weight: bold;
+  font-size: 14px;
+}
+
+.control_panel .select2-container--default .select2-selection--single {
+  border: none;
 }

--- a/docs/stylesheets/custom.css
+++ b/docs/stylesheets/custom.css
@@ -52,3 +52,16 @@
 #test_table_wrapper .dt-search {
   display: none;
 }
+
+.twemoji {
+  --md-icon-size: 1.125em;
+  display: inline-flex;
+  height: var(--md-icon-size);
+  vertical-align: text-top;
+}
+
+.twemoji svg {
+  fill: currentcolor;
+  max-height: 100%;
+  width: var(--md-icon-size);
+}

--- a/docs/templates/function.html.j2
+++ b/docs/templates/function.html.j2
@@ -8,19 +8,15 @@
     <link rel="stylesheet" href="https://cdn.datatables.net/2.1.7/css/dataTables.dataTables.min.css">
     <link rel="stylesheet" href="{{ base_url }}stylesheets/custom.css">
 </head>
-<div class="container">
-  <div class="row">
-    <div class="col">
-        {% block title %}
-        <h1>Test Function: <code>{{ title }}()</code></h1>
-        {% endblock %}
-        <p>{{ docstring_one_liner }}</p>
-        {% if cases %}
-        <h2>Parametrized Test Cases</h2>
-        {% include 'function_parameter_datatable.html.j2' %}
-        {% endif %}
-    </div>  
-  </div>
+<div class="stand_alone_container">
+    {% block title %}
+    <h1>Test Function: <code>{{ title }}()</code></h1>
+    {% endblock %}
+    <p>{{ docstring_one_liner }}</p>
+    {% if cases %}
+    <h2>Parametrized Test Cases</h2>
+    {% include 'function_parameter_datatable.html.j2' %}
+    {% endif %}
 </div>
 <script type="text/javascript" charset="utf8" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>

--- a/docs/templates/function.html.j2
+++ b/docs/templates/function.html.j2
@@ -8,16 +8,20 @@
     <link rel="stylesheet" href="https://cdn.datatables.net/2.1.7/css/dataTables.dataTables.min.css">
     <link rel="stylesheet" href="{{ base_url }}stylesheets/custom.css">
 </head>
-
-{% block title %}
-<h1>Test Function: <code>{{ title }}()</code></h1>
-{% endblock %}
-<p>{{ docstring_one_liner }}</p>
-{% if cases %}
-<h2>Parametrized Test Cases</h2>
-{% include 'function_parameter_datatable.html.j2' %}
-{% endif %}
-
+<div class="container">
+  <div class="row">
+    <div class="col">
+        {% block title %}
+        <h1>Test Function: <code>{{ title }}()</code></h1>
+        {% endblock %}
+        <p>{{ docstring_one_liner }}</p>
+        {% if cases %}
+        <h2>Parametrized Test Cases</h2>
+        {% include 'function_parameter_datatable.html.j2' %}
+        {% endif %}
+    </div>  
+  </div>
+</div>
 <script type="text/javascript" charset="utf8" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
 <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/2.1.7/js/dataTables.min.js"></script>

--- a/docs/templates/function.html.j2
+++ b/docs/templates/function.html.j2
@@ -3,8 +3,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ title }}()</title>
     <link rel="icon" href="{{ base_url }}img/ETH-logo-icon.svg" type="image/x-icon">
-    <link rel="stylesheet" href="https://cdn.datatables.net/2.1.7/css/dataTables.dataTables.min.css">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdn.datatables.net/2.1.7/css/dataTables.dataTables.min.css">
     <link rel="stylesheet" href="{{ base_url }}stylesheets/custom.css">
 </head>
 
@@ -18,5 +19,6 @@
 {% endif %}
 
 <script type="text/javascript" charset="utf8" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
 <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/2.1.7/js/dataTables.min.js"></script>
 <script src="{{ base_url }}javascripts/site.js"></script>

--- a/docs/templates/function.html.j2
+++ b/docs/templates/function.html.j2
@@ -3,7 +3,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ title }}()</title>
     <link rel="icon" href="{{ base_url }}img/ETH-logo-icon.svg" type="image/x-icon">
-    <link rel="stylesheet" href="https://cdn.datatables.net/1.10.21/css/jquery.dataTables.css">
+    <link rel="stylesheet" href="https://cdn.datatables.net/2.1.7/css/dataTables.dataTables.min.css">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="{{ base_url }}stylesheets/custom.css">
 </head>
@@ -17,6 +17,6 @@
 {% include 'function_parameter_datatable.html.j2' %}
 {% endif %}
 
-<script type="text/javascript" charset="utf8" src="https://code.jquery.com/jquery-3.5.1.js"></script>
-<script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/1.10.21/js/jquery.dataTables.js"></script>
+<script type="text/javascript" charset="utf8" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+<script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/2.1.7/js/dataTables.min.js"></script>
 <script src="{{ base_url }}javascripts/site.js"></script>

--- a/docs/templates/function_parameter_datatable.html.j2
+++ b/docs/templates/function_parameter_datatable.html.j2
@@ -1,21 +1,46 @@
-<label for="fork_selector">Filter by Fork: </label>
-<select id="fork_selector" class="custom_dt_filter" data-criteria="fork" >
-    <option value="all">All Forks</option>
-    {% set default_fork = target_fork if target_fork in cases | map(attribute='fork') | list else cases | map(attribute='fork') | list | last %}
-    {% for fork in cases | map(attribute='fork') | unique %}
-    <option value="{{ fork }}" {% if fork == default_fork %}selected{% endif %}>{{ fork }}</option>
-    {% endfor %}
-</select>
-
-<label for="fixture_selector">Filter by Fixture Type: </label>
-<select id="fixture_selector" class="custom_dt_filter" data-criteria="fixture">
-    <option value="all">All Fixture Types</option>
-    {% set default_fixture_type = "STATE_TEST" if "STATE_TEST" in cases | map(attribute='fixture_type') | list else cases[0].fixture_type %}
-    {% for fixture_type in cases | map(attribute='fixture_type') | unique %}
-    <option value="{{ fixture_type }}" {% if fixture_type == default_fixture_type %}selected{% endif %}>{{ fixture_type }}</option>
-    {% endfor %}
-</select>
-
+<div class="control_panel">
+    <div class="panel_row filters">
+    <div class="filter_wrapper">
+        <label for="fork_selector">
+         <span class="twemoji">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                <path d="M6 2a3 3 0 0 1 3 3c0 1.28-.81 2.38-1.94 2.81.09.46.33 1.02.94 1.82 1 1.29 3 3.2 4 4.54 1-1.34 3-3.25 4-4.54.61-.8.85-1.36.94-1.82A3.015 3.015 0 0 1 15 5a3 3 0 0 1 3-3 3 3 0 0 1 3 3c0 1.32-.86 2.45-2.05 2.85-.08.52-.31 1.15-.95 1.98-1 1.34-3 3.25-4 4.55-.61.79-.85 1.35-.94 1.81C14.19 16.62 15 17.72 15 19a3 3 0 0 1-3 3 3 3 0 0 1-3-3c0-1.28.81-2.38 1.94-2.81-.09-.46-.33-1.02-.94-1.81-1-1.3-3-3.21-4-4.55-.64-.83-.87-1.46-.95-1.98A3.015 3.015 0 0 1 3 5a3 3 0 0 1 3-3m0 2a1 1 0 0 0-1 1 1 1 0 0 0 1 1 1 1 0 0 0 1-1 1 1 0 0 0-1-1m12 0a1 1 0 0 0-1 1 1 1 0 0 0 1 1 1 1 0 0 0 1-1 1 1 0 0 0-1-1m-6 14a1 1 0 0 0-1 1 1 1 0 0 0 1 1 1 1 0 0 0 1-1 1 1 0 0 0-1-1Z"></path>
+            </svg>
+          </span>
+         Fork
+        </label>
+        <select id="fork_selector" class="custom_dt_filter" data-criteria="fork" >
+            <option value="all">All Forks</option>
+            {% set default_fork = target_fork if target_fork in cases | map(attribute='fork') | list else cases | map(attribute='fork') | list | last %}
+            {% for fork in cases | map(attribute='fork') | unique %}
+            <option value="{{ fork }}" {% if fork == default_fork %}selected{% endif %}>{{ fork }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div class="filter_wrapper">
+        <label for="fixture_selector">
+        <span class="twemoji">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+            <path d="M21.818 3.646H2.182C.982 3.646 0 4.483 0 5.505v3.707h2.182V5.486h19.636v13.036H2.182v-3.735H0v3.726c0 1.022.982 1.84 2.182 1.84h19.636c1.2 0 2.182-.818 2.182-1.84V5.505c0-1.032-.982-1.859-2.182-1.859Zm-10.909 12.07L15.273 12l-4.364-3.717v2.787H0v1.859h10.909v2.787Z"></path>
+            </svg>
+        </span>
+         Fixture Type
+        </label>
+        <select id="fixture_selector" class="custom_dt_filter" data-criteria="fixture">
+            <option value="all">All Fixture Types</option>
+            {% set default_fixture_type = "STATE_TEST" if "STATE_TEST" in cases | map(attribute='fixture_type') | list else cases[0].fixture_type %}
+            {% for fixture_type in cases | map(attribute='fixture_type') | unique %}
+            <option value="{{ fixture_type }}" {% if fixture_type == default_fixture_type %}selected{% endif %}>{{ fixture_type }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    </div>
+    <div class"panel_row search">
+        <div class="search_wrapper">
+            <input type="text" class="form-control" id="custom_dt_search" placeholder="🔍 Search...">
+        </div>
+    </div>
+</div>
 <table id="test_table" class="display nowrap">
     <thead>
         <tr>

--- a/docs/templates/function_parameter_datatable.html.j2
+++ b/docs/templates/function_parameter_datatable.html.j2
@@ -37,11 +37,11 @@
     </div>
     <div class"panel_row search">
         <div class="search_wrapper">
-            <input type="text" class="form-control" id="custom_dt_search" placeholder="🔍 Search...">
+            <input type="text" class="form-control" id="custom_dt_search" placeholder="🔍 Search test cases...">
         </div>
     </div>
 </div>
-<table id="test_table" class="display nowrap">
+<table id="test_table" class="display compact nowrap">
     <thead>
         <tr>
             <th>Test ID (Abbreviated)</th>

--- a/docs/templates/function_parameter_datatable.html.j2
+++ b/docs/templates/function_parameter_datatable.html.j2
@@ -1,5 +1,5 @@
 <label for="fork_selector">Filter by Fork: </label>
-<select id="fork_selector">
+<select id="fork_selector" class="custom_dt_filter" data-criteria="fork" >
     <option value="all">All Forks</option>
     {% set default_fork = target_fork if target_fork in cases | map(attribute='fork') | list else cases | map(attribute='fork') | list | last %}
     {% for fork in cases | map(attribute='fork') | unique %}
@@ -8,7 +8,7 @@
 </select>
 
 <label for="fixture_selector">Filter by Fixture Type: </label>
-<select id="fixture_selector">
+<select id="fixture_selector" class="custom_dt_filter" data-criteria="fixture">
     <option value="all">All Fixture Types</option>
     {% set default_fixture_type = "STATE_TEST" if "STATE_TEST" in cases | map(attribute='fixture_type') | list else cases[0].fixture_type %}
     {% for fixture_type in cases | map(attribute='fixture_type') | unique %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@ site_url: https://ethereum.github.io/execution-spec-tests/
 repo_url: https://github.com/ethereum/execution-spec-tests
 repo_name: execution-spec-tests
 edit_uri: edit/main/docs/
-copyright: 'Copyright: 2024, Ethereum Community'
+copyright: "Copyright: 2024, Ethereum Community"
 
 plugins:
   - git-authors:
@@ -31,7 +31,7 @@ watch:
   - src/
   - tests/
 
-theme: 
+theme:
   name: material
   logo: img/Ethereum-logo-600px.png
   favicon: img/ETH-logo-icon.svg
@@ -113,10 +113,10 @@ extra:
     provider: mike
 
 extra_javascript:
-  - https://code.jquery.com/jquery-3.5.1.js
-  - https://cdn.datatables.net/1.10.21/js/jquery.dataTables.js
+  - https://code.jquery.com/jquery-3.7.1.min.js
+  - https://cdn.datatables.net/2.1.7/js/dataTables.min.js
   - javascripts/site.js
 
 extra_css:
-  - https://cdn.datatables.net/1.10.21/css/jquery.dataTables.css
+  - https://cdn.datatables.net/2.1.7/css/dataTables.dataTables.min.css
   - stylesheets/custom.css

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,9 +114,11 @@ extra:
 
 extra_javascript:
   - https://code.jquery.com/jquery-3.7.1.min.js
+  - https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js
   - https://cdn.datatables.net/2.1.7/js/dataTables.min.js
   - javascripts/site.js
 
 extra_css:
+  - https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css
   - https://cdn.datatables.net/2.1.7/css/dataTables.dataTables.min.css
   - stylesheets/custom.css


### PR DESCRIPTION
## 🗒️ Description
Fixes:
-  Issues with custom fork and test filters.
-  Resolved a bug causing the datatable to break when changing entries per page.

Enhancements:

-  Upgraded jQuery from 3.5.1 to 3.7.1.
-  Upgraded DataTables from 1.10.21 to 2.1.7.
-  Migrated to minified scripts / css where possible for faster page load.
-  Added a plugin for searchable dropdowns.

![image](https://github.com/user-attachments/assets/7f3608d5-1fd3-4e2c-8e5a-02feae69b184)

## 🔗 Related Issues
#842 

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] ~~All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.~~ **skipped**
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
