### PR TITLE
new(tests): EOF - EIP-7692: migrate `CALLF` execution tests

### DIFF
--- a/converted-ethereum-tests.txt
+++ b/converted-ethereum-tests.txt
@@ -21,6 +21,8 @@ EOFTests/efValidation/EOF1_returncontract_valid_.json
 
 EIPTests/StateTests/stEOF/stEIP3540/EOF1_Execution.json
 EIPTests/StateTests/stEOF/stEIP4200/EOF1_RJUMP_RJUMPI_RJUMPV_Execution.json
+EIPTests/StateTests/stEOF/stEIP4750/CALLF_RETF_Execution.json
+EIPTests/StateTests/stEOF/stEIP5450/EOF1_CALLF_Execution.json
 
 ([#440](https://github.com/ethereum/execution-spec-tests/pull/440))
 GeneralStateTests/Cancun/stEIP1153-transientStorage/01_tloadBeginningTxn.json

--- a/tests/osaka/eip7692_eof_v1/eof_tracker.md
+++ b/tests/osaka/eip7692_eof_v1/eof_tracker.md
@@ -325,7 +325,7 @@
 
 ### Execution
 
-- [ ] Max stack size (1024) in CALLF-ed function (ethereum/tests: src/EIPTestsFiller/StateTests/stEOF/stEIP4200/EOF1_CALLF_ExecutionFiller.yml)
+- [x] Max stack size (1024) in CALLF-ed function ([`tests/osaka/eip7692_eof_v1/eip4750_functions/test_callf_execution.py::test_callf_operand_stack_size_max`](./eip4750_functions/test_callf_execution/test_callf_operand_stack_size_max.md)
 
 
 ## EIP-6206: EOF - JUMPF and non-returning functions


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened: https://github.com/ethereum/tests/pull/1410.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
