### PR TITLE
feat(base_types): storage key hint in Storage class

### DIFF
--- a/src/ethereum_test_base_types/composite_types.py
+++ b/src/ethereum_test_base_types/composite_types.py
@@ -25,7 +25,7 @@ class Storage(RootModel[Dict[StorageKeyValueType, StorageKeyValueType]]):
     root: Dict[StorageKeyValueType, StorageKeyValueType] = Field(default_factory=dict)
 
     _current_slot: int = PrivateAttr(0)
-    _hint_map: Dict[StorageKeyValueType, str] = {}
+    _hint_map: Dict[StorageKeyValueType, str] = PrivateAttr(default_factory=dict)
 
     StorageDictType: ClassVar[TypeAlias] = Dict[
         str | int | bytes | SupportsBytes, str | int | bytes | SupportsBytes
@@ -111,7 +111,7 @@ class Storage(RootModel[Dict[StorageKeyValueType, StorageKeyValueType]]):
                 label_str = f" ({self.address.label})"
             return (
                 f"incorrect value in address {self.address}{label_str} for "
-                + f"key {Hash(self.key)} ({self.hint}):"
+                + f"key {Hash(self.key)}{f' ({self.hint})' if self.hint else ''}:"
                 + f" want {HexNumber(self.want)} (dec:{int(self.want)}),"
                 + f" got {HexNumber(self.got)} (dec:{int(self.got)})"
             )
@@ -196,7 +196,8 @@ class Storage(RootModel[Dict[StorageKeyValueType, StorageKeyValueType]]):
         """
         slot = StorageKeyValueTypeAdapter.validate_python(self._current_slot)
         self._current_slot += 1
-        self._hint_map[slot] = hint
+        if hint:
+            self._hint_map[slot] = hint
         self[slot] = StorageKeyValueTypeAdapter.validate_python(value)
         return slot
 

--- a/src/ethereum_test_base_types/composite_types.py
+++ b/src/ethereum_test_base_types/composite_types.py
@@ -1,6 +1,7 @@
 """
 Base composite types for Ethereum test cases.
 """
+
 from dataclasses import dataclass
 from typing import Any, ClassVar, Dict, SupportsBytes, Type, TypeAlias
 
@@ -24,6 +25,7 @@ class Storage(RootModel[Dict[StorageKeyValueType, StorageKeyValueType]]):
     root: Dict[StorageKeyValueType, StorageKeyValueType] = Field(default_factory=dict)
 
     _current_slot: int = PrivateAttr(0)
+    _hint_map: Dict[StorageKeyValueType, str] = {}
 
     StorageDictType: ClassVar[TypeAlias] = Dict[
         str | int | bytes | SupportsBytes, str | int | bytes | SupportsBytes
@@ -92,13 +94,15 @@ class Storage(RootModel[Dict[StorageKeyValueType, StorageKeyValueType]]):
         key: int
         want: int
         got: int
+        hint: str
 
-        def __init__(self, address: Address, key: int, want: int, got: int, *args):
+        def __init__(self, address: Address, key: int, want: int, got: int, hint: str = "", *args):
             super().__init__(args)
             self.address = address
             self.key = key
             self.want = want
             self.got = got
+            self.hint = hint
 
         def __str__(self):
             """Print exception string"""
@@ -107,7 +111,7 @@ class Storage(RootModel[Dict[StorageKeyValueType, StorageKeyValueType]]):
                 label_str = f" ({self.address.label})"
             return (
                 f"incorrect value in address {self.address}{label_str} for "
-                + f"key {Hash(self.key)}:"
+                + f"key {Hash(self.key)} ({self.hint}):"
                 + f" want {HexNumber(self.want)} (dec:{int(self.want)}),"
                 + f" got {HexNumber(self.got)} (dec:{int(self.got)})"
             )
@@ -182,7 +186,7 @@ class Storage(RootModel[Dict[StorageKeyValueType, StorageKeyValueType]]):
         return self.root.items()
 
     def store_next(
-        self, value: StorageKeyValueTypeConvertible | StorageKeyValueType | bool
+        self, value: StorageKeyValueTypeConvertible | StorageKeyValueType | bool, hint: str = ""
     ) -> StorageKeyValueType:
         """
         Stores a value in the storage and returns the key where the value is stored.
@@ -192,6 +196,7 @@ class Storage(RootModel[Dict[StorageKeyValueType, StorageKeyValueType]]):
         """
         slot = StorageKeyValueTypeAdapter.validate_python(self._current_slot)
         self._current_slot += 1
+        self._hint_map[slot] = hint
         self[slot] = StorageKeyValueTypeAdapter.validate_python(value)
         return slot
 
@@ -230,7 +235,11 @@ class Storage(RootModel[Dict[StorageKeyValueType, StorageKeyValueType]]):
                     raise Storage.MissingKey(key=key)
             elif self[key] != other[key]:
                 raise Storage.KeyValueMismatch(
-                    address=address, key=key, want=self[key], got=other[key]
+                    address=address,
+                    key=key,
+                    want=self[key],
+                    got=other[key],
+                    hint=self._hint_map.get(key, ""),
                 )
 
     def must_be_equal(self, address: Address, other: "Storage | None"):
@@ -243,17 +252,33 @@ class Storage(RootModel[Dict[StorageKeyValueType, StorageKeyValueType]]):
         for key in self.keys() & other.keys():
             if self[key] != other[key]:
                 raise Storage.KeyValueMismatch(
-                    address=address, key=key, want=self[key], got=other[key]
+                    address=address,
+                    key=key,
+                    want=self[key],
+                    got=other[key],
+                    hint=self._hint_map.get(key, ""),
                 )
 
         # Test keys contained in either one of the storage objects
         for key in self.keys() ^ other.keys():
             if key in self:
                 if self[key] != 0:
-                    raise Storage.KeyValueMismatch(address=address, key=key, want=self[key], got=0)
+                    raise Storage.KeyValueMismatch(
+                        address=address,
+                        key=key,
+                        want=self[key],
+                        got=0,
+                        hint=self._hint_map.get(key, ""),
+                    )
 
             elif other[key] != 0:
-                raise Storage.KeyValueMismatch(address=address, key=key, want=0, got=other[key])
+                raise Storage.KeyValueMismatch(
+                    address=address,
+                    key=key,
+                    want=0,
+                    got=other[key],
+                    hint=self._hint_map.get(key, ""),
+                )
 
     def canary(self) -> "Storage":
         """


### PR DESCRIPTION
## 🗒️ Description
Print hint string if assigned in Storage class
Usage:

```
Op.SSTORE(post.store_next(0, hint="expected_result"), Op.MLOAD(0))
...
        post={
            runner_contract: Account(
                storage=post,
            )
        },
```

## 🔗 Related Issues
Surpasses https://github.com/ethereum/execution-spec-tests/pull/807

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
