### PR TITLE
new(tests): EIP-7702: More delegation clearing tests

### DIFF
--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -3256,7 +3256,9 @@ def test_delegation_clearing_and_set(
 
     auth_signer = pre.fund_eoa(0, delegation=pre_set_delegation_address)
 
-    reset_code_address = pre.deploy_contract(Op.CALL(address=Spec.RESET_DELEGATION_ADDRESS))
+    reset_code_address = pre.deploy_contract(
+        Op.CALL(address=Spec.RESET_DELEGATION_ADDRESS) + Op.SSTORE(0, 1) + Op.STOP
+    )
 
     sender = pre.fund_eoa()
 
@@ -3287,7 +3289,9 @@ def test_delegation_clearing_and_set(
             auth_signer: Account(
                 nonce=auth_signer.nonce + 2,
                 code=Spec.delegation_designation(reset_code_address),
-                storage={},
+                storage={
+                    0: 1,
+                },
             ),
         },
     )


### PR DESCRIPTION
## 🗒️ Description
Tests:

- Sending the transaction directly to the account that is clearing its delegation
- Set the delegation again in the same transaction and call the zero address (check that it was not added to the access list)
- Check that the max call stack is respected when delegated accounts are being used

@lightclient 

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.