### PR TITLE
new(tests): EOF - EIP-4750: Stack  validation in CALLF

### DIFF
--- a/tests/osaka/eip7692_eof_v1/eip4750_functions/helpers.py
+++ b/tests/osaka/eip7692_eof_v1/eip4750_functions/helpers.py
@@ -9,6 +9,8 @@ _slot = itertools.count()
 next(_slot)  # don't use slot 0
 slot_code_worked = next(_slot)
 slot_last_slot = next(_slot)
+slot_stack_canary = next(_slot)
 
 """Storage values for common testing fields"""
 value_code_worked = 0x2015
+value_canary_written = 0xDEADB12D

--- a/tests/osaka/eip7692_eof_v1/eip4750_functions/test_callf_execution.py
+++ b/tests/osaka/eip7692_eof_v1/eip4750_functions/test_callf_execution.py
@@ -386,24 +386,24 @@ def test_callf_max_stack(
         code=Container(
             sections=[
                 Section.Code(
-                    code=Op.PUSH0 * 4 # fill the stack up a little bit
+                    code=Op.PUSH0 * 4  # fill the stack up a little bit
                     + Op.PUSH2(stack_height)
                     + Op.CALLF[1]
                     + Op.SSTORE(slot_code_worked, value_code_worked)
                     + Op.RETURN(0, 0),
-                    max_stack_height=7
+                    max_stack_height=7,
                 ),
                 Section.Code(
-                    Op.PUSH1(1)     # arg, 1
-                    + Op.SWAP1      # 1, arg
-                    + Op.SUB        # arg-1,
-                    + Op.DUP1       # arg-1, arg-1
-                    + Op.CALLF[2]   # arg-1, arg-1
-                    + Op.ISZERO     # jump?, arg-1,
+                    Op.PUSH1(1)  # arg, 1
+                    + Op.SWAP1  # 1, arg
+                    + Op.SUB  # arg-1,
+                    + Op.DUP1  # arg-1, arg-1
+                    + Op.CALLF[2]  # arg-1, arg-1
+                    + Op.ISZERO  # jump?, arg-1,
                     + Op.RJUMPI[5]  # arg-1
-                    + Op.DUP1       # arg-1, arg-1
-                    + Op.CALLF[1]   # ret, arg-1
-                    + Op.POP        # arg-1
+                    + Op.DUP1  # arg-1, arg-1
+                    + Op.CALLF[1]  # ret, arg-1
+                    + Op.POP  # arg-1
                     + Op.RETF,
                     code_inputs=1,
                     code_outputs=1,

--- a/tests/osaka/eip7692_eof_v1/eip4750_functions/test_callf_execution.py
+++ b/tests/osaka/eip7692_eof_v1/eip4750_functions/test_callf_execution.py
@@ -262,8 +262,8 @@ def test_callf_with_inputs_stack_overflow(
 @pytest.mark.parametrize(
     ("stack_height", "inputs", "outputs", "failure"),
     (
-        pytest.param(1020, 1, 3, False, id="1020"),
-        pytest.param(1021, 1, 3, True, id="1021"),
+        pytest.param(1020, 1, 3, False, id="no_overflow"),
+        pytest.param(1021, 1, 3, True, id="with_overflow"),
     ),
 )
 def test_callf_sneaky_stack_overflow(
@@ -351,8 +351,6 @@ def test_callf_sneaky_stack_overflow(
     tx = Transaction(
         to=contract_address,
         gas_limit=10_000_000,
-        gas_price=10,
-        protected=False,
         sender=sender,
     )
     state_test(env=env, pre=pre, post=post, tx=tx)

--- a/tests/osaka/eip7692_eof_v1/eip4750_functions/test_callf_execution.py
+++ b/tests/osaka/eip7692_eof_v1/eip4750_functions/test_callf_execution.py
@@ -1,15 +1,20 @@
 """
 EOF CALLF execution tests
 """
-
 import pytest
 
+from ethereum_test_specs import StateTestFiller
 from ethereum_test_tools import Account, EOFStateTestFiller
 from ethereum_test_tools import Opcodes as Op
 from ethereum_test_tools.eof.v1 import Container, Section
+from ethereum_test_types import Alloc, Environment, Transaction
 
 from .. import EOF_FORK_NAME
-from .helpers import slot_code_worked, value_code_worked
+from ..eip7620_eof_create.helpers import (
+    value_canary_should_not_change,
+    value_canary_to_be_overwritten,
+)
+from .helpers import slot_code_worked, slot_stack_canary, value_canary_written, value_code_worked
 
 REFERENCE_SPEC_GIT_PATH = "EIPS/eip-4750.md"
 REFERENCE_SPEC_VERSION = "14400434e1199c57d912082127b1d22643788d11"
@@ -252,3 +257,102 @@ def test_callf_with_inputs_stack_overflow(
         ),
         container_post=Account(storage={slot_code_worked: 0}),
     )
+
+
+@pytest.mark.parametrize(
+    ("stack_height", "inputs", "outputs", "failure"),
+    (
+        pytest.param(1020, 1, 3, False, id="1020"),
+        pytest.param(1021, 1, 3, True, id="1021"),
+    ),
+)
+def test_callf_sneaky_stack_overflow(
+    stack_height: int,
+    inputs: int,
+    outputs: int,
+    failure: bool,
+    state_test: StateTestFiller,
+    pre: Alloc,
+):
+    """
+    CALLF where a normal execution would not overflow, but EIP-4750 CALLF rule #3 triggers.
+
+    Code Section 0 - Mostly fills the stack
+    Code Section 1 - jumper to 2, so class verification passes (we want a runtime failure)
+    Code Section 2 - Could require too much stack, but doesn't as it JUMPFs to 3
+    Code Section 3 - Writes canary values
+
+    The intent is to catch implementations of CALLF that don't enforce rule #3
+    """
+    env = Environment()
+    sender = pre.fund_eoa()
+    contract_address = pre.deploy_contract(
+        code=Container(
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0 * stack_height
+                    + Op.CALLF[1]
+                    + Op.POP * stack_height
+                    + Op.SSTORE(slot_code_worked, value_code_worked)
+                    + Op.RETURN(0, 0),
+                    max_stack_height=stack_height + outputs - inputs,
+                ),
+                Section.Code(
+                    Op.CALLF[2] + Op.POP + Op.RETF,
+                    code_inputs=inputs,
+                    code_outputs=outputs,
+                    max_stack_height=outputs + 1,
+                ),
+                Section.Code(
+                    Op.RJUMPI[4]
+                    + Op.PUSH0
+                    + Op.JUMPF[3]
+                    + Op.PUSH0 * (outputs - inputs + 3)
+                    + Op.POP
+                    + Op.RETF,
+                    code_inputs=inputs,
+                    code_outputs=outputs + 1,
+                    max_stack_height=outputs + 2,
+                ),
+                Section.Code(
+                    Op.POP * inputs
+                    + Op.SSTORE(slot_stack_canary, value_canary_written)
+                    + Op.PUSH0 * (outputs + 1)
+                    + Op.RETF,
+                    code_inputs=inputs,
+                    code_outputs=outputs + 1,
+                    max_stack_height=outputs + 1,
+                ),
+            ],
+        ),
+        storage={
+            slot_code_worked: (
+                value_canary_should_not_change if failure else value_canary_to_be_overwritten
+            ),
+            slot_stack_canary: (
+                value_canary_should_not_change if failure else value_canary_to_be_overwritten
+            ),
+        },
+    )
+
+    post = {
+        contract_address: Account(
+            storage={
+                slot_code_worked: (
+                    value_canary_should_not_change if failure else value_code_worked
+                ),
+                slot_stack_canary: (
+                    value_canary_should_not_change if failure else value_canary_written
+                ),
+            }
+        )
+    }
+
+    tx = Transaction(
+        to=contract_address,
+        gas_limit=10_000_000,
+        gas_price=10,
+        protected=False,
+        sender=sender,
+    )
+    state_test(env=env, pre=pre, post=post, tx=tx)

--- a/tests/osaka/eip7692_eof_v1/eip4750_functions/test_callf_execution.py
+++ b/tests/osaka/eip7692_eof_v1/eip4750_functions/test_callf_execution.py
@@ -278,7 +278,7 @@ def test_callf_sneaky_stack_overflow(
     CALLF where a normal execution would not overflow, but EIP-4750 CALLF rule #3 triggers.
 
     Code Section 0 - Mostly fills the stack
-    Code Section 1 - jumper to 2, so class verification passes (we want a runtime failure)
+    Code Section 1 - jumper to 2, so container verification passes (we want a runtime failure)
     Code Section 2 - Could require too much stack, but doesn't as it JUMPFs to 3
     Code Section 3 - Writes canary values
 

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -120,6 +120,7 @@ eip4844
 eip6110
 eip7002
 eip7069
+eip7620
 eip7692
 eip7251
 eips


### PR DESCRIPTION
## 🗒️ Description

Add a test to cover cases where stack would not overflow but CALLF stack
reservation rules would cause a revert.


## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
