### PR TITLE
fix(vm): `Bytecode` comparison

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -52,6 +52,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Improve `fill` terminal output to emphasize that filling tests is not actually testing a client ([#807](https://github.com/ethereum/execution-spec-tests/pull/887)).
 - ✨ Add the `BlockchainTestEngine` test spec type that only generates a fixture in the `EngineFixture` (`blockchain_test_engine`) format ([#888](https://github.com/ethereum/execution-spec-tests/pull/888)).
 - 🔀 `ethereum_test_forks` forks now contain gas-calculating functions, which return the appropriate function to calculate the gas used by a transaction or memory function for the given fork ([#779](https://github.com/ethereum/execution-spec-tests/pull/779)).
+- 🐞 Fix `Bytecode` class `__eq__` method ([#939](https://github.com/ethereum/execution-spec-tests/pull/939)).
 
 ### 🔧 EVM Tools
 

--- a/src/ethereum_test_vm/bytecode.py
+++ b/src/ethereum_test_vm/bytecode.py
@@ -127,7 +127,7 @@ class Bytecode:
             )
         if isinstance(other, SupportsBytes):
             return bytes(self) == bytes(other)
-        raise NotImplementedError(f"Unsupported type for comparison f{type(other)}")
+        raise NotImplementedError(f"Unsupported type for comparison: {type(other)}")
 
     def __hash__(self):
         """

--- a/src/ethereum_test_vm/bytecode.py
+++ b/src/ethereum_test_vm/bytecode.py
@@ -117,6 +117,14 @@ class Bytecode:
         - NotImplementedError: if the comparison is not between an Bytecode
             or a bytes object.
         """
+        if isinstance(other, Bytecode):
+            return (
+                bytes(self) == bytes(other)
+                and self.popped_stack_items == other.popped_stack_items
+                and self.pushed_stack_items == other.pushed_stack_items
+                and self.max_stack_height == other.max_stack_height
+                and self.min_stack_height == other.min_stack_height
+            )
         if isinstance(other, SupportsBytes):
             return bytes(self) == bytes(other)
         raise NotImplementedError(f"Unsupported type for comparison f{type(other)}")


### PR DESCRIPTION
## 🗒️ Description
Fixes `Bytecode` equality comparison method to take other properties into account when comparing against some other `Bytecode` object.

The issue surfaced when I tried to implement tests for EIP-5920 that contains the `PAY` opcode, which collides with the `EXTDELEGATECALL` opcode for EOF. When both opcodes were included in the same Enum, it seems like this class internally performs an optimization that compares all items and reuses instances that return `__eq__() == True`, which lead to the `Op.PAY` being equal to the value assigned to `Op.EXTDELEGATECALL`.

## 🔗 Related Issues
None.

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.