### PR TITLE
new(tests): EIP-7702:  Set code of non-empty-storage account

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - 💥 `PragueEIP7692` fork in tests has been updated to `Osaka` ([#869](https://github.com/ethereum/execution-spec-tests/pull/869))
 - ✨ Update [EIP-6110](https://eips.ethereum.org/EIPS/eip-6110), [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002), [EIP-7251](https://eips.ethereum.org/EIPS/eip-7251), [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685), and [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) tests for Devnet-4 ([#832](https://github.com/ethereum/execution-spec-tests/pull/832))
 - ✨ [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) many delegations test ([#923](https://github.com/ethereum/execution-spec-tests/pull/923))
+- ✨ [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) set code of non-empty-storage account test ([#948](https://github.com/ethereum/execution-spec-tests/pull/948))
 
 ### 🛠️ Framework
 

--- a/src/pytest_plugins/filler/pre_alloc.py
+++ b/src/pytest_plugins/filler/pre_alloc.py
@@ -228,7 +228,12 @@ class Alloc(BaseAlloc):
                 # Type-4 transaction is sent to the EOA to set the storage, so the nonce must be 1
                 if not isinstance(delegation, Address) and delegation == "Self":
                     delegation = eoa
-                nonce = Number(1 if nonce is None else nonce)
+                # If delegation is None but storage is not, realistically the nonce should be 2
+                # because the account must have delegated to set the storage and then again to
+                # reset the delegation (but can be overridden by the test for a non-realistic
+                # scenario)
+                real_nonce = 2 if delegation is None else 1
+                nonce = Number(real_nonce if nonce is None else nonce)
                 account = Account(
                     nonce=nonce,
                     balance=amount,


### PR DESCRIPTION
## 🗒️ Description
Simple test to verify that the code can be set for an account with a non-empty storage (In case account delegated previously, set some storage value, then reset its delegation to empty).

Also fixes the `pre.fund_eoa` method to consider the extra nonce bump that would realistically be required if an account removed its delegation.

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.