### PR TITLE
feat(docs): add prague-devnet-5 link; add EOF EIP links/info

### DIFF
--- a/tests/osaka/eip7692_eof_v1/__init__.py
+++ b/tests/osaka/eip7692_eof_v1/__init__.py
@@ -1,5 +1,22 @@
 """
-Test cases for all EIPs mentioned in the EOF V1 meta-EIP.
-"""
+abstract: Test cases for [EIP-7692: EVM Object Format (EOFv1) Meta](https://eips.ethereum.org/EIPS/eip-7692)
+    Test cases for the EIPs included in [EIP-7692 EOFv1 Meta](https://eips.ethereum.org/EIPS/eip-7692):
+
+    * [EIP-663: SWAPN, DUPN and EXCHANGE instructions](https://eips.ethereum.org/EIPS/eip-663).
+    * [EIP-3540: EOF - EVM Object Format v1](https://eips.ethereum.org/EIPS/eip-3540).
+    * [EIP-3670: EOF - Code Validation](https://eips.ethereum.org/EIPS/eip-3670).
+    * [EIP-4200: EOF - Static relative jumps](https://eips.ethereum.org/EIPS/eip-4200).
+    * [EIP-4750: EOF - Functions](https://eips.ethereum.org/EIPS/eip-4750).
+    * [EIP-5450: EOF - Stack Validation](https://eips.ethereum.org/EIPS/eip-5450).
+    * [EIP-6206: EOF - JUMPF and non-returning functions](https://eips.ethereum.org/EIPS/eip-6206).
+    * [EIP-7069: Revamped CALL instructions](https://eips.ethereum.org/EIPS/eip-7069).
+    * [EIP-7480: EOF - Data section access instructions](https://eips.ethereum.org/EIPS/eip-7480).
+    * [EIP-7620: EOF Contract Creation](https://eips.ethereum.org/EIPS/eip-7620).
+    * [EIP-7698: EOF - Creation transaction](https://eips.ethereum.org/EIPS/eip-7698).
+
+## Devnet Specifications
+
+- [ethpandaops/eof-devnet-0](https://notes.ethereum.org/@ethpandaops/eof-devnet-0).
+"""  # noqa: E501
 
 EOF_FORK_NAME = "CancunEIP7692,Osaka"

--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/__init__.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/__init__.py
@@ -1,3 +1,5 @@
 """
-Cross-client EVM Object Format Tests
-"""
+abstract: Test cases for [EIP-3540: EOF - EVM Object Format v1](https://eips.ethereum.org/EIPS/eip-3540)
+    EIP-3540 introduces a structured format for EVM bytecode, with separate sections for code and data.
+    Opcodes introduced: None (defines a new bytecode structure but no new opcodes).
+"""  # noqa: E501

--- a/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/__init__.py
+++ b/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/__init__.py
@@ -1,3 +1,5 @@
 """
-EOF tests for EIP-4200 relative jumps
-"""
+abstract: Test cases for [EIP-4200: EOF - Static relative jumps](https://eips.ethereum.org/EIPS/eip-4200)
+    EIP-4200 replaces dynamic jump instructions with relative jump offsets for improved control flow predictability.
+    Opcodes introduced: `RJUMP` (`0xE0`), `RJUMPI` (`0xE1`), `RJUMPV` (`0xE2`).
+"""  # noqa: E501

--- a/tests/osaka/eip7692_eof_v1/eip4750_functions/__init__.py
+++ b/tests/osaka/eip7692_eof_v1/eip4750_functions/__init__.py
@@ -1,3 +1,5 @@
 """
-EOF tests for EIP-4750 functions
-"""
+abstract: Test cases for [EIP-4750: EOF - Functions](https://eips.ethereum.org/EIPS/eip-4750)
+    EIP-4750 formalizes functions in the EVM object format, introducing callable units of code.
+    Opcodes introduced: `CALLF` (`0xE3`), `RETF` (`0xE4`).
+"""  # noqa: E501

--- a/tests/osaka/eip7692_eof_v1/eip5450_stack/__init__.py
+++ b/tests/osaka/eip7692_eof_v1/eip5450_stack/__init__.py
@@ -1,3 +1,5 @@
 """
-EOF tests for EIP-5450 stack validation
-"""
+abstract: Test cases for [EIP-5450: EOF - Stack Validation](https://eips.ethereum.org/EIPS/eip-5450)
+    EIP-5450 defines stack validation requirements to ensure consistent behavior during execution.
+    Opcodes introduced: None (specifies validation rules for stack usage).
+"""  # noqa: E501

--- a/tests/osaka/eip7692_eof_v1/eip6206_jumpf/__init__.py
+++ b/tests/osaka/eip7692_eof_v1/eip6206_jumpf/__init__.py
@@ -1,3 +1,5 @@
 """
-EOF tests for EIP-6206 JUMPF
-"""
+abstract: Test cases for [EIP-6206: EOF - JUMPF and non-returning functions](https://eips.ethereum.org/EIPS/eip-6206)
+    EIP-6206 adds a conditional forward jump instruction and support for functions without return values.
+    Opcodes introduced: `JUMPF` (`0xE5`).
+"""  # noqa: E501

--- a/tests/osaka/eip7692_eof_v1/eip663_dupn_swapn_exchange/__init__.py
+++ b/tests/osaka/eip7692_eof_v1/eip663_dupn_swapn_exchange/__init__.py
@@ -1,6 +1,7 @@
 """
-abstract: Tests [EIP-663: SWAPN, DUPN and EXCHANGE instructions](https://eips.ethereum.org/EIPS/eip-663)
-    Tests for [EIP-663: SWAPN, DUPN and EXCHANGE instructions](https://eips.ethereum.org/EIPS/eip-663).
+abstract: Test cases for [EIP-663: SWAPN, DUPN and EXCHANGE instructions](https://eips.ethereum.org/EIPS/eip-663)
+    EIP-663 defines new stack manipulation instructions that allow accessing the stack at higher depths.
+    Opcodes introduced: `DUPN` (`0xE6`), `SWAPN` (`0xE7`), `EXCHANGEN` (`0xE8`).
 """  # noqa: E501
 
 REFERENCE_SPEC_GIT_PATH = "EIPS/eip-663.md"

--- a/tests/osaka/eip7692_eof_v1/eip7069_extcall/__init__.py
+++ b/tests/osaka/eip7692_eof_v1/eip7069_extcall/__init__.py
@@ -1,6 +1,8 @@
 """
-Revamped Call Instructions Tests
-"""
+abstract: Test cases for [EIP-7069: Revamped CALL instructions](https://eips.ethereum.org/EIPS/eip-7069)
+    EIP-7069 proposes modifications to `CALL` instructions to align with the structured EOF format.
+    Opcodes introduced: `EXTCALL` (`0xF8`), `EXTDELEGATECALL` (`0xF9`), `EXTSTATICCALL` (`0xFB`), `RETURNDATALOAD` (`0xF7`).
+"""  # noqa: E501
 
 REFERENCE_SPEC_GIT_PATH = "EIPS/eip-7069.md"
 REFERENCE_SPEC_VERSION = "1795943aeacc86131d5ab6bb3d65824b3b1d4cad"

--- a/tests/osaka/eip7692_eof_v1/eip7480_data_section/__init__.py
+++ b/tests/osaka/eip7692_eof_v1/eip7480_data_section/__init__.py
@@ -1,3 +1,5 @@
 """
-Cross-client EVM Object Format Tests
-"""
+abstract: Test cases for [EIP-7480: EOF - Data section access instructions](https://eips.ethereum.org/EIPS/eip-7480)
+    EIP-7480 specifies instructions for accessing data stored in the dedicated data section of the EOF format.
+    Opcodes introduced: `DATALOAD` (`0xD0`), `DATALOADN` (`0xD1`), `DATASIZE` (`0xD2`), `DATACOPY` (`0xD3`).
+"""  # noqa: E501

--- a/tests/osaka/eip7692_eof_v1/eip7620_eof_create/__init__.py
+++ b/tests/osaka/eip7692_eof_v1/eip7620_eof_create/__init__.py
@@ -1,14 +1,19 @@
 """
+abstract: Test cases for [EIP-7620: EOF Contract Creation](https://eips.ethereum.org/EIPS/eip-7620)
+    EIP-7620 replaces `CREATE` and `CREATE2` with `EOFCREATE` for deploying contracts in the EOF format.
+    Opcodes introduced: `EOFCREATE` (`0xEC`), `RETURNCONTRACT` (`0xEE`).
+
+
 EOFCREATE, RETURNCONTRACT, and container tests
 
 evmone tests not ported
 
-create_tx_with_eof_initcode - This calls it invalid, it is now the way to add EOF contacts to state
-eofcreate_extcall_returncontract - per the new initcode mode tests you cannot have RETURNCONTRACT
+- create_tx_with_eof_initcode - This calls it invalid, it is now the way to add EOF contacts to state
+- eofcreate_extcall_returncontract - per the new initcode mode tests you cannot have RETURNCONTRACT
     in a deployed contract
-eofcreate_dataloadn_referring_to_auxdata - covered by
+- eofcreate_dataloadn_referring_to_auxdata - covered by
     tests.osaka.eip7480_data_section.test_data_opcodes.test_data_section_succeed
-eofcreate_initcontainer_return - RETURN is banned in initcode containers
-eofcreate_initcontainer_stop - STOP is banned in initcode containers
-All TXCREATE tests - TXCREATE has been removed from Prague
-"""
+- eofcreate_initcontainer_return - RETURN is banned in initcode containers
+- eofcreate_initcontainer_stop - STOP is banned in initcode containers
+- All TXCREATE tests.
+"""  # noqa: E501

--- a/tests/osaka/eip7692_eof_v1/eip7698_eof_creation_tx/__init__.py
+++ b/tests/osaka/eip7692_eof_v1/eip7698_eof_creation_tx/__init__.py
@@ -1,3 +1,5 @@
 """
-EOF creation transaction (empty `to`) tests
-"""
+abstract: Test cases for [EIP-7698: EOF - Creation transaction](https://eips.ethereum.org/EIPS/eip-7698)
+    EIP-7698 defines the transaction format for creating EOF-based contracts.
+    Opcodes introduced: None (focuses on the transaction format).
+"""  # noqa: E501

--- a/tests/prague/__init__.py
+++ b/tests/prague/__init__.py
@@ -3,6 +3,7 @@ Test cases for EVM functionality introduced in Prague, [EIP-7600: Hardfork Meta 
 
 Devnet Specifications:
 
+- [ethpandaops/pectra-devnet-5](https://notes.ethereum.org/@ethpandaops/pectra-devnet-5).
 - [ethpandaops/pectra-devnet-4](https://notes.ethereum.org/@ethpandaops/pectra-devnet-4).
 - [ethpandaops/pectra-devnet-3](https://notes.ethereum.org/@ethpandaops/pectra-devnet-3).
 - [ethpandaops/pectra-devnet-2](https://notes.ethereum.org/@ethpandaops/pectra-devnet-2).


### PR DESCRIPTION
## 🗒️ Description
- Adds a link to prague-devnet-5,
- Adds EOF EIP links and a top-level description of every EOF EIP included.

## 🔗 Related Issues
#956 

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
