### PR TITLE
feat(clis/transition_tool): Pass `state_test` to transition tool if supported

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -58,6 +58,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 - ✨ Fill test fixtures using EELS by default. EEST now uses the [`ethereum-specs-evm-resolver`](https://github.com/petertdavies/ethereum-spec-evm-resolver) with the EELS daemon ([#792](https://github.com/ethereum/execution-spec-tests/pull/792)).
 - 🔀 Move the `evm_transition_tool` package to `ethereum_clis` and derive the transition tool CL interfaces from a shared `EthereumCLI` class that can be reused for other sub-commands ([#894](https://github.com/ethereum/execution-spec-tests/pull/894)).
+- ✨ Pass `state_test` property to T8N tools that support it (Only EELS at the time of merge) ([#943](https://github.com/ethereum/execution-spec-tests/pull/943)).
 
 ### 📋 Misc
 

--- a/src/ethereum_clis/clis/besu.py
+++ b/src/ethereum_clis/clis/besu.py
@@ -108,6 +108,7 @@ class BesuTransitionTool(TransitionTool):
         reward: int = 0,
         eips: Optional[List[int]] = None,
         debug_output_path: str = "",
+        state_test: bool = False,
     ) -> TransitionToolOutput:
         """
         Executes `evm t8n` with the specified arguments.

--- a/src/ethereum_clis/clis/execution_specs.py
+++ b/src/ethereum_clis/clis/execution_specs.py
@@ -9,7 +9,7 @@ import time
 from pathlib import Path
 from re import compile
 from tempfile import TemporaryDirectory
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from ethereum_test_exceptions import (
     EOFException,
@@ -111,13 +111,15 @@ class ExecutionSpecsTransitionTool(TransitionTool):
         """
         return (fork.transition_tool_name() + "\n") in self.help_string
 
-    def _generate_post_args(self, t8n_data: TransitionTool.TransitionToolData) -> List[str]:
+    def _generate_post_args(
+        self, t8n_data: TransitionTool.TransitionToolData
+    ) -> Dict[str, List[str] | str]:
         """
         Generate the arguments for the POST request to the t8n-server.
 
         EELS T8N expects `--state-test` when running a state test.
         """
-        return ["arg=--state-test"] if t8n_data.state_test else []
+        return {"arg": "--state-test"} if t8n_data.state_test else {}
 
 
 class ExecutionSpecsExceptionMapper(ExceptionMapper):

--- a/src/ethereum_clis/clis/execution_specs.py
+++ b/src/ethereum_clis/clis/execution_specs.py
@@ -9,7 +9,7 @@ import time
 from pathlib import Path
 from re import compile
 from tempfile import TemporaryDirectory
-from typing import Optional
+from typing import List, Optional
 
 from ethereum_test_exceptions import (
     EOFException,
@@ -110,6 +110,14 @@ class ExecutionSpecsTransitionTool(TransitionTool):
         `ethereum-spec-evm` appends newlines to forks in the help string.
         """
         return (fork.transition_tool_name() + "\n") in self.help_string
+
+    def _generate_post_args(self, t8n_data: TransitionTool.TransitionToolData) -> List[str]:
+        """
+        Generate the arguments for the POST request to the t8n-server.
+
+        EELS T8N expects `--state-test` when running a state test.
+        """
+        return ["arg=--state-test"] if t8n_data.state_test else []
 
 
 class ExecutionSpecsExceptionMapper(ExceptionMapper):

--- a/src/ethereum_clis/transition_tool.py
+++ b/src/ethereum_clis/transition_tool.py
@@ -13,6 +13,7 @@ from abc import abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Type
+from urllib.parse import urlencode
 
 from requests import Response
 from requests.exceptions import ConnectionError
@@ -275,7 +276,7 @@ class TransitionTool(EthereumCLI, FixtureVerifier):
     def _server_post(
         self,
         data: Dict[str, Any],
-        url_args: List[str] = [],
+        url_args: Dict[str, List[str] | str] = {},
         retries: int = 5,
     ) -> Response:
         """
@@ -285,7 +286,7 @@ class TransitionTool(EthereumCLI, FixtureVerifier):
         while True:
             try:
                 response = Session().post(
-                    f"{self.server_url}?{'&'.join(url_args)}",
+                    f"{self.server_url}?{urlencode(url_args, doseq=True)}",
                     json=data,
                     timeout=20,
                 )
@@ -304,11 +305,11 @@ class TransitionTool(EthereumCLI, FixtureVerifier):
             )
         return response
 
-    def _generate_post_args(self, t8n_data: TransitionToolData) -> List[str]:
+    def _generate_post_args(self, t8n_data: TransitionToolData) -> Dict[str, List[str] | str]:
         """
         Generate the arguments for the POST request to the t8n-server.
         """
-        return []
+        return {}
 
     def _evaluate_server(
         self,

--- a/src/ethereum_test_specs/state.py
+++ b/src/ethereum_test_specs/state.py
@@ -6,6 +6,7 @@ from pprint import pprint
 from typing import Any, Callable, ClassVar, Dict, Generator, List, Optional, Type
 
 import pytest
+from pydantic import Field
 
 from ethereum_clis import TransitionTool
 from ethereum_test_exceptions import EngineAPIError
@@ -39,7 +40,7 @@ class StateTest(BaseTest):
     Filler type that tests transactions over the period of a single block.
     """
 
-    env: Environment
+    env: Environment = Field(default_factory=Environment)
     pre: Alloc
     post: Alloc
     tx: Transaction
@@ -149,6 +150,7 @@ class StateTest(BaseTest):
             reward=0,  # Reward on state tests is always zero
             eips=eips,
             debug_output_path=self.get_next_transition_tool_output_path(),
+            state_test=True,
         )
 
         try:

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -113,6 +113,7 @@ discordapp
 dockerdocs
 docstring
 docstrings
+doseq
 dunder
 dup
 EEST


### PR DESCRIPTION
## 🗒️ Description
Pass the `state_test` property to the t8n that support/require it.

In this PR the only updated tool is EELS, and the information is passed as an URL parameter, which is then converted to a CLI argument on the receiving end.

Requires:
- https://github.com/ethereum/execution-specs/pull/1030
- https://github.com/petertdavies/ethereum-spec-evm-resolver/pull/5

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.