### PR TITLE
feat(pytests): OmmersRoot is EmptyOmmersRoot by default instead of 0

### DIFF
--- a/src/ethereum_test_types/tests/test_types.py
+++ b/src/ethereum_test_types/tests/test_types.py
@@ -486,7 +486,7 @@ CHECKSUM_ADDRESS = "0x8a0A19589531694250d570040a0c4B74576919B8"
                 "blockHashes": {},
                 "ommers": [],
                 "parentUncleHash": (
-                    "0x0000000000000000000000000000000000000000000000000000000000000000"
+                    "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
                 ),
             },
             id="environment_1",

--- a/src/ethereum_test_types/types.py
+++ b/src/ethereum_test_types/types.py
@@ -31,6 +31,7 @@ from ethereum_test_base_types import (
     BLSSignature,
     Bytes,
     CamelModel,
+    EmptyOmmersRoot,
     Hash,
     HexNumber,
     Number,
@@ -402,7 +403,7 @@ class Environment(EnvironmentGeneric[Number]):
     """
 
     blob_gas_used: Number | None = Field(None, alias="currentBlobGasUsed")
-    parent_ommers_hash: Hash = Field(Hash(0), alias="parentUncleHash")
+    parent_ommers_hash: Hash = Field(Hash(EmptyOmmersRoot), alias="parentUncleHash")
     parent_blob_gas_used: Number | None = Field(None)
     parent_excess_blob_gas: Number | None = Field(None)
     parent_beacon_block_root: Hash | None = Field(None)


### PR DESCRIPTION
## 🗒️ Description
We see this check done by ethereumjs t8n that actually after PoS, ommers root is required to be a has of empty list. 
But pyspec passes 0 padded hash by default. only ethereumjs does this check. this seems to only be related to ParentUncleHash field. 

## 🔗 Related Issues


## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
