### PR TITLE
fix(docs): fix link to installation troubleshooting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ uv sync --all-extras
 uv run solc-select use 0.8.24 --always-install
 ```
 
-See [Installation Troubleshooting](./installation_troubleshooting.md) in the online docs if you encounter issues.
+See [Installation Troubleshooting](https://ethereum.github.io/execution-spec-tests/main/getting_started/installation_troubleshooting/) in the online docs if you encounter issues.
 
 ### Exploring and Filling Test Cases
 


### PR DESCRIPTION
## 🗒️ Description
`README.md` had one working link and one broken link to the `installation_troubleshooting` page. This sets the broken one to match the working one.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
