### PR TITLE
 fix(eof): eofwrap.py to respect original genesis env

### DIFF
--- a/src/cli/eofwrap.py
+++ b/src/cli/eofwrap.py
@@ -232,7 +232,14 @@ class EofWrapper:
         return short
 
     def _wrap_fixture(self, fixture: BlockchainFixture, traces: bool):
-        env = Environment()
+        env = Environment(
+            difficulty=fixture.genesis.difficulty,
+            gas_limit=fixture.genesis.gas_limit,
+            base_fee_per_gas=fixture.genesis.base_fee_per_gas,
+            blob_gas_used=fixture.genesis.blob_gas_used,
+            excess_blob_gas=fixture.genesis.excess_blob_gas,
+            parent_beacon_block_root=fixture.genesis.parent_beacon_block_root,
+        )
 
         pre = fixture.pre
 

--- a/tests/cancun/eip4844_blobs/test_excess_blob_gas.py
+++ b/tests/cancun/eip4844_blobs/test_excess_blob_gas.py
@@ -457,9 +457,9 @@ def all_invalid_blob_gas_used_combinations() -> Iterator[Tuple[int, int]]:
     Returns all invalid blob gas used combinations.
     """
     for new_blobs in range(0, SpecHelpers.max_blobs_per_block() + 1):
-        for header_blob_gas_used in range(0, SpecHelpers.max_blobs_per_block() + 1):
-            if new_blobs != header_blob_gas_used:
-                yield (new_blobs, header_blob_gas_used * Spec.GAS_PER_BLOB)
+        for header_blobs in range(0, SpecHelpers.max_blobs_per_block() + 1):
+            if new_blobs != header_blobs:
+                yield (new_blobs, header_blobs * Spec.GAS_PER_BLOB)
         yield (new_blobs, 2**64 - 1)
 
 


### PR DESCRIPTION
## 🗒️ Description

Credit to @jochem-brouwer for reporting this, `eofwrap.py` hasn't been respecting some genesis block values from the input test to wrap, now this should be fixed.

Also smuggling an unrelated nitpick to variable naming which caught me off guard for a second

## 🔗 Related Issues

NA

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
