### PR TITLE
chore(ci): change image from ubuntu-24.04 to ubuntu-latest

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   evmone-coverage-diff:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         driver: [retesteth, native]

--- a/.github/workflows/docs_main.yaml
+++ b/.github/workflows/docs_main.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   deploy:
     if: github.repository_owner == 'ethereum' # don't run on forks
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/docs_tags.yaml
+++ b/.github/workflows/docs_tags.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   deploy:
     if: github.repository_owner == 'ethereum' # don't run on forks
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/fixtures.yaml
+++ b/.github/workflows/fixtures.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   features:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     outputs:
       features: ${{ steps.parse.outputs.features }}
     steps:
@@ -20,7 +20,7 @@ jobs:
           echo "features=$(grep -Po "^[0-9a-zA-Z_\-]+" ./.github/configs/feature.yaml | jq -R . | jq -cs .)" >> "$GITHUB_OUTPUT"
   build:
     needs: features
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         name: ${{ fromJson(needs.features.outputs.features) }}
@@ -32,7 +32,7 @@ jobs:
         with:
           release_name: ${{ matrix.name }}
   release:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: build
     if: startsWith(github.ref, 'refs/tags/')
     steps:

--- a/.github/workflows/fixtures_feature.yaml
+++ b/.github/workflows/fixtures_feature.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   feature-names:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     outputs:
       names: ${{ steps.feature-name.outputs.names }}
     steps:
@@ -23,7 +23,7 @@ jobs:
           echo names=${names}
           echo names=${names} >> "$GITHUB_OUTPUT"
   build:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: feature-names
     strategy:
       matrix:
@@ -36,7 +36,7 @@ jobs:
         with:
           release_name: ${{ matrix.feature }}
   release:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: build
     if: startsWith(github.ref, 'refs/tags/')
     steps:


### PR DESCRIPTION
## 🗒️ Description
#792 changed the images used from `ubuntu-latest` to `ubuntu-24.04` (latest pointed to `ubuntu-22.04` at the time). This PR reverts this change as latest has been bumped to `ubuntu-24.04` in Github Actions in https://github.com/actions/runner-images/commit/ae99c16b0cf27c0cca7ef0b08e7bcf13c33f6cfa.

Using `ubuntu-latest` simplified the need to use `-P` to map the image correctly. The following is from the never published and now defunct docs:
```
"Specifying the `ubuntu-24.04` docker image"

    [#792](https://github.com/ethereum/execution-spec-tests/pull/792/) made EELS the default `t8n` tool. Our Github workflows were changed to use the `ubuntu-24.04` docker image which has OpenSSL 3.0.7, required by EELs to have RIPEMD160 support (used by the precompile at `0x03`). As of 2024-09-30 `ubuntu-latest` resolves to `ubuntu-22-04`.

    To run workflows that use `ubuntu-24.04` with `act` (as of version 0.2.67) the following must be added to the command-line:

    ```bash
    -P ubuntu-24.04=ghcr.io/catthehacker/ubuntu:full-24.04
    ```
```


## 🔗 Related Issues
#792 

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] ~~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~ **skipped**
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
