### PR TITLE
chore(consume): rename test suites

### DIFF
--- a/src/pytest_plugins/consume/hive_simulators/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/conftest.py
@@ -63,6 +63,7 @@ def hive_consume_command(
 
 @pytest.fixture(scope="function")
 def eest_consume_commands(
+    request: pytest.FixtureRequest,
     test_suite_name: str,
     client_type: ClientType,
     test_case: TestCaseIndexFile | TestCaseStream,
@@ -71,8 +72,9 @@ def eest_consume_commands(
     Commands to run the test within EEST using a hive dev back-end.
     """
     hive_dev = f"./hive --dev --client-file configs/prague.yaml --client {client_type.name}"
+    input_source = request.config.getoption("fixture_source")
     consume = (
-        f'consume {test_suite_name.split("-")[-1]} -v --input latest-develop-release -k '
+        f'consume {test_suite_name.split("-")[-1]} -v --input={input_source} -k '
         f'"{test_case.id}"'
     )
     return [hive_dev, consume]

--- a/src/pytest_plugins/consume/hive_simulators/engine/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/engine/conftest.py
@@ -33,7 +33,7 @@ def test_suite_name() -> str:
     """
     The name of the hive test suite used in this simulator.
     """
-    return "eest-engine"
+    return "eest/consume-engine"
 
 
 @pytest.fixture(scope="module")
@@ -41,7 +41,7 @@ def test_suite_description() -> str:
     """
     The description of the hive test suite used in this simulator.
     """
-    return "Execute blockchain tests by against clients using the Engine API."
+    return "Execute blockchain tests against clients using the Engine API."
 
 
 @pytest.fixture(scope="function")

--- a/src/pytest_plugins/consume/hive_simulators/rlp/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/rlp/conftest.py
@@ -22,7 +22,7 @@ def test_suite_name() -> str:
     """
     The name of the hive test suite used in this simulator.
     """
-    return "eest-block-rlp"
+    return "eest/consume-rlp"
 
 
 @pytest.fixture(scope="module")

--- a/src/pytest_plugins/execute/rpc/hive.py
+++ b/src/pytest_plugins/execute/rpc/hive.py
@@ -332,7 +332,7 @@ def test_suite_name() -> str:
     """
     The name of the hive test suite used in this simulator.
     """
-    return "EEST Execute Test, Hive Mode"
+    return "eest/execute, hive mode"
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## 🗒️ Description
EEST's Hive simulators are now organized in Hive as:
```
simulators/ethereum/eest
├── consume-engine
│   └── Dockerfile
├── consume-rlp
│   └── Dockerfile
└── execute
    └── Dockerfile
```

This PR: 

- Renames the test suite names used in `hiveview` to better reflect this (current status in screenshot below).
- Uses the value provided on the consume command-line for the input value displayed in `hiveview`'s test report "Description" for the help on how to reproduce the commands.

![image](https://github.com/user-attachments/assets/f0a6fe06-b158-436a-8690-867cc64ab148)

## 🔗 Related Issues
None

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.


