### PR TITLE
fix(ci): use local eels

### DIFF
--- a/.github/configs/eels_resolutions.json
+++ b/.github/configs/eels_resolutions.json
@@ -1,0 +1,36 @@
+{
+    "EELSMaster": {
+        "git_url": "https://github.com/ethereum/execution-specs.git",
+        "branch": "master"
+    },
+    "Frontier": {
+        "path": "../../execution-specs/src/ethereum/frontier"
+    },
+    "Homestead": {
+        "path": "../../execution-specs/src/ethereum/homestead"
+    },
+    "Byzantium": {
+        "path": "../../execution-specs/src/ethereum/byzantium"
+    },
+    "ConstantinopleFix": {
+        "path": "../../execution-specs/src/ethereum/constantinople"
+    },
+    "Istanbul": {
+        "path": "../../execution-specs/src/ethereum/istanbul"
+    },
+    "Berlin": {
+        "path": "../../execution-specs/src/ethereum/berlin"
+    },
+    "London": {
+        "path": "../../execution-specs/src/ethereum/london"
+    },
+    "Paris": {
+        "path": "../../execution-specs/src/ethereum/paris"
+    },
+    "Shanghai": {
+        "path": "../../execution-specs/src/ethereum/shanghai"
+    },
+    "Cancun": {
+        "path": "../../execution-specs/src/ethereum/cancun"
+    }
+}

--- a/.github/workflows/tox_verify.yaml
+++ b/.github/workflows/tox_verify.yaml
@@ -34,6 +34,15 @@ jobs:
     steps:
       - name: Checkout ethereum/execution-spec-tests
         uses: actions/checkout@v4
+      - name: Checkout ethereum/execution-specs
+        uses: actions/checkout@v4
+        with:
+          repository: ethereum/execution-specs
+          ref: 9b95554a88d2a8485f8180254d0f6a493a593fda
+          path: execution-specs
+          sparse-checkout: |
+            src/ethereum
+          fetch-depth: 1
       - uses: ./.github/actions/build-evm-base
         id: evm-builder
         with:
@@ -53,6 +62,8 @@ jobs:
           # Add additional packages on 3.11: https://github.com/ethereum/execution-spec-tests/issues/274
           if [ ${{ matrix.python }} == '3.11' ]; then brew install autoconf automake libtool; fi
       - name: Run Tox (CPython)
+        env:
+          EELS_RESOLUTIONS_FILE: ${{ github.workspace }}/.github/configs/eels_resolutions.json
         run: ${{ matrix.tox-cmd }}
       - uses: DavidAnson/markdownlint-cli2-action@v16
         with:

--- a/.github/workflows/tox_verify.yaml
+++ b/.github/workflows/tox_verify.yaml
@@ -32,9 +32,8 @@ jobs:
             evm-type: "stable"
             tox-cmd: "uvx --with=tox-uv tox"  # run-parallel --parallel-no-spinner"
     steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
+      - name: Checkout ethereum/execution-spec-tests
+        uses: actions/checkout@v4
       - uses: ./.github/actions/build-evm-base
         id: evm-builder
         with:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -75,6 +75,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - 🔀 Move pytest plugin `pytest_plugins.filler.solc` to `pytest_plugins.solc.solc` ([#823](https://github.com/ethereum/execution-spec-tests/pull/823)).
 - 🐞 Asserts that the deploy docs tags workflow is only triggered for full releases ([#857](https://github.com/ethereum/execution-spec-tests/pull/857)).
 - ✨ A new application-wide configuration manager provides access to environment and application configurations. ([#892](https://github.com/ethereum/execution-spec-tests/pull/892)).
+- 🐞 Use a local version of ethereum/execution-specs (EELS) when running the framework tests in CI ([#997](https://github.com/ethereum/execution-spec-tests/pull/997)).
 
 ### 💥 Breaking Change
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,10 @@ wheel_build_env = .pkg
 [testenv:framework]
 description = Run checks on helper libraries and test framework
 
+setenv =
+    # Only use EELS_RESOLUTIONS_FILE if it is set in the environment (eg, in CI)
+    EELS_RESOLUTIONS_FILE = {env:EELS_RESOLUTIONS_FILE:}
+
 extras =
     test
     lint


### PR DESCRIPTION
## 🗒️ Description
This PR proposes an alternative to #995 to fix the current CI fails running the framework tests:
- `tox_verify` checks out ethereum/execution-specs.
- Added `.github/configs/eels_resolutions.json` which resolves forks to this local clone.
- `tox_verify` sets the `EELS_RESOLUTIONS_FILE` env var to `<WORKSPACE>/.github/configs/eels_resolutions.json`
- `tox.ini` uses the `EELS_RESOLUTIONS_FILE` env var (**(only) in the `framework` testenv**) if it has been set.

Improvements:
- It'd be nice to provide the ref as a config and use it for local, user runs, via the resolver too. If this is the preferred approach, I would do this in a follow-up PR.

### Verifying the EELS resolution file
![image](https://github.com/user-attachments/assets/2e660645-58da-491b-aa57-cf095451a4b5)

## 🔗 Related Issues
#995.

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.

