### PR TITLE
fix(github): Fix `eip7692-osaka` to also fill `tests/prague`

### DIFF
--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -16,7 +16,7 @@ eip7692:
   solc: 0.8.21
 eip7692-osaka:
   evm-type: eip7692-osaka
-  fill-params: --fork=Osaka ./tests/osaka -k "not slow"
+  fill-params: --fork=Osaka ./tests/prague ./tests/osaka -k "not slow"
   solc: 0.8.21
 pectra-devnet-3:
   evm-type: pectra-devnet-3


### PR DESCRIPTION
## 🗒️ Description
Updates `eip7692-osaka` feature configuration to also fill tests under `tests/prague`, in order to fill tests that do cross-functional testing on Prague EIPs too.

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.