### PR TITLE
✨ feat(tests): PUSH opcode tests added

### DIFF
--- a/tests/frontier/opcodes/test_push.py
+++ b/tests/frontier/opcodes/test_push.py
@@ -1,0 +1,124 @@
+"""
+abstract: Test PUSH
+    Test the PUSH opcodes.
+
+"""
+
+import pytest
+
+from ethereum_test_forks import Frontier, Homestead
+from ethereum_test_tools import Account, Alloc, Environment
+from ethereum_test_tools import Opcodes as Op
+from ethereum_test_tools import StateTestFiller, Storage, Transaction
+
+
+@pytest.mark.parametrize(
+    "push_opcode",
+    [
+        Op.PUSH0,
+        Op.PUSH1,
+        Op.PUSH2,
+        Op.PUSH3,
+        Op.PUSH4,
+        Op.PUSH5,
+        Op.PUSH6,
+        Op.PUSH7,
+        Op.PUSH8,
+        Op.PUSH9,
+        Op.PUSH10,
+        Op.PUSH11,
+        Op.PUSH12,
+        Op.PUSH13,
+        Op.PUSH14,
+        Op.PUSH15,
+        Op.PUSH16,
+        Op.PUSH17,
+        Op.PUSH18,
+        Op.PUSH19,
+        Op.PUSH20,
+        Op.PUSH21,
+        Op.PUSH22,
+        Op.PUSH23,
+        Op.PUSH24,
+        Op.PUSH25,
+        Op.PUSH26,
+        Op.PUSH27,
+        Op.PUSH28,
+        Op.PUSH29,
+        Op.PUSH30,
+        Op.PUSH31,
+        Op.PUSH32,
+    ],
+    ids=lambda op: str(op),
+)
+@pytest.mark.with_all_evm_code_types
+def test_push(
+    state_test: StateTestFiller,
+    fork: str,
+    push_opcode: Op,
+    pre: Alloc,
+):
+    """
+    Test the PUSH0-PUSH32 opcodes.
+    """
+
+    env = Environment()
+    sender = pre.fund_eoa()
+    post = {}
+
+    # 0x5F is PUSH0, so from the current opcode's int we can derive which iteration we are in
+    #    PUSH0  = iteration 0
+    #    PUSH1  = iteration 1
+    #    ...
+    #    PUSH32 = iteration 32
+    current_iter = (
+        push_opcode.int() - 0x5F
+    )  # also equal to the amount of bytes required to store value chosen in current iteration
+
+    account_code = b"".join(
+        # first pushX (X changes each iteration) a value, then push1 key=1, then sstore
+        [
+            bytes([push_opcode.int()]),
+            values[current_iter].to_bytes(current_iter, byteorder="big"),
+            bytes([Op.PUSH1.int()]),
+            bytes([0x01]),
+            bytes([Op.SSTORE.int()]),
+        ]
+    )
+
+    account = pre.deploy_contract(account_code)
+
+    tx = Transaction(
+        ty=0x0,
+        nonce=0,
+        to=account,
+        gas_limit=500000,
+        gas_price=10,
+        protected=False if fork in [Frontier, Homestead] else True,
+        data="",
+        sender=sender,
+    )
+
+    s: Storage.StorageDictType = {1: values[current_iter]}
+
+    post[account] = Account(storage=s)
+
+    state_test(env=env, pre=pre, post=post, tx=tx)
+
+
+def get_largest_value_that_requires_at_least_x_bytes(bytes_required):
+    """Returns the largest value that can be stored with the specified amount of bytes
+
+    Args:
+        bytes_required (int): Amount of bytes that are available
+
+    Returns:
+        int: Largest  possible value that can be stored with specified amount of bytes
+    """
+    if bytes_required > 0:
+        return (2 ** (8 * bytes_required)) - 1
+
+
+# in global scope so that it doesn't get re-created every iteration
+# generate list of values that require x bytes, x+1 bytes, etc. to store
+values = [0] + [get_largest_value_that_requires_at_least_x_bytes(i) for i in range(1, 33)]

--- a/tests/frontier/opcodes/test_push.py
+++ b/tests/frontier/opcodes/test_push.py
@@ -14,41 +14,7 @@ from ethereum_test_tools import StateTestFiller, Storage, Transaction
 
 @pytest.mark.parametrize(
     "push_opcode",
-    [
-        Op.PUSH0,
-        Op.PUSH1,
-        Op.PUSH2,
-        Op.PUSH3,
-        Op.PUSH4,
-        Op.PUSH5,
-        Op.PUSH6,
-        Op.PUSH7,
-        Op.PUSH8,
-        Op.PUSH9,
-        Op.PUSH10,
-        Op.PUSH11,
-        Op.PUSH12,
-        Op.PUSH13,
-        Op.PUSH14,
-        Op.PUSH15,
-        Op.PUSH16,
-        Op.PUSH17,
-        Op.PUSH18,
-        Op.PUSH19,
-        Op.PUSH20,
-        Op.PUSH21,
-        Op.PUSH22,
-        Op.PUSH23,
-        Op.PUSH24,
-        Op.PUSH25,
-        Op.PUSH26,
-        Op.PUSH27,
-        Op.PUSH28,
-        Op.PUSH29,
-        Op.PUSH30,
-        Op.PUSH31,
-        Op.PUSH32,
-    ],
+    [getattr(Op, f"PUSH{i}") for i in range(0, 33)],
     ids=lambda op: str(op),
 )
 @pytest.mark.with_all_evm_code_types
@@ -57,6 +23,7 @@ def test_push(
     fork: str,
     push_opcode: Op,
     pre: Alloc,
+    get_number_list,
 ):
     """
     Test the PUSH0-PUSH32 opcodes.
@@ -65,6 +32,8 @@ def test_push(
     env = Environment()
     sender = pre.fund_eoa()
     post = {}
+
+    values = get_number_list
 
     # 0x5F is PUSH0, so from the current opcode's int we can derive which iteration we are in
     #    PUSH0  = iteration 0
@@ -119,6 +88,7 @@ def get_largest_value_that_requires_at_least_x_bytes(bytes_required):
         return (2 ** (8 * bytes_required)) - 1
 
 
-# in global scope so that it doesn't get re-created every iteration
-# generate list of values that require x bytes, x+1 bytes, etc. to store
-values = [0] + [get_largest_value_that_requires_at_least_x_bytes(i) for i in range(1, 33)]
+@pytest.fixture(scope="module")
+def get_number_list():
+    """Returns a list consisting of values that take an increasing amount of bytes to be stored"""
+    return [0] + [get_largest_value_that_requires_at_least_x_bytes(i) for i in range(1, 33)]


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
hi, this is my first PR for this repo. please let me know if the tests are faulty or not useful. 

i still have a few questions:
1. i ran `fill --fork=Cancun ./tests/frontier/opcodes/test_push.py` to get 99 passed. However, it also says 'No tests executed - the test fixtures in "fixtures/" may now be executed against a client'. How can I do this?
2. i wanted to include 'negative tests' (e.g. PUSH4 value that requires more than 4 bytes) to see that it correctly fails, but I didn't know how to signal this in this Python script. I would also then have to somehow programmatically specify which failure reason is the 'correct' one. LMK if this is possible

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->
Fixes #972 

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
