### PR TITLE
 feat(ci,eof): include eofwrap in EOF prerelease

### DIFF
--- a/.github/actions/build-evm-base/action.yaml
+++ b/.github/actions/build-evm-base/action.yaml
@@ -60,6 +60,8 @@ runs:
       with:
         repo: ${{ steps.config-evm-reader.outputs.repo }}
         ref: ${{ steps.config-evm-reader.outputs.ref }}
+        # `targets` in the evm.yaml must be an inline array to not interfere with `config-evm-reader`'s parsing
+        targets: ${{ join(fromJSON(steps.config-evm-reader.outputs.targets), ' ') }}
     - name: Build the EVM using Besu action
       if: steps.config-evm-reader.outputs.impl == 'besu'
       uses: ./.github/actions/build-evm-client/besu

--- a/.github/actions/build-fixtures/action.yaml
+++ b/.github/actions/build-fixtures/action.yaml
@@ -28,11 +28,15 @@ runs:
       shell: bash
       if: ${{ steps.properties.outputs.eofwrap }}
       run: |
-        curl -L https://github.com/ethereum/tests/archive/refs/tags/v14.1.tar.gz | tar -xz
+        curl -L ${tests_url}${tests_version}.tar.gz | tar -xz
         ls -l
-        uv run eofwrap tests-14.1/BlockchainTests/GeneralStateTests/ fixtures_${{ inputs.release_name }}/blockchain_tests/osaka/eofwrap
+        uv run eofwrap tests-${tests_version}/BlockchainTests/GeneralStateTests/ fixtures_${{ inputs.release_name }}/${output_path}
         mkdir -p ./fixtures_${{ inputs.release_name }}/.meta/
-        mv fixtures_${{ inputs.release_name }}/blockchain_tests/osaka/eofwrap/metrics.json ./fixtures_${{ inputs.release_name }}/.meta/eofwrap_metrics.json
+        mv fixtures_${{ inputs.release_name }}/${output_path}/metrics.json ./fixtures_${{ inputs.release_name }}/.meta/eofwrap_metrics.json
+      env:
+        tests_url: https://github.com/ethereum/tests/archive/refs/tags/v
+        tests_version: 14.1
+        output_path: blockchain_tests/osaka/eofwrap
     - name: Generate fixtures using fill
       shell: bash
       run: |

--- a/.github/actions/build-fixtures/action.yaml
+++ b/.github/actions/build-fixtures/action.yaml
@@ -24,6 +24,15 @@ runs:
       id: evm-builder
       with:
         type: ${{ steps.properties.outputs.evm-type }}
+    - name: Wrap ethereum/tests fixtures with eofwrap tool
+      shell: bash
+      if: ${{ steps.properties.outputs.eofwrap }}
+      run: |
+        curl -L https://github.com/ethereum/tests/archive/refs/tags/v14.1.tar.gz | tar -xz
+        ls -l
+        uv run eofwrap tests-14.1/BlockchainTests/GeneralStateTests/ fixtures_${{ inputs.release_name }}/blockchain_tests/osaka/eofwrap
+        mkdir -p ./fixtures_${{ inputs.release_name }}/.meta/
+        mv fixtures_${{ inputs.release_name }}/blockchain_tests/osaka/eofwrap/metrics.json ./fixtures_${{ inputs.release_name }}/.meta/eofwrap_metrics.json
     - name: Generate fixtures using fill
       shell: bash
       run: |

--- a/.github/configs/evm.yaml
+++ b/.github/configs/evm.yaml
@@ -10,10 +10,6 @@ eip7692:
   impl: evmone
   repo: ethereum/evmone
   ref: master
-eip7692-osaka:
-  impl: besu
-  repo: hyperledger/besu
-  ref: main
 pectra-devnet-3:
   impl: ethjs
   repo: ethereumjs/ethereumjs-monorepo

--- a/.github/configs/evm.yaml
+++ b/.github/configs/evm.yaml
@@ -10,6 +10,7 @@ eip7692:
   impl: evmone
   repo: ethereum/evmone
   ref: master
+  targets: ["evmone-t8n", "evmone-eofparse"]
 pectra-devnet-3:
   impl: ethjs
   repo: ethereumjs/ethereumjs-monorepo

--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -12,8 +12,9 @@ develop:
   solc: 0.8.21
 eip7692:
   evm-type: eip7692
-  fill-params: --fork=CancunEIP7692 ./tests/osaka
+  fill-params: --fork=Osaka ./tests/osaka
   solc: 0.8.21
+  eofwrap: true
 eip7692-osaka:
   evm-type: eip7692-osaka
   fill-params: --fork=Osaka ./tests/prague ./tests/osaka -k "not slow"

--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -15,10 +15,6 @@ eip7692:
   fill-params: --fork=Osaka ./tests/osaka
   solc: 0.8.21
   eofwrap: true
-eip7692-osaka:
-  evm-type: eip7692-osaka
-  fill-params: --fork=Osaka ./tests/prague ./tests/osaka -k "not slow"
-  solc: 0.8.21
 pectra-devnet-3:
   evm-type: pectra-devnet-3
   fill-params: --fork=Prague -m "not slow" ./tests/prague/

--- a/src/ethereum_test_vm/bytecode.py
+++ b/src/ethereum_test_vm/bytecode.py
@@ -57,7 +57,7 @@ class Bytecode:
             instance._name_ = name
             return instance
 
-        if type(bytes_or_byte_code_base) is Bytecode:
+        if isinstance(bytes_or_byte_code_base, Bytecode):
             # Required because Enum class calls the base class with the instantiated object as
             # parameter.
             obj = super().__new__(cls)


### PR DESCRIPTION
## 🗒️ Description

Follows up #896 with a new build step which adds eofwrapped `ethereum/tests` to the EOF tests prerelease. Depends on #961 , hence opening as draft.

## 🔗 Related Issues

na

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
