### PR TITLE
feat(fill): emphasize that no tests were executed during a fill pytest session

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -56,7 +56,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 ### 📋 Misc
 
 - ✨ Feature releases can now include multiple types of fixture tarball files from different releases that start with the same prefix ([#736](https://github.com/ethereum/execution-spec-tests/pull/736)).
-- ✨ Releases for feature eip  now include both Cancun and Prague based tests in the same release, in files `fixtures_eip7692.tar.gz` and `fixtures_eip7692-prague.tar.gz` respectively ([#743](https://github.com/ethereum/execution-spec-tests/pull/743)).
+- ✨ Releases for feature eip7692 now include both Cancun and Prague based tests in the same release, in files `fixtures_eip7692.tar.gz` and `fixtures_eip7692-prague.tar.gz` respectively ([#743](https://github.com/ethereum/execution-spec-tests/pull/743)).
 ✨ Re-write the test case reference doc flow as a pytest plugin and add pages for test functions with a table providing an overview of their parametrized test cases ([#801](https://github.com/ethereum/execution-spec-tests/pull/801), [#842](https://github.com/ethereum/execution-spec-tests/pull/842)).
 - 🔀 Simplify Python project configuration and consolidate it into `pyproject.toml` ([#764](https://github.com/ethereum/execution-spec-tests/pull/764)).
 - 🔀 Created `pytest_plugins.concurrency` plugin to sync multiple `xdist` processes without using a command flag to specify the temporary working folder ([#824](https://github.com/ethereum/execution-spec-tests/pull/824))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -47,6 +47,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Pin EELS versions in `eels_resolutions.json` and include this file in fixture releases ([#872](https://github.com/ethereum/execution-spec-tests/pull/872)).
 - 🔀 Replace `ethereum.base_types` with `ethereum-types` ([#850](https://github.com/ethereum/execution-spec-tests/pull/850)).
 - 💥 `PragueEIP7692` fork has been renamed to `Osaka` ([#869](https://github.com/ethereum/execution-spec-tests/pull/869))
+- ✨ Improve `fill` terminal output to emphasize that filling tests is not actually testing a client ([#807](https://github.com/ethereum/execution-spec-tests/pull/887)).
 
 ### 🔧 EVM Tools
 
@@ -55,7 +56,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 ### 📋 Misc
 
 - ✨ Feature releases can now include multiple types of fixture tarball files from different releases that start with the same prefix ([#736](https://github.com/ethereum/execution-spec-tests/pull/736)).
-- ✨ Releases for feature eip7692 now include both Cancun and Prague based tests in the same release, in files `fixtures_eip7692.tar.gz` and `fixtures_eip7692-prague.tar.gz` respectively ([#743](https://github.com/ethereum/execution-spec-tests/pull/743)).
+- ✨ Releases for feature eip  now include both Cancun and Prague based tests in the same release, in files `fixtures_eip7692.tar.gz` and `fixtures_eip7692-prague.tar.gz` respectively ([#743](https://github.com/ethereum/execution-spec-tests/pull/743)).
 ✨ Re-write the test case reference doc flow as a pytest plugin and add pages for test functions with a table providing an overview of their parametrized test cases ([#801](https://github.com/ethereum/execution-spec-tests/pull/801), [#842](https://github.com/ethereum/execution-spec-tests/pull/842)).
 - 🔀 Simplify Python project configuration and consolidate it into `pyproject.toml` ([#764](https://github.com/ethereum/execution-spec-tests/pull/764)).
 - 🔀 Created `pytest_plugins.concurrency` plugin to sync multiple `xdist` processes without using a command flag to specify the temporary working folder ([#824](https://github.com/ethereum/execution-spec-tests/pull/824))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "requests_unixsocket2>=0.4.0",
     "colorlog>=6.7.0,<7",
     "pytest>7.3.2,<8",
+    "pytest-custom-report>=1.0.1,<2",
     "pytest-html>=4.1.0,<5",
     "pytest-metadata>=3,<4",
     "pytest-xdist>=3.3.1,<4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ docs = [
 
 [project.scripts]
 fill = "cli.pytest_commands.fill:fill"
+phil = "cli.pytest_commands.fill:phil"
 tf = "cli.pytest_commands.fill:tf"
 checkfixtures = "cli.check_fixtures:check_fixtures"
 consume = "cli.pytest_commands.consume:consume"

--- a/pytest.ini
+++ b/pytest.ini
@@ -19,3 +19,6 @@ addopts =
     --tb short
     --dist loadscope
     --ignore tests/cancun/eip4844_blobs/point_evaluation_vectors/
+# these customizations require the pytest-custom-report plugin
+report_passed_verbose = FILLED
+report_xpassed_verbose = XFILLED

--- a/src/cli/pytest_commands/fill.py
+++ b/src/cli/pytest_commands/fill.py
@@ -65,3 +65,32 @@ def fill(pytest_args: List[str], **kwargs) -> None:
         ),
     )
     sys.exit(result)
+
+
+@click.command(context_settings=dict(ignore_unknown_options=True))
+@common_click_options
+def phil(pytest_args: List[str], **kwargs) -> None:
+    """
+    A friendly alias for the fill command.
+    """
+    args = handle_fill_command_flags(
+        ["--index", *pytest_args],
+    )
+    result = pytest.main(
+        args
+        + [
+            "-o",
+            "report_passed=🦄",
+            "-o",
+            "report_xpassed=🌈",
+            "-o",
+            "report_failed=👾",
+            "-o",
+            "report_xfailed=🦺",
+            "-o",
+            "report_skipped=🦘",
+            "-o",
+            "report_error=🚨",
+        ],
+    )
+    sys.exit(result)

--- a/src/cli/tests/test_pytest_fill_command.py
+++ b/src/cli/tests/test_pytest_fill_command.py
@@ -11,7 +11,7 @@ from click.testing import CliRunner
 
 import pytest_plugins.filler.filler
 
-from ..pytest_commands.fill import fill
+from ..pytest_commands.fill import fill, phil
 
 
 @pytest.fixture
@@ -191,3 +191,13 @@ class TestHtmlReportFlags:
         assert result.exit_code == pytest.ExitCode.OK
         assert html_path.exists()
         assert (output_dir / "state_tests").exists(), "No fixtures in output directory"
+
+
+def test_phil_default_output_options(runner):
+    """
+    Test default pytest html behavior: Neither `--html` or `--output` is specified.
+    """
+    fill_args = ["-k", "test_dup and state_test-DUP16 and LEGACY", "--fork", "Frontier"]
+    result = runner.invoke(phil, fill_args)
+    assert result.exit_code == pytest.ExitCode.OK
+    assert "🦄" in result.output

--- a/src/cli/tests/test_pytest_fill_command.py
+++ b/src/cli/tests/test_pytest_fill_command.py
@@ -195,7 +195,7 @@ class TestHtmlReportFlags:
 
 def test_phil_default_output_options(runner):
     """
-    Test default pytest html behavior: Neither `--html` or `--output` is specified.
+    A simple sanity test for phil.
     """
     fill_args = ["-k", "test_dup and state_test-DUP16 and LEGACY", "--fork", "Frontier"]
     result = runner.invoke(phil, fill_args)

--- a/src/pytest_plugins/filler/filler.py
+++ b/src/pytest_plugins/filler/filler.py
@@ -298,13 +298,9 @@ def pytest_terminal_summary(
     Emphasize that fixtures have only been filled; they must now be executed to
     actually run the tests.
     """
-    passed_display_text = "fixtures filled"
-    stats = terminalreporter.stats
-    if "passed" in stats:
-        terminalreporter._add_stats(passed_display_text, stats["passed"])
-        stats.pop("passed")
     yield
-    if passed_display_text in stats and stats[passed_display_text]:
+    stats = terminalreporter.stats
+    if "passed" in stats and stats["passed"]:
         # append / to indicate this is a directory
         output_dir = str(strip_output_tarball_suffix(config.getoption("output"))) + "/"
         terminalreporter.write_sep(

--- a/src/pytest_plugins/filler/filler.py
+++ b/src/pytest_plugins/filler/filler.py
@@ -273,18 +273,15 @@ def pytest_report_teststatus(report, config: pytest.Config):
     """
     This hook modifies the test results in pytest's terminal output.
 
-    We use this for:
+    We use this:
 
-    1. To change the test results to display `FILLED` instead of `PASSED`.
-    2. To disable test session progress report if we're writing the JSON
+    1. To disable test session progress report if we're writing the JSON
         fixtures to stdout to be read by a consume command on stdin. I.e.,
         don't write this type of output to the console:
     ```text
     ...x...
     ```
     """
-    if report.when == "call" and report.passed:
-        return (report.outcome, ".", "FILLED")
     if is_output_stdout(config.getoption("output")):
         return report.outcome, "", report.outcome.upper()
 

--- a/src/pytest_plugins/filler/filler.py
+++ b/src/pytest_plugins/filler/filler.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any, Dict, Generator, List, Type
 
 import pytest
+from _pytest.terminal import TerminalReporter
 from filelock import FileLock
 from pytest_metadata.plugin import metadata_key  # type: ignore
 
@@ -269,16 +270,51 @@ def pytest_report_header(config: pytest.Config):
 
 def pytest_report_teststatus(report, config: pytest.Config):
     """
-    Disable test session progress report if we're writing the JSON fixtures to
-    stdout to be read by a consume command on stdin. I.e., don't write this
-    type of output to the console:
+    This hook modifies the test results in pytest's terminal output.
 
+    We use this for:
+
+    1. To change the test results to display `FILLED` instead of `PASSED`.
+    2. To disable test session progress report if we're writing the JSON
+        fixtures to stdout to be read by a consume command on stdin. I.e.,
+        don't write this type of output to the console:
     ```text
     ...x...
     ```
     """
+    if report.when == "call" and report.passed:
+        return (report.outcome, ".", "FILLED")
     if is_output_stdout(config.getoption("output")):
         return report.outcome, "", report.outcome.upper()
+
+
+@pytest.hookimpl(hookwrapper=True, trylast=True)
+def pytest_terminal_summary(
+    terminalreporter: TerminalReporter, exitstatus: int, config: pytest.Config
+):
+    """
+    Modify pytest's terminal summary to emphasize that no tests were ran.
+
+    Emphasize that fixtures have only been filled; they must now be executed to
+    actually run the tests.
+    """
+    passed_display_text = "fixtures filled"
+    stats = terminalreporter.stats
+    if "passed" in stats:
+        terminalreporter._add_stats(passed_display_text, stats["passed"])
+        stats.pop("passed")
+    yield
+    if passed_display_text in stats and stats[passed_display_text]:
+        # append / to indicate this is a directory
+        output_dir = str(strip_output_tarball_suffix(config.getoption("output"))) + "/"
+        terminalreporter.write_sep(
+            "=",
+            (
+                f' No tests executed - the test fixtures in "{output_dir}" may now be executed '
+                "against a client "
+            ),
+            bold=True,
+        )
 
 
 def pytest_metadata(metadata):

--- a/src/pytest_plugins/filler/filler.py
+++ b/src/pytest_plugins/filler/filler.py
@@ -5,6 +5,7 @@ Top-level pytest configuration file providing:
 and that modifies pytest hooks in order to fill test specs for all tests and
 writes the generated fixtures to file.
 """
+
 import configparser
 import datetime
 import os
@@ -310,6 +311,7 @@ def pytest_terminal_summary(
                 "against a client "
             ),
             bold=True,
+            yellow=True,
         )
 
 

--- a/src/pytest_plugins/forks/forks.py
+++ b/src/pytest_plugins/forks/forks.py
@@ -438,7 +438,7 @@ def pytest_report_header(config, start_path):
     header = [
         (
             bold
-            + "Executing tests for: "
+            + "Generating fixtures for: "
             + ", ".join([f.name() for f in sorted(list(config.fork_set))])
             + reset
         ),
@@ -446,7 +446,7 @@ def pytest_report_header(config, start_path):
     if all(fork.is_deployed() for fork in config.fork_set):
         header += [
             (
-                bold + warning + "Only executing tests with stable/deployed forks: "
+                bold + warning + "Only generating fixtures with stable/deployed forks: "
                 "Specify an upcoming fork via --until=fork to "
                 "add forks under development." + reset
             )

--- a/uv.lock
+++ b/uv.lock
@@ -525,6 +525,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyjwt" },
     { name = "pytest" },
+    { name = "pytest-custom-report" },
     { name = "pytest-html" },
     { name = "pytest-metadata" },
     { name = "pytest-xdist" },
@@ -607,6 +608,7 @@ requires-dist = [
     { name = "pyspelling", marker = "extra == 'docs'", specifier = ">=2.8.2,<3" },
     { name = "pytest", specifier = ">7.3.2,<8" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.1.0,<5" },
+    { name = "pytest-custom-report", specifier = ">=1.0.1,<2" },
     { name = "pytest-html", specifier = ">=4.1.0,<5" },
     { name = "pytest-metadata", specifier = ">=3,<4" },
     { name = "pytest-xdist", specifier = ">=3.3.1,<4" },
@@ -1561,6 +1563,17 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7a/15/da3df99fd551507694a9b01f512a2f6cf1254f33601605843c3775f39460/pytest-cov-4.1.0.tar.gz", hash = "sha256:3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6", size = 63245 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/4b/8b78d126e275efa2379b1c2e09dc52cf70df16fc3b90613ef82531499d73/pytest_cov-4.1.0-py3-none-any.whl", hash = "sha256:6ba70b9e97e69fcc3fb45bfeab2d0a138fb65c4d0d6a41ef33983ad114be8c3a", size = 21949 },
+]
+
+[[package]]
+name = "pytest-custom-report"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/9a/a2d1e9173c8ed7df06de8a50b1c526b0b3a912c5925c153e46e3da69d7d8/pytest_custom_report-1.0.1-py2.py3-none-any.whl", hash = "sha256:f048c5a06faf1621099a27571f4d749a666e8bfc038e158e10f17775add27364", size = 5099 },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🗒️ Description
Changes the terminal output to emphasize that `fill` did not test the client; rather it generated fixtures that can be executed against a client.

### Before
![image](https://github.com/user-attachments/assets/27069a40-eba6-4cc1-9580-02db84ad838b)

### After
![image](https://github.com/user-attachments/assets/6550b230-bd94-44cb-82c5-f2348a713f8f)
<!-- ![image](https://github.com/user-attachments/assets/88354db9-d740-4091-808b-671342248c5d) -->



## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
