### PR TITLE
fix(cli): Fix hasher, skip `.meta`

### DIFF
--- a/src/cli/hasher.py
+++ b/src/cli/hasher.py
@@ -78,7 +78,7 @@ class HashableItem:
             if not isinstance(item, dict):
                 raise TypeError(f"Expected dict, got {type(item)} for {key}")
             if "_info" not in item:
-                raise KeyError(f"Expected '_info' in {key}")
+                raise KeyError(f"Expected '_info' in {key}, json file: {file_path.name}")
 
             # EEST uses 'hash'; ethereum/tests use 'generatedTestHash'
             hash_value = item["_info"].get("hash") or item["_info"].get("generatedTestHash")
@@ -103,7 +103,7 @@ class HashableItem:
         """
         items = {}
         for file_path in sorted(folder_path.iterdir()):
-            if file_path.name == "index.json":
+            if ".meta" in file_path.parts:
                 continue
             if file_path.is_file() and file_path.suffix == ".json":
                 item = cls.from_json_file(


### PR DESCRIPTION
## 🗒️ Description
Small fix to the `hasher` command to skip `.meta` folder in the fixtures folder.

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
