### PR TITLE
fix: upgrade questionary to allow compatbility with ipython

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,12 @@ dependencies = [
     "pyyaml>=6.0.2,<7",
     "types-pyyaml>=6.0.12.20240917,<7",
     "pytest-json-report>=1.5.0,<2",
-    "questionary>=2.0.1,<3",
+    # TODO: bump questionary to a newer release, when it becomes available. 
+    # The current release questionary 2.0.1 requires `prompt_toolkit = ">=2.0,<=3.0.36"`.
+    # This conflicts with ipython; while not an EEST dependency, ipython a very useful tool:
+    # https://ethereum.github.io/execution-spec-tests/main/dev/interactive_usage/
+    "questionary @ git+https://github.com/tmbo/questionary@ff22aeae1cd9c1c734f14329934e349bec7873bc",
+    "prompt_toolkit>=3.0.48,<4",  # ensure we have a new enough version for ipython
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -522,6 +522,7 @@ dependencies = [
     { name = "filelock" },
     { name = "gitpython" },
     { name = "hive-py" },
+    { name = "prompt-toolkit" },
     { name = "pydantic" },
     { name = "pyjwt" },
     { name = "pytest" },
@@ -607,6 +608,7 @@ requires-dist = [
     { name = "mypy", marker = "implementation_name == 'cpython' and extra == 'lint'", specifier = "==0.991" },
     { name = "pep8-naming", marker = "extra == 'lint'", specifier = "==0.13.3" },
     { name = "pillow", marker = "extra == 'docs'", specifier = ">=10.0.1,<11" },
+    { name = "prompt-toolkit", specifier = ">=3.0.48,<4" },
     { name = "pydantic", specifier = ">=2.9.0,<3" },
     { name = "pyjwt", specifier = ">=2.3.0,<3" },
     { name = "pyspelling", marker = "extra == 'docs'", specifier = ">=2.8.2,<3" },
@@ -618,7 +620,7 @@ requires-dist = [
     { name = "pytest-metadata", specifier = ">=3,<4" },
     { name = "pytest-xdist", specifier = ">=3.3.1,<4" },
     { name = "pyyaml", specifier = ">=6.0.2,<7" },
-    { name = "questionary", specifier = ">=2.0.1,<3" },
+    { name = "questionary", git = "https://github.com/tmbo/questionary?rev=ff22aeae1cd9c1c734f14329934e349bec7873bc#ff22aeae1cd9c1c734f14329934e349bec7873bc" },
     { name = "requests", specifier = ">=2.31.0,<3" },
     { name = "requests-unixsocket2", specifier = ">=0.4.0" },
     { name = "rich", specifier = ">=13.7.0,<14" },
@@ -1345,14 +1347,14 @@ wheels = [
 
 [[package]]
 name = "prompt-toolkit"
-version = "3.0.36"
+version = "3.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "wcwidth" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/93/180be2342f89f16543ec4eb3f25083b5b84eba5378f68efff05409fb39a9/prompt_toolkit-3.0.36.tar.gz", hash = "sha256:3e163f254bef5a03b146397d7c1963bd3e2812f0964bb9a24e6ec761fd28db63", size = 423863 }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/4f/feb5e137aff82f7c7f3248267b97451da3644f6cdc218edfe549fb354127/prompt_toolkit-3.0.48.tar.gz", hash = "sha256:d6623ab0477a80df74e646bdbc93621143f5caf104206aa29294d53de1a03d90", size = 424684 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/37/791f1a6edd13c61cac85282368aa68cb0f3f164440fdf60032f2cc6ca34e/prompt_toolkit-3.0.36-py3-none-any.whl", hash = "sha256:aa64ad242a462c5ff0363a7b9cfe696c20d55d9fc60c11fd8e632d064804d305", size = 386414 },
+    { url = "https://files.pythonhosted.org/packages/a9/6a/fd08d94654f7e67c52ca30523a178b3f8ccc4237fce4be90d39c938a831a/prompt_toolkit-3.0.48-py3-none-any.whl", hash = "sha256:f49a827f90062e411f1ce1f854f2aedb3c23353244f8108b89283587397ac10e", size = 386595 },
 ]
 
 [[package]]
@@ -1719,13 +1721,9 @@ wheels = [
 [[package]]
 name = "questionary"
 version = "2.0.1"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/tmbo/questionary?rev=ff22aeae1cd9c1c734f14329934e349bec7873bc#ff22aeae1cd9c1c734f14329934e349bec7873bc" }
 dependencies = [
     { name = "prompt-toolkit" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/84/d0/d73525aeba800df7030ac187d09c59dc40df1c878b4fab8669bdc805535d/questionary-2.0.1.tar.gz", hash = "sha256:bcce898bf3dbb446ff62830c86c5c6fb9a22a54146f0f5597d3da43b10d8fc8b", size = 24726 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/e7/2dd8f59d1d328773505f78b85405ddb1cfe74126425d076ce72e65540b8b/questionary-2.0.1-py3-none-any.whl", hash = "sha256:8ab9a01d0b91b68444dff7f6652c1e754105533f083cbe27597c8110ecc230a2", size = 34248 },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🗒️ Description
This PR fixes [interactive usage of EEST with ipython](https://ethereum.github.io/execution-spec-tests/main/dev/interactive_usage/).

I tested this change on top of dac90491d0 from [`raxhvl/feat/make-test`](https://github.com/raxhvl/execution-spec-tests/tree/feat/make-test) cf #950: The interactive CLI command `uv run et make test` works without a problem with these changes, CC @raxhvl .

Here's the explanation from `pyproject.toml`:
```toml
    # TODO: bump questionary to a newer release, when it becomes available. 
    # The current release questionary 2.0.1 requires `prompt_toolkit = ">=2.0,<=3.0.36"`.
    # This conflicts with ipython; while not an EEST dependency, ipython a very useful tool:
    # https://ethereum.github.io/execution-spec-tests/main/dev/interactive_usage/
    "questionary @ git+https://github.com/tmbo/questionary@ff22aeae1cd9c1c734f14329934e349bec7873bc",
    "prompt_toolkit>=3.0.48,<4",  # ensure we have a new enough version for ipython
```
## 🔗 Related Issues
This issue was introduced in #947 

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.