### PR TITLE
✨ feat: Styling of native dataTable buttons

### DIFF
--- a/docs/javascripts/site.js
+++ b/docs/javascripts/site.js
@@ -2,6 +2,8 @@
 const FILTER_INPUT_SELECTOR = ".custom_dt_filter";
 const FILTER_SEARCH_SELECTOR = "#custom_dt_search";
 let table;
+const ICON_COLUMN_FILTER =
+  '<span class="twemoji"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M17 16.88c.56 0 1 .44 1 1s-.44 1-1 1-1-.45-1-1 .44-1 1-1m0-3c2.73 0 5.06 1.66 6 4-.94 2.34-3.27 4-6 4s-5.06-1.66-6-4c.94-2.34 3.27-4 6-4m0 1.5a2.5 2.5 0 0 0 0 5 2.5 2.5 0 0 0 0-5M18 3H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h5.42c-.16-.32-.3-.66-.42-1 .12-.34.26-.68.42-1H4v-4h6v2.97c.55-.86 1.23-1.6 2-2.21V13h1.15c1.16-.64 2.47-1 3.85-1 1.06 0 2.07.21 3 .59V5c0-1.1-.9-2-2-2m-8 8H4V7h6v4m8 0h-6V7h6v4Z"></path></svg></span>';
 
 // This script is used both within mkdocs and in standalone html files.
 // As such, a uniform listener to page load event is required.
@@ -28,6 +30,10 @@ document$.subscribe(() => {
 
     // Listen for copy event
     listenForClipboardCopy();
+
+    // Style native daaTable buttons
+    $(".dt-buttons").detach().appendTo(".panel_row.filters");
+    $(".buttons-collection").prepend(ICON_COLUMN_FILTER);
   }
 
   // Setup up select 2
@@ -45,9 +51,9 @@ const initDataTable = () => {
     autoWidth: false,
     layout: {
       topStart: {
-          buttons: ['colvis']
-      }
-    }
+        buttons: ["colvis"],
+      },
+    },
   });
 };
 

--- a/docs/javascripts/site.js
+++ b/docs/javascripts/site.js
@@ -31,7 +31,7 @@ document$.subscribe(() => {
     // Listen for copy event
     listenForClipboardCopy();
 
-    // Style native daaTable buttons
+    // Style native dataTable buttons
     $(".dt-buttons").detach().appendTo(".panel_row.filters");
     $(".buttons-collection").prepend(ICON_COLUMN_FILTER);
   }

--- a/docs/stylesheets/custom.css
+++ b/docs/stylesheets/custom.css
@@ -69,3 +69,23 @@
 .stand_alone_container {
   margin: 10px 15px;
 }
+
+.control_panel .filters .buttons-collection,
+.control_panel .filters .buttons-collection:hover {
+  background: transparent;
+  padding: 10px 15px;
+  vertical-align: middle;
+  border: 1px solid #9e9e9e;
+  margin-bottom: 10px;
+}
+
+.control_panel div.dt-buttons > .dt-button:hover:not(.disabled),
+div.dt-buttons > div.dt-button-split .dt-button:hover:not(.disabled) {
+  background: transparent;
+  border: 1px solid #9e9e9e;
+}
+
+.buttons-collection .twemoji {
+  color: #8f8f8f;
+  margin-right: 4px;
+}

--- a/docs/templates/function_parameter_datatable.html.j2
+++ b/docs/templates/function_parameter_datatable.html.j2
@@ -1,39 +1,39 @@
 <div class="control_panel">
     <div class="panel_row filters">
-    <div class="filter_wrapper">
-        <label for="fork_selector">
-         <span class="twemoji">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-                <path d="M6 2a3 3 0 0 1 3 3c0 1.28-.81 2.38-1.94 2.81.09.46.33 1.02.94 1.82 1 1.29 3 3.2 4 4.54 1-1.34 3-3.25 4-4.54.61-.8.85-1.36.94-1.82A3.015 3.015 0 0 1 15 5a3 3 0 0 1 3-3 3 3 0 0 1 3 3c0 1.32-.86 2.45-2.05 2.85-.08.52-.31 1.15-.95 1.98-1 1.34-3 3.25-4 4.55-.61.79-.85 1.35-.94 1.81C14.19 16.62 15 17.72 15 19a3 3 0 0 1-3 3 3 3 0 0 1-3-3c0-1.28.81-2.38 1.94-2.81-.09-.46-.33-1.02-.94-1.81-1-1.3-3-3.21-4-4.55-.64-.83-.87-1.46-.95-1.98A3.015 3.015 0 0 1 3 5a3 3 0 0 1 3-3m0 2a1 1 0 0 0-1 1 1 1 0 0 0 1 1 1 1 0 0 0 1-1 1 1 0 0 0-1-1m12 0a1 1 0 0 0-1 1 1 1 0 0 0 1 1 1 1 0 0 0 1-1 1 1 0 0 0-1-1m-6 14a1 1 0 0 0-1 1 1 1 0 0 0 1 1 1 1 0 0 0 1-1 1 1 0 0 0-1-1Z"></path>
-            </svg>
-          </span>
-         Fork
-        </label>
-        <select id="fork_selector" class="custom_dt_filter" data-criteria="fork" >
-            <option value="all">All Forks</option>
-            {% set default_fork = target_fork if target_fork in cases | map(attribute='fork') | list else cases | map(attribute='fork') | list | last %}
-            {% for fork in cases | map(attribute='fork') | unique %}
-            <option value="{{ fork }}" {% if fork == default_fork %}selected{% endif %}>{{ fork }}</option>
-            {% endfor %}
-        </select>
-    </div>
-    <div class="filter_wrapper">
-        <label for="fixture_selector">
-        <span class="twemoji">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-            <path d="M21.818 3.646H2.182C.982 3.646 0 4.483 0 5.505v3.707h2.182V5.486h19.636v13.036H2.182v-3.735H0v3.726c0 1.022.982 1.84 2.182 1.84h19.636c1.2 0 2.182-.818 2.182-1.84V5.505c0-1.032-.982-1.859-2.182-1.859Zm-10.909 12.07L15.273 12l-4.364-3.717v2.787H0v1.859h10.909v2.787Z"></path>
-            </svg>
-        </span>
-         Fixture Type
-        </label>
-        <select id="fixture_selector" class="custom_dt_filter" data-criteria="fixture">
-            <option value="all">All Fixture Types</option>
-            {% set default_fixture_type = "STATE_TEST" if "STATE_TEST" in cases | map(attribute='fixture_type') | list else cases[0].fixture_type %}
-            {% for fixture_type in cases | map(attribute='fixture_type') | unique %}
-            <option value="{{ fixture_type }}" {% if fixture_type == default_fixture_type %}selected{% endif %}>{{ fixture_type }}</option>
-            {% endfor %}
-        </select>
-    </div>
+        <div class="filter_wrapper">
+            <label for="fork_selector">
+            <span class="twemoji">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                    <path d="M6 2a3 3 0 0 1 3 3c0 1.28-.81 2.38-1.94 2.81.09.46.33 1.02.94 1.82 1 1.29 3 3.2 4 4.54 1-1.34 3-3.25 4-4.54.61-.8.85-1.36.94-1.82A3.015 3.015 0 0 1 15 5a3 3 0 0 1 3-3 3 3 0 0 1 3 3c0 1.32-.86 2.45-2.05 2.85-.08.52-.31 1.15-.95 1.98-1 1.34-3 3.25-4 4.55-.61.79-.85 1.35-.94 1.81C14.19 16.62 15 17.72 15 19a3 3 0 0 1-3 3 3 3 0 0 1-3-3c0-1.28.81-2.38 1.94-2.81-.09-.46-.33-1.02-.94-1.81-1-1.3-3-3.21-4-4.55-.64-.83-.87-1.46-.95-1.98A3.015 3.015 0 0 1 3 5a3 3 0 0 1 3-3m0 2a1 1 0 0 0-1 1 1 1 0 0 0 1 1 1 1 0 0 0 1-1 1 1 0 0 0-1-1m12 0a1 1 0 0 0-1 1 1 1 0 0 0 1 1 1 1 0 0 0 1-1 1 1 0 0 0-1-1m-6 14a1 1 0 0 0-1 1 1 1 0 0 0 1 1 1 1 0 0 0 1-1 1 1 0 0 0-1-1Z"></path>
+                </svg>
+            </span>
+            Fork
+            </label>
+            <select id="fork_selector" class="custom_dt_filter" data-criteria="fork" >
+                <option value="all">All Forks</option>
+                {% set default_fork = target_fork if target_fork in cases | map(attribute='fork') | list else cases | map(attribute='fork') | list | last %}
+                {% for fork in cases | map(attribute='fork') | unique %}
+                <option value="{{ fork }}" {% if fork == default_fork %}selected{% endif %}>{{ fork }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="filter_wrapper">
+            <label for="fixture_selector">
+            <span class="twemoji">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                <path d="M21.818 3.646H2.182C.982 3.646 0 4.483 0 5.505v3.707h2.182V5.486h19.636v13.036H2.182v-3.735H0v3.726c0 1.022.982 1.84 2.182 1.84h19.636c1.2 0 2.182-.818 2.182-1.84V5.505c0-1.032-.982-1.859-2.182-1.859Zm-10.909 12.07L15.273 12l-4.364-3.717v2.787H0v1.859h10.909v2.787Z"></path>
+                </svg>
+            </span>
+            Fixture Type
+            </label>
+            <select id="fixture_selector" class="custom_dt_filter" data-criteria="fixture">
+                <option value="all">All Fixture Types</option>
+                {% set default_fixture_type = "STATE_TEST" if "STATE_TEST" in cases | map(attribute='fixture_type') | list else cases[0].fixture_type %}
+                {% for fixture_type in cases | map(attribute='fixture_type') | unique %}
+                <option value="{{ fixture_type }}" {% if fixture_type == default_fixture_type %}selected{% endif %}>{{ fixture_type }}</option>
+                {% endfor %}
+            </select>
+        </div>
     </div>
     <div class="panel_row search">
         <div class="search_wrapper">


### PR DESCRIPTION
## 🗒️ Description

A native button for selecting visible column has been added to the parameter test cases dataTable. This PR makes the styling of the button consistent with the existing UI.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
