### PR TITLE
✨ feat(tests): PUSH*

### DIFF
--- a/converted-ethereum-tests.txt
+++ b/converted-ethereum-tests.txt
@@ -57,3 +57,6 @@ GeneralStateTests/Cancun/stEIP1153-transientStorage/16_tloadGas.json
 GeneralStateTests/Cancun/stEIP1153-transientStorage/18_tloadAfterStore.json
 
 GeneralStateTests/Cancun/stEIP1153-transientStorage/20_oogUndoesTransientStoreInCall.json
+
+([#975](https://github.com/ethereum/execution-spec-tests/pull/975))
+src/GeneralStateTestsFiller/VMTests/vmTests/pushFiller.yml

--- a/converted-ethereum-tests.txt
+++ b/converted-ethereum-tests.txt
@@ -59,4 +59,4 @@ GeneralStateTests/Cancun/stEIP1153-transientStorage/18_tloadAfterStore.json
 GeneralStateTests/Cancun/stEIP1153-transientStorage/20_oogUndoesTransientStoreInCall.json
 
 ([#975](https://github.com/ethereum/execution-spec-tests/pull/975))
-src/GeneralStateTestsFiller/VMTests/vmTests/pushFiller.yml
+GeneralStateTests/VMTests/vmTests/push.json

--- a/tests/frontier/opcodes/test_push.py
+++ b/tests/frontier/opcodes/test_push.py
@@ -1,0 +1,62 @@
+"""
+A State test for the set of `PUSH*` opcodes.
+Ported from: https://github.com/ethereum/tests/blob/4f65a0a7cbecf4442415c226c65e089acaaf6a8b/src/GeneralStateTestsFiller/VMTests/vmTests/pushFiller.yml # noqa: E501
+"""
+
+import pytest
+
+from ethereum_test_forks import Frontier, Homestead
+from ethereum_test_tools import Account, Alloc, Environment
+from ethereum_test_tools import Opcodes as Op
+from ethereum_test_tools import StateTestFiller, Transaction
+
+
+@pytest.mark.parametrize(
+    "push_opcode",
+    [getattr(Op, f"PUSH{i}") for i in range(1, 33)],  # Dynamically parametrize PUSH opcodes
+    ids=lambda op: str(op),
+)
+@pytest.mark.valid_from("Frontier")
+def test_push(state_test: StateTestFiller, fork: str, push_opcode: Op, pre: Alloc):
+    """
+    The set of `PUSH*` opcodes pushes data onto the stack.
+
+    In this test, we ensure that the set of `PUSH*` opcodes writes
+    a portion of an excerpt from the Ethereum yellow paper to
+    storage.
+    """
+    # Input used to test the `PUSH*` opcode.
+    ethereum_state_machine = b"Ethereum is as a transaction-based state machine."
+
+    # Determine the size of the data to be pushed by the `PUSH*` opcode,
+    # and trim the input to an appropriate excerpt.
+    input_size = int(str(push_opcode)[4:])
+    excerpt = ethereum_state_machine[0:input_size]
+
+    env = Environment()
+
+    """
+     **               Bytecode explanation              **
+     +---------------------------------------------------+
+     | Bytecode      | Stack        | Storage            |
+     |---------------------------------------------------|
+     | PUSH* excerpt | excerpt      |                    |
+     | PUSH1 0       | 0 excerpt    |                    |
+     | SSTORE        |              | [0]: excerpt       |
+     +---------------------------------------------------+
+    """
+
+    contract_code = push_opcode(excerpt) + Op.PUSH1(0) + Op.SSTORE
+    contract = pre.deploy_contract(contract_code)
+
+    tx = Transaction(
+        sender=pre.fund_eoa(),
+        to=contract,
+        gas_limit=500_000,
+        protected=False if fork in [Frontier, Homestead] else True,
+    )
+
+    post = {}
+    post[contract] = Account(storage={0: int.from_bytes(excerpt)})
+
+    state_test(env=env, pre=pre, post=post, tx=tx)

--- a/tests/frontier/opcodes/test_push.py
+++ b/tests/frontier/opcodes/test_push.py
@@ -57,6 +57,6 @@ def test_push(state_test: StateTestFiller, fork: str, push_opcode: Op, pre: Allo
     )
 
     post = {}
-    post[contract] = Account(storage={0: int.from_bytes(excerpt)})
+    post[contract] = Account(storage={0: int.from_bytes(excerpt, byteorder="big")})
 
     state_test(env=env, pre=pre, post=post, tx=tx)

--- a/tests/frontier/opcodes/test_push.py
+++ b/tests/frontier/opcodes/test_push.py
@@ -1,14 +1,13 @@
 """
 A State test for the set of `PUSH*` opcodes.
-Ported from: https://github.com/ethereum/tests/blob/4f65a0a7cbecf4442415c226c65e089acaaf6a8b/src/GeneralStateTestsFiller/VMTests/vmTests/pushFiller.yml # noqa: E501
-"""
+Ported from: https://github.com/ethereum/tests/blob/4f65a0a7cbecf4442415c226c65e089acaaf6a8b/src/GeneralStateTestsFiller/VMTests/vmTests/pushFiller.yml.
+"""  # noqa: E501
 
 import pytest
 
 from ethereum_test_forks import Frontier, Homestead
-from ethereum_test_tools import Account, Alloc, Environment
+from ethereum_test_tools import Account, Alloc, Environment, StateTestFiller, Transaction
 from ethereum_test_tools import Opcodes as Op
-from ethereum_test_tools import StateTestFiller, Transaction
 
 
 @pytest.mark.parametrize(
@@ -61,12 +60,11 @@ def test_push(state_test: StateTestFiller, fork: str, push_opcode: Op, pre: Allo
 
     state_test(env=env, pre=pre, post=post, tx=tx)
 
+
 @pytest.mark.parametrize("stack_height", range(1024, 1026))
 @pytest.mark.valid_from("Frontier")
 def test_stack_overflow(state_test: StateTestFiller, fork: str, pre: Alloc, stack_height: int):
-    """
-    A test to ensure that the stack overflows when the stack limit of 1024 is exceeded.
-    """
+    """A test to ensure that the stack overflows when the stack limit of 1024 is exceeded."""
     env = Environment()
 
     msg = b"hello"

--- a/tests/frontier/opcodes/test_push.py
+++ b/tests/frontier/opcodes/test_push.py
@@ -10,6 +10,17 @@ from ethereum_test_tools import Account, Alloc, Environment, StateTestFiller, Tr
 from ethereum_test_tools import Opcodes as Op
 
 
+def get_input_for_push_opcode(opcode: Op) -> bytes:
+    """
+    Get a sample input for the `PUSH*` opcode.
+
+    The input is a portion of an excerpt from the Ethereum yellow paper.
+    """
+    ethereum_state_machine = b"Ethereum is a transaction-based state machine."
+    input_size = opcode.data_portion_length
+    return ethereum_state_machine[0:input_size]
+
+
 @pytest.mark.parametrize(
     "push_opcode",
     [getattr(Op, f"PUSH{i}") for i in range(1, 33)],  # Dynamically parametrize PUSH opcodes
@@ -25,12 +36,7 @@ def test_push(state_test: StateTestFiller, fork: Fork, pre: Alloc, push_opcode: 
     storage.
     """
     # Input used to test the `PUSH*` opcode.
-    ethereum_state_machine = b"Ethereum is as a transaction-based state machine."
-
-    # Determine the size of the data to be pushed by the `PUSH*` opcode,
-    # and trim the input to an appropriate excerpt.
-    input_size = push_opcode.data_portion_length
-    excerpt = ethereum_state_machine[0:input_size]
+    excerpt = get_input_for_push_opcode(push_opcode)
 
     env = Environment()
 
@@ -75,12 +81,7 @@ def test_stack_overflow(
     env = Environment()
 
     # Input used to test the `PUSH*` opcode.
-    ethereum_state_machine = b"Ethereum is as a transaction-based state machine."
-
-    # Determine the size of the data to be pushed by the `PUSH*` opcode,
-    # and trim the input to an appropriate excerpt.
-    input_size = push_opcode.data_portion_length
-    excerpt = ethereum_state_machine[0:input_size]
+    excerpt = get_input_for_push_opcode(push_opcode)
 
     """
     Essentially write a n-byte message to storage by pushing [1024,1025] times to stack. This


### PR DESCRIPTION
## 🗒️ Description
Introduces tests for `PUSH*` opcodes ported from `ethereum/tests`.

## 🔗 Related Issues
closes #974 

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
