### PR TITLE
bug(ci): fix deploy docs tags workflow trigger

### DIFF
--- a/.github/workflows/docs_tags.yaml
+++ b/.github/workflows/docs_tags.yaml
@@ -3,7 +3,7 @@ name: Deploy Docs Tags
 on:
   push:
     tags:
-      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10, v0.1.1a1
+      - "v[0-9]+.[0-9]+.[0-9]+*" # Push events to matching v*, i.e. v1.0, v20.15.10, v0.1.1a1
 
 jobs:
   deploy:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -57,6 +57,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - 🔀 Simplify Python project configuration and consolidate it into `pyproject.toml` ([#764](https://github.com/ethereum/execution-spec-tests/pull/764)).
 - 🔀 Created `pytest_plugins.concurrency` plugin to sync multiple `xdist` processes without using a command flag to specify the temporary working folder ([#824](https://github.com/ethereum/execution-spec-tests/pull/824))
 - 🔀 Move pytest plugin `pytest_plugins.filler.solc` to `pytest_plugins.solc.solc` ([#823](https://github.com/ethereum/execution-spec-tests/pull/823)).
+- 🐞 Asserts that the deploy docs tags workflow is only triggered for full releases ([#857](https://github.com/ethereum/execution-spec-tests/pull/857)).
 
 ### 💥 Breaking Change
 


### PR DESCRIPTION
## 🗒️ Description
Fixes a bug within the `Deploy Docs Tags` workflow trigger.

For pre-releases such as `verkle@v0.0.4`, this workflow was triggered deploying and publishing the docs for this tag.

Please see the docs: https://ethereum.github.io/execution-spec-tests/verkle@v0.0.4/

Our check to trigger this workflow was `v*` so any pre-release starting with `v` would always trigger this docs deployment. The past 3 verkle releases did not trigger this as they failed at the docs build step.

### Note

Open to changing to always build and deploy the docs for all releases, including pre-releases.

## 🔗 Related Issues
N/A

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
