### PR TITLE
fix(tests): Fix `test_all_opcodes.py`

### DIFF
--- a/tests/frontier/opcodes/test_all_opcodes.py
+++ b/tests/frontier/opcodes/test_all_opcodes.py
@@ -99,7 +99,7 @@ def test_cover_revert(state_test: StateTestFiller, pre: Alloc):
     tx = Transaction(
         sender=pre.fund_eoa(),
         gas_limit=1_000_000,
-        data=Op.SSTORE(1, 1) + Op.REVERT,
+        data=Op.SSTORE(1, 1) + Op.REVERT(0, 0),
         to=None,
         value=0,
         protected=False,

--- a/tests/frontier/opcodes/test_all_opcodes.py
+++ b/tests/frontier/opcodes/test_all_opcodes.py
@@ -100,7 +100,7 @@ def test_cover_revert(state_test: StateTestFiller, pre: Alloc):
         sender=pre.fund_eoa(),
         gas_limit=1_000_000,
         data=Op.SSTORE(1, 1) + Op.REVERT,
-        to=b"",
+        to=None,
         value=0,
         protected=False,
     )


### PR DESCRIPTION
## 🗒️ Description
Fixes a test broken by #933.

Contract creating transactions should be defined as `to=None` and not `to=b""`.

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.