### PR TITLE
new(tests): Blockhash at 255/256/257 (ethereum/execution-specs#374)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 ### 🧪 Test Cases
 
+- ✨ Opcode tests for BLOCKHASH at blocks 254/255/256 `tests/frontier/opcodes/test_chain_sync.py` includes an EOF test case ([#988](https://github.com/ethereum/execution-spec-tests/pull/988)).
 - ✨ EIP-4844 test `tests/cancun/eip4844_blobs/test_point_evaluation_precompile.py` includes an EOF test case ([#610](https://github.com/ethereum/execution-spec-tests/pull/610)).
 - ✨ Example test `tests/frontier/opcodes/test_dup.py` now includes EOF parametrization ([#610](https://github.com/ethereum/execution-spec-tests/pull/610)).
 - ✨ Convert all opcodes validation test `tests/frontier/opcodes/test_all_opcodes.py` ([#748](https://github.com/ethereum/execution-spec-tests/pull/748)).

--- a/tests/frontier/opcodes/test_chain_sync.py
+++ b/tests/frontier/opcodes/test_chain_sync.py
@@ -50,7 +50,7 @@ def test_blockhash(
         ),
     }
 
-    blockhash_transaction = Transaction(
+    tx = Transaction(
         ty=0x0,
         nonce=0,
         to=account,

--- a/tests/frontier/opcodes/test_chain_sync.py
+++ b/tests/frontier/opcodes/test_chain_sync.py
@@ -52,7 +52,6 @@ def test_blockhash(
 
     tx = Transaction(
         ty=0x0,
-        nonce=0,
         to=account,
         gas_limit=500000,
         gas_price=10,

--- a/tests/frontier/opcodes/test_chain_sync.py
+++ b/tests/frontier/opcodes/test_chain_sync.py
@@ -1,0 +1,70 @@
+"""
+abstract: Test the chain synchronization feature.
+    Ensure that the chain synchronization feature accurately validates the transaction chain
+"""
+
+import pytest
+
+from ethereum_test_forks import Frontier, Homestead
+from ethereum_test_tools import Account, Alloc, Block, BlockchainTestFiller, Environment
+from ethereum_test_tools import Opcodes as Op
+from ethereum_test_tools import Transaction
+
+
+@pytest.mark.parametrize(
+    "offset,expected",
+    [
+        (254, 0x59E4655F093809C72B7655D2C4E17A29E1AFC868D50D074AE33FAE4FF7F45B57),
+        (255, 0x3B37DF5B367774496FEB057125414B8B02C6A16BE37C5CFEE48F6EA310476895),
+        (256, 0xCA4B3DF81146433C8B710608B2AE7D59CB949F721D87DDBA579339E9452188F1),
+        (257, 0x0),
+    ],
+)
+@pytest.mark.with_all_evm_code_types
+@pytest.mark.valid_from("Frontier")
+@pytest.mark.valid_until(
+    "Frontier"
+)  # Can only do one right now because of how hashes change between forks
+def test_blockhash(
+    offset: int, expected: int, blockchain_test: BlockchainTestFiller, fork: str, pre: Alloc
+):
+    """
+    Tests the BLOCKHASH opcode when the blocks are in extreme positions near the limit of the chain
+
+    Note: Hardcoded blockhashes to get us started. Will look for a better
+    way of doing this in future
+    """
+    env = Environment()
+    sender = pre.fund_eoa()
+    blockhash_code = Op.SSTORE(
+        0,
+        Op.BLOCKHASH(Op.SUB(Op.NUMBER, offset)),
+    )
+    generated_blocks = [Block() for _ in range(offset - 1)]
+
+    # Deploy the contract to the chain (to be called later)
+    account = pre.deploy_contract(blockhash_code)
+    post = {
+        account: Account(
+            storage={"0x0": expected},
+        ),
+    }
+
+    blockhash_transaction = Transaction(
+        ty=0x0,
+        nonce=0,
+        to=account,
+        gas_limit=500000,
+        gas_price=10,
+        protected=fork not in [Frontier, Homestead],
+        sender=sender,
+    )
+
+    blockhash_block = Block(txs=[blockhash_transaction])
+
+    blockchain_test(
+        env=env,
+        pre=pre,
+        post=post,
+        blocks=generated_blocks + [blockhash_block],
+    )

--- a/tests/frontier/opcodes/test_chain_sync.py
+++ b/tests/frontier/opcodes/test_chain_sync.py
@@ -59,7 +59,7 @@ def test_blockhash(
         sender=sender,
     )
 
-    blockhash_block = Block(txs=[blockhash_transaction])
+    blockhash_block = Block(txs=[tx])
 
     blockchain_test(
         env=env,

--- a/tests/frontier/opcodes/test_chain_sync.py
+++ b/tests/frontier/opcodes/test_chain_sync.py
@@ -5,18 +5,23 @@ abstract: Test the chain synchronization feature.
 
 import pytest
 
-from ethereum_test_forks import Frontier, Homestead
-from ethereum_test_tools import Account, Alloc, Block, BlockchainTestFiller, Environment
-from ethereum_test_tools import Opcodes as Op
-from ethereum_test_tools import Transaction
+from ethereum_test_base_types import Account
+from ethereum_test_forks.forks.forks import Frontier, Homestead
+from ethereum_test_specs.blockchain import Block, BlockchainTestFiller, Environment, Transaction
+from ethereum_test_types.types import Alloc
+from ethereum_test_vm import Opcodes as Op
+
+EXPECTED_BH_254 = 0x59E4655F093809C72B7655D2C4E17A29E1AFC868D50D074AE33FAE4FF7F45B57
+EXPECTED_BH_255 = 0x3B37DF5B367774496FEB057125414B8B02C6A16BE37C5CFEE48F6EA310476895
+EXPECTED_BH256 = 0xCA4B3DF81146433C8B710608B2AE7D59CB949F721D87DDBA579339E9452188F1
 
 
 @pytest.mark.parametrize(
     "offset,expected",
     [
-        (254, 0x59E4655F093809C72B7655D2C4E17A29E1AFC868D50D074AE33FAE4FF7F45B57),
-        (255, 0x3B37DF5B367774496FEB057125414B8B02C6A16BE37C5CFEE48F6EA310476895),
-        (256, 0xCA4B3DF81146433C8B710608B2AE7D59CB949F721D87DDBA579339E9452188F1),
+        (254, EXPECTED_BH_254),
+        (255, EXPECTED_BH_255),
+        (256, EXPECTED_BH256),
         (257, 0x0),
     ],
 )


### PR DESCRIPTION
## 🗒️ Description
This adds tests designed to test the BLOCKHASH opcode for when there are 255, 256, and 257 blocks in the chain.

Filled with https://github.com/ethereum/execution-specs#9b95554a88d2a8485f8180254d0f6a493a593fda

## 🔗 Related Issues
This is actually issue (ethereum/execution-specs#374) in the execution-specs 

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.

I will add the CHANGELOG update before this gets merged after review.

Do I need to update the docs in the codebase for this one too?