### PR TITLE
fix(ethereum_clis): Retry on connection error in `_evaluate_server()` for EELS daemon

### DIFF
--- a/src/ethereum_clis/clis/execution_specs.py
+++ b/src/ethereum_clis/clis/execution_specs.py
@@ -11,8 +11,6 @@ from re import compile
 from tempfile import TemporaryDirectory
 from typing import Optional
 
-from requests_unixsocket import Session  # type: ignore
-
 from ethereum_test_forks import Fork
 
 from ..transition_tool import TransitionTool
@@ -78,22 +76,12 @@ class ExecutionSpecsTransitionTool(TransitionTool):
             ],
         )
         start = time.time()
-        wait_time = 0.1
-        while not self.server_file_path.exists():
-            time.sleep(wait_time)
-            wait_time *= 2
         while True:
-            try:
-                # This will probably 404, but we are only checking whether connections are
-                # accepted.
-                Session().get(self.server_url + "heartbeat/")
+            if self.server_file_path.exists():
                 break
-            except ConnectionError:
-                time.sleep(wait_time)
-                wait_time *= 2
-                pass
-        if time.time() - start > DAEMON_STARTUP_TIMEOUT_SECONDS:
-            raise Exception("Failed starting ethereum-spec-evm subprocess")
+            if time.time() - start > DAEMON_STARTUP_TIMEOUT_SECONDS:
+                raise Exception("Failed starting ethereum-spec-evm subprocess")
+            time.sleep(0)  # yield to other processes
 
     def shutdown(self):
         """

--- a/src/ethereum_clis/transition_tool.py
+++ b/src/ethereum_clis/transition_tool.py
@@ -8,11 +8,14 @@ import shutil
 import subprocess
 import tempfile
 import textwrap
+import time
 from abc import abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Mapping, Optional, Type
+from typing import Any, Dict, List, Mapping, Optional, Type
 
+from requests import Response
+from requests.exceptions import ConnectionError
 from requests_unixsocket import Session  # type: ignore
 
 from ethereum_test_fixtures import FixtureFormat, FixtureVerifier
@@ -265,6 +268,29 @@ class TransitionTool(EthereumCLI, FixtureVerifier):
 
         return output
 
+    def _server_post(self, data: Dict[str, Any], retries: int = 10) -> Response:
+        """
+        Send a POST request to the t8n-server and return the response.
+        """
+        post_delay = 0.1
+        while True:
+            try:
+                response = Session().post(self.server_url, json=data, timeout=20)
+                break
+            except ConnectionError as e:
+                retries -= 1
+                if retries == 0:
+                    raise e
+                time.sleep(post_delay)
+                post_delay *= 2
+        response.raise_for_status()
+        if response.status_code != 200:
+            raise Exception(
+                f"t8n-server returned status code {response.status_code}, "
+                f"response: {response.text}"
+            )
+        return response
+
     def _evaluate_server(
         self,
         *,
@@ -303,14 +329,7 @@ class TransitionTool(EthereumCLI, FixtureVerifier):
                 },
             )
 
-        response = Session().post(self.server_url, json=post_data, timeout=20)
-        response.raise_for_status()  # exception visible in pytest failure output
-        if response.status_code != 200:
-            raise Exception(
-                f"t8n-server returned status code {response.status_code}, "
-                f"response: {response.text}"
-            )
-
+        response = self._server_post(post_data)
         output: TransitionToolOutput = TransitionToolOutput.model_validate(response.json())
 
         if debug_output_path:
@@ -463,9 +482,6 @@ class TransitionTool(EthereumCLI, FixtureVerifier):
         If a client's `t8n` tool varies from the default behavior, this method
         can be overridden.
         """
-        if not self.process:
-            self.start_server()
-
         fork_name = fork.transition_tool_name(
             block_number=env.number,
             timestamp=env.timestamp,
@@ -484,6 +500,8 @@ class TransitionTool(EthereumCLI, FixtureVerifier):
         )
 
         if self.t8n_use_server:
+            if not self.process:
+                self.start_server()
             return self._evaluate_server(t8n_data=t8n_data, debug_output_path=debug_output_path)
 
         if self.t8n_use_stream:


### PR DESCRIPTION
## 🗒️ Description
There appears to be a brief delay between the Unix socket file being created and connections being accepted on the socket. This may be the cause of sporadic CI failures with the EELS daemon.

This PR adds a check to `start_server()` to see if the EELS daemon has actually started accepting connections.

## 🔗 Related Issues
Resolves #852

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
