### PR TITLE
feat(fw,tests): Remove EIP-7742 from Prague, Add EIP-7691 and EIP-7762

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -61,6 +61,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Add framework changes for EIP-7742, required for Prague devnet-5 ([#931](https://github.com/ethereum/execution-spec-tests/pull/931)).
 - ✨ Add the `eest make env` command that generates a default env file (`env.yaml`)([#996](https://github.com/ethereum/execution-spec-tests/pull/996)).
 - ✨ Generate Transaction Test type ([#933](https://github.com/ethereum/execution-spec-tests/pull/933)).
+- ✨ Disable EIP-7742 framework changes for Pectra ([#NNN](https://github.com/ethereum/execution-spec-tests/pull/NNN)).
 
 ### 🔧 EVM Tools
 

--- a/docs/writing_tests/test_markers.md
+++ b/docs/writing_tests/test_markers.md
@@ -276,6 +276,7 @@ In this example, the test will be skipped if `tx_type` is equal to 1 by returnin
 Custom fork covariant markers can be created by using the `fork_covariant_parametrize` decorator.
 
 This decorator takes three arguments:
+
 - `parameter_names`: A list of parameter names that will be parametrized using the custom function.
 - `fn`: A function that takes the fork as parameter and returns a list of values that will be used to parametrize the test.
 - `marks`: A marker, list of markers, or a lambda function that can be used to add additional markers to the test.

--- a/docs/writing_tests/test_markers.md
+++ b/docs/writing_tests/test_markers.md
@@ -271,6 +271,34 @@ def test_something_with_all_tx_types_but_skip_type_1(state_test_only, tx_type):
 
 In this example, the test will be skipped if `tx_type` is equal to 1 by returning a `pytest.mark.skip` marker, and return `None` otherwise.
 
+## Custom Fork Covariant Markers
+
+Custom fork covariant markers can be created by using the `fork_covariant_parametrize` decorator.
+
+This decorator takes three arguments:
+- `parameter_names`: A list of parameter names that will be parametrized using the custom function.
+- `fn`: A function that takes the fork as parameter and returns a list of values that will be used to parametrize the test.
+- `marks`: A marker, list of markers, or a lambda function that can be used to add additional markers to the test.
+
+```python
+import pytest
+
+from pytest_plugins import fork_covariant_parametrize
+
+def covariant_function(fork):
+    return [[1, 2], [3, 4]] if fork.name() == "Paris" else [[4, 5], [5, 6], [6, 7]]
+
+@fork_covariant_parametrize(parameter_names=[
+    "test_parameter", "test_parameter_2"
+], fn=covariant_function)
+@pytest.mark.valid_from("Paris")
+@pytest.mark.valid_until("Shanghai")
+def test_case(state_test_only, test_parameter, test_parameter_2):
+    pass
+```
+
+In this example, the test will be parametrized with the values `[1, 2]` and `[3, 4]` for the Paris fork, with values `1` and `3` being assigned to `test_parameter` and `2` and `4` being assigned to `test_parameter_2`. For the Shanghai fork, the test will be parametrized with the values `[4, 5]`, `[5, 6]`, and `[6, 7]`. Therefore, more test cases will be generated for the Shanghai fork.
+
 ## Fill/Execute Markers
 
 These markers are used to apply different markers to a test depending on whether it is being filled or executed.

--- a/docs/writing_tests/test_markers.md
+++ b/docs/writing_tests/test_markers.md
@@ -300,6 +300,10 @@ def test_case(state_test_only, test_parameter, test_parameter_2):
 
 In this example, the test will be parametrized with the values `[1, 2]` and `[3, 4]` for the Paris fork, with values `1` and `3` being assigned to `test_parameter` and `2` and `4` being assigned to `test_parameter_2`. For the Shanghai fork, the test will be parametrized with the values `[4, 5]`, `[5, 6]`, and `[6, 7]`. Therefore, more test cases will be generated for the Shanghai fork.
 
+If the parameters that are being parametrized is only a single parameter, the return value of `fn` should be a list of values for that parameter.
+
+If the parameters that are being parametrized are multiple, the return value of `fn` should be a list of tuples/lists, where each tuple contains the values for each parameter.
+
 ## Fill/Execute Markers
 
 These markers are used to apply different markers to a test depending on whether it is being filled or executed.

--- a/docs/writing_tests/test_markers.md
+++ b/docs/writing_tests/test_markers.md
@@ -304,6 +304,8 @@ If the parameters that are being parametrized is only a single parameter, the re
 
 If the parameters that are being parametrized are multiple, the return value of `fn` should be a list of tuples/lists, where each tuple contains the values for each parameter.
 
+The function can also return a list of `pytest.param` objects, which allows for additional markers and test IDs to be added to the test.
+
 ## Fill/Execute Markers
 
 These markers are used to apply different markers to a test depending on whether it is being filled or executed.

--- a/src/ethereum_test_fixtures/blockchain.py
+++ b/src/ethereum_test_fixtures/blockchain.py
@@ -247,7 +247,6 @@ EngineNewPayloadV4Parameters = Tuple[
     List[Hash],
     Hash,
     List[Bytes],
-    HexNumber,
 ]
 
 # Important: We check EngineNewPayloadV3Parameters first as it has more fields, and pydantic

--- a/src/ethereum_test_fixtures/tests/test_blockchain.py
+++ b/src/ethereum_test_fixtures/tests/test_blockchain.py
@@ -16,7 +16,6 @@ from ethereum_test_base_types import (
     Bytes,
     Hash,
     HeaderNonce,
-    HexNumber,
     TestPrivateKey,
     ZeroPaddedHexNumber,
     to_json,
@@ -669,7 +668,6 @@ fixture_header_ones = FixtureHeader(
                     excess_blob_gas=18,
                     parent_beacon_block_root=19,
                     requests_hash=20,
-                    target_blobs_per_block=21,
                 ),
                 transactions=[
                     Transaction(
@@ -731,7 +729,7 @@ fixture_header_ones = FixtureHeader(
                         "blobGasUsed": hex(17),
                         "excessBlobGas": hex(18),
                         "blockHash": (
-                            "0x9f6459fb2eca2b75ee861e97d679ba91457bb446c8484a7ad76d1675a7f78fde"
+                            "0x93bd662d8a80a1f54bffc6d140b83d6cda233209998809f9540be51178b4d0b6"
                         ),
                         "transactions": [
                             Transaction(
@@ -789,9 +787,8 @@ fixture_header_ones = FixtureHeader(
                             ),
                         ).requests_list
                     ],
-                    HexNumber(21).hex(),
                 ],
-                "forkchoiceUpdatedVersion": "4",
+                "forkchoiceUpdatedVersion": "3",
                 "newPayloadVersion": "4",
                 "validationError": "BlockException.INCORRECT_BLOCK_FORMAT"
                 "|TransactionException.INTRINSIC_GAS_TOO_LOW",
@@ -826,7 +823,6 @@ fixture_header_ones = FixtureHeader(
                     excess_blob_gas=18,
                     parent_beacon_block_root=19,
                     requests_hash=20,
-                    target_blobs_per_block=21,
                 ),
                 transactions=[
                     Transaction(
@@ -887,7 +883,7 @@ fixture_header_ones = FixtureHeader(
                         "blobGasUsed": hex(17),
                         "excessBlobGas": hex(18),
                         "blockHash": (
-                            "0x9f6459fb2eca2b75ee861e97d679ba91457bb446c8484a7ad76d1675a7f78fde"
+                            "0x93bd662d8a80a1f54bffc6d140b83d6cda233209998809f9540be51178b4d0b6"
                         ),
                         "transactions": [
                             Transaction(
@@ -945,10 +941,9 @@ fixture_header_ones = FixtureHeader(
                             ),
                         ).requests_list
                     ],
-                    HexNumber(21).hex(),
                 ],
                 "newPayloadVersion": "4",
-                "forkchoiceUpdatedVersion": "4",
+                "forkchoiceUpdatedVersion": "3",
                 "validationError": "BlockException.INCORRECT_BLOCK_FORMAT"
                 "|TransactionException.INTRINSIC_GAS_TOO_LOW",
             },
@@ -1232,7 +1227,6 @@ EngineNewPayloadParametersAdapter = TypeAdapter(EngineNewPayloadParameters)  # t
                         target_pubkey=BLSPublicKey(2),
                     ),
                 ).requests_list,
-                HexNumber(9),
             ),
             [
                 {
@@ -1298,7 +1292,6 @@ EngineNewPayloadParametersAdapter = TypeAdapter(EngineNewPayloadParameters)  # t
                         ),
                     ).requests_list
                 ],
-                HexNumber(9).hex(),
             ],
             id="fixture_engine_new_payload_parameters_v4",
         ),

--- a/src/ethereum_test_forks/base_fork.py
+++ b/src/ethereum_test_forks/base_fork.py
@@ -205,6 +205,14 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
         """
         pass
 
+    @classmethod
+    @abstractmethod
+    def header_target_blobs_per_block_required(cls, block_number: int, timestamp: int) -> bool:
+        """
+        Returns true if the header must contain target blobs per block.
+        """
+        pass
+
     # Gas related abstract methods
 
     @classmethod
@@ -243,14 +251,6 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
     ) -> TransactionIntrinsicCostCalculator:
         """
         Returns a callable that calculates the intrinsic gas cost of a transaction for the fork.
-        """
-        pass
-
-    @classmethod
-    @abstractmethod
-    def header_target_blobs_per_block_required(cls, block_number: int, timestamp: int) -> bool:
-        """
-        Returns true if the header must contain target blobs per block.
         """
         pass
 

--- a/src/ethereum_test_forks/base_fork.py
+++ b/src/ethereum_test_forks/base_fork.py
@@ -29,7 +29,7 @@ class ForkAttribute(Protocol):
 
 class MemoryExpansionGasCalculator(Protocol):
     """
-    A protocol to calculate the gas cost of memory expansion for a given fork.
+    A protocol to calculate the gas cost of memory expansion at a given fork.
     """
 
     def __call__(self, *, new_bytes: int, previous_bytes: int = 0) -> int:
@@ -41,7 +41,7 @@ class MemoryExpansionGasCalculator(Protocol):
 
 class CalldataGasCalculator(Protocol):
     """
-    A protocol to calculate the transaction gas cost of calldata for a given fork.
+    A protocol to calculate the transaction gas cost of calldata at a given fork.
     """
 
     def __call__(self, *, data: BytesConvertible) -> int:
@@ -53,7 +53,7 @@ class CalldataGasCalculator(Protocol):
 
 class TransactionIntrinsicCostCalculator(Protocol):
     """
-    A protocol to calculate the intrinsic gas cost of a transaction for a given fork.
+    A protocol to calculate the intrinsic gas cost of a transaction at a given fork.
     """
 
     def __call__(
@@ -66,6 +66,37 @@ class TransactionIntrinsicCostCalculator(Protocol):
     ) -> int:
         """
         Returns the intrinsic gas cost of a transaction given its properties.
+        """
+        pass
+
+
+class BlobGasPriceCalculator(Protocol):
+    """
+    A protocol to calculate the blob gas price given the excess blob gas at a given fork.
+    """
+
+    def __call__(self, *, excess_blob_gas: int) -> int:
+        """
+        Returns the blob gas price given the excess blob gas.
+        """
+        pass
+
+
+class ExcessBlobGasCalculator(Protocol):
+    """
+    A protocol to calculate the excess blob gas for a block at a given fork.
+    """
+
+    def __call__(
+        self,
+        *,
+        parent_excess_blob_gas: int | None = None,
+        parent_excess_blobs: int | None = None,
+        parent_blob_gas_used: int | None = None,
+        parent_blob_count: int | None = None,
+    ) -> int:
+        """
+        Returns the excess blob gas given the parent's excess blob gas and blob gas used.
         """
         pass
 
@@ -191,7 +222,7 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
 
     @classmethod
     @abstractmethod
-    def header_beacon_root_required(cls, block_number: int, timestamp: int) -> bool:
+    def header_beacon_root_required(cls, block_number: int = 0, timestamp: int = 0) -> bool:
         """
         Returns true if the header must contain parent beacon block root
         """
@@ -199,7 +230,7 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
 
     @classmethod
     @abstractmethod
-    def header_requests_required(cls, block_number: int, timestamp: int) -> bool:
+    def header_requests_required(cls, block_number: int = 0, timestamp: int = 0) -> bool:
         """
         Returns true if the header must contain beacon chain requests
         """
@@ -207,7 +238,9 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
 
     @classmethod
     @abstractmethod
-    def header_target_blobs_per_block_required(cls, block_number: int, timestamp: int) -> bool:
+    def header_target_blobs_per_block_required(
+        cls, block_number: int = 0, timestamp: int = 0
+    ) -> bool:
         """
         Returns true if the header must contain target blobs per block.
         """
@@ -256,25 +289,61 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
 
     @classmethod
     @abstractmethod
-    def blob_gas_per_blob(cls, block_number: int, timestamp: int) -> int:
+    def blob_gas_price_calculator(
+        cls, block_number: int = 0, timestamp: int = 0
+    ) -> BlobGasPriceCalculator:
         """
-        Returns the amount of blob gas used per blob for a given fork.
-        """
-        pass
-
-    @classmethod
-    @abstractmethod
-    def target_blobs_per_block(cls, block_number: int, timestamp: int) -> int:
-        """
-        Returns the target blobs per block for a given fork.
+        Returns a callable that calculates the blob gas price at a given fork.
         """
         pass
 
     @classmethod
     @abstractmethod
-    def max_blobs_per_block(cls, block_number: int, timestamp: int) -> int:
+    def excess_blob_gas_calculator(
+        cls, block_number: int = 0, timestamp: int = 0
+    ) -> ExcessBlobGasCalculator:
         """
-        Returns the max blobs per block for a given fork.
+        Returns a callable that calculates the excess blob gas for a block at a given fork.
+        """
+        pass
+
+    @classmethod
+    @abstractmethod
+    def min_base_fee_per_blob_gas(cls, block_number: int = 0, timestamp: int = 0) -> int:
+        """
+        Returns the minimum base fee per blob gas at a given fork.
+        """
+        pass
+
+    @classmethod
+    @abstractmethod
+    def blob_gas_per_blob(cls, block_number: int = 0, timestamp: int = 0) -> int:
+        """
+        Returns the amount of blob gas used per blob at a given fork.
+        """
+        pass
+
+    @classmethod
+    @abstractmethod
+    def blob_base_fee_update_fraction(cls, block_number: int = 0, timestamp: int = 0) -> int:
+        """
+        Returns the blob base fee update fraction at a given fork.
+        """
+        pass
+
+    @classmethod
+    @abstractmethod
+    def target_blobs_per_block(cls, block_number: int = 0, timestamp: int = 0) -> int:
+        """
+        Returns the target blobs per block at a given fork.
+        """
+        pass
+
+    @classmethod
+    @abstractmethod
+    def max_blobs_per_block(cls, block_number: int = 0, timestamp: int = 0) -> int:
+        """
+        Returns the max blobs per block at a given fork.
         """
         pass
 

--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -1249,30 +1249,9 @@ class Prague(Cancun):
         return True
 
     @classmethod
-    def header_target_blobs_per_block_required(
-        cls,
-        block_number: int = 0,
-        timestamp: int = 0,
-    ) -> bool:
-        """
-        Prague requires that the execution layer header contains the beacon
-        chain target blobs per block.
-        """
-        return True
-
-    @classmethod
     def engine_new_payload_requests(cls, block_number: int = 0, timestamp: int = 0) -> bool:
         """
         Starting at Prague, new payloads include the requests hash as a parameter.
-        """
-        return True
-
-    @classmethod
-    def engine_new_payload_target_blobs_per_block(
-        cls, block_number: int = 0, timestamp: int = 0
-    ) -> bool:
-        """
-        Starting at Prague, new payloads include the target blobs per block as a parameter.
         """
         return True
 
@@ -1286,22 +1265,13 @@ class Prague(Cancun):
         return 4
 
     @classmethod
-    def engine_payload_attribute_target_blobs_per_block(
+    def engine_forkchoice_updated_version(
         cls, block_number: int = 0, timestamp: int = 0
-    ) -> bool:
+    ) -> Optional[int]:
         """
-        Starting at Prague, payload attributes include the target blobs per block.
+        At Prague, version number of NewPayload and ForkchoiceUpdated diverge.
         """
-        return True
-
-    @classmethod
-    def engine_payload_attribute_max_blobs_per_block(
-        cls, block_number: int = 0, timestamp: int = 0
-    ) -> bool:
-        """
-        Starting at Prague, payload attributes include the max blobs per block.
-        """
-        return True
+        return 3
 
 
 class CancunEIP7692(  # noqa: SC200

--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -259,7 +259,7 @@ class Frontier(BaseFork, solc_name="homestead"):
         """
         Returns the amount of blob gas used per blob at a given fork.
         """
-        raise NotImplementedError("Blob gas per blob is not supported in Frontier")
+        return 0
 
     @classmethod
     def target_blobs_per_block(cls, block_number: int = 0, timestamp: int = 0) -> int:

--- a/src/ethereum_test_forks/forks/helpers.py
+++ b/src/ethereum_test_forks/forks/helpers.py
@@ -1,0 +1,25 @@
+"""
+Helpers used to return fork-specific values.
+"""
+
+
+def ceiling_division(a: int, b: int) -> int:
+    """
+    Calculates the ceil without using floating point.
+    Used by many of the EVM's formulas
+    """
+    return -(a // -b)
+
+
+def fake_exponential(factor: int, numerator: int, denominator: int) -> int:
+    """
+    Used to calculate the blob gas cost.
+    """
+    i = 1
+    output = 0
+    numerator_accumulator = factor * denominator
+    while numerator_accumulator > 0:
+        output += numerator_accumulator
+        numerator_accumulator = (numerator_accumulator * numerator) // (denominator * i)
+        i += 1
+    return output // denominator

--- a/src/ethereum_test_specs/state.py
+++ b/src/ethereum_test_specs/state.py
@@ -32,8 +32,6 @@ from .blockchain import Block, BlockchainTest, Header
 from .debugging import print_traces
 from .helpers import verify_transactions
 
-TARGET_BLOB_GAS_PER_BLOCK = 393216
-
 
 class StateTest(BaseTest):
     """
@@ -58,7 +56,7 @@ class StateTest(BaseTest):
         TransactionPost,
     ]
 
-    def _generate_blockchain_genesis_environment(self) -> Environment:
+    def _generate_blockchain_genesis_environment(self, *, fork: Fork) -> Environment:
         """
         Generate the genesis environment for the BlockchainTest formatted test.
         """
@@ -79,8 +77,8 @@ class StateTest(BaseTest):
             # set the excess blob gas by setting the excess blob gas of the genesis block
             # to the expected value plus the TARGET_BLOB_GAS_PER_BLOCK, which is the value
             # that will be subtracted from the excess blob gas when the first block is mined.
-            updated_values["excess_blob_gas"] = (
-                self.env.excess_blob_gas + TARGET_BLOB_GAS_PER_BLOCK
+            updated_values["excess_blob_gas"] = self.env.excess_blob_gas + (
+                fork.target_blobs_per_block() * fork.blob_gas_per_blob()
             )
 
         return self.env.copy(**updated_values)
@@ -107,12 +105,12 @@ class StateTest(BaseTest):
             )
         ]
 
-    def generate_blockchain_test(self) -> BlockchainTest:
+    def generate_blockchain_test(self, *, fork: Fork) -> BlockchainTest:
         """
         Generate a BlockchainTest fixture from this StateTest fixture.
         """
         return BlockchainTest(
-            genesis_environment=self._generate_blockchain_genesis_environment(),
+            genesis_environment=self._generate_blockchain_genesis_environment(fork=fork),
             pre=self.pre,
             post=self.post,
             blocks=self._generate_blockchain_blocks(),
@@ -195,7 +193,7 @@ class StateTest(BaseTest):
         Generate the BlockchainTest fixture.
         """
         if fixture_format in BlockchainTest.supported_fixture_formats:
-            return self.generate_blockchain_test().generate(
+            return self.generate_blockchain_test(fork=fork).generate(
                 request=request, t8n=t8n, fork=fork, fixture_format=fixture_format, eips=eips
             )
         elif fixture_format == StateFixture:

--- a/src/pytest_plugins/__init__.py
+++ b/src/pytest_plugins/__init__.py
@@ -1,3 +1,7 @@
 """
 Package containing pytest plugins related to test filling.
 """
+
+from .forks import fork_covariant_parametrize
+
+__all__ = ["fork_covariant_parametrize"]

--- a/src/pytest_plugins/forks/__init__.py
+++ b/src/pytest_plugins/forks/__init__.py
@@ -3,3 +3,7 @@ A pytest plugin to configure the forks in the test session. It parametrizes
 tests based on the user-provided fork range the tests' specified validity
 markers.
 """
+
+from .forks import fork_covariant_parametrize
+
+__all__ = ["fork_covariant_parametrize"]

--- a/src/pytest_plugins/forks/forks.py
+++ b/src/pytest_plugins/forks/forks.py
@@ -7,7 +7,7 @@ import sys
 import textwrap
 from dataclasses import dataclass, field
 from types import FunctionType
-from typing import Any, Callable, ClassVar, List, Set, Tuple, Type
+from typing import Any, Callable, ClassVar, Iterable, List, Set, Tuple, Type
 
 import pytest
 from _pytest.mark.structures import ParameterSet
@@ -134,7 +134,7 @@ class CovariantDescriptor:
     """
 
     parameter_names: List[str] = []
-    fn: Callable[[Fork], List[Any]] | None = None
+    fn: Callable[[Fork], List[Any] | Iterable[Any]] | None = None
 
     selector: FunctionType | None = None
     marks: None | pytest.Mark | pytest.MarkDecorator | List[
@@ -144,7 +144,7 @@ class CovariantDescriptor:
     def __init__(
         self,
         parameter_names: List[str] | str,
-        fn: Callable[[Fork], List[Any]] | None = None,
+        fn: Callable[[Fork], List[Any] | Iterable[Any]] | None = None,
         selector: FunctionType | None = None,
         marks: None
         | pytest.Mark
@@ -347,7 +347,7 @@ FORK_COVARIANT_PARAMETRIZE_ATTRIBUTE = "fork_covariant_parametrize"
 def fork_covariant_parametrize(
     *,
     parameter_names: List[str] | str,
-    fn: Callable[[Fork], List[Any]],
+    fn: Callable[[Fork], List[Any] | Iterable[Any]],
     marks: None
     | pytest.Mark
     | pytest.MarkDecorator

--- a/src/pytest_plugins/forks/forks.py
+++ b/src/pytest_plugins/forks/forks.py
@@ -190,7 +190,7 @@ class CovariantDescriptor:
 
         return None
 
-    def process_values(self, values: List[Any]) -> List[ParameterSet]:
+    def process_values(self, values: Iterable[Any]) -> List[ParameterSet]:
         """
         Filter the values for the covariant parameter.
 
@@ -212,9 +212,8 @@ class CovariantDescriptor:
             return
         fork = fork_parametrizer.fork
         values = self.fn(fork)
-        assert isinstance(values, list)
-        assert len(values) > 0
         values = self.process_values(values)
+        assert len(values) > 0
         fork_parametrizer.fork_covariant_parameters.append(
             ForkCovariantParameter(names=self.parameter_names, values=values)
         )

--- a/src/pytest_plugins/forks/tests/test_covariant_markers.py
+++ b/src/pytest_plugins/forks/tests/test_covariant_markers.py
@@ -290,7 +290,7 @@ import pytest
             """
             import pytest
 
-            from pytest_plugins.forks.forks import fork_covariant_parametrize
+            from pytest_plugins import fork_covariant_parametrize
 
             def covariant_function(fork):
                 return [1, 2] if fork.name() == "Paris" else [3, 4, 5]
@@ -309,7 +309,7 @@ import pytest
             """
             import pytest
 
-            from pytest_plugins.forks.forks import fork_covariant_parametrize
+            from pytest_plugins import fork_covariant_parametrize
 
             def covariant_function(fork):
                 return [[1, 2], [3, 4]] if fork.name() == "Paris" else [[4, 5], [5, 6], [6, 7]]

--- a/src/pytest_plugins/forks/tests/test_covariant_markers.py
+++ b/src/pytest_plugins/forks/tests/test_covariant_markers.py
@@ -286,6 +286,46 @@ import pytest
             "Only keyword arguments are supported",
             id="selector_as_positional_argument",
         ),
+        pytest.param(
+            """
+            import pytest
+
+            from pytest_plugins.forks.forks import fork_covariant_parametrize
+
+            def covariant_function(fork):
+                return [1, 2] if fork.name() == "Paris" else [3, 4, 5]
+
+            @fork_covariant_parametrize(parameter_names=["test_parameter"], fn=covariant_function)
+            @pytest.mark.valid_from("Paris")
+            @pytest.mark.valid_until("Shanghai")
+            def test_case(state_test_only, test_parameter):
+                pass
+            """,
+            dict(passed=5, failed=0, skipped=0, errors=0),
+            None,
+            id="custom_covariant_marker",
+        ),
+        pytest.param(
+            """
+            import pytest
+
+            from pytest_plugins.forks.forks import fork_covariant_parametrize
+
+            def covariant_function(fork):
+                return [[1, 2], [3, 4]] if fork.name() == "Paris" else [[4, 5], [5, 6], [6, 7]]
+
+            @fork_covariant_parametrize(parameter_names=[
+                "test_parameter", "test_parameter_2"
+            ], fn=covariant_function)
+            @pytest.mark.valid_from("Paris")
+            @pytest.mark.valid_until("Shanghai")
+            def test_case(state_test_only, test_parameter, test_parameter_2):
+                pass
+            """,
+            dict(passed=5, failed=0, skipped=0, errors=0),
+            None,
+            id="multi_parameter_custom_covariant_marker",
+        ),
     ],
 )
 def test_fork_covariant_markers(

--- a/src/pytest_plugins/forks/tests/test_covariant_markers.py
+++ b/src/pytest_plugins/forks/tests/test_covariant_markers.py
@@ -326,6 +326,60 @@ import pytest
             None,
             id="multi_parameter_custom_covariant_marker",
         ),
+        pytest.param(
+            """
+            import pytest
+
+            from pytest_plugins import fork_covariant_parametrize
+
+            def covariant_function(fork):
+                return [
+                    pytest.param(1, id="first_value"),
+                    2,
+                ] if fork.name() == "Paris" else [
+                    pytest.param(3, id="third_value"),
+                    4,
+                    5,
+                ]
+
+            @fork_covariant_parametrize(parameter_names=["test_parameter"], fn=covariant_function)
+            @pytest.mark.valid_from("Paris")
+            @pytest.mark.valid_until("Shanghai")
+            def test_case(state_test_only, test_parameter):
+                pass
+            """,
+            dict(passed=5, failed=0, skipped=0, errors=0),
+            None,
+            id="custom_covariant_marker_pytest_param_id",
+        ),
+        pytest.param(
+            """
+            import pytest
+
+            from pytest_plugins import fork_covariant_parametrize
+
+            def covariant_function(fork):
+                return [
+                    pytest.param(1, 2, id="first_test"),
+                    pytest.param(3, 4, id="second_test"),
+                ] if fork.name() == "Paris" else [
+                    pytest.param(4, 5, id="fourth_test"),
+                    pytest.param(5, 6, id="fifth_test"),
+                    pytest.param(6, 7, id="sixth_test"),
+                ]
+
+            @fork_covariant_parametrize(parameter_names=[
+                "test_parameter", "test_parameter_2"
+            ], fn=covariant_function)
+            @pytest.mark.valid_from("Paris")
+            @pytest.mark.valid_until("Shanghai")
+            def test_case(state_test_only, test_parameter, test_parameter_2):
+                pass
+            """,
+            dict(passed=5, failed=0, skipped=0, errors=0),
+            None,
+            id="multi_parameter_custom_covariant_marker_pytest_param_id",
+        ),
     ],
 )
 def test_fork_covariant_markers(

--- a/src/pytest_plugins/forks/tests/test_fork_parametrizer_types.py
+++ b/src/pytest_plugins/forks/tests/test_fork_parametrizer_types.py
@@ -12,7 +12,6 @@ from ethereum_test_forks import Frontier
 from ..forks import (
     ForkCovariantParameter,
     ForkParametrizer,
-    MarkedValue,
     parameters_from_fork_parametrizer_list,
 )
 
@@ -31,9 +30,7 @@ from ..forks import (
                 ForkParametrizer(
                     fork=Frontier,
                     fork_covariant_parameters=[
-                        ForkCovariantParameter(
-                            names=["some_value"], values=[[MarkedValue(value=1)]]
-                        )
+                        ForkCovariantParameter(names=["some_value"], values=[pytest.param(1)])
                     ],
                 )
             ],
@@ -48,7 +45,7 @@ from ..forks import (
                     fork_covariant_parameters=[
                         ForkCovariantParameter(
                             names=["some_value"],
-                            values=[[MarkedValue(value=1)], [MarkedValue(value=2)]],
+                            values=[pytest.param(1), pytest.param(2)],
                         )
                     ],
                 )
@@ -65,8 +62,8 @@ from ..forks import (
                         ForkCovariantParameter(
                             names=["some_value"],
                             values=[
-                                [MarkedValue(value=1, marks=[pytest.mark.some_mark])],
-                                [MarkedValue(value=2)],
+                                pytest.param(1, marks=[pytest.mark.some_mark]),
+                                pytest.param(2),
                             ],
                         )
                     ],
@@ -81,12 +78,8 @@ from ..forks import (
                 ForkParametrizer(
                     fork=Frontier,
                     fork_covariant_parameters=[
-                        ForkCovariantParameter(
-                            names=["some_value"], values=[[MarkedValue(value=1)]]
-                        ),
-                        ForkCovariantParameter(
-                            names=["another_value"], values=[[MarkedValue(value=2)]]
-                        ),
+                        ForkCovariantParameter(names=["some_value"], values=[pytest.param(1)]),
+                        ForkCovariantParameter(names=["another_value"], values=[pytest.param(2)]),
                     ],
                 )
             ],
@@ -99,12 +92,10 @@ from ..forks import (
                 ForkParametrizer(
                     fork=Frontier,
                     fork_covariant_parameters=[
-                        ForkCovariantParameter(
-                            names=["some_value"], values=[[MarkedValue(value=1)]]
-                        ),
+                        ForkCovariantParameter(names=["some_value"], values=[pytest.param(1)]),
                         ForkCovariantParameter(
                             names=["another_value"],
-                            values=[[MarkedValue(value=2)], [MarkedValue(value=3)]],
+                            values=[pytest.param(2), pytest.param(3)],
                         ),
                     ],
                 )
@@ -121,8 +112,8 @@ from ..forks import (
                         ForkCovariantParameter(
                             names=["some_value", "another_value"],
                             values=[
-                                [MarkedValue(value=1), MarkedValue(value="a")],
-                                [MarkedValue(value=2), MarkedValue(value="b")],
+                                pytest.param(1, "a"),
+                                pytest.param(2, "b"),
                             ],
                         )
                     ],
@@ -140,15 +131,15 @@ from ..forks import (
                         ForkCovariantParameter(
                             names=["some_value", "another_value"],
                             values=[
-                                [MarkedValue(value=1), MarkedValue(value="a")],
-                                [MarkedValue(value=2), MarkedValue(value="b")],
+                                pytest.param(1, "a"),
+                                pytest.param(2, "b"),
                             ],
                         ),
                         ForkCovariantParameter(
                             names=["yet_another_value", "last_value"],
                             values=[
-                                [MarkedValue(value=3), MarkedValue(value="x")],
-                                [MarkedValue(value=4), MarkedValue(value="y")],
+                                pytest.param(3, "x"),
+                                pytest.param(4, "y"),
                             ],
                         ),
                     ],
@@ -171,15 +162,15 @@ from ..forks import (
                         ForkCovariantParameter(
                             names=["shared_value", "different_value_1"],
                             values=[
-                                [MarkedValue(value=1), MarkedValue(value="a")],
-                                [MarkedValue(value=2), MarkedValue(value="b")],
+                                pytest.param(1, "a"),
+                                pytest.param(2, "b"),
                             ],
                         ),
                         ForkCovariantParameter(
                             names=["shared_value", "different_value_2"],
                             values=[
-                                [MarkedValue(value=1), MarkedValue(value="x")],
-                                [MarkedValue(value=2), MarkedValue(value="y")],
+                                pytest.param(1, "x"),
+                                pytest.param(2, "y"),
                             ],
                         ),
                     ],

--- a/tests/cancun/eip4788_beacon_root/conftest.py
+++ b/tests/cancun/eip4788_beacon_root/conftest.py
@@ -7,20 +7,10 @@ from typing import Dict, Iterator, List
 
 import pytest
 
-from ethereum_test_tools import (
-    AccessList,
-    Account,
-    Address,
-    Alloc,
-    Bytecode,
-    Environment,
-    Hash,
-    Storage,
-    Transaction,
-    add_kzg_version,
-    keccak256,
-)
-from ethereum_test_tools.vm.opcode import Opcodes as Op
+from ethereum_test_forks import Fork
+from ethereum_test_tools import AccessList, Account, Address, Alloc, Bytecode, Environment, Hash
+from ethereum_test_tools import Opcodes as Op
+from ethereum_test_tools import Storage, Transaction, add_kzg_version, keccak256
 
 from .spec import Spec, SpecHelpers
 
@@ -232,6 +222,7 @@ def tx_type() -> int:
 @pytest.fixture
 def tx(
     pre: Alloc,
+    fork: Fork,
     tx_to_address: Address,
     tx_data: bytes,
     tx_type: int,
@@ -254,7 +245,7 @@ def tx(
         kwargs["access_list"] = access_list
 
     if tx_type == 3:
-        kwargs["max_fee_per_blob_gas"] = 1
+        kwargs["max_fee_per_blob_gas"] = fork.min_base_fee_per_blob_gas()
         kwargs["blob_versioned_hashes"] = add_kzg_version([0], BLOB_COMMITMENT_VERSION_KZG)
 
     if tx_type > 3:

--- a/tests/cancun/eip4844_blobs/common.py
+++ b/tests/cancun/eip4844_blobs/common.py
@@ -14,7 +14,7 @@ from ethereum_test_tools import (
 )
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
-from .spec import Spec, SpecHelpers
+from .spec import Spec
 
 INF_POINT = (0xC0 << 376).to_bytes(48, byteorder="big")
 Z = 0x623CE31CF9759A5C8DAF3A357992F9F3DD7F9339D8998BC8E68373E54F00B75E
@@ -56,12 +56,6 @@ class Blob:
             kzg_proofs.append(blob.kzg_proof)
         return (blobs, kzg_commitments, kzg_proofs)
 
-
-# Simple list of blob versioned hashes ranging from bytes32(1 to 4)
-simple_blob_hashes: list[bytes] = add_kzg_version(
-    [(1 << x) for x in range(SpecHelpers.max_blobs_per_block())],
-    Spec.BLOB_COMMITMENT_VERSION_KZG,
-)
 
 # Random fixed list of blob versioned hashes
 random_blob_hashes = add_kzg_version(
@@ -284,7 +278,7 @@ class BlobhashScenario:
     """
 
     @staticmethod
-    def create_blob_hashes_list(length: int) -> list[list[bytes]]:
+    def create_blob_hashes_list(length: int, max_blobs_per_block: int) -> list[list[bytes]]:
         """
         Creates a list of MAX_BLOBS_PER_BLOCK blob hashes
         using `random_blob_hashes`.
@@ -293,20 +287,20 @@ class BlobhashScenario:
         length: MAX_BLOBS_PER_BLOCK * length
         -> [0x01, 0x02, 0x03, 0x04, ..., 0x0A, 0x0B, 0x0C, 0x0D]
 
-        Then split list into smaller chunks of SpecHelpers.max_blobs_per_block()
+        Then split list into smaller chunks of max_blobs_per_block
         -> [[0x01, 0x02, 0x03, 0x04], ..., [0x0a, 0x0b, 0x0c, 0x0d]]
         """
         b_hashes = [
             random_blob_hashes[i % len(random_blob_hashes)]
-            for i in range(SpecHelpers.max_blobs_per_block() * length)
+            for i in range(max_blobs_per_block * length)
         ]
         return [
-            b_hashes[i : i + SpecHelpers.max_blobs_per_block()]
-            for i in range(0, len(b_hashes), SpecHelpers.max_blobs_per_block())
+            b_hashes[i : i + max_blobs_per_block]
+            for i in range(0, len(b_hashes), max_blobs_per_block)
         ]
 
     @staticmethod
-    def blobhash_sstore(index: int):
+    def blobhash_sstore(index: int, max_blobs_per_block: int):
         """
         Returns an BLOBHASH sstore to the given index.
 
@@ -315,35 +309,38 @@ class BlobhashScenario:
         the BLOBHASH sstore.
         """
         invalidity_check = Op.SSTORE(index, 0x01)
-        if index < 0 or index >= SpecHelpers.max_blobs_per_block():
+        if index < 0 or index >= max_blobs_per_block:
             return invalidity_check + Op.SSTORE(index, Op.BLOBHASH(index))
         return Op.SSTORE(index, Op.BLOBHASH(index))
 
     @classmethod
-    def generate_blobhash_bytecode(cls, scenario_name: str) -> bytes:
+    def generate_blobhash_bytecode(cls, scenario_name: str, max_blobs_per_block: int) -> bytes:
         """
         Returns BLOBHASH bytecode for the given scenario.
         """
         scenarios = {
             "single_valid": sum(
-                cls.blobhash_sstore(i) for i in range(SpecHelpers.max_blobs_per_block())
+                cls.blobhash_sstore(i, max_blobs_per_block) for i in range(max_blobs_per_block)
             ),
             "repeated_valid": sum(
-                sum(cls.blobhash_sstore(i) for _ in range(10))
-                for i in range(SpecHelpers.max_blobs_per_block())
+                sum(cls.blobhash_sstore(i, max_blobs_per_block) for _ in range(10))
+                for i in range(max_blobs_per_block)
             ),
             "valid_invalid": sum(
-                cls.blobhash_sstore(i)
-                + cls.blobhash_sstore(SpecHelpers.max_blobs_per_block())
-                + cls.blobhash_sstore(i)
-                for i in range(SpecHelpers.max_blobs_per_block())
+                cls.blobhash_sstore(i, max_blobs_per_block)
+                + cls.blobhash_sstore(max_blobs_per_block, max_blobs_per_block)
+                + cls.blobhash_sstore(i, max_blobs_per_block)
+                for i in range(max_blobs_per_block)
             ),
             "varied_valid": sum(
-                cls.blobhash_sstore(i) + cls.blobhash_sstore(i + 1) + cls.blobhash_sstore(i)
-                for i in range(SpecHelpers.max_blobs_per_block() - 1)
+                cls.blobhash_sstore(i, max_blobs_per_block)
+                + cls.blobhash_sstore(i + 1, max_blobs_per_block)
+                + cls.blobhash_sstore(i, max_blobs_per_block)
+                for i in range(max_blobs_per_block - 1)
             ),
             "invalid_calls": sum(
-                cls.blobhash_sstore(i) for i in range(-5, SpecHelpers.max_blobs_per_block() + 5)
+                cls.blobhash_sstore(i, max_blobs_per_block)
+                for i in range(-5, max_blobs_per_block + 5)
             ),
         }
         scenario = scenarios.get(scenario_name)

--- a/tests/cancun/eip4844_blobs/conftest.py
+++ b/tests/cancun/eip4844_blobs/conftest.py
@@ -62,6 +62,7 @@ def genesis_excess_blob_gas(
     parent_excess_blob_gas: int | None,
     parent_blobs: int,
     target_blobs_per_block: int,
+    blob_gas_per_blob: int,
 ) -> int:
     """
     Default excess blob gas for the genesis block.
@@ -71,7 +72,7 @@ def genesis_excess_blob_gas(
         # We increase the excess blob gas of the genesis because
         # we cannot include blobs in the genesis, so the
         # test blobs are actually in block 1.
-        excess_blob_gas += target_blobs_per_block
+        excess_blob_gas += target_blobs_per_block * blob_gas_per_blob
     return excess_blob_gas
 
 

--- a/tests/cancun/eip4844_blobs/conftest.py
+++ b/tests/cancun/eip4844_blobs/conftest.py
@@ -3,17 +3,102 @@ Pytest (plugin) definitions local to EIP-4844 tests.
 """
 import pytest
 
-from ethereum_test_tools import Alloc, Block, Hash, Transaction, add_kzg_version
+from ethereum_test_forks import Fork
+from ethereum_test_tools import Alloc, Block, Environment, Hash, Transaction, add_kzg_version
 
-from .spec import BlockHeaderBlobGasFields, Spec
+from .spec import Spec
+
+
+@pytest.fixture
+def block_base_fee() -> int:  # noqa: D103
+    return 7
+
+
+@pytest.fixture
+def target_blobs_per_block(fork: Fork) -> int:
+    """
+    Default number of blobs to be included in the block.
+    """
+    return fork.target_blobs_per_block()
+
+
+@pytest.fixture(autouse=True)
+def parent_excess_blobs() -> int | None:
+    """
+    Default excess blobs of the parent block.
+
+    Can be overloaded by a test case to provide a custom parent excess blob
+    count.
+    """
+    return 10  # Defaults to a blob gas price of 1.
+
+
+@pytest.fixture(autouse=True)
+def parent_blobs() -> int | None:
+    """
+    Default data blobs of the parent blob.
+
+    Can be overloaded by a test case to provide a custom parent blob count.
+    """
+    return 0
+
+
+@pytest.fixture
+def parent_excess_blob_gas(
+    parent_excess_blobs: int | None,
+    blob_gas_per_blob: int,
+) -> int | None:
+    """
+    Calculates the excess blob gas of the parent block from the excess blobs.
+    """
+    if parent_excess_blobs is None:
+        return None
+    assert parent_excess_blobs >= 0
+    return parent_excess_blobs * blob_gas_per_blob
+
+
+@pytest.fixture
+def genesis_excess_blob_gas(
+    parent_excess_blob_gas: int | None,
+    parent_blobs: int,
+    target_blobs_per_block: int,
+) -> int:
+    """
+    Default excess blob gas for the genesis block.
+    """
+    excess_blob_gas = parent_excess_blob_gas if parent_excess_blob_gas else 0
+    if parent_blobs:
+        # We increase the excess blob gas of the genesis because
+        # we cannot include blobs in the genesis, so the
+        # test blobs are actually in block 1.
+        excess_blob_gas += target_blobs_per_block
+    return excess_blob_gas
+
+
+@pytest.fixture
+def env(
+    block_base_fee: int,
+    genesis_excess_blob_gas: int,
+) -> Environment:
+    """
+    Prepare the environment of the genesis block for all blockchain tests.
+    """
+    return Environment(
+        excess_blob_gas=genesis_excess_blob_gas,
+        blob_gas_used=0,
+        base_fee_per_gas=block_base_fee,
+    )
 
 
 @pytest.fixture
 def non_zero_blob_gas_used_genesis_block(
     pre: Alloc,
     parent_blobs: int,
+    fork: Fork,
+    genesis_excess_blob_gas: int,
     parent_excess_blob_gas: int,
     tx_max_fee_per_gas: int,
+    target_blobs_per_block: int,
 ) -> Block | None:
     """
     For test cases with a non-zero blobGasUsed field in the
@@ -32,15 +117,18 @@ def non_zero_blob_gas_used_genesis_block(
     if parent_blobs == 0:
         return None
 
-    parent_excess_blob_gas += Spec.TARGET_BLOB_GAS_PER_BLOCK
-    excess_blob_gas = Spec.calc_excess_blob_gas(
-        BlockHeaderBlobGasFields(parent_excess_blob_gas, 0)
-    )
+    excess_blob_gas_calculator = fork.excess_blob_gas_calculator(block_number=1)
+    assert parent_excess_blob_gas == excess_blob_gas_calculator(
+        parent_excess_blob_gas=genesis_excess_blob_gas,
+        parent_blob_count=0,
+    ), "parent excess blob gas is not as expected for extra block"
 
     sender = pre.fund_eoa(10**27)
 
     # Address that contains no code, nor balance and is not a contract.
     empty_account_destination = pre.fund_eoa(0)
+
+    blob_gas_price_calculator = fork.blob_gas_price_calculator(block_number=1)
 
     return Block(
         txs=[
@@ -52,7 +140,9 @@ def non_zero_blob_gas_used_genesis_block(
                 gas_limit=21_000,
                 max_fee_per_gas=tx_max_fee_per_gas,
                 max_priority_fee_per_gas=0,
-                max_fee_per_blob_gas=Spec.get_blob_gasprice(excess_blob_gas=excess_blob_gas),
+                max_fee_per_blob_gas=blob_gas_price_calculator(
+                    excess_blob_gas=parent_excess_blob_gas
+                ),
                 access_list=[],
                 blob_versioned_hashes=add_kzg_version(
                     [Hash(x) for x in range(parent_blobs)],

--- a/tests/cancun/eip4844_blobs/conftest.py
+++ b/tests/cancun/eip4844_blobs/conftest.py
@@ -215,8 +215,32 @@ def tx_max_priority_fee_per_gas() -> int:
 
 
 @pytest.fixture
+def tx_max_fee_per_blob_gas_multiplier() -> int:
+    """
+    Default max fee per blob gas multiplier for transactions sent during test.
+
+    Can be overloaded by a test case to provide a custom max fee per blob gas
+    multiplier.
+    """
+    return 1
+
+
+@pytest.fixture
+def tx_max_fee_per_blob_gas_delta() -> int:
+    """
+    Default max fee per blob gas delta for transactions sent during test.
+
+    Can be overloaded by a test case to provide a custom max fee per blob gas
+    delta.
+    """
+    return 0
+
+
+@pytest.fixture
 def tx_max_fee_per_blob_gas(  # noqa: D103
     blob_gas_price: int | None,
+    tx_max_fee_per_blob_gas_multiplier: int,
+    tx_max_fee_per_blob_gas_delta: int,
 ) -> int:
     """
     Default max fee per blob gas for transactions sent during test.
@@ -229,7 +253,7 @@ def tx_max_fee_per_blob_gas(  # noqa: D103
     if blob_gas_price is None:
         # When fork transitioning, the default blob gas price is 1.
         return 1
-    return blob_gas_price
+    return (blob_gas_price * tx_max_fee_per_blob_gas_multiplier) + tx_max_fee_per_blob_gas_delta
 
 
 @pytest.fixture

--- a/tests/cancun/eip4844_blobs/conftest.py
+++ b/tests/cancun/eip4844_blobs/conftest.py
@@ -10,7 +10,8 @@ from .spec import Spec
 
 
 @pytest.fixture
-def block_base_fee() -> int:  # noqa: D103
+def block_base_fee_per_gas() -> int:
+    """Default max fee per gas for transactions sent during test."""
     return 7
 
 
@@ -20,6 +21,20 @@ def target_blobs_per_block(fork: Fork) -> int:
     Default number of blobs to be included in the block.
     """
     return fork.target_blobs_per_block()
+
+
+@pytest.fixture
+def max_blobs_per_block(fork: Fork) -> int:
+    """
+    Default number of blobs to be included in the block.
+    """
+    return fork.max_blobs_per_block()
+
+
+@pytest.fixture
+def blob_gas_per_blob(fork: Fork) -> int:
+    """Default blob gas cost per blob."""
+    return fork.blob_gas_per_blob()
 
 
 @pytest.fixture(autouse=True)
@@ -58,6 +73,72 @@ def parent_excess_blob_gas(
 
 
 @pytest.fixture
+def excess_blob_gas(
+    fork: Fork,
+    parent_excess_blobs: int | None,
+    parent_blobs: int | None,
+) -> int | None:
+    """
+    Calculates the excess blob gas of the block under test from the parent block.
+
+    Value can be overloaded by a test case to provide a custom excess blob gas.
+    """
+    if parent_excess_blobs is None or parent_blobs is None:
+        return None
+    excess_blob_gas = fork.excess_blob_gas_calculator()
+    return excess_blob_gas(
+        parent_excess_blobs=parent_excess_blobs,
+        parent_blob_count=parent_blobs,
+    )
+
+
+@pytest.fixture
+def correct_excess_blob_gas(
+    fork: Fork,
+    parent_excess_blobs: int | None,
+    parent_blobs: int | None,
+) -> int:
+    """
+    Calculates the correct excess blob gas of the block under test from the parent block.
+
+    Should not be overloaded by a test case.
+    """
+    if parent_excess_blobs is None or parent_blobs is None:
+        return 0
+    excess_blob_gas = fork.excess_blob_gas_calculator()
+    return excess_blob_gas(
+        parent_excess_blobs=parent_excess_blobs,
+        parent_blob_count=parent_blobs,
+    )
+
+
+@pytest.fixture
+def block_fee_per_blob_gas(  # noqa: D103
+    fork: Fork,
+    correct_excess_blob_gas: int,
+) -> int:
+    get_blob_gas_price = fork.blob_gas_price_calculator()
+    return get_blob_gas_price(excess_blob_gas=correct_excess_blob_gas)
+
+
+@pytest.fixture
+def blob_gas_price(
+    fork: Fork,
+    excess_blob_gas: int | None,
+) -> int | None:
+    """
+    Blob gas price for the block of the test.
+    """
+    if excess_blob_gas is None:
+        return None
+
+    get_blob_gas_price = fork.blob_gas_price_calculator()
+    return get_blob_gas_price(
+        excess_blob_gas=excess_blob_gas,
+    )
+
+
+@pytest.fixture
 def genesis_excess_blob_gas(
     parent_excess_blob_gas: int | None,
     parent_blobs: int,
@@ -78,7 +159,7 @@ def genesis_excess_blob_gas(
 
 @pytest.fixture
 def env(
-    block_base_fee: int,
+    block_base_fee_per_gas: int,
     genesis_excess_blob_gas: int,
 ) -> Environment:
     """
@@ -87,8 +168,68 @@ def env(
     return Environment(
         excess_blob_gas=genesis_excess_blob_gas,
         blob_gas_used=0,
-        base_fee_per_gas=block_base_fee,
+        base_fee_per_gas=block_base_fee_per_gas,
     )
+
+
+@pytest.fixture
+def tx_value() -> int:
+    """
+    Default value contained by the transactions sent during test.
+
+    Can be overloaded by a test case to provide a custom transaction value.
+    """
+    return 1
+
+
+@pytest.fixture
+def tx_calldata() -> bytes:
+    """Default calldata in transactions sent during test."""
+    return b""
+
+
+@pytest.fixture(autouse=True)
+def tx_max_fee_per_gas(
+    block_base_fee_per_gas: int,
+) -> int:
+    """
+    Max fee per gas value used by all transactions sent during test.
+
+    By default the max fee per gas is the same as the block fee per gas.
+
+    Can be overloaded by a test case to test rejection of transactions where
+    the max fee per gas is insufficient.
+    """
+    return block_base_fee_per_gas
+
+
+@pytest.fixture
+def tx_max_priority_fee_per_gas() -> int:
+    """
+    Default max priority fee per gas for transactions sent during test.
+
+    Can be overloaded by a test case to provide a custom max priority fee per
+    gas.
+    """
+    return 0
+
+
+@pytest.fixture
+def tx_max_fee_per_blob_gas(  # noqa: D103
+    blob_gas_price: int | None,
+) -> int:
+    """
+    Default max fee per blob gas for transactions sent during test.
+
+    By default, it is set to the blob gas price of the block.
+
+    Can be overloaded by a test case to test rejection of transactions where
+    the max fee per blob gas is insufficient.
+    """
+    if blob_gas_price is None:
+        # When fork transitioning, the default blob gas price is 1.
+        return 1
+    return blob_gas_price
 
 
 @pytest.fixture

--- a/tests/cancun/eip4844_blobs/spec.py
+++ b/tests/cancun/eip4844_blobs/spec.py
@@ -117,7 +117,8 @@ class SpecHelpers:
         gas_per_blob = fork.blob_gas_per_blob()
         return (
             cls.get_min_excess_blob_gas_for_blob_gas_price(
-                fork=fork, blob_gas_price=blob_gas_price,
+                fork=fork,
+                blob_gas_price=blob_gas_price,
             )
             // gas_per_blob
         )

--- a/tests/cancun/eip4844_blobs/spec.py
+++ b/tests/cancun/eip4844_blobs/spec.py
@@ -1,10 +1,12 @@
 """
 Defines EIP-4844 specification constants and functions.
 """
+import itertools
 from dataclasses import dataclass
 from hashlib import sha256
-from typing import Optional
+from typing import List, Optional, Tuple
 
+from ethereum_test_forks import Fork
 from ethereum_test_tools import Transaction
 
 
@@ -19,16 +21,6 @@ class ReferenceSpec:
 
 
 ref_spec_4844 = ReferenceSpec("EIPS/eip-4844.md", "f0eb6a364aaf5ccb43516fa2c269a54fb881ecfd")
-
-
-@dataclass(frozen=True)
-class BlockHeaderBlobGasFields:
-    """
-    A helper class for the blob gas fields in a block header.
-    """
-
-    excess_blob_gas: int
-    blob_gas_used: int
 
 
 # Constants
@@ -48,17 +40,12 @@ class Spec:
     BLOB_COMMITMENT_VERSION_KZG = 1
     POINT_EVALUATION_PRECOMPILE_ADDRESS = 10
     POINT_EVALUATION_PRECOMPILE_GAS = 50_000
-    MAX_BLOB_GAS_PER_BLOCK = 786432
-    TARGET_BLOB_GAS_PER_BLOCK = 393216
-    MIN_BLOB_GASPRICE = 1
-    BLOB_GASPRICE_UPDATE_FRACTION = 3338477
     # MAX_VERSIONED_HASHES_LIST_SIZE = 2**24
     # MAX_CALLDATA_SIZE = 2**24
     # MAX_ACCESS_LIST_SIZE = 2**24
     # MAX_ACCESS_LIST_STORAGE_KEYS = 2**24
     # MAX_TX_WRAP_COMMITMENTS = 2**12
     # LIMIT_BLOBS_PER_TX = 2**12
-    GAS_PER_BLOB = 2**17
     HASH_OPCODE_BYTE = 0x49
     HASH_GAS_COST = 3
 
@@ -80,49 +67,13 @@ class Spec:
         return blob_commitment_version_kzg + sha256(kzg_commitment).digest()[1:]
 
     @classmethod
-    def fake_exponential(cls, factor: int, numerator: int, denominator: int) -> int:
-        """
-        Used to calculate the blob gas cost.
-        """
-        i = 1
-        output = 0
-        numerator_accumulator = factor * denominator
-        while numerator_accumulator > 0:
-            output += numerator_accumulator
-            numerator_accumulator = (numerator_accumulator * numerator) // (denominator * i)
-            i += 1
-        return output // denominator
-
-    @classmethod
-    def calc_excess_blob_gas(cls, parent: BlockHeaderBlobGasFields) -> int:
-        """
-        Calculate the excess blob gas for a block given the excess blob gas
-        and blob gas used from the parent block header.
-        """
-        if parent.excess_blob_gas + parent.blob_gas_used < cls.TARGET_BLOB_GAS_PER_BLOCK:
-            return 0
-        else:
-            return parent.excess_blob_gas + parent.blob_gas_used - cls.TARGET_BLOB_GAS_PER_BLOCK
-
-    @classmethod
-    def get_total_blob_gas(cls, tx: Transaction) -> int:
+    def get_total_blob_gas(cls, *, tx: Transaction, blob_gas_per_blob: int) -> int:
         """
         Calculate the total blob gas for a transaction.
         """
         if tx.blob_versioned_hashes is None:
             return 0
-        return cls.GAS_PER_BLOB * len(tx.blob_versioned_hashes)
-
-    @classmethod
-    def get_blob_gasprice(cls, *, excess_blob_gas: int) -> int:
-        """
-        Calculate the blob gas price from the excess.
-        """
-        return cls.fake_exponential(
-            cls.MIN_BLOB_GASPRICE,
-            excess_blob_gas,
-            cls.BLOB_GASPRICE_UPDATE_FRACTION,
-        )
+        return blob_gas_per_blob * len(tx.blob_versioned_hashes)
 
 
 @dataclass(frozen=True)
@@ -135,49 +86,85 @@ class SpecHelpers:
     BYTES_PER_FIELD_ELEMENT = 32
 
     @classmethod
-    def max_blobs_per_block(cls) -> int:  # MAX_BLOBS_PER_BLOCK =
-        """
-        Returns the maximum number of blobs per block.
-        """
-        return Spec.MAX_BLOB_GAS_PER_BLOCK // Spec.GAS_PER_BLOB
-
-    @classmethod
-    def target_blobs_per_block(cls) -> int:
-        """
-        Returns the target number of blobs per block.
-        """
-        return Spec.TARGET_BLOB_GAS_PER_BLOCK // Spec.GAS_PER_BLOB
-
-    @classmethod
-    def calc_excess_blob_gas_from_blob_count(
-        cls, parent_excess_blob_gas: int, parent_blob_count: int
+    def get_min_excess_blob_gas_for_blob_gas_price(
+        cls,
+        *,
+        fork: Fork,
+        blob_gas_price: int,
     ) -> int:
-        """
-        Calculate the excess blob gas for a block given the parent excess blob gas
-        and the number of blobs in the block.
-        """
-        parent_consumed_blob_gas = parent_blob_count * Spec.GAS_PER_BLOB
-        return Spec.calc_excess_blob_gas(
-            BlockHeaderBlobGasFields(parent_excess_blob_gas, parent_consumed_blob_gas)
-        )
-
-    @classmethod
-    def get_min_excess_blob_gas_for_blob_gas_price(cls, blob_gas_price: int) -> int:
         """
         Gets the minimum required excess blob gas value to get a given blob gas cost in a block
         """
         current_excess_blob_gas = 0
         current_blob_gas_price = 1
+        get_blob_gas_price = fork.blob_gas_price_calculator()
+        gas_per_blob = fork.blob_gas_per_blob()
         while current_blob_gas_price < blob_gas_price:
-            current_excess_blob_gas += Spec.GAS_PER_BLOB
-            current_blob_gas_price = Spec.get_blob_gasprice(
-                excess_blob_gas=current_excess_blob_gas
-            )
+            current_excess_blob_gas += gas_per_blob
+            current_blob_gas_price = get_blob_gas_price(excess_blob_gas=current_excess_blob_gas)
         return current_excess_blob_gas
 
     @classmethod
-    def get_min_excess_blobs_for_blob_gas_price(cls, blob_gas_price: int) -> int:
+    def get_min_excess_blobs_for_blob_gas_price(
+        cls,
+        *,
+        fork: Fork,
+        blob_gas_price: int,
+    ) -> int:
         """
         Gets the minimum required excess blobs to get a given blob gas cost in a block
         """
-        return cls.get_min_excess_blob_gas_for_blob_gas_price(blob_gas_price) // Spec.GAS_PER_BLOB
+        gas_per_blob = fork.blob_gas_per_blob()
+        return (
+            cls.get_min_excess_blob_gas_for_blob_gas_price(
+                fork=fork, blob_gas_price=blob_gas_price,
+            )
+            // gas_per_blob
+        )
+
+    @classmethod
+    def get_blob_combinations(
+        cls,
+        blob_count: int,
+    ) -> List[Tuple[int, ...]]:
+        """
+        Get all possible combinations of blobs that result in a given blob count.
+        """
+        all = [
+            seq
+            for i in range(
+                blob_count + 1, 0, -1
+            )  # We can have from 1 to at most MAX_BLOBS_PER_BLOCK blobs per block
+            for seq in itertools.combinations_with_replacement(
+                range(1, blob_count + 2), i
+            )  # We iterate through all possible combinations
+            if sum(seq) == blob_count  # And we only keep the ones that match the
+            # expected invalid blob count
+        ]
+
+        # We also add the reversed version of each combination, only if it's not
+        # already in the list. E.g. (4, 1) is added from (1, 4) but not
+        # (1, 1, 1, 1, 1) because its reversed version is identical.
+        all += [tuple(reversed(x)) for x in all if tuple(reversed(x)) not in all]
+        return all
+
+    @classmethod
+    def all_valid_blob_combinations(cls, fork: Fork) -> List[Tuple[int, ...]]:
+        """
+        Returns all valid blob tx combinations for a given block,
+        assuming the given MAX_BLOBS_PER_BLOCK
+        """
+        max_blobs_per_block = fork.max_blobs_per_block()
+        all: List[Tuple[int, ...]] = []
+        for i in range(1, max_blobs_per_block + 1):
+            all += cls.get_blob_combinations(i)
+        return all
+
+    @classmethod
+    def invalid_blob_combinations(cls, fork: Fork) -> List[Tuple[int, ...]]:
+        """
+        Returns invalid blob tx combinations for a given block that use up to
+        MAX_BLOBS_PER_BLOCK+1 blobs
+        """
+        max_blobs_per_block = fork.max_blobs_per_block()
+        return cls.get_blob_combinations(max_blobs_per_block + 1)

--- a/tests/cancun/eip4844_blobs/test_blob_txs.py
+++ b/tests/cancun/eip4844_blobs/test_blob_txs.py
@@ -20,7 +20,7 @@ from typing import List, Optional, Tuple
 
 import pytest
 
-from ethereum_test_forks import Fork, Prague
+from ethereum_test_forks import Fork
 from ethereum_test_tools import (
     EOA,
     AccessList,
@@ -290,24 +290,14 @@ def tx_access_list() -> List[AccessList]:
 
 
 @pytest.fixture
-def tx_error(
-    request: pytest.FixtureRequest,
-    fork: Fork,
-) -> Optional[TransactionException]:
+def tx_error() -> Optional[TransactionException]:
     """
     Default expected error produced by the block transactions (no error).
 
     Can be overloaded on test cases where the transactions are expected
     to fail.
     """
-    if not hasattr(request, "param"):
-        return None
-    if fork >= Prague and request.param in [
-        TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED,
-        TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED,
-    ]:
-        return None
-    return request.param
+    return None
 
 
 @pytest.fixture
@@ -746,10 +736,7 @@ def test_invalid_normal_gas(
     invalid_blob_combinations(),
 )
 @pytest.mark.parametrize(
-    "tx_error",
-    [TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED],
-    ids=[""],
-    indirect=True,
+    "tx_error", [TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED], ids=[""]
 )
 @pytest.mark.valid_from("Cancun")
 def test_invalid_block_blob_count(
@@ -1020,7 +1007,6 @@ def test_insufficient_balance_blob_tx_combinations(
         ),
     ],
     ids=["too_few_blobs", "too_many_blobs"],
-    indirect=["tx_error"],
 )
 @pytest.mark.valid_from("Cancun")
 def test_invalid_tx_blob_count(

--- a/tests/cancun/eip4844_blobs/test_blob_txs.py
+++ b/tests/cancun/eip4844_blobs/test_blob_txs.py
@@ -1268,7 +1268,7 @@ def test_blob_tx_attribute_calldata_opcodes(
 
 @pytest.mark.parametrize("tx_max_priority_fee_per_gas", [0, 2])  # always below data fee
 @pytest.mark.parametrize("tx_max_fee_per_blob_gas_delta", [0, 1])  # normal and above priority fee
-@pytest.mark.parametrize("tx_max_fee_per_gas", [100])  # always above priority fee
+@pytest.mark.parametrize("tx_max_fee_per_gas", [100])  # always above priority fee (FOR CANCUN)
 @pytest.mark.parametrize("opcode", [Op.GASPRICE], indirect=True)
 @pytest.mark.parametrize("tx_gas", [500_000])
 @pytest.mark.valid_from("Cancun")

--- a/tests/cancun/eip4844_blobs/test_blob_txs_full.py
+++ b/tests/cancun/eip4844_blobs/test_blob_txs_full.py
@@ -7,6 +7,7 @@ from typing import List, Optional
 
 import pytest
 
+from ethereum_test_forks import Fork
 from ethereum_test_tools import (
     Address,
     Alloc,
@@ -18,6 +19,7 @@ from ethereum_test_tools import (
     Transaction,
     TransactionException,
 )
+from pytest_plugins import fork_covariant_parametrize
 
 from .common import INF_POINT, Blob
 from .spec import Spec, SpecHelpers, ref_spec_4844
@@ -54,12 +56,6 @@ def tx_calldata() -> bytes:
     return b""
 
 
-@pytest.fixture
-def block_fee_per_gas() -> int:
-    """Default max fee per gas for transactions sent during test."""
-    return 7
-
-
 @pytest.fixture(autouse=True)
 def parent_excess_blobs() -> int:
     """
@@ -79,32 +75,6 @@ def parent_blobs() -> int:
     Can be overloaded by a test case to provide a custom parent blob count.
     """
     return 0
-
-
-@pytest.fixture
-def parent_excess_blob_gas(
-    parent_excess_blobs: int,
-) -> int:
-    """
-    Calculates the excess blob gas of the parent block from the excess blobs.
-    """
-    return parent_excess_blobs * Spec.GAS_PER_BLOB
-
-
-@pytest.fixture
-def blob_gasprice(
-    parent_excess_blob_gas: int,
-    parent_blobs: int,
-) -> int:
-    """
-    Blob gas price for the block of the test.
-    """
-    return Spec.get_blob_gasprice(
-        excess_blob_gas=SpecHelpers.calc_excess_blob_gas_from_blob_count(
-            parent_excess_blob_gas=parent_excess_blob_gas,
-            parent_blob_count=parent_blobs,
-        ),
-    )
 
 
 @pytest.fixture
@@ -128,7 +98,7 @@ def txs_versioned_hashes(txs_blobs: List[List[Blob]]) -> List[List[bytes]]:
 
 @pytest.fixture(autouse=True)
 def tx_max_fee_per_gas(
-    block_fee_per_gas: int,
+    block_base_fee_per_gas: int,
 ) -> int:
     """
     Max fee per gas value used by all transactions sent during test.
@@ -138,12 +108,12 @@ def tx_max_fee_per_gas(
     Can be overloaded by a test case to test rejection of transactions where
     the max fee per gas is insufficient.
     """
-    return block_fee_per_gas
+    return block_base_fee_per_gas
 
 
 @pytest.fixture
 def tx_max_fee_per_blob_gas(  # noqa: D103
-    blob_gasprice: Optional[int],
+    blob_gas_price: Optional[int],
 ) -> int:
     """
     Default max fee per blob gas for transactions sent during test.
@@ -153,10 +123,10 @@ def tx_max_fee_per_blob_gas(  # noqa: D103
     Can be overloaded by a test case to test rejection of transactions where
     the max fee per blob gas is insufficient.
     """
-    if blob_gasprice is None:
+    if blob_gas_price is None:
         # When fork transitioning, the default blob gas price is 1.
         return 1
-    return blob_gasprice
+    return blob_gas_price
 
 
 @pytest.fixture
@@ -236,6 +206,7 @@ def env(
 def blocks(
     txs: List[Transaction],
     txs_wrapped_blobs: List[bool],
+    blob_gas_per_blob: int,
 ) -> List[Block]:
     """
     Prepare the list of blocks for all test cases.
@@ -258,7 +229,7 @@ def blocks(
                     if tx.blob_versioned_hashes is not None
                 ]
             )
-            * Spec.GAS_PER_BLOB
+            * blob_gas_per_blob
         )
     return [
         Block(
@@ -267,59 +238,63 @@ def blocks(
     ]
 
 
-@pytest.mark.parametrize(
-    "txs_blobs,txs_wrapped_blobs",
-    [
-        (
+def generate_full_blob_tests(
+    fork: Fork,
+) -> List:
+    """
+    Returns a list of tests for invalid blob transactions due to insufficient max fee per blob gas
+    parametrized for each different fork.
+    """
+    blob_size = Spec.FIELD_ELEMENTS_PER_BLOB * SpecHelpers.BYTES_PER_FIELD_ELEMENT
+    max_blobs = fork.max_blobs_per_block()
+    return [
+        pytest.param(
             [  # Txs
                 [  # Blobs per transaction
                     Blob(
-                        blob=bytes(
-                            Spec.FIELD_ELEMENTS_PER_BLOB * SpecHelpers.BYTES_PER_FIELD_ELEMENT
-                        ),
+                        blob=bytes(blob_size),
                         kzg_commitment=INF_POINT,
                         kzg_proof=INF_POINT,
                     ),
                 ]
             ],
             [True],
+            id="one_full_blob_one_tx",
         ),
-        (
+        pytest.param(
             [  # Txs
                 [  # Blobs per transaction
                     Blob(
-                        blob=bytes(
-                            Spec.FIELD_ELEMENTS_PER_BLOB * SpecHelpers.BYTES_PER_FIELD_ELEMENT
-                        ),
+                        blob=bytes(blob_size),
                         kzg_commitment=INF_POINT,
                         kzg_proof=INF_POINT,
                     )
                 ]
-                for _ in range(SpecHelpers.max_blobs_per_block())
+                for _ in range(max_blobs)
             ],
-            [True] + ([False] * (SpecHelpers.max_blobs_per_block() - 1)),
+            [True] + ([False] * (max_blobs - 1)),
+            id="one_full_blob_max_txs",
         ),
-        (
+        pytest.param(
             [  # Txs
                 [  # Blobs per transaction
                     Blob(
-                        blob=bytes(
-                            Spec.FIELD_ELEMENTS_PER_BLOB * SpecHelpers.BYTES_PER_FIELD_ELEMENT
-                        ),
+                        blob=bytes(blob_size),
                         kzg_commitment=INF_POINT,
                         kzg_proof=INF_POINT,
                     )
                 ]
-                for _ in range(SpecHelpers.max_blobs_per_block())
+                for _ in range(max_blobs)
             ],
-            ([False] * (SpecHelpers.max_blobs_per_block() - 1)) + [True],
+            ([False] * (max_blobs - 1)) + [True],
+            id="one_full_blob_at_the_end_max_txs",
         ),
-    ],
-    ids=[
-        "one_full_blob_one_tx",
-        "one_full_blob_max_txs",
-        "one_full_blob_at_the_end_max_txs",
-    ],
+    ]
+
+
+@fork_covariant_parametrize(
+    parameter_names="txs_blobs,txs_wrapped_blobs",
+    fn=generate_full_blob_tests,
 )
 @pytest.mark.valid_from("Cancun")
 def test_reject_valid_full_blob_in_block_rlp(

--- a/tests/cancun/eip4844_blobs/test_blobhash_opcode.py
+++ b/tests/cancun/eip4844_blobs/test_blobhash_opcode.py
@@ -20,6 +20,7 @@ from typing import List
 
 import pytest
 
+from ethereum_test_forks import Fork
 from ethereum_test_tools import (
     Account,
     Address,
@@ -59,6 +60,7 @@ blobhash_index_values = [
 @pytest.mark.with_all_tx_types
 def test_blobhash_gas_cost(
     pre: Alloc,
+    fork: Fork,
     tx_type: int,
     blobhash_index: int,
     state_test: StateTestFiller,
@@ -90,7 +92,7 @@ def test_blobhash_gas_cost(
         access_list=[] if tx_type >= 1 else None,
         max_fee_per_gas=10 if tx_type >= 2 else None,
         max_priority_fee_per_gas=10 if tx_type >= 2 else None,
-        max_fee_per_blob_gas=10 if tx_type == 3 else None,
+        max_fee_per_blob_gas=(fork.min_base_fee_per_blob_gas() * 10) if tx_type == 3 else None,
         blob_versioned_hashes=random_blob_hashes[0:target_blobs_per_block]
         if tx_type == 3
         else None,
@@ -116,6 +118,7 @@ def test_blobhash_gas_cost(
 )
 def test_blobhash_scenarios(
     pre: Alloc,
+    fork: Fork,
     scenario: str,
     blockchain_test: BlockchainTestFiller,
     max_blobs_per_block: int,
@@ -152,7 +155,7 @@ def test_blobhash_scenarios(
                         access_list=[],
                         max_fee_per_gas=10,
                         max_priority_fee_per_gas=10,
-                        max_fee_per_blob_gas=10,
+                        max_fee_per_blob_gas=(fork.min_base_fee_per_blob_gas() * 10),
                         blob_versioned_hashes=b_hashes_list[i],
                     )
                 ]
@@ -176,6 +179,7 @@ def test_blobhash_scenarios(
 )
 def test_blobhash_invalid_blob_index(
     pre: Alloc,
+    fork: Fork,
     blockchain_test: BlockchainTestFiller,
     scenario: str,
     max_blobs_per_block: int,
@@ -213,7 +217,7 @@ def test_blobhash_invalid_blob_index(
                         access_list=[],
                         max_fee_per_gas=10,
                         max_priority_fee_per_gas=10,
-                        max_fee_per_blob_gas=10,
+                        max_fee_per_blob_gas=(fork.min_base_fee_per_blob_gas() * 10),
                         blob_versioned_hashes=blobs,
                     )
                 ]
@@ -237,6 +241,7 @@ def test_blobhash_invalid_blob_index(
 
 def test_blobhash_multiple_txs_in_block(
     pre: Alloc,
+    fork: Fork,
     blockchain_test: BlockchainTestFiller,
     max_blobs_per_block: int,
 ):
@@ -264,7 +269,7 @@ def test_blobhash_multiple_txs_in_block(
             access_list=[] if type >= 1 else None,
             max_fee_per_gas=10,
             max_priority_fee_per_gas=10,
-            max_fee_per_blob_gas=10 if type >= 3 else None,
+            max_fee_per_blob_gas=(fork.min_base_fee_per_blob_gas() * 10) if type >= 3 else None,
             blob_versioned_hashes=random_blob_hashes[0:max_blobs_per_block] if type >= 3 else None,
         )
 

--- a/tests/cancun/eip4844_blobs/test_blobhash_opcode_contexts.py
+++ b/tests/cancun/eip4844_blobs/test_blobhash_opcode_contexts.py
@@ -9,6 +9,7 @@ from typing import List
 
 import pytest
 
+from ethereum_test_forks import Fork
 from ethereum_test_tools import (
     Account,
     Block,
@@ -54,6 +55,7 @@ def simple_blob_hashes(
 
 @pytest.fixture()
 def tx_type_3(
+    fork: Fork,
     simple_blob_hashes: List[bytes],
 ) -> Transaction:
     """Blob transaction template."""
@@ -63,7 +65,7 @@ def tx_type_3(
         gas_limit=3000000,
         max_fee_per_gas=10,
         max_priority_fee_per_gas=10,
-        max_fee_per_blob_gas=10,
+        max_fee_per_blob_gas=fork.min_base_fee_per_blob_gas() * 10,
         access_list=[],
         blob_versioned_hashes=simple_blob_hashes,
     )

--- a/tests/cancun/eip4844_blobs/test_excess_blob_gas.py
+++ b/tests/cancun/eip4844_blobs/test_excess_blob_gas.py
@@ -22,7 +22,7 @@ note: Adding a new test
 """  # noqa: E501
 
 import itertools
-from typing import Dict, Iterator, List, Mapping, Optional, Tuple
+from typing import Callable, Dict, Iterator, List, Mapping, Optional, Tuple
 
 import pytest
 
@@ -42,6 +42,7 @@ from ethereum_test_tools import (
 )
 from ethereum_test_tools import Opcodes as Op
 from ethereum_test_tools import Transaction, add_kzg_version
+from pytest_plugins import fork_covariant_parametrize
 
 from .spec import Spec, SpecHelpers, ref_spec_4844
 
@@ -53,27 +54,11 @@ pytestmark = pytest.mark.valid_from("Cancun")
 
 
 @pytest.fixture
-def parent_excess_blobs() -> int:  # noqa: D103
+def parent_excess_blobs(fork: Fork) -> int:  # noqa: D103
     """
     By default we start with an intermediate value between the target and max.
     """
-    return (SpecHelpers.max_blobs_per_block() + SpecHelpers.target_blobs_per_block()) // 2 + 1
-
-
-@pytest.fixture
-def parent_excess_blob_gas(fork: Fork, parent_excess_blobs: int) -> int:  # noqa: D103
-    return parent_excess_blobs * fork.blob_gas_per_blob()
-
-
-@pytest.fixture
-def correct_excess_blob_gas(  # noqa: D103
-    parent_excess_blob_gas: int,
-    parent_blobs: int,
-) -> int:
-    return SpecHelpers.calc_excess_blob_gas_from_blob_count(
-        parent_excess_blob_gas=parent_excess_blob_gas,
-        parent_blob_count=parent_blobs,
-    )
+    return (fork.max_blobs_per_block() + fork.target_blobs_per_block()) // 2 + 1
 
 
 @pytest.fixture
@@ -91,10 +76,11 @@ def header_excess_blob_gas(  # noqa: D103
     correct_excess_blob_gas: int,
     header_excess_blobs_delta: Optional[int],
     header_excess_blob_gas_delta: Optional[int],
+    blob_gas_per_blob: int,
 ) -> Optional[int]:
     if header_excess_blobs_delta is not None:
         modified_excess_blob_gas = correct_excess_blob_gas + (
-            header_excess_blobs_delta * Spec.GAS_PER_BLOB
+            header_excess_blobs_delta * blob_gas_per_blob
         )
         if modified_excess_blob_gas < 0:
             modified_excess_blob_gas = 2**64 + (modified_excess_blob_gas)
@@ -105,37 +91,12 @@ def header_excess_blob_gas(  # noqa: D103
 
 
 @pytest.fixture
-def block_fee_per_blob_gas(  # noqa: D103
-    correct_excess_blob_gas: int,
-) -> int:
-    return Spec.get_blob_gasprice(excess_blob_gas=correct_excess_blob_gas)
-
-
-@pytest.fixture
-def tx_max_fee_per_gas(  # noqa: D103
-    block_base_fee: int,
-) -> int:
-    return block_base_fee
-
-
-@pytest.fixture
-def tx_max_fee_per_blob_gas(  # noqa: D103
-    block_fee_per_blob_gas: int,
-) -> int:
-    return block_fee_per_blob_gas
-
-
-@pytest.fixture
-def tx_data_cost(  # noqa: D103
+def tx_blob_data_cost(  # noqa: D103
     tx_max_fee_per_blob_gas: int,
     new_blobs: int,
+    blob_gas_per_blob: int,
 ) -> int:
-    return tx_max_fee_per_blob_gas * Spec.GAS_PER_BLOB * new_blobs
-
-
-@pytest.fixture
-def tx_value() -> int:  # noqa: D103
-    return 1
+    return tx_max_fee_per_blob_gas * blob_gas_per_blob * new_blobs
 
 
 @pytest.fixture
@@ -145,9 +106,9 @@ def tx_gas_limit() -> int:  # noqa: D103
 
 @pytest.fixture
 def tx_exact_cost(  # noqa: D103
-    tx_value: int, tx_max_fee_per_gas: int, tx_data_cost: int, tx_gas_limit: int
+    tx_value: int, tx_max_fee_per_gas: int, tx_blob_data_cost: int, tx_gas_limit: int
 ) -> int:
-    return (tx_gas_limit * tx_max_fee_per_gas) + tx_value + tx_data_cost
+    return (tx_gas_limit * tx_max_fee_per_gas) + tx_value + tx_blob_data_cost
 
 
 @pytest.fixture
@@ -171,11 +132,11 @@ def sender(pre: Alloc, tx_exact_cost: int) -> Address:  # noqa: D103
 
 @pytest.fixture
 def post(  # noqa: D103
-    destination_account: Address, tx_value: int, block_fee_per_blob_gas: int
+    destination_account: Address, tx_value: int, blob_gas_price: int
 ) -> Mapping[Address, Account]:
     return {
         destination_account: Account(
-            storage={0: block_fee_per_blob_gas},
+            storage={0: blob_gas_price},
             balance=tx_value,
         ),
     }
@@ -227,10 +188,10 @@ def header_blob_gas_used() -> Optional[int]:  # noqa: D103
 
 @pytest.fixture
 def correct_blob_gas_used(  # noqa: D103
-    fork: Fork,
     tx: Transaction,
+    blob_gas_per_blob: int,
 ) -> int:
-    return Spec.get_total_blob_gas(tx=tx, blob_gas_per_blob=Spec.GAS_PER_BLOB)
+    return Spec.get_total_blob_gas(tx=tx, blob_gas_per_blob=blob_gas_per_blob)
 
 
 @pytest.fixture
@@ -241,6 +202,8 @@ def blocks(  # noqa: D103
     correct_excess_blob_gas: int,
     correct_blob_gas_used: int,
     non_zero_blob_gas_used_genesis_block: Block,
+    max_blobs_per_block: int,
+    blob_gas_per_blob: int,
 ):
     blocks = (
         []
@@ -273,7 +236,7 @@ def blocks(  # noqa: D103
             exception_message=BlockException.INCORRECT_EXCESS_BLOB_GAS,
         )
     elif header_blob_gas_used is not None:
-        if header_blob_gas_used > Spec.MAX_BLOB_GAS_PER_BLOCK:
+        if header_blob_gas_used > (max_blobs_per_block * blob_gas_per_blob):
             add_block(
                 header_modifier={"blob_gas_used": header_blob_gas_used},
                 exception_message=[
@@ -292,8 +255,14 @@ def blocks(  # noqa: D103
     return blocks
 
 
-@pytest.mark.parametrize("parent_blobs", range(0, SpecHelpers.max_blobs_per_block() + 1))
-@pytest.mark.parametrize("parent_excess_blobs", range(0, SpecHelpers.target_blobs_per_block() + 1))
+@fork_covariant_parametrize(
+    parameter_names="parent_blobs",
+    fn=lambda fork: range(0, fork.max_blobs_per_block() + 1),
+)
+@fork_covariant_parametrize(
+    parameter_names="parent_excess_blobs",
+    fn=lambda fork: range(0, fork.target_blobs_per_block() + 1),
+)
 @pytest.mark.parametrize("new_blobs", [1])
 def test_correct_excess_blob_gas_calculation(
     blockchain_test: BlockchainTestFiller,
@@ -319,26 +288,42 @@ def test_correct_excess_blob_gas_calculation(
     )
 
 
-BLOB_GAS_COST_INCREASES = [
-    SpecHelpers.get_min_excess_blobs_for_blob_gas_price(i)
-    for i in [
-        2,  # First blob gas cost increase
-        2**32 // Spec.GAS_PER_BLOB,  # Data tx wei cost 2^32
-        2**32,  # blob gas cost 2^32
-        2**64 // Spec.GAS_PER_BLOB,  # Data tx wei cost 2^64
-        2**64,  # blob gas cost 2^64
-        (
-            120_000_000 * (10**18) // Spec.GAS_PER_BLOB
-        ),  # Data tx wei is current total Ether supply
-    ]
-]
+def generate_blob_gas_cost_increases_tests(delta: int) -> Callable[[Fork], List[int]]:
+    """
+    Generates a list of block excess blob gas values where the blob gas price increases
+    based on fork properties.
+    """
+
+    def generator_function(fork: Fork) -> List[int]:
+        gas_per_blob = fork.blob_gas_per_blob()
+        return [
+            SpecHelpers.get_min_excess_blobs_for_blob_gas_price(
+                fork=fork, blob_gas_price=blob_gas_price
+            )
+            + delta
+            for blob_gas_price in [
+                2,  # First blob gas cost increase
+                2**32 // gas_per_blob,  # Data tx wei cost 2^32
+                2**32,  # blob gas cost 2^32
+                2**64 // gas_per_blob,  # Data tx wei cost 2^64
+                2**64,  # blob gas cost 2^64
+                (
+                    120_000_000 * (10**18) // gas_per_blob
+                ),  # Data tx wei is current total Ether supply
+            ]
+        ]
+
+    return generator_function
 
 
-@pytest.mark.parametrize(
-    "parent_excess_blobs",
-    [g - 1 for g in BLOB_GAS_COST_INCREASES],
+@fork_covariant_parametrize(
+    parameter_names="parent_excess_blobs",
+    fn=generate_blob_gas_cost_increases_tests(-1),
 )
-@pytest.mark.parametrize("parent_blobs", [SpecHelpers.target_blobs_per_block() + 1])
+@fork_covariant_parametrize(
+    parameter_names="parent_blobs",
+    fn=lambda fork: [fork.target_blobs_per_block() + 1],
+)
 @pytest.mark.parametrize("new_blobs", [1])
 def test_correct_increasing_blob_gas_costs(
     blockchain_test: BlockchainTestFiller,
@@ -368,11 +353,14 @@ def test_correct_increasing_blob_gas_costs(
     )
 
 
-@pytest.mark.parametrize(
-    "parent_excess_blobs",
-    [g for g in BLOB_GAS_COST_INCREASES],
+@fork_covariant_parametrize(
+    parameter_names="parent_excess_blobs",
+    fn=generate_blob_gas_cost_increases_tests(0),
 )
-@pytest.mark.parametrize("parent_blobs", [SpecHelpers.target_blobs_per_block() - 1])
+@fork_covariant_parametrize(
+    parameter_names="parent_blobs",
+    fn=lambda fork: [fork.target_blobs_per_block() - 1],
+)
 @pytest.mark.parametrize("new_blobs", [1])
 def test_correct_decreasing_blob_gas_costs(
     blockchain_test: BlockchainTestFiller,
@@ -399,7 +387,10 @@ def test_correct_decreasing_blob_gas_costs(
 
 @pytest.mark.parametrize("header_excess_blob_gas", [0])
 @pytest.mark.parametrize("new_blobs", [0, 1])
-@pytest.mark.parametrize("parent_blobs", range(0, SpecHelpers.max_blobs_per_block() + 1))
+@fork_covariant_parametrize(
+    parameter_names="parent_blobs",
+    fn=lambda fork: range(0, fork.max_blobs_per_block() + 1),
+)
 def test_invalid_zero_excess_blob_gas_in_header(
     blockchain_test: BlockchainTestFiller,
     env: Environment,
@@ -433,20 +424,21 @@ def test_invalid_zero_excess_blob_gas_in_header(
     )
 
 
-def all_invalid_blob_gas_used_combinations() -> Iterator[Tuple[int, int]]:
+def all_invalid_blob_gas_used_combinations(fork: Fork) -> Iterator[Tuple[int, int]]:
     """
     Returns all invalid blob gas used combinations.
     """
-    for new_blobs in range(0, SpecHelpers.max_blobs_per_block() + 1):
-        for header_blob_gas_used in range(0, SpecHelpers.max_blobs_per_block() + 1):
+    gas_per_blob = fork.blob_gas_per_blob()
+    for new_blobs in range(0, fork.max_blobs_per_block() + 1):
+        for header_blob_gas_used in range(0, fork.max_blobs_per_block() + 1):
             if new_blobs != header_blob_gas_used:
-                yield (new_blobs, header_blob_gas_used * Spec.GAS_PER_BLOB)
+                yield (new_blobs, header_blob_gas_used * gas_per_blob)
         yield (new_blobs, 2**64 - 1)
 
 
-@pytest.mark.parametrize(
-    "new_blobs,header_blob_gas_used",
-    all_invalid_blob_gas_used_combinations(),
+@fork_covariant_parametrize(
+    parameter_names="new_blobs,header_blob_gas_used",
+    fn=all_invalid_blob_gas_used_combinations,
 )
 @pytest.mark.parametrize("parent_blobs", [0])
 def test_invalid_blob_gas_used_in_header(
@@ -456,6 +448,7 @@ def test_invalid_blob_gas_used_in_header(
     blocks: List[Block],
     new_blobs: int,
     header_blob_gas_used: Optional[int],
+    blob_gas_per_blob: int,
 ):
     """
     Test rejection of blocks where the `blobGasUsed` in the header is invalid:
@@ -472,20 +465,26 @@ def test_invalid_blob_gas_used_in_header(
         genesis_environment=env,
         tag="-".join(
             [
-                f"correct:{hex(new_blobs * Spec.GAS_PER_BLOB)}",
+                f"correct:{hex(new_blobs * blob_gas_per_blob)}",
                 f"header:{hex(header_blob_gas_used)}",
             ]
         ),
     )
 
 
-@pytest.mark.parametrize(
-    "header_excess_blobs_delta,parent_blobs",
-    [
-        (-1, 0),
-        (+1, SpecHelpers.max_blobs_per_block()),
-    ],
-    ids=["zero_blobs_decrease_more_than_expected", "max_blobs_increase_more_than_expected"],
+def generate_invalid_excess_blob_gas_above_target_change_tests(fork: Fork) -> List:
+    """
+    Returns all invalid excess blob gas above target change tests.
+    """
+    return [
+        pytest.param(-1, 0, id="zero_blobs_decrease_more_than_expected"),
+        pytest.param(+1, fork.max_blobs_per_block(), id="max_blobs_increase_more_than_expected"),
+    ]
+
+
+@fork_covariant_parametrize(
+    parameter_names="header_excess_blobs_delta,parent_blobs",
+    fn=generate_invalid_excess_blob_gas_above_target_change_tests,
 )
 @pytest.mark.parametrize("new_blobs", [1])
 def test_invalid_excess_blob_gas_above_target_change(
@@ -522,15 +521,15 @@ def test_invalid_excess_blob_gas_above_target_change(
     )
 
 
-@pytest.mark.parametrize(
-    "parent_blobs",
-    [
-        b
-        for b in range(0, SpecHelpers.max_blobs_per_block() + 1)
-        if b != SpecHelpers.target_blobs_per_block()
+@fork_covariant_parametrize(
+    parameter_names="parent_blobs",
+    fn=lambda fork: [
+        b for b in range(0, fork.max_blobs_per_block() + 1) if b != fork.target_blobs_per_block()
     ],
 )
-@pytest.mark.parametrize("parent_excess_blobs", [1, SpecHelpers.target_blobs_per_block()])
+@fork_covariant_parametrize(
+    parameter_names="parent_excess_blobs", fn=lambda fork: [1, fork.target_blobs_per_block()]
+)
 @pytest.mark.parametrize("new_blobs", [1])
 def test_invalid_static_excess_blob_gas(
     blockchain_test: BlockchainTestFiller,
@@ -563,8 +562,14 @@ def test_invalid_static_excess_blob_gas(
     )
 
 
-@pytest.mark.parametrize("header_excess_blobs_delta", range(1, SpecHelpers.max_blobs_per_block()))
-@pytest.mark.parametrize("parent_blobs", range(0, SpecHelpers.target_blobs_per_block() + 1))
+@fork_covariant_parametrize(
+    parameter_names="header_excess_blobs_delta",
+    fn=lambda fork: range(1, fork.max_blobs_per_block()),
+)
+@fork_covariant_parametrize(
+    parameter_names="parent_blobs",
+    fn=lambda fork: range(0, fork.target_blobs_per_block() + 1),
+)
 @pytest.mark.parametrize("parent_excess_blobs", [0])  # Start at 0
 @pytest.mark.parametrize("new_blobs", [1])
 def test_invalid_excess_blob_gas_target_blobs_increase_from_zero(
@@ -602,9 +607,9 @@ def test_invalid_excess_blob_gas_target_blobs_increase_from_zero(
 
 
 @pytest.mark.parametrize("header_excess_blob_gas", [0])
-@pytest.mark.parametrize(
-    "parent_blobs",
-    range(SpecHelpers.target_blobs_per_block() + 1, SpecHelpers.max_blobs_per_block() + 1),
+@fork_covariant_parametrize(
+    parameter_names="parent_blobs",
+    fn=lambda fork: range(fork.target_blobs_per_block() + 1, fork.max_blobs_per_block() + 1),
 )
 @pytest.mark.parametrize("parent_excess_blobs", [0])  # Start at 0
 @pytest.mark.parametrize("new_blobs", [1])
@@ -642,17 +647,15 @@ def test_invalid_static_excess_blob_gas_from_zero_on_blobs_above_target(
     )
 
 
-@pytest.mark.parametrize(
-    "parent_blobs,header_excess_blobs_delta",
-    itertools.product(
+@fork_covariant_parametrize(
+    parameter_names="parent_blobs,header_excess_blobs_delta",
+    fn=lambda fork: itertools.product(
         # parent_blobs
-        range(0, SpecHelpers.max_blobs_per_block() + 1),
+        range(0, fork.max_blobs_per_block() + 1),
         # header_excess_blobs_delta (from correct value)
         [
             x
-            for x in range(
-                -SpecHelpers.target_blobs_per_block(), SpecHelpers.target_blobs_per_block() + 1
-            )
+            for x in range(-fork.target_blobs_per_block(), fork.target_blobs_per_block() + 1)
             if x != 0
         ],
     ),
@@ -694,13 +697,22 @@ def test_invalid_excess_blob_gas_change(
     )
 
 
-@pytest.mark.parametrize(
-    "header_excess_blob_gas",
-    [(2**64 + (x * Spec.GAS_PER_BLOB)) for x in range(-SpecHelpers.target_blobs_per_block(), 0)],
+@fork_covariant_parametrize(
+    parameter_names="header_excess_blob_gas",
+    fn=lambda fork: [
+        (2**64 + (x * fork.blob_gas_per_blob()))
+        for x in range(-fork.target_blobs_per_block(), 0)
+    ],
 )
-@pytest.mark.parametrize("parent_blobs", range(SpecHelpers.target_blobs_per_block()))
+@fork_covariant_parametrize(
+    parameter_names="parent_blobs",
+    fn=lambda fork: range(fork.target_blobs_per_block()),
+)
 @pytest.mark.parametrize("new_blobs", [1])
-@pytest.mark.parametrize("parent_excess_blobs", range(SpecHelpers.target_blobs_per_block()))
+@fork_covariant_parametrize(
+    parameter_names="parent_excess_blobs",
+    fn=lambda fork: range(fork.target_blobs_per_block()),
+)
 def test_invalid_negative_excess_blob_gas(
     blockchain_test: BlockchainTestFiller,
     env: Environment,
@@ -736,17 +748,20 @@ def test_invalid_negative_excess_blob_gas(
     )
 
 
-@pytest.mark.parametrize(
-    "parent_blobs,header_excess_blob_gas_delta",
-    [
-        (SpecHelpers.target_blobs_per_block() + 1, 1),
-        (SpecHelpers.target_blobs_per_block() + 1, Spec.GAS_PER_BLOB - 1),
-        (SpecHelpers.target_blobs_per_block() - 1, -1),
-        (SpecHelpers.target_blobs_per_block() - 1, -(Spec.GAS_PER_BLOB - 1)),
+@fork_covariant_parametrize(
+    parameter_names="parent_blobs,header_excess_blob_gas_delta",
+    fn=lambda fork: [
+        (fork.target_blobs_per_block() + 1, 1),
+        (fork.target_blobs_per_block() + 1, fork.blob_gas_per_blob() - 1),
+        (fork.target_blobs_per_block() - 1, -1),
+        (fork.target_blobs_per_block() - 1, -(fork.blob_gas_per_blob() - 1)),
     ],
 )
 @pytest.mark.parametrize("new_blobs", [1])
-@pytest.mark.parametrize("parent_excess_blobs", [SpecHelpers.target_blobs_per_block() + 1])
+@fork_covariant_parametrize(
+    parameter_names="parent_excess_blobs",
+    fn=lambda fork: [fork.target_blobs_per_block() + 1],
+)
 def test_invalid_non_multiple_excess_blob_gas(
     blockchain_test: BlockchainTestFiller,
     env: Environment,

--- a/tests/cancun/eip4844_blobs/test_excess_blob_gas.py
+++ b/tests/cancun/eip4844_blobs/test_excess_blob_gas.py
@@ -26,6 +26,7 @@ from typing import Dict, Iterator, List, Mapping, Optional, Tuple
 
 import pytest
 
+from ethereum_test_forks import Fork
 from ethereum_test_tools import (
     EOA,
     Account,
@@ -60,8 +61,8 @@ def parent_excess_blobs() -> int:  # noqa: D103
 
 
 @pytest.fixture
-def parent_excess_blob_gas(parent_excess_blobs: int) -> int:  # noqa: D103
-    return parent_excess_blobs * Spec.GAS_PER_BLOB
+def parent_excess_blob_gas(fork: Fork, parent_excess_blobs: int) -> int:  # noqa: D103
+    return parent_excess_blobs * fork.blob_gas_per_blob()
 
 
 @pytest.fixture
@@ -108,27 +109,6 @@ def block_fee_per_blob_gas(  # noqa: D103
     correct_excess_blob_gas: int,
 ) -> int:
     return Spec.get_blob_gasprice(excess_blob_gas=correct_excess_blob_gas)
-
-
-@pytest.fixture
-def block_base_fee() -> int:  # noqa: D103
-    return 7
-
-
-@pytest.fixture
-def env(  # noqa: D103
-    parent_excess_blob_gas: int,
-    block_base_fee: int,
-    parent_blobs: int,
-) -> Environment:
-    return Environment(
-        excess_blob_gas=(
-            parent_excess_blob_gas
-            if parent_blobs == 0
-            else parent_excess_blob_gas + Spec.TARGET_BLOB_GAS_PER_BLOCK
-        ),
-        base_fee_per_gas=block_base_fee,
-    )
 
 
 @pytest.fixture
@@ -247,9 +227,10 @@ def header_blob_gas_used() -> Optional[int]:  # noqa: D103
 
 @pytest.fixture
 def correct_blob_gas_used(  # noqa: D103
+    fork: Fork,
     tx: Transaction,
 ) -> int:
-    return Spec.get_total_blob_gas(tx)
+    return Spec.get_total_blob_gas(tx=tx, blob_gas_per_blob=Spec.GAS_PER_BLOB)
 
 
 @pytest.fixture

--- a/tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py
+++ b/tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py
@@ -7,6 +7,7 @@ from typing import List, Mapping
 
 import pytest
 
+from ethereum_test_forks import Cancun, Fork
 from ethereum_test_tools import (
     Account,
     Address,
@@ -56,12 +57,12 @@ def pre_fork_blocks():
 
 
 @pytest.fixture
-def post_fork_block_count() -> int:
+def post_fork_block_count(fork: Fork) -> int:
     """
     Amount of blocks to produce with the post-fork rules.
     """
-    return SpecHelpers.get_min_excess_blobs_for_blob_gas_price(2) // (
-        SpecHelpers.max_blobs_per_block() - SpecHelpers.target_blobs_per_block()
+    return SpecHelpers.get_min_excess_blobs_for_blob_gas_price(fork=fork, blob_gas_price=2) // (
+        fork.max_blobs_per_block() - fork.target_blobs_per_block()
     )
 
 
@@ -225,13 +226,13 @@ def test_invalid_post_fork_block_without_blob_fields(
     "post_fork_block_count,blob_count_per_block",
     [
         (
-            SpecHelpers.get_min_excess_blobs_for_blob_gas_price(2)
-            // (SpecHelpers.max_blobs_per_block() - SpecHelpers.target_blobs_per_block())
+            SpecHelpers.get_min_excess_blobs_for_blob_gas_price(fork=Cancun, blob_gas_price=2)
+            // (Cancun.max_blobs_per_block() - Cancun.target_blobs_per_block())
             + 2,
-            SpecHelpers.max_blobs_per_block(),
+            Cancun.max_blobs_per_block(),
         ),
         (10, 0),
-        (10, SpecHelpers.target_blobs_per_block()),
+        (10, Cancun.target_blobs_per_block()),
     ],
     ids=["max_blobs", "no_blobs", "target_blobs"],
 )

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -2768,6 +2768,7 @@ def test_eoa_tx_after_set_code(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
     tx_type: int,
+    fork: Fork,
     evm_code_type: EVMCodeType,
 ):
     """
@@ -2855,7 +2856,7 @@ def test_eoa_tx_after_set_code(
                     value=0,
                     max_fee_per_gas=1_000,
                     max_priority_fee_per_gas=1_000,
-                    max_fee_per_blob_gas=1_000,
+                    max_fee_per_blob_gas=fork.min_base_fee_per_blob_gas() * 10,
                     blob_versioned_hashes=add_kzg_version(
                         [Hash(1)],
                         Spec4844.BLOB_COMMITMENT_VERSION_KZG,


### PR DESCRIPTION
## 🗒️ Description
This PR removes activation of EIP-7742 at Prague, but leaves the framework changes.

Adds [EIP-7691 Blob throughput increase](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7691.md) and [EIP-7762 Increase MIN_BASE_FEE_PER_BLOB_GAS](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7762.md).

Tests for both new EIPs are EIP-4844 tests updated and refactored to dynamically update on Prague to use the new constants.

Missing from this PR:
- Test fork transition and activation of EIP-7762: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7762.md#excess_blob_gas-reset

This PR requires #1019.

## 🔗 Related Issues
None

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
