### PR TITLE
refactor(execute,fill): share common plugin functionality

### DIFF
--- a/pytest-execute-hive.ini
+++ b/pytest-execute-hive.ini
@@ -13,6 +13,7 @@ addopts =
     -p pytest_plugins.solc.solc
     -p pytest_plugins.execute.rpc.hive
     -p pytest_plugins.execute.execute
+    -p pytest_plugins.shared.execute_fill
     -p pytest_plugins.forks.forks
     -p pytest_plugins.spec_version_checker.spec_version_checker
     -p pytest_plugins.pytest_hive.pytest_hive

--- a/pytest-execute.ini
+++ b/pytest-execute.ini
@@ -12,6 +12,7 @@ addopts =
     -p pytest_plugins.execute.pre_alloc
     -p pytest_plugins.solc.solc
     -p pytest_plugins.execute.execute
+    -p pytest_plugins.shared.execute_fill
     -p pytest_plugins.execute.rpc.remote_seed_sender
     -p pytest_plugins.execute.rpc.remote
     -p pytest_plugins.forks.forks

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,6 +11,7 @@ addopts =
     -p pytest_plugins.filler.pre_alloc
     -p pytest_plugins.solc.solc
     -p pytest_plugins.filler.filler
+    -p pytest_plugins.shared.execute_fill
     -p pytest_plugins.forks.forks
     -p pytest_plugins.spec_version_checker.spec_version_checker
     -p pytest_plugins.help.help

--- a/src/ethereum_test_fixtures/base.py
+++ b/src/ethereum_test_fixtures/base.py
@@ -59,7 +59,7 @@ class BaseFixture(CamelModel):
     def fill_info(
         self,
         t8n_version: str,
-        fixture_description: str,
+        test_case_description: str,
         fixture_source_url: str,
         ref_spec: ReferenceSpec | None,
     ):
@@ -69,7 +69,7 @@ class BaseFixture(CamelModel):
         if "comment" not in self.info:
             self.info["comment"] = "`execution-spec-tests` generated test"
         self.info["filling-transition-tool"] = t8n_version
-        self.info["description"] = fixture_description
+        self.info["description"] = test_case_description
         self.info["url"] = fixture_source_url
         if ref_spec is not None:
             ref_spec.write_info(self.info)

--- a/src/pytest_plugins/consume/hive_simulators/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/conftest.py
@@ -79,7 +79,7 @@ def eest_consume_commands(
 
 
 @pytest.fixture(scope="function")
-def fixture_description(
+def test_case_description(
     blockchain_fixture: BlockchainFixtureCommon,
     test_case: TestCaseIndexFile | TestCaseStream,
     hive_consume_command: str,

--- a/src/pytest_plugins/execute/execute.py
+++ b/src/pytest_plugins/execute/execute.py
@@ -117,17 +117,7 @@ def pytest_configure(config):
     if config.getoption("disable_html") and config.getoption("htmlpath") is None:
         # generate an html report by default, unless explicitly disabled
         config.option.htmlpath = Path(default_html_report_file_path())
-    config.solc_version = Solc(config.getoption("solc_bin")).version
-    if config.solc_version < Frontier.solc_min_version():
-        pytest.exit(
-            f"Unsupported solc version: {config.solc_version}. Minimum required version is "
-            f"{Frontier.solc_min_version()}",
-            returncode=pytest.ExitCode.USAGE_ERROR,
-        )
 
-    config.stash[metadata_key]["Tools"] = {
-        "solc": str(config.solc_version),
-    }
     command_line_args = "fill " + " ".join(config.invocation_params.args)
     config.stash[metadata_key]["Command-line args"] = f"<code>{command_line_args}</code>"
 
@@ -203,14 +193,6 @@ def pytest_html_report_title(report):
     Set the HTML report title (pytest-html plugin).
     """
     report.title = "Execute Test Report"
-
-
-@pytest.fixture(autouse=True, scope="session")
-def solc_bin(request):
-    """
-    Returns the configured solc binary path.
-    """
-    return request.config.getoption("solc_bin")
 
 
 @pytest.fixture(scope="session")

--- a/src/pytest_plugins/execute/execute.py
+++ b/src/pytest_plugins/execute/execute.py
@@ -91,27 +91,6 @@ def pytest_configure(config):
         called before the pytest-html plugin's pytest_configure to ensure that
         it uses the modified `htmlpath` option.
     """
-    for execute_format in EXECUTE_FORMATS.values():
-        config.addinivalue_line(
-            "markers",
-            (f"{execute_format.execute_format_name.lower()}: {execute_format.description}"),
-        )
-    config.addinivalue_line(
-        "markers",
-        "yul_test: a test case that compiles Yul code.",
-    )
-    config.addinivalue_line(
-        "markers",
-        "compile_yul_with(fork): Always compile Yul source using the corresponding evm version.",
-    )
-    config.addinivalue_line(
-        "markers",
-        "fill: Markers to be added in fill mode only.",
-    )
-    config.addinivalue_line(
-        "markers",
-        "execute: Markers to be added in execute mode only.",
-    )
     if config.option.collectonly:
         return
     if config.getoption("disable_html") and config.getoption("htmlpath") is None:

--- a/src/pytest_plugins/execute/execute.py
+++ b/src/pytest_plugins/execute/execute.py
@@ -141,15 +141,6 @@ def pytest_configure(config):
         )
 
 
-@pytest.hookimpl(trylast=True)
-def pytest_report_header(config, start_path):
-    """Add lines to pytest's console output header"""
-    if config.option.collectonly:
-        return
-    solc_version = config.stash[metadata_key]["Tools"]["solc"]
-    return [(f"{solc_version}")]
-
-
 def pytest_metadata(metadata):
     """
     Add or remove metadata to/from the pytest report.

--- a/src/pytest_plugins/execute/execute.py
+++ b/src/pytest_plugins/execute/execute.py
@@ -2,7 +2,6 @@
 Test execution plugin for pytest, to run Ethereum tests using in live networks.
 """
 
-import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Generator, List, Type
@@ -12,14 +11,9 @@ from pytest_metadata.plugin import metadata_key  # type: ignore
 
 from ethereum_test_base_types import Number
 from ethereum_test_execution import EXECUTE_FORMATS, BaseExecute
-from ethereum_test_forks import (
-    Fork,
-    Frontier,
-    get_closest_fork_with_solc_support,
-    get_forks_with_solc_support,
-)
+from ethereum_test_forks import Fork, Frontier
 from ethereum_test_rpc import EthRPC
-from ethereum_test_tools import SPEC_TYPES, BaseTest, TestInfo, Transaction, Yul
+from ethereum_test_tools import SPEC_TYPES, BaseTest, TestInfo, Transaction
 from ethereum_test_tools.code import Solc
 from ethereum_test_types import TransactionDefaults
 from pytest_plugins.spec_version_checker.spec_version_checker import EIPSpecTestItem
@@ -293,62 +287,6 @@ def collector(
     yield collector
 
 
-@pytest.fixture(autouse=True)
-def eips():
-    """
-    A fixture specifying that, by default, no EIPs should be activated for
-    tests.
-
-    This fixture (function) may be redefined in test filler modules in order
-    to overwrite this default and return a list of integers specifying which
-    EIPs should be activated for the tests in scope.
-    """
-    return []
-
-
-@pytest.fixture
-def yul(fork: Fork, request):
-    """
-    A fixture that allows contract code to be defined with Yul code.
-
-    This fixture defines a class that wraps the ::ethereum_test_tools.Yul
-    class so that upon instantiation within the test case, it provides the
-    test case's current fork parameter. The forks is then available for use
-    in solc's arguments for the Yul code compilation.
-
-    Test cases can override the default value by specifying a fixed version
-    with the @pytest.mark.compile_yul_with(FORK) marker.
-    """
-    solc_target_fork: Fork | None
-    marker = request.node.get_closest_marker("compile_yul_with")
-    if marker:
-        if not marker.args[0]:
-            pytest.fail(
-                f"{request.node.name}: Expected one argument in 'compile_yul_with' marker."
-            )
-        for fork in request.config.forks:
-            if fork.name() == marker.args[0]:
-                solc_target_fork = fork
-                break
-        else:
-            pytest.fail(f"{request.node.name}: Fork {marker.args[0]} not found in forks list.")
-        assert solc_target_fork in get_forks_with_solc_support(request.config.solc_version)
-    else:
-        solc_target_fork = get_closest_fork_with_solc_support(fork, request.config.solc_version)
-        assert solc_target_fork is not None, "No fork supports provided solc version."
-        if solc_target_fork != fork and request.config.getoption("verbose") >= 1:
-            warnings.warn(f"Compiling Yul for {solc_target_fork.name()}, not {fork.name()}.")
-
-    class YulWrapper(Yul):
-        def __new__(cls, *args, **kwargs):
-            return super(YulWrapper, cls).__new__(cls, *args, **kwargs, fork=solc_target_fork)
-
-    return YulWrapper
-
-
-SPEC_TYPES_PARAMETERS: List[str] = [s.pytest_parameter_name() for s in SPEC_TYPES]
-
-
 def node_to_test_info(node) -> TestInfo:
     """
     Returns the test info of the current node item.
@@ -359,24 +297,6 @@ def node_to_test_info(node) -> TestInfo:
         original_name=node.originalname,
         path=Path(node.path),
     )
-
-
-@pytest.fixture(scope="function")
-def fixture_description(request):
-    """Fixture to extract and combine docstrings from the test class and the test function."""
-    description_unavailable = (
-        "No description available - add a docstring to the python test class or function."
-    )
-    test_class_doc = f"Test class documentation:\n{request.cls.__doc__}" if request.cls else ""
-    test_function_doc = (
-        f"Test function documentation:\n{request.function.__doc__}"
-        if request.function.__doc__
-        else ""
-    )
-    if not test_class_doc and not test_function_doc:
-        return description_unavailable
-    combined_docstring = f"{test_class_doc}\n\n{test_function_doc}".strip()
-    return combined_docstring
 
 
 def base_test_parametrizer(cls: Type[BaseTest]):
@@ -522,36 +442,3 @@ def pytest_collection_modifyitems(config: pytest.Config, items: List[pytest.Item
                 item.add_marker(pytest.mark.skip(reason="transition tests not executable"))
         if "yul" in item.fixturenames:  # type: ignore
             item.add_marker(pytest.mark.yul_test)
-
-
-def pytest_make_parametrize_id(config, val, argname):
-    """
-    Pytest hook called when generating test ids. We use this to generate
-    more readable test ids for the generated tests.
-    """
-    return f"{argname}_{val}"
-
-
-def pytest_runtest_call(item):
-    """
-    Pytest hook called in the context of test execution.
-    """
-    if isinstance(item, EIPSpecTestItem):
-        return
-
-    class InvalidFiller(Exception):
-        def __init__(self, message):
-            super().__init__(message)
-
-    if "state_test" in item.fixturenames and "blockchain_test" in item.fixturenames:
-        raise InvalidFiller(
-            "A filler should only implement either a state test or " "a blockchain test; not both."
-        )
-
-    # Check that the test defines either test type as parameter.
-    if not any([i for i in item.funcargs if i in SPEC_TYPES_PARAMETERS]):
-        pytest.fail(
-            "Test must define either one of the following parameters to "
-            + "properly generate a test: "
-            + ", ".join(SPEC_TYPES_PARAMETERS)
-        )

--- a/src/pytest_plugins/execute/execute.py
+++ b/src/pytest_plugins/execute/execute.py
@@ -11,10 +11,9 @@ from pytest_metadata.plugin import metadata_key  # type: ignore
 
 from ethereum_test_base_types import Number
 from ethereum_test_execution import EXECUTE_FORMATS, BaseExecute
-from ethereum_test_forks import Fork, Frontier
+from ethereum_test_forks import Fork
 from ethereum_test_rpc import EthRPC
 from ethereum_test_tools import SPEC_TYPES, BaseTest, TestInfo, Transaction
-from ethereum_test_tools.code import Solc
 from ethereum_test_types import TransactionDefaults
 from pytest_plugins.spec_version_checker.spec_version_checker import EIPSpecTestItem
 

--- a/src/pytest_plugins/execute/rpc/hive.py
+++ b/src/pytest_plugins/execute/rpc/hive.py
@@ -820,7 +820,7 @@ class EthRPC(BaseEthRPC):
         )
 
     def _handle_pending_transactions(
-        self, last_pending_tx_hashes_count: int | None, i: int
+        self, last_pending_tx_hashes_count: int | None, i: int, block_generation_interval: int = 10
     ) -> None:
         """
         Manages block generation based on the number of pending transactions.
@@ -830,6 +830,8 @@ class EthRPC(BaseEthRPC):
                 from the last iteration.
             i: The current loop iteration index, used for conditional block
                 generation.
+            block_generation_interval: The number of iterations after which a block
+                is generated if no new transactions are added (default: 10).
         """
         with self.pending_tx_hashes:
             if len(self.pending_tx_hashes) >= self.transactions_per_block:
@@ -838,7 +840,7 @@ class EthRPC(BaseEthRPC):
                 if (
                     last_pending_tx_hashes_count is not None
                     and len(self.pending_tx_hashes) == last_pending_tx_hashes_count
-                    and i % 10 == 0
+                    and i % block_generation_interval == 0
                 ):
                     # If no new transactions have been added to the pending list,
                     # generate a block to avoid potential deadlock.

--- a/src/pytest_plugins/execute/rpc/hive.py
+++ b/src/pytest_plugins/execute/rpc/hive.py
@@ -393,41 +393,6 @@ def base_hive_test(
             users_file.unlink()
 
 
-@pytest.fixture(autouse=True, scope="function")
-def hive_test(request, test_suite: HiveTestSuite):
-    """
-    Hive test instance for the current test.
-    """
-    test: HiveTest = test_suite.start_test(
-        name=request.node.nodeid,
-        description=request.node.function.__doc__,
-    )
-    yield test
-    try:
-        # TODO: Handle xfail/skip, does this work with run=False?
-        if hasattr(request.node, "result_call") and request.node.result_call.passed:
-            test_passed = True
-            test_result_details = "Test passed."
-        elif hasattr(request.node, "result_call") and not request.node.result_call.passed:
-            test_passed = False
-            test_result_details = request.node.result_call.longreprtext
-        elif hasattr(request.node, "result_setup") and not request.node.result_setup.passed:
-            test_passed = False
-            test_result_details = "Test setup failed.\n" + request.node.result_setup.longreprtext
-        elif hasattr(request.node, "result_teardown") and not request.node.result_teardown.passed:
-            test_passed = False
-            test_result_details = (
-                "Test teardown failed.\n" + request.node.result_teardown.longreprtext
-            )
-        else:
-            test_passed = False
-            test_result_details = "Test failed for unknown reason (setup or call status unknown)."
-    except Exception as e:
-        test_passed = False
-        test_result_details = f"Exception whilst processing test result: {str(e)}"
-    test.end(result=HiveTestResult(test_pass=test_passed, details=test_result_details))
-
-
 @pytest.fixture(scope="session")
 def client_type(simulator: Simulation) -> ClientType:
     """

--- a/src/pytest_plugins/filler/filler.py
+++ b/src/pytest_plugins/filler/filler.py
@@ -201,27 +201,6 @@ def pytest_configure(config):
         called before the pytest-html plugin's pytest_configure to ensure that
         it uses the modified `htmlpath` option.
     """
-    for fixture_format in FIXTURE_FORMATS.values():
-        config.addinivalue_line(
-            "markers",
-            (f"{fixture_format.fixture_format_name.lower()}: {fixture_format.description}"),
-        )
-    config.addinivalue_line(
-        "markers",
-        "yul_test: a test case that compiles Yul code.",
-    )
-    config.addinivalue_line(
-        "markers",
-        "compile_yul_with(fork): Always compile Yul source using the corresponding evm version.",
-    )
-    config.addinivalue_line(
-        "markers",
-        "fill: Markers to be added in fill mode only.",
-    )
-    config.addinivalue_line(
-        "markers",
-        "execute: Markers to be added in execute mode only.",
-    )
     if config.option.collectonly:
         return
     if not config.getoption("disable_html") and config.getoption("htmlpath") is None:

--- a/src/pytest_plugins/filler/filler.py
+++ b/src/pytest_plugins/filler/filler.py
@@ -709,7 +709,7 @@ def base_test_parametrizer(cls: Type[BaseTest]):
         output_dir: Path,
         dump_dir_parameter_level: Path | None,
         fixture_collector: FixtureCollector,
-        fixture_description: str,
+        test_case_description: str,
         fixture_source_url: str,
     ):
         """
@@ -740,7 +740,7 @@ def base_test_parametrizer(cls: Type[BaseTest]):
                 )
                 fixture.fill_info(
                     t8n.version(),
-                    fixture_description,
+                    test_case_description,
                     fixture_source_url=fixture_source_url,
                     ref_spec=reference_spec,
                 )

--- a/src/pytest_plugins/filler/filler.py
+++ b/src/pytest_plugins/filler/filler.py
@@ -266,8 +266,7 @@ def pytest_report_header(config: pytest.Config):
     if config.option.collectonly:
         return
     t8n_version = config.stash[metadata_key]["Tools"]["t8n"]
-    solc_version = config.stash[metadata_key]["Tools"]["solc"]
-    return [(f"{t8n_version}, {solc_version}")]
+    return [(f"{t8n_version}")]
 
 
 def pytest_report_teststatus(report, config: pytest.Config):

--- a/src/pytest_plugins/filler/filler.py
+++ b/src/pytest_plugins/filler/filler.py
@@ -20,13 +20,8 @@ from pytest_metadata.plugin import metadata_key  # type: ignore
 from cli.gen_index import generate_fixtures_index
 from ethereum_test_base_types import Alloc, ReferenceSpec
 from ethereum_test_fixtures import FIXTURE_FORMATS, BaseFixture, FixtureCollector, TestInfo
-from ethereum_test_forks import (
-    Fork,
-    get_closest_fork_with_solc_support,
-    get_forks_with_solc_support,
-)
+from ethereum_test_forks import Fork
 from ethereum_test_specs import SPEC_TYPES, BaseTest
-from ethereum_test_tools import Yul
 from ethereum_test_tools.utility.versioning import (
     generate_github_url,
     get_current_commit_hash_or_tag,
@@ -666,62 +661,6 @@ def filler_path(request: pytest.FixtureRequest) -> Path:
     return request.config.getoption("filler_path")
 
 
-@pytest.fixture(autouse=True)
-def eips():
-    """
-    A fixture specifying that, by default, no EIPs should be activated for
-    tests.
-
-    This fixture (function) may be redefined in test filler modules in order
-    to overwrite this default and return a list of integers specifying which
-    EIPs should be activated for the tests in scope.
-    """
-    return []
-
-
-@pytest.fixture
-def yul(fork: Fork, request):
-    """
-    A fixture that allows contract code to be defined with Yul code.
-
-    This fixture defines a class that wraps the ::ethereum_test_tools.Yul
-    class so that upon instantiation within the test case, it provides the
-    test case's current fork parameter. The forks is then available for use
-    in solc's arguments for the Yul code compilation.
-
-    Test cases can override the default value by specifying a fixed version
-    with the @pytest.mark.compile_yul_with(FORK) marker.
-    """
-    solc_target_fork: Fork | None
-    marker = request.node.get_closest_marker("compile_yul_with")
-    if marker:
-        if not marker.args[0]:
-            pytest.fail(
-                f"{request.node.name}: Expected one argument in 'compile_yul_with' marker."
-            )
-        for fork in request.config.forks:
-            if fork.name() == marker.args[0]:
-                solc_target_fork = fork
-                break
-        else:
-            pytest.fail(f"{request.node.name}: Fork {marker.args[0]} not found in forks list.")
-        assert solc_target_fork in get_forks_with_solc_support(request.config.solc_version)
-    else:
-        solc_target_fork = get_closest_fork_with_solc_support(fork, request.config.solc_version)
-        assert solc_target_fork is not None, "No fork supports provided solc version."
-        if solc_target_fork != fork and request.config.getoption("verbose") >= 1:
-            warnings.warn(f"Compiling Yul for {solc_target_fork.name()}, not {fork.name()}.")
-
-    class YulWrapper(Yul):
-        def __new__(cls, *args, **kwargs):
-            return super(YulWrapper, cls).__new__(cls, *args, **kwargs, fork=solc_target_fork)
-
-    return YulWrapper
-
-
-SPEC_TYPES_PARAMETERS: List[str] = [s.pytest_parameter_name() for s in SPEC_TYPES]
-
-
 def node_to_test_info(node: pytest.Item) -> TestInfo:
     """
     Returns the test info of the current node item.
@@ -746,24 +685,6 @@ def fixture_source_url(request: pytest.FixtureRequest) -> str:
         module_relative_path, branch_or_commit_or_tag=hash_or_tag, line_number=function_line_number
     )
     return github_url
-
-
-@pytest.fixture(scope="function")
-def fixture_description(request: pytest.FixtureRequest) -> str:
-    """Fixture to extract and combine docstrings from the test class and the test function."""
-    description_unavailable = (
-        "No description available - add a docstring to the python test class or function."
-    )
-    test_class_doc = f"Test class documentation:\n{request.cls.__doc__}" if request.cls else ""
-    test_function_doc = (
-        f"Test function documentation:\n{request.function.__doc__}"
-        if request.function.__doc__
-        else ""
-    )
-    if not test_class_doc and not test_function_doc:
-        return description_unavailable
-    combined_docstring = f"{test_class_doc}\n\n{test_function_doc}".strip()
-    return combined_docstring
 
 
 def base_test_parametrizer(cls: Type[BaseTest]):
@@ -895,36 +816,3 @@ def pytest_collection_modifyitems(config: pytest.Config, items: List[pytest.Item
                     item.add_marker(mark)
         if "yul" in item.fixturenames:  # type: ignore
             item.add_marker(pytest.mark.yul_test)
-
-
-def pytest_make_parametrize_id(config, val, argname):
-    """
-    Pytest hook called when generating test ids. We use this to generate
-    more readable test ids for the generated tests.
-    """
-    return f"{argname}_{val}"
-
-
-def pytest_runtest_call(item):
-    """
-    Pytest hook called in the context of test execution.
-    """
-    if isinstance(item, EIPSpecTestItem):
-        return
-
-    class InvalidFiller(Exception):
-        def __init__(self, message):
-            super().__init__(message)
-
-    if "state_test" in item.fixturenames and "blockchain_test" in item.fixturenames:
-        raise InvalidFiller(
-            "A filler should only implement either a state test or " "a blockchain test; not both."
-        )
-
-    # Check that the test defines either test type as parameter.
-    if not any([i for i in item.funcargs if i in SPEC_TYPES_PARAMETERS]):
-        pytest.fail(
-            "Test must define either one of the following parameters to "
-            + "properly generate a test: "
-            + ", ".join(SPEC_TYPES_PARAMETERS)
-        )

--- a/src/pytest_plugins/filler/filler.py
+++ b/src/pytest_plugins/filler/filler.py
@@ -19,7 +19,7 @@ from pytest_metadata.plugin import metadata_key  # type: ignore
 
 from cli.gen_index import generate_fixtures_index
 from ethereum_test_base_types import Alloc, ReferenceSpec
-from ethereum_test_fixtures import FIXTURE_FORMATS, BaseFixture, FixtureCollector, TestInfo
+from ethereum_test_fixtures import BaseFixture, FixtureCollector, TestInfo
 from ethereum_test_forks import Fork
 from ethereum_test_specs import SPEC_TYPES, BaseTest
 from ethereum_test_tools.utility.versioning import (

--- a/src/pytest_plugins/pytest_hive/pytest_hive.py
+++ b/src/pytest_plugins/pytest_hive/pytest_hive.py
@@ -169,16 +169,16 @@ def hive_test(request, test_suite: HiveTestSuite):
     Propagate the pytest test case and its result to the hive server.
     """
     try:
-        fixture_description = request.getfixturevalue("fixture_description")
+        test_case_description = request.getfixturevalue("test_case_description")
     except pytest.FixtureLookupError:
         pytest.exit(
-            "Error: The 'fixture_description' fixture has not been defined by the simulator "
+            "Error: The 'test_case_description' fixture has not been defined by the simulator "
             "or pytest plugin using this plugin!"
         )
     test_parameter_string = request.node.name  # consume pytest test id
     test: HiveTest = test_suite.start_test(
         name=test_parameter_string,
-        description=fixture_description,
+        description=test_case_description,
     )
     yield test
     try:

--- a/src/pytest_plugins/shared/execute_fill.py
+++ b/src/pytest_plugins/shared/execute_fill.py
@@ -72,7 +72,7 @@ def yul(fork: Fork, request: pytest.FixtureRequest):
 
 
 @pytest.fixture(scope="function")
-def fixture_description(request: pytest.FixtureRequest) -> str:
+def test_case_description(request: pytest.FixtureRequest) -> str:
     """Fixture to extract and combine docstrings from the test class and the test function."""
     description_unavailable = (
         "No description available - add a docstring to the python test class or function."

--- a/src/pytest_plugins/shared/execute_fill.py
+++ b/src/pytest_plugins/shared/execute_fill.py
@@ -1,0 +1,127 @@
+"""
+Shared pytest fixtures and hooks for EEST generation modes (fill and execute).
+"""
+
+import warnings
+from typing import List, cast
+
+import pytest
+
+from ethereum_test_forks import (
+    Fork,
+    get_closest_fork_with_solc_support,
+    get_forks_with_solc_support,
+)
+from ethereum_test_specs import SPEC_TYPES
+from ethereum_test_tools import Yul
+from pytest_plugins.spec_version_checker.spec_version_checker import EIPSpecTestItem
+
+
+@pytest.fixture(autouse=True)
+def eips():
+    """
+    A fixture specifying that, by default, no EIPs should be activated for
+    tests.
+
+    This fixture (function) may be redefined in test filler modules in order
+    to overwrite this default and return a list of integers specifying which
+    EIPs should be activated for the tests in scope.
+    """
+    return []
+
+
+@pytest.fixture
+def yul(fork: Fork, request: pytest.FixtureRequest):
+    """
+    A fixture that allows contract code to be defined with Yul code.
+
+    This fixture defines a class that wraps the ::ethereum_test_tools.Yul
+    class so that upon instantiation within the test case, it provides the
+    test case's current fork parameter. The forks is then available for use
+    in solc's arguments for the Yul code compilation.
+
+    Test cases can override the default value by specifying a fixed version
+    with the @pytest.mark.compile_yul_with(FORK) marker.
+    """
+    solc_target_fork: Fork | None
+    marker = request.node.get_closest_marker("compile_yul_with")
+    assert hasattr(request.config, "solc_version"), "solc_version not set in pytest config."
+    if marker:
+        if not marker.args[0]:
+            pytest.fail(
+                f"{request.node.name}: Expected one argument in 'compile_yul_with' marker."
+            )
+        for fork in request.config.forks:  # type: ignore
+            if fork.name() == marker.args[0]:
+                solc_target_fork = fork
+                break
+        else:
+            pytest.fail(f"{request.node.name}: Fork {marker.args[0]} not found in forks list.")
+        assert solc_target_fork in get_forks_with_solc_support(request.config.solc_version)
+    else:
+        solc_target_fork = get_closest_fork_with_solc_support(fork, request.config.solc_version)
+        assert solc_target_fork is not None, "No fork supports provided solc version."
+        if solc_target_fork != fork and request.config.getoption("verbose") >= 1:
+            warnings.warn(f"Compiling Yul for {solc_target_fork.name()}, not {fork.name()}.")
+
+    class YulWrapper(Yul):
+        def __new__(cls, *args, **kwargs):
+            return super(YulWrapper, cls).__new__(cls, *args, **kwargs, fork=solc_target_fork)
+
+    return YulWrapper
+
+
+@pytest.fixture(scope="function")
+def fixture_description(request: pytest.FixtureRequest) -> str:
+    """Fixture to extract and combine docstrings from the test class and the test function."""
+    description_unavailable = (
+        "No description available - add a docstring to the python test class or function."
+    )
+    test_class_doc = f"Test class documentation:\n{request.cls.__doc__}" if request.cls else ""
+    test_function_doc = (
+        f"Test function documentation:\n{request.function.__doc__}"
+        if request.function.__doc__
+        else ""
+    )
+    if not test_class_doc and not test_function_doc:
+        return description_unavailable
+    combined_docstring = f"{test_class_doc}\n\n{test_function_doc}".strip()
+    return combined_docstring
+
+
+def pytest_make_parametrize_id(config: pytest.Config, val: str, argname: str):
+    """
+    Pytest hook called when generating test ids. We use this to generate
+    more readable test ids for the generated tests.
+    """
+    return f"{argname}_{val}"
+
+
+SPEC_TYPES_PARAMETERS: List[str] = [s.pytest_parameter_name() for s in SPEC_TYPES]
+
+
+def pytest_runtest_call(item: pytest.Item):
+    """
+    Pytest hook called in the context of test execution.
+    """
+    if isinstance(item, EIPSpecTestItem):
+        return
+
+    class InvalidFiller(Exception):
+        def __init__(self, message):
+            super().__init__(message)
+
+    item = cast(pytest.Function, item)  # help mypy infer type
+
+    if "state_test" in item.fixturenames and "blockchain_test" in item.fixturenames:
+        raise InvalidFiller(
+            "A filler should only implement either a state test or " "a blockchain test; not both."
+        )
+
+    # Check that the test defines either test type as parameter.
+    if not any([i for i in item.funcargs if i in SPEC_TYPES_PARAMETERS]):
+        pytest.fail(
+            "Test must define either one of the following parameters to "
+            + "properly generate a test: "
+            + ", ".join(SPEC_TYPES_PARAMETERS)
+        )

--- a/src/pytest_plugins/shared/execute_fill.py
+++ b/src/pytest_plugins/shared/execute_fill.py
@@ -3,12 +3,12 @@ Shared pytest fixtures and hooks for EEST generation modes (fill and execute).
 """
 
 import warnings
-from typing import Dict, List, cast
+from typing import List, cast
 
 import pytest
 
-from ethereum_test_execution import EXECUTE_FORMATS, ExecuteFormat
-from ethereum_test_fixtures import FIXTURE_FORMATS, FixtureFormat
+from ethereum_test_execution import EXECUTE_FORMATS
+from ethereum_test_fixtures import FIXTURE_FORMATS
 from ethereum_test_forks import (
     Fork,
     get_closest_fork_with_solc_support,

--- a/src/pytest_plugins/solc/solc.py
+++ b/src/pytest_plugins/solc/solc.py
@@ -101,3 +101,12 @@ def solc_bin(request: pytest.FixtureRequest):
     Returns the configured solc binary path.
     """
     return request.config.getoption("solc_bin")
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_report_header(config, start_path):
+    """Add lines to pytest's console output header"""
+    if config.option.collectonly:
+        return
+    solc_version = config.stash[metadata_key]["Tools"]["solc"]
+    return [(f"solc: {solc_version}")]


### PR DESCRIPTION
## 🗒️ Description
- Moves some common pytest fixtures and hooks to a new shared plugin `pytest_plugins.shared.execute_fill`.
- Removes some duplicate code and unused fixtures from the `execute` plugins and helper functions.

Mario, could be easier/faster to review each commit individually, they're quite small.
 
## 🔗 Related Issues
#686 

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] ~~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~ **Skipped**
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
