### PR TITLE
chore(ci): update for `pectra-devnet-5`

### DIFF
--- a/.github/configs/evm.yaml
+++ b/.github/configs/evm.yaml
@@ -11,11 +11,7 @@ eip7692:
   repo: ethereum/evmone
   ref: master
   targets: ["evmone-t8n", "evmone-eofparse"]
-pectra-devnet-3:
-  impl: ethjs
-  repo: ethereumjs/ethereumjs-monorepo
-  ref: t8ntool
-pectra-devnet-4:
-  impl: ethjs
-  repo: ethereumjs/ethereumjs-monorepo
-  ref: 7702-devnet-4-plus-t8ntool
+pectra-devnet-5:
+  impl: eels
+  repo: null
+  ref: null  

--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -17,5 +17,5 @@ eip7692:
   eofwrap: true
 pectra-devnet-5:
   evm-type: pectra-devnet-5
-  fill-params: --fork=Prague -m "not slow and not eip_version_check" ./tests/prague/
+  fill-params: --fork=Prague -m "not eip_version_check"
   solc: 0.8.21

--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -15,11 +15,7 @@ eip7692:
   fill-params: --fork=Osaka ./tests/osaka
   solc: 0.8.21
   eofwrap: true
-pectra-devnet-3:
-  evm-type: pectra-devnet-3
-  fill-params: --fork=Prague -m "not slow" ./tests/prague/
-  solc: 0.8.21
-pectra-devnet-4:
-  evm-type: pectra-devnet-4
+pectra-devnet-5:
+  evm-type: pectra-devnet-5
   fill-params: --fork=Prague -m "not slow and not eip_version_check" ./tests/prague/
   solc: 0.8.21

--- a/eels_resolutions.json
+++ b/eels_resolutions.json
@@ -35,8 +35,7 @@
         "same_as": "EELSMaster"
     },
     "Prague": {
-        "git_url": "https://github.com/spencer-tb/execution-specs.git",
-        "branch": "forks/prague",
-        "commit": "51f5476045500bcb2e902cdf8fc4b6ee3f90a0fc"
+        "git_url": "https://github.com/ethereum/execution-specs.git",
+        "branch": "devnets/prague/5",
     }
 }

--- a/eels_resolutions.json
+++ b/eels_resolutions.json
@@ -35,8 +35,8 @@
         "same_as": "EELSMaster"
     },
     "Prague": {
-        "git_url": "https://github.com/ethereum/execution-specs.git",
+        "git_url": "https://github.com/spencer-tb/execution-specs.git",
         "branch": "forks/prague",
-        "commit": "1ea4a8d30d68bb819e77ff52eeb2095ae3c67f5f"
+        "commit": "51f5476045500bcb2e902cdf8fc4b6ee3f90a0fc"
     }
 }

--- a/eels_resolutions.json
+++ b/eels_resolutions.json
@@ -36,6 +36,6 @@
     },
     "Prague": {
         "git_url": "https://github.com/ethereum/execution-specs.git",
-        "branch": "devnets/prague/5",
+        "branch": "devnets/prague/5"
     }
 }


### PR DESCRIPTION
## 🗒️ Description
Add EELS as the filler for any `pectra-devnet-5` release.

Removes the `pectra-devnet-3`/`pectra-devnet-4` evm release candidates.

## 🔗 Related Issues
N/A

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.