### PR TITLE
new(tests): EOF - EIP-4200: migrate remaining RJUMP* execution tests

### DIFF
--- a/converted-ethereum-tests.txt
+++ b/converted-ethereum-tests.txt
@@ -20,6 +20,7 @@ EOFTests/efValidation/EOF1_returncontract_invalid_.json
 EOFTests/efValidation/EOF1_returncontract_valid_.json
 
 EIPTests/StateTests/stEOF/stEIP3540/EOF1_Execution.json
+EIPTests/StateTests/stEOF/stEIP4200/EOF1_RJUMP_RJUMPI_RJUMPV_Execution.json
 
 ([#440](https://github.com/ethereum/execution-spec-tests/pull/440))
 GeneralStateTests/Cancun/stEIP1153-transientStorage/01_tloadBeginningTxn.json

--- a/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjump.py
+++ b/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjump.py
@@ -20,6 +20,23 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
 RJUMP_LEN = len(Op.RJUMP[0])
 
 
+def test_rjump_negative(
+    eof_state_test: EOFStateTestFiller,
+):
+    """Test for a forward RJUMPI and backward RJUMP"""
+    eof_state_test(
+        data=Container.Code(
+            Op.PUSH1[1]
+            + Op.RJUMPI[7]  # RJUMP cannot be used because of the backward jump restriction
+            + Op.SSTORE(slot_code_worked, Op.MLOAD(0))
+            + Op.STOP
+            + Op.MSTORE(0, value_code_worked)
+            + Op.RJUMP[-16]
+        ),
+        container_post=Account(storage={slot_code_worked: value_code_worked}),
+    )
+
+
 def test_rjump_positive_negative(
     eof_state_test: EOFStateTestFiller,
 ):


### PR DESCRIPTION
## 🗒️ Description

The RJUMP/RJUMPI/RJUMPV execution tests were actually migrated by @shemnon in https://github.com/ethereum/execution-spec-tests/pull/581

This adds just one more basic RJUMPI/RJUMP test.

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened: https://github.com/ethereum/tests/pull/1410.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
