### PR TITLE
:lady_beetle: fill,genindex,eels_resolver: don't treat eels resolutions as a fixture

### DIFF
--- a/src/cli/gen_index.py
+++ b/src/cli/gen_index.py
@@ -172,7 +172,7 @@ def generate_fixtures_index(
 
         test_cases: List[TestCaseIndexFile] = []
         for file in input_path.rglob("*.json"):
-            if file.name == "index.json":
+            if file.name == "index.json" or ".meta" in file.parts:
                 continue
             if any(fixture in str(file) for fixture in fixtures_to_skip):
                 rich.print(f"Skipping '{file}'")

--- a/src/pytest_plugins/eels_resolver.py
+++ b/src/pytest_plugins/eels_resolver.py
@@ -48,9 +48,11 @@ def pytest_configure(config: pytest.Config) -> None:
         os.environ[env_var_name] = str(default_file_path)
         eels_resolutions_file = str(default_file_path)
 
-    if "Tools" not in config.stash[metadata_key]:
-        config.stash[metadata_key]["Tools"] = {}
-    config.stash[metadata_key]["Tools"]["EELS Resolutions"] = str(eels_resolutions_file)
+    if "Tools" in config.stash[metadata_key]:
+        # don't overwrite existing tools metadata added by other plugins
+        config.stash[metadata_key]["Tools"]["EELS Resolutions"] = str(eels_resolutions_file)
+    else:
+        config.stash[metadata_key]["Tools"] = {"EELS Resolutions": str(eels_resolutions_file)}
 
     config._eels_resolutions_file = eels_resolutions_file  # type: ignore
 


### PR DESCRIPTION
## 🗒️ Description
Two very small fixes:
- The `eels_resolver` plugin copies the `eels_resolutions.json` file to the `./meta/` sub-folder of the output fixtures directory. If `fill` (or `genindex`) is re-ran with the same output directory, there will be many pydantic errors as `gen_index` will try to load `eels_resolutions.json` and treat it as a JSON fixture. Doesn't effect CI; but very annoying locally.
- Don't overwrite the `Tools` field added to the metadata plugin.

## 🔗 Related Issues
Follow-up from #872. 

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: ~~Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~ **Skipped**
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
