### PR TITLE
new(tests): EOF - EIP-4200 EIP-6206 RJUMPI with JUMPF

### DIFF
--- a/src/ethereum_test_vm/opcode.py
+++ b/src/ethereum_test_vm/opcode.py
@@ -4959,7 +4959,7 @@ class Opcodes(Opcode, Enum):
     3
     """
 
-    JUMPF = Opcode(0xE5, data_portion_length=2, terminating=True)
+    JUMPF = Opcode(0xE5, data_portion_length=2, terminating=True, unchecked_stack=True)
     """
     !!! Note: This opcode is under development
 

--- a/tests/osaka/eip7692_eof_v1/eip5450_stack/test_code_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip5450_stack/test_code_validation.py
@@ -246,13 +246,13 @@ possible_inputs_outputs = range(2)
 )
 @pytest.mark.parametrize(
     "rjump_kind",
-    RjumpKind.__members__.values(),
+    RjumpKind,
 )
 # Parameter value fixed for first iteration, to cover the most important case.
 @pytest.mark.parametrize("rjump_section_idx", [0, 1])
 @pytest.mark.parametrize(
     "rjump_spot",
-    RjumpSpot.__members__.values(),
+    RjumpSpot,
 )
 def test_rjumps_callf_retf(
     eof_test: EOFTestFiller,
@@ -360,7 +360,7 @@ def test_rjumps_callf_retf(
 )
 @pytest.mark.parametrize(
     "rjump_kind",
-    RjumpKind.__members__.values(),
+    RjumpKind,
 )
 # Parameter value fixed for first iteration, to cover the most important case.
 @pytest.mark.parametrize("rjump_section_idx", [0, 1])
@@ -368,7 +368,7 @@ def test_rjumps_callf_retf(
     "rjump_spot",
     # `termination` is empty for JUMPF codes, because JUMPF serves as one. Spot
     # `BEFORE_TERMINATION` is unreachable code.
-    [k for k in RjumpSpot.__members__.values() if k not in [RjumpSpot.BEFORE_TERMINATION]],
+    [k for k in RjumpSpot if k not in [RjumpSpot.BEFORE_TERMINATION]],
 )
 def test_rjumps_jumpf_nonreturning(
     eof_test: EOFTestFiller,

--- a/tests/osaka/eip7692_eof_v1/eip5450_stack/test_code_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip5450_stack/test_code_validation.py
@@ -385,7 +385,6 @@ def test_rjumps_jumpf_nonreturning(
     inputs = (0,) + inputs
 
     sections = []
-    container_has_invalid_back_jump = False
     container_has_rjump_pops = False
     container_has_rjump_off_code = False
     container_has_non_returning_retf = False
@@ -402,11 +401,13 @@ def test_rjumps_jumpf_nonreturning(
             call = None
             termination = Op.STOP
 
+        # `section_has_invalid_back_jump` - never happens: we excluded RJUMP from the end
+        # `rjump_snippet_pushes` - never happens: we never RETF where too large stack would fail
         (
             code,
-            section_has_invalid_back_jump,
+            _section_has_invalid_back_jump,
             rjump_snippet_pops,
-            rjump_snippet_pushes,
+            _rjump_snippet_pushes,
             rjump_falls_off_code,
         ) = section_code_with(
             inputs[section_idx],
@@ -417,8 +418,6 @@ def test_rjumps_jumpf_nonreturning(
             termination,
         )
 
-        if section_has_invalid_back_jump:
-            container_has_invalid_back_jump = True
         if rjump_snippet_pops:
             container_has_rjump_pops = True
         if rjump_falls_off_code:
@@ -438,8 +437,6 @@ def test_rjumps_jumpf_nonreturning(
             sections.append(Section.Code(code))
 
     possible_exceptions = []
-    if container_has_invalid_back_jump:
-        possible_exceptions.append(EOFException.STACK_HEIGHT_MISMATCH)
     if container_has_rjump_pops:
         possible_exceptions.append(EOFException.STACK_UNDERFLOW)
     if container_has_rjump_off_code:

--- a/tests/osaka/eip7692_eof_v1/eip5450_stack/test_code_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip5450_stack/test_code_validation.py
@@ -12,6 +12,7 @@ from ethereum_test_exceptions.exceptions import EOFException
 from ethereum_test_tools import EOFTestFiller
 from ethereum_test_tools.eof.v1 import Container, Section
 from ethereum_test_tools.vm.opcode import Opcodes as Op
+from ethereum_test_types.eof.v1.constants import NON_RETURNING_SECTION
 from ethereum_test_vm.bytecode import Bytecode
 
 from .. import EOF_FORK_NAME
@@ -175,7 +176,8 @@ def section_code_with(
     Also returns some traits of the section: `has_invalid_back_jump`, `rjump_snippet_pops`,
     `rjump_snippet_pushes`, `rjump_falls_off_code`
     """
-    code = Bytecode(min_stack_height=inputs, max_stack_height=inputs)
+    code = Bytecode()
+    code.pushed_stack_items, code.max_stack_height = (inputs, inputs)
 
     if call:
         body = call_code_with(inputs, outputs, call)
@@ -208,11 +210,16 @@ def section_code_with(
 
         if is_backwards and inputs != outputs:
             has_invalid_back_jump = True
+
+    if rjump_spot == RjumpSpot.BEFORE_TERMINATION or (
+        rjump_spot == RjumpSpot.BEGINNING and len(termination) == 0
+    ):
         if rjump_kind in [
             RjumpKind.RJUMPI_OVER_NEXT,
             RjumpKind.RJUMPI_OVER_NEXT_NESTED,
             RjumpKind.RJUMPV_EMPTY_AND_OVER_NEXT,
         ]:
+            # Jump over termination or jump over body, but there is nothing after the body.
             rjump_falls_off_code = True
 
     code += termination
@@ -247,7 +254,7 @@ possible_inputs_outputs = range(2)
     "rjump_spot",
     RjumpSpot.__members__.values(),
 )
-def test_eof_validity(
+def test_rjumps_callf_retf(
     eof_test: EOFTestFiller,
     inputs: Tuple[int, ...],
     outputs: Tuple[int, ...],
@@ -341,6 +348,103 @@ def test_eof_validity(
     if container_has_rjump_off_code:
         possible_exceptions.append(EOFException.INVALID_RJUMP_DESTINATION)
     if container_has_section_0_retf:
+        possible_exceptions.append(EOFException.INVALID_NON_RETURNING_FLAG)
+
+    eof_test(
+        data=bytes(Container(sections=sections)), expect_exception=possible_exceptions or None
+    )
+
+
+@pytest.mark.parametrize(
+    "inputs", itertools.product(*([possible_inputs_outputs] * (num_sections - 1)))
+)
+@pytest.mark.parametrize(
+    "rjump_kind",
+    RjumpKind.__members__.values(),
+)
+# Parameter value fixed for first iteration, to cover the most important case.
+@pytest.mark.parametrize("rjump_section_idx", [0, 1])
+@pytest.mark.parametrize(
+    "rjump_spot",
+    # `termination` is empty for JUMPF codes, because JUMPF serves as one. Spot
+    # `BEFORE_TERMINATION` is unreachable code.
+    [k for k in RjumpSpot.__members__.values() if k not in [RjumpSpot.BEFORE_TERMINATION]],
+)
+def test_rjumps_jumpf_nonreturning(
+    eof_test: EOFTestFiller,
+    inputs: Tuple[int, ...],
+    rjump_kind: RjumpKind,
+    rjump_section_idx: int,
+    rjump_spot: RjumpSpot,
+):
+    """
+    Test EOF container validaiton for EIP-4200 vs EIP-6206 interactions on non-returning
+    functions.
+    """
+    # Zeroth section has always 0 inputs and 0 outputs, so is excluded from param
+    inputs = (0,) + inputs
+
+    sections = []
+    container_has_invalid_back_jump = False
+    container_has_rjump_pops = False
+    container_has_rjump_off_code = False
+    container_has_non_returning_retf = False
+
+    for section_idx in range(num_sections):
+        if section_idx < num_sections - 1:
+            call = Op.JUMPF[section_idx + 1]
+            call.popped_stack_items = inputs[section_idx + 1]
+            call.pushed_stack_items = 0
+            call.min_stack_height = call.popped_stack_items
+            call.max_stack_height = max(call.popped_stack_items, call.pushed_stack_items)
+            termination = Bytecode()
+        else:
+            call = None
+            termination = Op.STOP
+
+        (
+            code,
+            section_has_invalid_back_jump,
+            rjump_snippet_pops,
+            rjump_snippet_pushes,
+            rjump_falls_off_code,
+        ) = section_code_with(
+            inputs[section_idx],
+            0,
+            rjump_kind if rjump_section_idx == section_idx else None,
+            rjump_spot,
+            call,
+            termination,
+        )
+
+        if section_has_invalid_back_jump:
+            container_has_invalid_back_jump = True
+        if rjump_snippet_pops:
+            container_has_rjump_pops = True
+        if rjump_falls_off_code:
+            container_has_rjump_off_code = True
+        if rjump_kind == RjumpKind.RJUMPI_OVER_RETF:
+            container_has_non_returning_retf = True
+
+        if section_idx > 0:
+            sections.append(
+                Section.Code(
+                    code,
+                    code_inputs=inputs[section_idx],
+                    code_outputs=NON_RETURNING_SECTION,
+                )
+            )
+        else:
+            sections.append(Section.Code(code))
+
+    possible_exceptions = []
+    if container_has_invalid_back_jump:
+        possible_exceptions.append(EOFException.STACK_HEIGHT_MISMATCH)
+    if container_has_rjump_pops:
+        possible_exceptions.append(EOFException.STACK_UNDERFLOW)
+    if container_has_rjump_off_code:
+        possible_exceptions.append(EOFException.INVALID_RJUMP_DESTINATION)
+    if container_has_non_returning_retf:
         possible_exceptions.append(EOFException.INVALID_NON_RETURNING_FLAG)
 
     eof_test(

--- a/tests/osaka/eip7692_eof_v1/eip5450_stack/test_code_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip5450_stack/test_code_validation.py
@@ -350,9 +350,7 @@ def test_rjumps_callf_retf(
     if container_has_section_0_retf:
         possible_exceptions.append(EOFException.INVALID_NON_RETURNING_FLAG)
 
-    eof_test(
-        data=Container(sections=sections), expect_exception=possible_exceptions or None
-    )
+    eof_test(data=Container(sections=sections), expect_exception=possible_exceptions or None)
 
 
 @pytest.mark.parametrize(
@@ -444,6 +442,4 @@ def test_rjumps_jumpf_nonreturning(
     if container_has_non_returning_retf:
         possible_exceptions.append(EOFException.INVALID_NON_RETURNING_FLAG)
 
-    eof_test(
-        data=Container(sections=sections), expect_exception=possible_exceptions or None
-    )
+    eof_test(data=Container(sections=sections), expect_exception=possible_exceptions or None)

--- a/tests/osaka/eip7692_eof_v1/eip5450_stack/test_code_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip5450_stack/test_code_validation.py
@@ -351,7 +351,7 @@ def test_rjumps_callf_retf(
         possible_exceptions.append(EOFException.INVALID_NON_RETURNING_FLAG)
 
     eof_test(
-        data=bytes(Container(sections=sections)), expect_exception=possible_exceptions or None
+        data=Container(sections=sections), expect_exception=possible_exceptions or None
     )
 
 
@@ -445,5 +445,5 @@ def test_rjumps_jumpf_nonreturning(
         possible_exceptions.append(EOFException.INVALID_NON_RETURNING_FLAG)
 
     eof_test(
-        data=bytes(Container(sections=sections)), expect_exception=possible_exceptions or None
+        data=Container(sections=sections), expect_exception=possible_exceptions or None
     )

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -631,6 +631,7 @@ jumpdest
 rjump
 rjumpi
 rjumpkind
+rjumps
 rjumpv
 RJUMPV
 callf


### PR DESCRIPTION
## 🗒️ Description

Continues #833 with some tests with JUMPF to non-returning functions. I got stuck on JUMPF to returning functions so I'm making this little step first.

## 🔗 Related Issues

na

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
