### PR TITLE
feat(verkle): add two-way exhaustive witness checks

### DIFF
--- a/src/ethereum_test_types/verkle/types.py
+++ b/src/ethereum_test_types/verkle/types.py
@@ -9,7 +9,12 @@ from ethereum.crypto.hash import keccak256
 from pydantic import Field, RootModel, field_validator
 from pydantic.functional_serializers import model_serializer
 
-from ethereum_test_base_types import Address, CamelModel, HexNumber, PaddedFixedSizeBytes
+from ethereum_test_base_types import (
+    Address,
+    CamelModel,
+    HexNumber,
+    PaddedFixedSizeBytes,
+)
 from ethereum_test_forks import Fork, Verkle
 from ethereum_test_types import Account
 
@@ -176,17 +181,14 @@ class WitnessCheck:
         """
         Initializes a WitnessCheck instance.
         """
-        assert fork >= Verkle, "WitnessCheck is only supported for Verkle fork and later"
+        assert (
+            fork >= Verkle
+        ), "WitnessCheck is only supported for Verkle fork and later"
         self.account_entries: List[
             Tuple[Address, WitnessCheck.AccountHeaderEntry, Optional[Hash]]
         ] = []
         self.storage_slots: List[Tuple[Address, int, Optional[Hash]]] = []
         self.code_chunks: List[Tuple[Address, int, Optional[Hash]]] = []
-
-        # Add the pre-allocation accounts by default
-        pre_allocations = fork.pre_allocation_blockchain()
-        for address, account_data in pre_allocations.items():
-            self.add_account_full(Address(address), Account(**account_data))
 
     def __repr__(self) -> str:
         """
@@ -257,15 +259,21 @@ class WitnessCheck:
         """
         Adds the code hash witness for the given address.
         """
-        self.account_entries.append((address, WitnessCheck.AccountHeaderEntry.CODEHASH, codehash))
+        self.account_entries.append(
+            (address, WitnessCheck.AccountHeaderEntry.CODEHASH, codehash)
+        )
 
-    def add_storage_slot(self, address: Address, storage_slot: int, value: Optional[Hash]) -> None:
+    def add_storage_slot(
+        self, address: Address, storage_slot: int, value: Optional[Hash]
+    ) -> None:
         """
         Adds the storage slot witness for the given address and storage slot.
         """
         self.storage_slots.append((address, storage_slot, value))
 
-    def add_code_chunk(self, address: Address, chunk_number: int, value: Optional[Hash]) -> None:
+    def add_code_chunk(
+        self, address: Address, chunk_number: int, value: Optional[Hash]
+    ) -> None:
         """
         Adds the code chunk witness for the given address and chunk number.
         """

--- a/tests/verkle/eip4762_verkle_gas_witness/test_codecopy_ext_precompile.py
+++ b/tests/verkle/eip4762_verkle_gas_witness/test_codecopy_ext_precompile.py
@@ -7,7 +7,7 @@ abstract: Tests [EIP-4762: Statelessness gas cost changes]
 
 import pytest
 
-from ethereum_test_forks import Verkle
+from ethereum_test_forks import Fork, Verkle
 from ethereum_test_tools import (
     Account,
     Address,
@@ -21,8 +21,6 @@ from ethereum_test_tools import (
 )
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 from ethereum_test_types.verkle.helpers import chunkify_code
-from ethereum_test_forks import Fork
-
 
 REFERENCE_SPEC_GIT_PATH = "EIPS/eip-4762.md"
 REFERENCE_SPEC_VERSION = "2f8299df31bb8173618901a03a8366a3183479b0"
@@ -74,8 +72,9 @@ def test_extcodecopy_precompile(blockchain_test: BlockchainTestFiller, fork: For
         witness_check.add_code_chunk(address=TestAddress2, chunk_number=i, value=chunk)
 
     if target == system_contract_address:
-        code = Account(**fork.pre_allocation_blockchain()[system_contract_address]).code
-        code_chunks = chunkify_code(code)
+        sys_contract_account = Account(**fork.pre_allocation_blockchain()[system_contract_address])
+        code_chunks = chunkify_code(sys_contract_account.code)
+        witness_check.add_account_basic_data(system_contract_address, sys_contract_account)
         witness_check.add_code_chunk(
             address=system_contract_address, chunk_number=0, value=code_chunks[0]
         )

--- a/tests/verkle/eip4762_verkle_gas_witness/test_codecopy_generic.py
+++ b/tests/verkle/eip4762_verkle_gas_witness/test_codecopy_generic.py
@@ -63,7 +63,9 @@ code_size = 130 * 31 + 60
         "partial_out_of_bounds_touching_further_non_existent_code_chunk",
     ],
 )
-def test_generic_codecopy(blockchain_test: BlockchainTestFiller, instruction, offset, size):
+def test_generic_codecopy(
+    blockchain_test: BlockchainTestFiller, instruction, offset, size
+):
     """
     Test *CODECOPY witness.
     """
@@ -203,7 +205,9 @@ def _generic_codecopy(
     extcodecopy_code = Op.EXTCODECOPY(TestAddress2, 0, offset, size) * repeat
     pre = {
         TestAddress: Account(balance=1000000000000000000000),
-        TestAddress2: Account(code=codecopy_code + Op.PUSH0 * (code_size - len(codecopy_code))),
+        TestAddress2: Account(
+            code=codecopy_code + Op.PUSH0 * (code_size - len(codecopy_code))
+        ),
         dummy_address: Account(code=extcodecopy_code),
     }
 
@@ -237,7 +241,9 @@ def _generic_codecopy(
         witness_check.add_code_chunk(to, i, code_chunks[i])
 
     if instr == Op.EXTCODECOPY:
-        witness_check.add_account_basic_data(address=TestAddress2, account=pre.get(TestAddress2))
+        witness_check.add_account_basic_data(
+            address=TestAddress2, account=pre.get(TestAddress2)
+        )
 
     # Depending on the CODECOPY/EXTCODECOPY offset and size, we include the extra expected
     # code-chunks.

--- a/tests/verkle/eip4762_verkle_gas_witness/test_codecopy_generic.py
+++ b/tests/verkle/eip4762_verkle_gas_witness/test_codecopy_generic.py
@@ -63,16 +63,14 @@ code_size = 130 * 31 + 60
         "partial_out_of_bounds_touching_further_non_existent_code_chunk",
     ],
 )
-def test_generic_codecopy(
-    blockchain_test: BlockchainTestFiller, instruction, offset, size
-):
+def test_generic_codecopy(blockchain_test: BlockchainTestFiller, instruction, offset, size):
     """
     Test *CODECOPY witness.
     """
     start = offset if offset < code_size else code_size
-    end = offset + size if offset + size < code_size else code_size
+    end = offset + size - 1 if offset + size < code_size else code_size - 1
     witness_code_chunks = range(0, 0)
-    if start < code_size and start != end:
+    if start < code_size:
         start_chunk = start // 31
         end_chunk = end // 31
         witness_code_chunks = range(start_chunk, end_chunk + 1)
@@ -205,9 +203,7 @@ def _generic_codecopy(
     extcodecopy_code = Op.EXTCODECOPY(TestAddress2, 0, offset, size) * repeat
     pre = {
         TestAddress: Account(balance=1000000000000000000000),
-        TestAddress2: Account(
-            code=codecopy_code + Op.PUSH0 * (code_size - len(codecopy_code))
-        ),
+        TestAddress2: Account(code=codecopy_code + Op.PUSH0 * (code_size - len(codecopy_code))),
         dummy_address: Account(code=extcodecopy_code),
     }
 
@@ -241,9 +237,7 @@ def _generic_codecopy(
         witness_check.add_code_chunk(to, i, code_chunks[i])
 
     if instr == Op.EXTCODECOPY:
-        witness_check.add_account_basic_data(
-            address=TestAddress2, account=pre.get(TestAddress2)
-        )
+        witness_check.add_account_basic_data(address=TestAddress2, account=pre.get(TestAddress2))
 
     # Depending on the CODECOPY/EXTCODECOPY offset and size, we include the extra expected
     # code-chunks.

--- a/tests/verkle/eip4762_verkle_gas_witness/test_coinbase_fees.py
+++ b/tests/verkle/eip4762_verkle_gas_witness/test_coinbase_fees.py
@@ -25,7 +25,13 @@ REFERENCE_SPEC_VERSION = "2f8299df31bb8173618901a03a8366a3183479b0"
 
 
 @pytest.mark.valid_from("Verkle")
-@pytest.mark.parametrize("priority_fee", [0, 100])
+@pytest.mark.parametrize(
+    "priority_fee",
+    [
+        0,
+        100,
+    ],
+)
 def test_coinbase_fees(blockchain_test: BlockchainTestFiller, priority_fee):
     """
     Test coinbase witness.
@@ -48,7 +54,8 @@ def test_coinbase_fees(blockchain_test: BlockchainTestFiller, priority_fee):
         to=TestAddress2,
         value=100,
         gas_limit=1_000_000,
-        gas_price=priority_fee,
+        max_fee_per_gas=1_000,
+        max_priority_fee_per_gas=priority_fee,
     )
 
     # TODO(verkle): change value when filling

--- a/tests/verkle/eip4762_verkle_gas_witness/test_contract_execution.py
+++ b/tests/verkle/eip4762_verkle_gas_witness/test_contract_execution.py
@@ -98,7 +98,7 @@ def code_with_jumps(size, jumps: list[Jump | Jumpi] = []):
         ),
         (  # pushn_with_data_in_chunk_that_cant_be_paid
             Op.PUSH0 * 30 + Op.PUSH1(42),
-            21000,
+            21_263,
             [[0, 0]],
         ),
         (  # jump_to_jumpdest_in_pushn_data
@@ -286,7 +286,7 @@ def test_contract_execution_2935_contract(blockchain_test: BlockchainTestFiller,
     addr = Address("0xfffffffffffffffffffffffffffffffffffffffe")
     pre = {
         TestAddress: Account(balance=1000000000000000000000),
-        TestAddress2: Account(code=Op.PUSH1(0) + Op.CALL(1_000, addr, 0, 0, 0, 0, 32)),
+        TestAddress2: Account(code=Op.PUSH1(0) + Op.CALL(100_000, addr, 0, 0, 0, 0, 32)),
     }
     tx = Transaction(
         ty=0x0,
@@ -308,7 +308,6 @@ def test_contract_execution_2935_contract(blockchain_test: BlockchainTestFiller,
 
     # TestAddress2 CALL to 2935 contract
     system_contract_account = Account(**fork.pre_allocation_blockchain()[addr])
-    witness_check.add_account_basic_data(address=addr, account=system_contract_account)
     # A successful execution of the 2935 contract would only include the first two code-chunks.
     code_chunks = chunkify_code(system_contract_account.code)
     witness_check.add_code_chunk(address=addr, chunk_number=0, value=code_chunks[0])

--- a/tests/verkle/eip4762_verkle_gas_witness/test_creates.py
+++ b/tests/verkle/eip4762_verkle_gas_witness/test_creates.py
@@ -68,6 +68,7 @@ def test_create(blockchain_test: BlockchainTestFiller, create_instruction: Opcod
 
 
 @pytest.mark.valid_from("Verkle")
+@pytest.mark.skip("TBD when exhaustive check PR gets merged")
 @pytest.mark.parametrize(
     "create_instruction",
     [
@@ -205,7 +206,7 @@ def test_create_big_calldata(
     Test *CREATE checking that code-chunk touching in the witness is not calculated from calldata
     size but actual returned code from initcode execution.
     """
-    contract_code = bytes(Op.PUSH0 * (1000 * 31 + 42))
+    contract_code = bytes(Op.PUSH0 * (10 * 31 + 42))
     _create(
         blockchain_test,
         create_instruction,
@@ -296,7 +297,9 @@ def _create(
     # - Otherwise, it should prove there's no collision.
     witness_check.add_account_full(contract_address, pre.get(contract_address))
     # Assert the code-chunks where the contract is deployed are provided
-    if not generate_collision:
+    # DO NOT include the code-chunks if there was a collision, or we're testing that
+    # code-chunk inclusion isn't based on calldata size (see big_calldata test).
+    if not generate_collision and not initcode_stop_prefix:
         code_chunks = chunkify_code(bytes(deploy_code.deploy_code))
         for i, chunk in enumerate(code_chunks, start=0):
             witness_check.add_code_chunk(address=contract_address, chunk_number=i, value=None)

--- a/tests/verkle/eip4762_verkle_gas_witness/test_extcodesize.py
+++ b/tests/verkle/eip4762_verkle_gas_witness/test_extcodesize.py
@@ -67,16 +67,31 @@ def test_extcodesize(blockchain_test: BlockchainTestFiller, target, bytecode, fo
 
 
 @pytest.mark.valid_from("Verkle")
-def test_extcodesize_insufficient_gas(blockchain_test: BlockchainTestFiller):
+@pytest.mark.parametrize(
+    "gas, enough_gas_basicdata",
+    [
+        (21_203 + 2099, False),
+        (21_203 + 2100, True),
+    ],
+)
+def test_extcodesize_insufficient_gas(
+    blockchain_test: BlockchainTestFiller, gas, enough_gas_basicdata
+):
     """
-    Test EXTCODESIZE with insufficient gas.
+    Test EXTCODESIZE with insufficient gas for witness.
     """
+    bytecode = Op.PUSH0 * 10
+    witness = WitnessCheck(fork=Verkle)
+    if enough_gas_basicdata:
+        account = Account(code=bytecode)
+        witness.add_account_basic_data(address=TestAddress2, account=account)
+
     _extcodesize(
         blockchain_test,
         TestAddress2,
-        Op.PUSH0 * 1000,
-        WitnessCheck(fork=Verkle),
-        gas_limit=53_540,
+        bytecode,
+        witness,
+        gas_limit=gas,
         fails=True,
     )
 
@@ -101,7 +116,6 @@ def _extcodesize(
     gas_limit=1_000_000,
     warm=False,
     fails=False,
-    fork: Fork = Verkle,
 ):
 
     env = Environment(
@@ -111,9 +125,10 @@ def _extcodesize(
         number=1,
         timestamp=1000,
     )
+    caller_addr = Address("0xffff19589531694250d570040a0c4b74576919b8")
     pre = {
         TestAddress: Account(balance=1000000000000000000000),
-        TestAddress2: Account(
+        caller_addr: Account(
             code=Op.EXTCODESIZE(target) * (2 if warm else 1) + Op.PUSH0 + Op.SSTORE
         ),
     }
@@ -124,26 +139,26 @@ def _extcodesize(
         ty=0x0,
         chain_id=0x01,
         nonce=0,
-        to=TestAddress2,
+        to=caller_addr,
         gas_limit=gas_limit,
         gas_price=10,
     )
 
     post = {}
     if not fails:
-        post[TestAddress2] = Account(code=pre[TestAddress2].code, storage={0: 0x424242})
+        post[caller_addr] = Account(code=pre[caller_addr].code, storage={0: 0x424242})
 
     witness_check = witness_check_extra
     witness_check.add_account_full(env.fee_recipient, None)
     witness_check.add_account_full(TestAddress, pre[TestAddress])
-    witness_check.add_account_full(TestAddress2, pre[TestAddress2])
+    witness_check.add_account_full(caller_addr, pre[caller_addr])
 
-    code_chunks = chunkify_code(pre[TestAddress2].code)
+    code_chunks = chunkify_code(pre[caller_addr].code)
     for i, chunk in enumerate(code_chunks, start=0):
-        witness_check.add_code_chunk(address=TestAddress2, chunk_number=i, value=chunk)
+        witness_check.add_code_chunk(address=caller_addr, chunk_number=i, value=chunk)
 
     if not fails:
-        witness_check.add_storage_slot(address=TestAddress2, storage_slot=0, value=None)
+        witness_check.add_storage_slot(address=caller_addr, storage_slot=0, value=None)
 
     blocks = [
         Block(


### PR DESCRIPTION
## 🗒️ Description
The previous exhaustive witness check was one way (iterating through the actual witness only). This PR expands upon this to fully check the expected/actual witness together.

## 🔗 Related Issues
N/A

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
