### PR TITLE
bug(tests) - CALLF rule #4 applies to return stack, not operand stack

### DIFF
--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_migrated_valid_invalid.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_migrated_valid_invalid.py
@@ -104,7 +104,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
         pytest.param(
             # Trailing bytes after code section with wrong first section type
             bytes.fromhex("ef0001 010004 0200010001 040000 00 00000000 fe aabbcc"),
-            EOFException.INVALID_FIRST_SECTION_TYPE,
+            [EOFException.INVALID_FIRST_SECTION_TYPE, EOFException.INVALID_SECTION_BODIES_SIZE],
             id="EOF1I3540_0027_trailing_bytes_after_code_section_with_wrong_first_section_type",
         ),
         pytest.param(
@@ -159,7 +159,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
         pytest.param(
             # Trailing bytes after data section with wrong first section type
             bytes.fromhex("ef0001 010004 0200010001 040002 00 00000000 fe aabbccdd"),
-            EOFException.INVALID_FIRST_SECTION_TYPE,
+            [EOFException.INVALID_FIRST_SECTION_TYPE, EOFException.INVALID_SECTION_BODIES_SIZE],
             id="EOF1I3540_0035_trailing_bytes_after_data_section_with_wrong_first_section_type",
         ),
         pytest.param(

--- a/tests/osaka/eip7692_eof_v1/eip4750_functions/test_callf_execution.py
+++ b/tests/osaka/eip7692_eof_v1/eip4750_functions/test_callf_execution.py
@@ -360,7 +360,8 @@ def test_callf_sneaky_stack_overflow(
     ("stack_height", "failure"),
     (
         pytest.param(1018, False, id="no_max_stack"),
-        pytest.param(1019, True, id="with_max_stack"),
+        pytest.param(1019, False, id="with_max_stack"),
+        pytest.param(1020, True, id="over_max_stack"),
     ),
 )
 def test_callf_max_stack(
@@ -374,11 +375,13 @@ def test_callf_max_stack(
 
     Code Section 0 - calls #1 with the configured height, but we load some operands so the
                      return stack does not overflow
-    Code Section 1 - recursively calls itself until input is zero, then calls 2 and returns.
+    Code Section 1 - expands stack, calls #2, THEN recursively calls itself until input is zero,
+                     and returns.
     Code Section 2 - Just returns, zero inputs, zero outputs
 
-    This will catch  CALLF rule #4: always fail if the operand stack is full. Not checking
-    rule 4 results in a call to section 2 and not overfilling the stack (as it is just RETF).
+    This will catch  CALLF execution rule #3: always fail if the operand stack is full. Not
+    checking rule 3 results in a call to section 2 and not overfilling the stack (as it is just
+    RETF).
     """
     env = Environment()
     sender = pre.fund_eoa()


### PR DESCRIPTION
## 🗒️ Description
Correct an erroneous test where a rule was applied to the operand stack that was meant for the return stack

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
