### PR TITLE
chore(fill): fix prague filling with EELS

### DIFF
--- a/eels_resolutions.json
+++ b/eels_resolutions.json
@@ -13,7 +13,7 @@
     "Byzantium": {
         "same_as": "EELSMaster"
     },
-    "Constantinople": {
+    "ConstantinopleFix": {
         "same_as": "EELSMaster"
     },
     "Istanbul": {

--- a/eels_resolutions.json
+++ b/eels_resolutions.json
@@ -37,6 +37,6 @@
     "Prague": {
         "git_url": "https://github.com/ethereum/execution-specs.git",
         "branch": "forks/prague",
-        "commit": "5278aa095572e267a487d2580930c6d8c263b262"
+        "commit": "1ea4a8d30d68bb819e77ff52eeb2095ae3c67f5f"
     }
 }

--- a/eels_resolutions.json
+++ b/eels_resolutions.json
@@ -36,7 +36,7 @@
     },
     "Prague": {
         "git_url": "https://github.com/ethereum/execution-specs.git",
-        "branch": "prague",
-        "commit": "2875a733d6b1e9e751e437c7894d3ebe6ff58ecc"
+        "branch": "forks/prague",
+        "commit": "5278aa095572e267a487d2580930c6d8c263b262"
     }
 }

--- a/src/pytest_plugins/forks/forks.py
+++ b/src/pytest_plugins/forks/forks.py
@@ -426,7 +426,7 @@ def pytest_configure(config: pytest.Config):
     if evm_bin is not None:
         t8n = TransitionTool.from_binary_path(binary_path=evm_bin)
         config.unsupported_forks = frozenset(  # type: ignore
-            filter(lambda fork: not t8n.is_fork_supported(fork), fork_set)
+            fork for fork in fork_set if not t8n.is_fork_supported(fork)
         )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ requires-dist = [
 [[package]]
 name = "ethereum-spec-evm-resolver"
 version = "0.0.5"
-source = { git = "https://github.com/petertdavies/ethereum-spec-evm-resolver#ed7dbce2e64c57812821d96297b6e0efc2967802" }
+source = { git = "https://github.com/petertdavies/ethereum-spec-evm-resolver#c68756230a27709e10426d5fbe4fa1b142a0b0ee" }
 dependencies = [
     { name = "coincurve" },
     { name = "filelock" },
@@ -645,6 +645,7 @@ dependencies = [
     { name = "platformdirs" },
     { name = "py-ecc" },
     { name = "pycryptodome" },
+    { name = "pydantic" },
     { name = "requests-unixsocket2" },
     { name = "typing-extensions" },
     { name = "urllib3" },


### PR DESCRIPTION
## 🗒️ Description
This PR aims to get a clean fill of `./tests/prague` as of `prague-devnet-4` specs with this EELS Prague fork: 
https://github.com/ethereum/execution-specs/tree/forks/prague

## 🔗 Related Issues
#943 

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] ~~Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth~~ See the eels_resolutions.json in the repository root.
