### PR TITLE
fix(cli/eofwrap): fix merge issue (EIP-7685 updates)

### DIFF
--- a/src/cli/eofwrap.py
+++ b/src/cli/eofwrap.py
@@ -262,13 +262,9 @@ class EofWrapper:
                     base_fee_per_gas=header.base_fee_per_gas,
                     withdrawals_root=header.withdrawals_root,
                     parent_beacon_block_root=header.parent_beacon_block_root,
-                    requests_root=header.requests_root,
                 )
                 assert not fixture_block.ommers
                 assert not fixture_block.withdrawals
-                assert not fixture_block.deposit_requests
-                assert not fixture_block.withdrawal_requests
-                assert not fixture_block.consolidation_requests
 
                 for fixture_tx in fixture_block.txs:
                     fixture_tx_dump = fixture_tx.model_dump()


### PR DESCRIPTION
## 🗒️ Description
Fixes a merge issue from #832, when merged after #896.

`requests_root` header field is removed in favor of `requests_hash`, but this field should not be manually overridden by `eofwrap` anyway since it's calculated by t8n automatically, and trying to force the value (or remove it by placing `None` instead) could render the block invalid.

Fix is to remove all EIP-7685 modifications in `eofwrap`.

Skipping changelog since I think it's not necessary.

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.