### PR TITLE
feat(fill): add a config file for the eels resolver to pin versions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -41,9 +41,10 @@ Test fixtures for use by clients are available for each release on the [Github r
 - 🐞 Fix erroneous fork message in pytest session header with development forks ([#806](https://github.com/ethereum/execution-spec-tests/pull/806)).
 - 🐞 Fix `Conditional` code generator in EOF mode ([#821](https://github.com/ethereum/execution-spec-tests/pull/821)).
 - 🐞 Ensure that `Block` objects keep track of their `fork`, for example, when the block's `rlp_modifier` is not `None` ([#854](https://github.com/ethereum/execution-spec-tests/pull/854)).
-- 🔀 `ethereum_test_rpc` library has been created with what was previously `ethereum_test_tools.rpc` ([#822](https://github.com/ethereum/execution-spec-tests/pull/822))
-- ✨ Add `Wei` type to `ethereum_test_base_types` which allows parsing wei amounts from strings like "1 ether", "1000 wei", "10**2 gwei", etc ([#825](https://github.com/ethereum/execution-spec-tests/pull/825))
-- 🔀 Replace `ethereum.base_types` with `ethereum-types` ([#850](https://github.com/ethereum/execution-spec-tests/pull/850))
+- 🔀 `ethereum_test_rpc` library has been created with what was previously `ethereum_test_tools.rpc` ([#822](https://github.com/ethereum/execution-spec-tests/pull/822)).
+- ✨ Add `Wei` type to `ethereum_test_base_types` which allows parsing wei amounts from strings like "1 ether", "1000 wei", "10**2 gwei", etc ([#825](https://github.com/ethereum/execution-spec-tests/pull/825)).
+- ✨ Pin EELS versions in `eels_resolutions.json` and include this file in fixture releases ([#872](https://github.com/ethereum/execution-spec-tests/pull/872)).
+- 🔀 Replace `ethereum.base_types` with `ethereum-types` ([#850](https://github.com/ethereum/execution-spec-tests/pull/850)).
 
 ### 🔧 EVM Tools
 

--- a/eels_resolutions.json
+++ b/eels_resolutions.json
@@ -1,0 +1,42 @@
+{
+    "EELSMaster": {
+        "git_url": "https://github.com/ethereum/execution-specs.git",
+        "branch": "master",
+        "commit": "9b95554a88d2a8485f8180254d0f6a493a593fda"
+    },
+    "Frontier": {
+        "same_as": "EELSMaster"
+    },
+    "Homestead": {
+        "same_as": "EELSMaster"
+    },
+    "Byzantium": {
+        "same_as": "EELSMaster"
+    },
+    "Constantinople": {
+        "same_as": "EELSMaster"
+    },
+    "Istanbul": {
+        "same_as": "EELSMaster"
+    },
+    "Berlin": {
+        "same_as": "EELSMaster"
+    },
+    "London": {
+        "same_as": "EELSMaster"
+    },
+    "Paris": {
+        "same_as": "EELSMaster"
+    },
+    "Shanghai": {
+        "same_as": "EELSMaster"
+    },
+    "Cancun": {
+        "same_as": "EELSMaster"
+    },
+    "Prague": {
+        "git_url": "https://github.com/ethereum/execution-specs.git",
+        "branch": "prague",
+        "commit": "2875a733d6b1e9e751e437c7894d3ebe6ff58ecc"
+    }
+}

--- a/pytest-framework.ini
+++ b/pytest-framework.ini
@@ -9,6 +9,7 @@ markers =
     run_in_serial
 addopts = 
     -p pytester
+    -p pytest_plugins.eels_resolver
     --ignore=src/pytest_plugins/consume/
     --ignore=src/pytest_plugins/consume/direct/test_via_direct.py
     --ignore=src/pytest_plugins/consume/hive_simulators/engine/test_via_engine.py

--- a/pytest.ini
+++ b/pytest.ini
@@ -13,6 +13,7 @@ addopts =
     -p pytest_plugins.filler.filler
     -p pytest_plugins.forks.forks
     -p pytest_plugins.spec_version_checker.spec_version_checker
+    -p pytest_plugins.eels_resolver
     -p pytest_plugins.help.help
     -m "not eip_version_check"
     --tb short

--- a/src/pytest_plugins/eels_resolver.py
+++ b/src/pytest_plugins/eels_resolver.py
@@ -49,11 +49,8 @@ def pytest_configure(config: pytest.Config) -> None:
         eels_resolutions_file = str(default_file_path)
 
     if "Tools" not in config.stash[metadata_key]:
-        config.stash[metadata_key]["Tools"] = {
-            "EELS Resolutions": str(eels_resolutions_file),
-        }
-    else:
-        config.stash[metadata_key]["Tools"]["EELS Resolutions"] = str(eels_resolutions_file)
+        config.stash[metadata_key]["Tools"] = {}
+    config.stash[metadata_key]["Tools"]["EELS Resolutions"] = str(eels_resolutions_file)
 
     config._eels_resolutions_file = eels_resolutions_file  # type: ignore
 

--- a/src/pytest_plugins/eels_resolver.py
+++ b/src/pytest_plugins/eels_resolver.py
@@ -1,0 +1,66 @@
+"""
+Pytest plugin to help working with the `ethereum-spec-evm-resolver`.
+
+This plugin sets the `EELS_RESOLUTIONS_FILE` environment variable to the path
+of the `eels_resolutions.json` file in the pytest root directory. If the
+environment variable is already set, the plugin will not override it.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """
+    Set the EELS_RESOLUTIONS_FILE environment variable.
+
+    Args:
+        config (pytest.Config): The pytest configuration object.
+    """
+    evm_bin = config.getoption("evm_bin", default=None)
+    if evm_bin and "resolver" not in str(evm_bin):
+        # evm_bin is not set for the framework tests: always set the env var.
+        return
+
+    env_var_name = "EELS_RESOLUTIONS_FILE"
+    eels_resolutions_file = os.getenv(env_var_name)
+
+    if os.getenv("EELS_RESOLUTIONS"):
+        # If the user sets this variable, assume they know what they're doing.
+        return
+
+    if eels_resolutions_file:
+        file_path = Path(eels_resolutions_file)
+        if not file_path.is_absolute():
+            raise ValueError(f"The path provided in {env_var_name} must be an absolute path.")
+        if not file_path.exists():
+            raise FileNotFoundError(
+                f"The file {file_path} does not exist. "
+                f"Ensure the {env_var_name} points to an existing file."
+            )
+    else:
+        root_dir = config.rootpath
+        default_file_path = root_dir / "eels_resolutions.json"
+        os.environ[env_var_name] = str(default_file_path)
+        eels_resolutions_file = str(default_file_path)
+
+    config._eels_resolutions_file = eels_resolutions_file  # type: ignore
+
+
+def pytest_report_header(config: pytest.Config, startdir: Path) -> str:
+    """
+    Report the EELS_RESOLUTIONS_FILE path to the pytest report header.
+
+    Args:
+        config (pytest.Config): The pytest configuration object.
+        startdir (Path): The starting directory for the test run.
+
+    Returns:
+        str: A string to add to the pytest report header.
+    """
+    eels_resolutions_file = getattr(config, "_eels_resolutions_file", None)
+    if eels_resolutions_file:
+        return f"EELS resolutions file: {eels_resolutions_file}"
+    return ""

--- a/src/pytest_plugins/filler/tests/test_filler.py
+++ b/src/pytest_plugins/filler/tests/test_filler.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import pytest
 
+from evm_transition_tool import ExecutionSpecsTransitionTool, TransitionTool
 from pytest_plugins.filler.filler import default_output_directory
 
 
@@ -537,6 +538,9 @@ def test_fixture_output_based_on_command_line_args(
 
     expected_ini_file = "fixtures.ini"
     expected_index_file = "index.json"
+    expected_resolver_file = None
+    if TransitionTool.default_tool == ExecutionSpecsTransitionTool:
+        expected_resolver_file = "eels_resolutions.json"
 
     ini_file = None
     index_file = None
@@ -545,10 +549,14 @@ def test_fixture_output_based_on_command_line_args(
             ini_file = file
         elif file.name == expected_index_file:
             index_file = file
+        elif expected_resolver_file and file.name == expected_resolver_file:
+            resolver_file = file
+            assert resolver_file.exists(), f"{resolver_file} does not exist"
 
-    all_fixtures = [
-        file for file in all_files if file.name not in {expected_ini_file, expected_index_file}
-    ]
+    expected_additional_files = {expected_ini_file, expected_index_file}
+    if resolver_file:
+        expected_additional_files.add(expected_resolver_file)
+    all_fixtures = [file for file in all_files if file.name not in expected_additional_files]
     for fixture_file, fixture_count in zip(expected_fixture_files, expected_fixture_counts):
         assert fixture_file.exists(), f"{fixture_file} does not exist"
         assert fixture_count == count_keys_in_fixture(

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -511,6 +511,7 @@ parametrization
 parametrizing
 popen
 prevrandao
+pytestconfig
 pytester
 pytestmark
 readline
@@ -521,8 +522,10 @@ ret
 rglob
 ripemd
 rjust
+rootpath
 runpytest
 runtest
+startdir
 subclasses
 subcommand
 subcontainer


### PR DESCRIPTION
## 🗒️ Description
Currently, as EEST doesn't configure the EELS resolver, it takes the HEAD of execution-specs `master` for all forks. This exposes EEST to any issues that make it to execution-specs `master`. This PR aims to eliminate this risk and improve reporting the EELS version used to fill forks: 
- Add a config file `eels_resolutions.json` that pins the ethereum/execution-specs main branch reference for deployed and Prague forks, see the [ethereum-spec-evm-resolver README](https://github.com/petertdavies/ethereum-spec-evm-resolver/tree/ed7dbce2e64c57812821d96297b6e0efc2967802?tab=readme-ov-file#example-config).
- Use the `eels_resolutions.json` in `fill` and the framework tests automatically by setting the `EELS_RESOLUTIONS_FILE` envvar in an `eels_resolver` plugin. The value will not be clobbered, however, if the user has manually set `EELS_RESOLUTIONS_FILE`.
- Report the resolutions file used in the pytest report header and metadata (metadata plugin).
- Copy the resolutions file to the fixture's `.meta` folder (to verify fixture origin in releases, for example).

## 🔗 Related Issues
#792 

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
