### PR TITLE
fix(tests): EIP-7702: Remove delegation behavior of EXTCODE*

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Update [EIP-6110](https://eips.ethereum.org/EIPS/eip-6110), [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002), [EIP-7251](https://eips.ethereum.org/EIPS/eip-7251), [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685), and [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) tests for Devnet-4 ([#832](https://github.com/ethereum/execution-spec-tests/pull/832))
 - ✨ [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) many delegations test ([#923](https://github.com/ethereum/execution-spec-tests/pull/923))
 - ✨ [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) set code of non-empty-storage account test ([#948](https://github.com/ethereum/execution-spec-tests/pull/948))
+- ✨ [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) Remove delegation behavior of EXTCODE* ([#984](https://github.com/ethereum/execution-spec-tests/pull/984))
 
 ### 🛠️ Framework
 

--- a/tests/prague/eip7702_set_code_tx/spec.py
+++ b/tests/prague/eip7702_set_code_tx/spec.py
@@ -30,7 +30,8 @@ class Spec:
     MAGIC = 0x05
     PER_AUTH_BASE_COST = 12_500
     PER_EMPTY_ACCOUNT_COST = 25_000
-    DELEGATION_DESIGNATION = bytes.fromhex("ef0100")
+    DELEGATION_DESIGNATION = Bytes("ef0100")
+    DELEGATION_DESIGNATION_READING = Bytes("ef01")
     RESET_DELEGATION_ADDRESS = Address(0)
 
     @staticmethod

--- a/tests/prague/eip7702_set_code_tx/test_gas.py
+++ b/tests/prague/eip7702_set_code_tx/test_gas.py
@@ -796,7 +796,7 @@ def test_account_warming(
     Test warming of the authority and authorized accounts for set-code transactions.
     """
     # Overhead cost is the single push operation required for the address to check.
-    OVERHEAD_COST = 3
+    OVERHEAD_COST = 3 * len(Op.CALL.kwargs)  # type: ignore
 
     COLD_ACCOUNT_COST = 2600
     WARM_ACCOUNT_COST = 100
@@ -891,7 +891,7 @@ def test_account_warming(
     callee_code: Bytecode = sum(  # type: ignore
         (
             CodeGasMeasure(
-                code=Op.EXTCODESIZE(check_address),
+                code=Op.CALL(gas=0, address=check_address),
                 overhead_cost=OVERHEAD_COST,
                 extra_stack_items=1,
                 sstore_key=callee_storage.store_next(access_cost),
@@ -994,10 +994,10 @@ def test_self_set_code_cost(
 
     slot_call_cost = 1
 
-    OVERHEAD_COST = 3
+    OVERHEAD_COST = 3 * len(Op.CALL.kwargs)  # type: ignore
 
     callee_code = CodeGasMeasure(
-        code=Op.EXTCODESIZE(address=auth_signer),
+        code=Op.CALL(gas=0, address=auth_signer),
         overhead_cost=OVERHEAD_COST,
         extra_stack_items=1,
         sstore_key=slot_call_cost,

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -40,7 +40,6 @@ from ethereum_test_tools import (
     add_kzg_version,
     call_return_code,
     compute_create_address,
-    keccak256,
 )
 from ethereum_test_tools.eof.v1 import Container, Section
 
@@ -1058,11 +1057,11 @@ def test_ext_code_on_set_code(
             raise ValueError(f"Unsupported set code type: {set_code_type}")
 
     callee_storage = Storage()
-    callee_storage[slot_ext_code_size_result] = len(set_code)
-    callee_storage[slot_ext_code_hash_result] = (
-        set_code.keccak256() if set_code_type != AddressType.EMPTY_ACCOUNT else 0
-    )
-    callee_storage[slot_ext_code_copy_result] = bytes(set_code).ljust(32, b"\x00")[:32]
+    callee_storage[slot_ext_code_size_result] = len(Spec.DELEGATION_DESIGNATION_READING)
+    callee_storage[slot_ext_code_hash_result] = Spec.DELEGATION_DESIGNATION_READING.keccak256()
+    callee_storage[slot_ext_code_copy_result] = Spec.DELEGATION_DESIGNATION_READING.ljust(
+        32, b"\x00"
+    )[:32]
     callee_storage[slot_ext_balance_result] = balance
 
     tx = Transaction(
@@ -1129,9 +1128,11 @@ def test_ext_code_on_self_set_code(
     set_code_address = pre.deploy_contract(set_code)
 
     set_code_storage = Storage()
-    set_code_storage[slot_ext_code_size_result] = len(set_code)
-    set_code_storage[slot_ext_code_hash_result] = set_code.keccak256()
-    set_code_storage[slot_ext_code_copy_result] = bytes(set_code).ljust(32, b"\x00")[:32]
+    set_code_storage[slot_ext_code_size_result] = len(Spec.DELEGATION_DESIGNATION_READING)
+    set_code_storage[slot_ext_code_hash_result] = Spec.DELEGATION_DESIGNATION_READING.keccak256()
+    set_code_storage[slot_ext_code_copy_result] = Spec.DELEGATION_DESIGNATION_READING.ljust(
+        32, b"\x00"
+    )[:32]
     set_code_storage[slot_ext_balance_result] = balance
 
     tx = Transaction(
@@ -1349,10 +1350,11 @@ def test_ext_code_on_self_delegating_set_code(
     callee_address = pre.deploy_contract(callee_code)
     callee_storage = Storage()
 
-    set_code = b"\xef\x01\x00" + bytes(auth_signer)
-    callee_storage[slot_ext_code_size_result] = len(set_code)
-    callee_storage[slot_ext_code_hash_result] = keccak256(set_code)
-    callee_storage[slot_ext_code_copy_result] = bytes(set_code).ljust(32, b"\x00")[:32]
+    callee_storage[slot_ext_code_size_result] = len(Spec.DELEGATION_DESIGNATION_READING)
+    callee_storage[slot_ext_code_hash_result] = Spec.DELEGATION_DESIGNATION_READING.keccak256()
+    callee_storage[slot_ext_code_copy_result] = Spec.DELEGATION_DESIGNATION_READING.ljust(
+        32, b"\x00"
+    )[:32]
     callee_storage[slot_ext_balance_result] = balance
 
     tx = Transaction(
@@ -1427,17 +1429,18 @@ def test_ext_code_on_chain_delegating_set_code(
     callee_address = pre.deploy_contract(callee_code)
     callee_storage = Storage()
 
-    set_code_1 = Spec.delegation_designation(auth_signer_2)
-    set_code_2 = Spec.delegation_designation(auth_signer_1)
-
-    callee_storage[slot_ext_code_size_result_1] = len(set_code_2)
-    callee_storage[slot_ext_code_hash_result_1] = set_code_2.keccak256()
-    callee_storage[slot_ext_code_copy_result_1] = bytes(set_code_2).ljust(32, b"\x00")[:32]
+    callee_storage[slot_ext_code_size_result_1] = len(Spec.DELEGATION_DESIGNATION_READING)
+    callee_storage[slot_ext_code_hash_result_1] = Spec.DELEGATION_DESIGNATION_READING.keccak256()
+    callee_storage[slot_ext_code_copy_result_1] = Spec.DELEGATION_DESIGNATION_READING.ljust(
+        32, b"\x00"
+    )[:32]
     callee_storage[slot_ext_balance_result_1] = auth_signer_1_balance
 
-    callee_storage[slot_ext_code_size_result_2] = len(set_code_1)
-    callee_storage[slot_ext_code_hash_result_2] = set_code_1.keccak256()
-    callee_storage[slot_ext_code_copy_result_2] = bytes(set_code_1).ljust(32, b"\x00")[:32]
+    callee_storage[slot_ext_code_size_result_2] = len(Spec.DELEGATION_DESIGNATION_READING)
+    callee_storage[slot_ext_code_hash_result_2] = Spec.DELEGATION_DESIGNATION_READING.keccak256()
+    callee_storage[slot_ext_code_copy_result_2] = Spec.DELEGATION_DESIGNATION_READING.ljust(
+        32, b"\x00"
+    )[:32]
     callee_storage[slot_ext_balance_result_2] = auth_signer_2_balance
 
     tx = Transaction(


### PR DESCRIPTION
## 🗒️ Description
Addresses changes in https://github.com/ethereum/EIPs/pull/8969

Requires https://github.com/ethereum/execution-specs/pull/1042

@petertdavies 

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.