### PR TITLE
new(tests): EIP-7702: Add many-delegations test

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,8 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Update [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) tests for Devnet-3 ([#733](https://github.com/ethereum/execution-spec-tests/pull/733))
 - 🐞 Fix [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702)+EOF tests due to incorrect test expectations and faulty `Conditional` test generator in EOF mode ([#821](https://github.com/ethereum/execution-spec-tests/pull/821))
 - 💥 `PragueEIP7692` fork in tests has been updated to `Osaka` ([#869](https://github.com/ethereum/execution-spec-tests/pull/869))
+- ✨ Update [EIP-6110](https://eips.ethereum.org/EIPS/eip-6110), [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002), [EIP-7251](https://eips.ethereum.org/EIPS/eip-7251), [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685), and [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) tests for Devnet-4 ([#832](https://github.com/ethereum/execution-spec-tests/pull/832))
+- ✨ [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) many delegations test ([#923](https://github.com/ethereum/execution-spec-tests/pull/923))
 
 ### 🛠️ Framework
 

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -3193,7 +3193,11 @@ def test_deploying_delegation_designation_contract(
     "signer_balance",
     [
         pytest.param(0, id="empty_balance"),
-        pytest.param(1, id="non_empty_balance"),
+        pytest.param(
+            1,
+            id="non_empty_balance",
+            marks=pytest.mark.execute(pytest.mark.skip(reason="excessive pre-fund txs")),
+        ),
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -3209,8 +3209,8 @@ def test_deploying_delegation_designation_contract(
             marks=pytest.mark.execute(pytest.mark.skip(reason="excessive gas")),
         ),
         pytest.param(
-            30_000_000,
-            id="30m",
+            20_000_000,
+            id="20m",
             marks=pytest.mark.fill(pytest.mark.skip(reason="execute-only test")),
         ),
     ],

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -3187,3 +3187,81 @@ def test_deploying_delegation_designation_contract(
             tx.created_contract: Account.NONEXISTENT,
         },
     )
+
+
+@pytest.mark.parametrize(
+    "signer_balance",
+    [
+        pytest.param(0, id="empty_balance"),
+        pytest.param(1, id="non_empty_balance"),
+    ],
+)
+@pytest.mark.parametrize(
+    "max_gas",
+    [
+        pytest.param(
+            120_000_000,
+            id="120m",
+            marks=pytest.mark.execute(pytest.mark.skip(reason="excessive gas")),
+        ),
+        pytest.param(
+            30_000_000,
+            id="30m",
+            marks=pytest.mark.fill(pytest.mark.skip(reason="execute-only test")),
+        ),
+    ],
+)
+def test_many_delegations(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    max_gas: int,
+    signer_balance: int,
+):
+    """
+    Perform as many delegations as possible in a single 120 million gas transaction.
+
+    Every delegation comes from a different signer.
+
+    The account of can be empty or not depending on the `signer_balance` parameter.
+
+    The transaction is expected to succeed and the state after the transaction is expected to have
+    the code of the entry contract set to 1.
+    """
+    gas_for_delegations = max_gas - 21_000 - 20_000 - (3 * 2)
+
+    delegation_count = gas_for_delegations // Spec.PER_EMPTY_ACCOUNT_COST
+
+    success_slot = 1
+    entry_code = Op.SSTORE(success_slot, 1) + Op.STOP
+    entry_address = pre.deploy_contract(entry_code)
+
+    signers = [pre.fund_eoa(signer_balance) for _ in range(delegation_count)]
+
+    tx = Transaction(
+        gas_limit=max_gas,
+        to=entry_address,
+        value=0,
+        authorization_list=[
+            AuthorizationTuple(
+                address=Address(i + 1),
+                nonce=0,
+                signer=signer,
+            )
+            for (i, signer) in enumerate(signers)
+        ],
+        sender=pre.fund_eoa(),
+    )
+
+    post = {entry_address: Account(storage={success_slot: 1},),} | {
+        signer: Account(
+            code=Spec.delegation_designation(Address(i + 1)),
+        )
+        for (i, signer) in enumerate(signers)
+    }
+
+    state_test(
+        env=Environment(),
+        pre=pre,
+        tx=tx,
+        post=post,
+    )


### PR DESCRIPTION
## 🗒️ Description
Add test where a single transaction includes as many delegations as the max block gas allows:
- With or without balance in the auth signer accounts (empty vs non-empty account in state)
- With 20 million gas (to execute test on live networks) or 120 million gas

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
