### PR TITLE
fix(fw): allow Bytecode(Opcode)

### DIFF
--- a/src/ethereum_test_vm/bytecode.py
+++ b/src/ethereum_test_vm/bytecode.py
@@ -57,7 +57,7 @@ class Bytecode:
             instance._name_ = name
             return instance
 
-        if type(bytes_or_byte_code_base) is Bytecode:
+        if isinstance(bytes_or_byte_code_base, Bytecode):
             # Required because Enum class calls the base class with the instantiated object as
             # parameter.
             obj = super().__new__(cls)


### PR DESCRIPTION
## 🗒️ Description

Without this, I cannot fill eof tests with:

```
$ fill  --fork Osaka tests/osaka/eip7692_eof_v1/
...
___________________________________________________________ test_invalid_opcodes_after_stop[fork_Osaka-eof_test-terminating_opcode_STOP-opcode_OPCODE_0C] ___________________________________________________________
[gw3] linux -- Python 3.10.12 /home/user/sources/ethereum/execution-spec-tests/.venv/bin/python3
tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_all_opcodes_in_container.py:141: in test_invalid_opcodes_after_stop
    terminating_code = Bytecode(terminating_opcode)
src/ethereum_test_vm/bytecode.py:92: in __new__
    raise TypeError("Bytecode constructor '__new__' didn't return an instance!")
E   TypeError: Bytecode constructor '__new__' didn't return an instance!
```

I think #932 introduced it.

I'm not sure if this is the correct way to Python this. Alternative I have is to do `Bytecode() + some_opcode` instead of `Bytecode(some_opcode)` in the said test

## 🔗 Related Issues

na

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
