### PR TITLE
chore: try to reproduce 'label empty or too long' on macOS

### DIFF
--- a/.github/workflows/tox_verify.yaml
+++ b/.github/workflows/tox_verify.yaml
@@ -28,7 +28,7 @@ jobs:
           #   evm-type: 'eip7692'
           #   tox-cmd: 'tox -e tests-eip7692'
           - os: macos-latest
-            python: "3.11"
+            python: "3.10"
             evm-type: "stable"
             tox-cmd: "uvx --with=tox-uv tox"  # run-parallel --parallel-no-spinner"
     steps:

--- a/.github/workflows/tox_verify.yaml
+++ b/.github/workflows/tox_verify.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: Setup Tools/Dependencies macOS
         if: runner.os == 'macOS'
         run: |
-          sudo scutil --set HostName $(head -c 255 < /dev/zero | tr '\0' 'a')
+          sudo scutil --set HostName .bar-localhost
           hostname
           brew install aspell
           # Add additional packages on 3.11: https://github.com/ethereum/execution-spec-tests/issues/274

--- a/.github/workflows/tox_verify.yaml
+++ b/.github/workflows/tox_verify.yaml
@@ -58,6 +58,7 @@ jobs:
       - name: Setup Tools/Dependencies macOS
         if: runner.os == 'macOS'
         run: |
+          sudo scutil --set HostName $(head -c 65 < /dev/zero | tr '\0' 'a')
           brew install aspell
           # Add additional packages on 3.11: https://github.com/ethereum/execution-spec-tests/issues/274
           if [ ${{ matrix.python }} == '3.11' ]; then brew install autoconf automake libtool; fi

--- a/.github/workflows/tox_verify.yaml
+++ b/.github/workflows/tox_verify.yaml
@@ -58,7 +58,8 @@ jobs:
       - name: Setup Tools/Dependencies macOS
         if: runner.os == 'macOS'
         run: |
-          sudo scutil --set HostName $(head -c 65 < /dev/zero | tr '\0' 'a')
+          sudo scutil --set HostName $(head -c 255 < /dev/zero | tr '\0' 'a')
+          hostname
           brew install aspell
           # Add additional packages on 3.11: https://github.com/ethereum/execution-spec-tests/issues/274
           if [ ${{ matrix.python }} == '3.11' ]; then brew install autoconf automake libtool; fi


### PR DESCRIPTION
## 🗒️ Description
WIP

## 🔗 Related Issues
None

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
