### PR TITLE
🧹 chore(ci): Remove duplicate step from Run Tox Verifications worflow

### DIFF
--- a/.github/workflows/tox_verify.yaml
+++ b/.github/workflows/tox_verify.yaml
@@ -32,8 +32,6 @@ jobs:
             evm-type: "stable"
             tox-cmd: "uvx --with=tox-uv tox"  # run-parallel --parallel-no-spinner"
     steps:
-      - name: Checkout ethereum/execution-spec-tests
-        uses: actions/checkout@v4
       - name: Checkout ethereum/execution-specs
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## 🗒️ Description
This PR removes a duplicate step from a CI workflow.

## 🔗 Related Issues
#1013 

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
