### PR TITLE
new(tests): EOF validation of opcodes

### DIFF
--- a/converted-ethereum-tests.txt
+++ b/converted-ethereum-tests.txt
@@ -9,10 +9,14 @@ GeneralStateTests/stCreate2/call_then_create2_successful_then_returndatasize.jso
 ([#598](https://github.com/ethereum/execution-spec-tests/pull/598))
 EOFTests/EIP3540/validInvalid.json
 
+EOFTests/EIP3670/validInvalid.json
 EOFTests/efValidation/EOF1_embedded_container_.json
 EOFTests/efValidation/EOF1_eofcreate_valid_.json
 EOFTests/efValidation/EOF1_section_order_.json
 EOFTests/efValidation/EOF1_truncated_section_.json
+EOFTests/efValidation/EOF1_undefined_opcodes_.json
+EOFTests/efValidation/EOF1_truncated_push_.json
+EOFTests/efValidation/deprecated_instructions_.json
 EOFTests/efValidation/unreachable_code_sections_.json
 
 ([#647](https://github.com/ethereum/execution-spec-tests/pull/647))

--- a/tests/osaka/eip7692_eof_v1/eof_tracker.md
+++ b/tests/osaka/eip7692_eof_v1/eof_tracker.md
@@ -96,12 +96,12 @@
 
 ### Validation
 
-- [ ] Code section with invalid opcodes is rejected (ethereum/tests: ./src/EOFTestsFiller/efExample/validInvalidFiller.yml src/EOFTestsFiller/efValidation/EOF1_undefined_opcodes_Copier.json src/EOFTestsFiller/EIP3670/validInvalidFiller.yml)
-- [ ] INVALID opcode is valid (ethereum/tests: ./src/EOFTestsFiller/efExample/validInvalidFiller.yml)
-- [ ] Truncated PUSH data (ethereum/tests: ./src/EOFTestsFiller/efExample/validInvalidFiller.yml src/EOFTestsFiller/efValidation/EOF1_truncated_push_Copier.json src/EOFTestsFiller/EIP3670/validInvalidFiller.yml)
-- [ ] Opcodes deprecated in EOF are rejected (ethereum/tests: src/EOFTestsFiller/efValidation/deprecated_instructions_Copier.json ethereum/tests: src/EOFTestsFiller/EIP3670/validInvalidFiller.yml)
-- [ ] Codes with each valid opcodes (ethereum/tests: src/EOFTestsFiller/EIP3670/validInvalidFiller.yml)
-- [ ] Undefined instruction after terminating instruction (ethereum/tests: src/EOFTestsFiller/EIP3670/validInvalidFiller.yml)
+- [x] Code section with invalid opcodes is rejected ([`tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_all_opcodes_in_container.py::test_all_opcodes_in_container.py`](./eip3540_eof_v1/test_all_opcodes_in_container/test_all_opcodes_in_container.md))
+- [x] INVALID opcode is valid ([`tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_all_opcodes_in_container.py::test_all_opcodes_in_container.py`](./eip3540_eof_v1/test_all_opcodes_in_container/test_all_opcodes_in_container.md))
+- [x] Truncated PUSH data ([`tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_all_opcodes_in_container.py::test_truncated_push_opcodes.py`](./eip3540_eof_v1/test_all_opcodes_in_container/test_truncated_push_opcodes.md))
+- [x] Opcodes deprecated in EOF are rejected ([`tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_all_opcodes_in_container.py::test_all_opcodes_in_container.py`](./eip3540_eof_v1/test_all_opcodes_in_container/test_all_opcodes_in_container.md))
+- [x] Codes with each valid opcodes ([`tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_all_opcodes_in_container.py::test_all_opcodes_in_container.py`](./eip3540_eof_v1/test_all_opcodes_in_container/test_all_opcodes_in_container.md))
+- [x] Undefined instruction after terminating instruction ([`tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_all_opcodes_in_container.py::test_invalid_opcodes_after_stop.py`](./eip3540_eof_v1/test_all_opcodes_in_container/test_invalid_opcodes_after_stop.md))
 
 ## EIP-4200: EOF - Static relative jumps
 


### PR DESCRIPTION
## 🗒️ Description

Add missing opcode tests:
- invalid opcode placed after a STOP instruction,
- PUSH opcodes with truncated immediate bytes.

Mark rest of the "opcode tests" as done by providing links to tests.

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened: https://github.com/ethereum/tests/pull/1412.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
