### PR TITLE
fix(cli/consume): fix duplication of user-provided pytest flags

### DIFF
--- a/src/cli/pytest_commands/consume.py
+++ b/src/cli/pytest_commands/consume.py
@@ -41,7 +41,7 @@ def handle_consume_command_flags(consume_args: List[str], is_hive: bool) -> List
     args = list(handle_help_flags(consume_args, pytest_type="consume"))
     args += ["-c", "pytest-consume.ini"]
     if is_hive:
-        args += handle_hive_env_flags(args)
+        args = handle_hive_env_flags(args)
         args += ["-p", "pytest_plugins.pytest_hive.pytest_hive"]
         # Ensure stdout is captured when timing data is enabled.
         if "--timing-data" in args and "-s" not in args:


### PR DESCRIPTION
## 🗒️ Description

Fixes the duplication of user-specified pytest flags to `consume` hive commands.

For example,
```
consume engine --collect-only -q
```
was actually executed as
```
uv run pytest --collect-only -q -c pytest-consume.ini -p pytest_plugins.pytest_hive.pytest_hive src/pytest_plugins/consume/hive_simulators/engine/test_via_engine.py
```

This often didn't have any side effects, but, in the above example, ran the command effectively as:
```
consume engine --collect-only -qq
```
which silenced the output of node ids from pytest, i.e,. the following was output:
```
src/pytest_plugins/consume/hive_simulators/engine/test_via_engine.py: 3
```
instead of the expected output
```
src/pytest_plugins/consume/hive_simulators/engine/test_via_engine.py::test_via_engine[tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Paris-blockchain_test_engine]-go-ethereum_prague-devnet-4]
src/pytest_plugins/consume/hive_simulators/engine/test_via_engine.py::test_via_engine[tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Shanghai-blockchain_test_engine]-go-ethereum_prague-devnet-4]
src/pytest_plugins/consume/hive_simulators/engine/test_via_engine.py::test_via_engine[tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Cancun-blockchain_test_engine]-go-ethereum_prague-devnet-4]

3 tests collected in 0.02s
```

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.