### PR TITLE
fix(plugins/eels_resolver): add `tryfirst`

### DIFF
--- a/src/pytest_plugins/eels_resolver.py
+++ b/src/pytest_plugins/eels_resolver.py
@@ -14,6 +14,7 @@ import pytest
 from pytest_metadata.plugin import metadata_key  # type: ignore
 
 
+@pytest.hookimpl(tryfirst=True)
 def pytest_configure(config: pytest.Config) -> None:
     """
     Set the EELS_RESOLUTIONS_FILE environment variable.


### PR DESCRIPTION
## 🗒️ Description
While debugging the eels-resolver to use a file and incorporate `Osaka`, I realized that the plugin was running after the fill `pytest_configure` so the resolver's help (to get the supported forks) was being run without the environment variables set.

This is fixed by adding a `@pytest.hookimpl(tryfirst=True)` decorator to the `pytest_configure` in the `eels_resolver` plugin. 

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.