### PR TITLE
feat(forks,specs,tests): EIP-7691, EIP-4844: Refactor to use dynamic parameters

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - 🔀 Update EIP-7251 according to [spec updates](https://github.com/ethereum/EIPs/pull/9127) ([#1024](https://github.com/ethereum/execution-spec-tests/pull/1024)).
 - 🔀 Update EIP-7002 according to [spec updates](https://github.com/ethereum/EIPs/pull/9119) ([#1024](https://github.com/ethereum/execution-spec-tests/pull/1024)).
 - 🔀 Update EIP-2935 according to [spec updates](https://github.com/ethereum/EIPs/pull/9144) ([#1046](https://github.com/ethereum/execution-spec-tests/pull/1046))
+- ✨ [EIP-7691](https://eips.ethereum.org/EIPS/eip-7691) Blob throughput increase tests by parametrization of existing EIP-4844 tests ([#1023](https://github.com/ethereum/execution-spec-tests/pull/1023))
 
 ### 🛠️ Framework
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -71,6 +71,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Slow tests now have greater timeout when making a request to the T8N server ([#1037](https://github.com/ethereum/execution-spec-tests/pull/1037)).
 - ✨ Introduce [`pytest.mark.parametrize_by_fork`](https://ethereum.github.io/execution-spec-tests/main/writing_tests/test_markers/#pytestmarkfork_parametrize) helper marker ([#1019](https://github.com/ethereum/execution-spec-tests/pull/1019), [#1057](https://github.com/ethereum/execution-spec-tests/pull/1057)).
 - 🐞 fix(consume): allow absolute paths with `--evm-bin` ([#1052](https://github.com/ethereum/execution-spec-tests/pull/1052)).
+- ✨ Disable EIP-7742 framework changes for Pectra ([#1023](https://github.com/ethereum/execution-spec-tests/pull/1023)).
 
 ### 🔧 EVM Tools
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -72,7 +72,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Slow tests now have greater timeout when making a request to the T8N server ([#1037](https://github.com/ethereum/execution-spec-tests/pull/1037)).
 - ✨ Introduce [`pytest.mark.parametrize_by_fork`](https://ethereum.github.io/execution-spec-tests/main/writing_tests/test_markers/#pytestmarkfork_parametrize) helper marker ([#1019](https://github.com/ethereum/execution-spec-tests/pull/1019), [#1057](https://github.com/ethereum/execution-spec-tests/pull/1057)).
 - 🐞 fix(consume): allow absolute paths with `--evm-bin` ([#1052](https://github.com/ethereum/execution-spec-tests/pull/1052)).
-- ✨ Disable EIP-7742 framework changes for Pectra ([#1023](https://github.com/ethereum/execution-spec-tests/pull/1023)).
+- ✨ Disable EIP-7742 framework changes for Prague ([#1023](https://github.com/ethereum/execution-spec-tests/pull/1023)).
 
 ### 🔧 EVM Tools
 

--- a/src/ethereum_test_fixtures/blockchain.py
+++ b/src/ethereum_test_fixtures/blockchain.py
@@ -229,7 +229,6 @@ EngineNewPayloadV4Parameters = Tuple[
     List[Hash],
     Hash,
     List[Bytes],
-    HexNumber,
 ]
 
 # Important: We check EngineNewPayloadV3Parameters first as it has more fields, and pydantic

--- a/src/ethereum_test_fixtures/tests/test_blockchain.py
+++ b/src/ethereum_test_fixtures/tests/test_blockchain.py
@@ -14,7 +14,6 @@ from ethereum_test_base_types import (
     Bytes,
     Hash,
     HeaderNonce,
-    HexNumber,
     TestPrivateKey,
     ZeroPaddedHexNumber,
     to_json,
@@ -667,7 +666,6 @@ fixture_header_ones = FixtureHeader(
                     excess_blob_gas=18,
                     parent_beacon_block_root=19,
                     requests_hash=20,
-                    target_blobs_per_block=21,
                 ),
                 transactions=[
                     Transaction(
@@ -729,7 +727,7 @@ fixture_header_ones = FixtureHeader(
                         "blobGasUsed": hex(17),
                         "excessBlobGas": hex(18),
                         "blockHash": (
-                            "0x9f6459fb2eca2b75ee861e97d679ba91457bb446c8484a7ad76d1675a7f78fde"
+                            "0x93bd662d8a80a1f54bffc6d140b83d6cda233209998809f9540be51178b4d0b6"
                         ),
                         "transactions": [
                             Transaction(
@@ -787,9 +785,8 @@ fixture_header_ones = FixtureHeader(
                             ),
                         ).requests_list
                     ],
-                    HexNumber(21).hex(),
                 ],
-                "forkchoiceUpdatedVersion": "4",
+                "forkchoiceUpdatedVersion": "3",
                 "newPayloadVersion": "4",
                 "validationError": "BlockException.INCORRECT_BLOCK_FORMAT"
                 "|TransactionException.INTRINSIC_GAS_TOO_LOW",
@@ -824,7 +821,6 @@ fixture_header_ones = FixtureHeader(
                     excess_blob_gas=18,
                     parent_beacon_block_root=19,
                     requests_hash=20,
-                    target_blobs_per_block=21,
                 ),
                 transactions=[
                     Transaction(
@@ -885,7 +881,7 @@ fixture_header_ones = FixtureHeader(
                         "blobGasUsed": hex(17),
                         "excessBlobGas": hex(18),
                         "blockHash": (
-                            "0x9f6459fb2eca2b75ee861e97d679ba91457bb446c8484a7ad76d1675a7f78fde"
+                            "0x93bd662d8a80a1f54bffc6d140b83d6cda233209998809f9540be51178b4d0b6"
                         ),
                         "transactions": [
                             Transaction(
@@ -943,10 +939,9 @@ fixture_header_ones = FixtureHeader(
                             ),
                         ).requests_list
                     ],
-                    HexNumber(21).hex(),
                 ],
                 "newPayloadVersion": "4",
-                "forkchoiceUpdatedVersion": "4",
+                "forkchoiceUpdatedVersion": "3",
                 "validationError": "BlockException.INCORRECT_BLOCK_FORMAT"
                 "|TransactionException.INTRINSIC_GAS_TOO_LOW",
             },
@@ -1224,7 +1219,6 @@ EngineNewPayloadParametersAdapter = TypeAdapter(EngineNewPayloadParameters)  # t
                         target_pubkey=BLSPublicKey(2),
                     ),
                 ).requests_list,
-                HexNumber(9),
             ),
             [
                 {
@@ -1290,7 +1284,6 @@ EngineNewPayloadParametersAdapter = TypeAdapter(EngineNewPayloadParameters)  # t
                         ),
                     ).requests_list
                 ],
-                HexNumber(9).hex(),
             ],
             id="fixture_engine_new_payload_parameters_v4",
         ),

--- a/src/ethereum_test_forks/base_fork.py
+++ b/src/ethereum_test_forks/base_fork.py
@@ -22,7 +22,7 @@ class ForkAttribute(Protocol):
 
 
 class MemoryExpansionGasCalculator(Protocol):
-    """A protocol to calculate the gas cost of memory expansion for a given fork."""
+    """A protocol to calculate the gas cost of memory expansion at a given fork."""
 
     def __call__(self, *, new_bytes: int, previous_bytes: int = 0) -> int:
         """Return gas cost of expanding the memory by the given length."""
@@ -30,7 +30,7 @@ class MemoryExpansionGasCalculator(Protocol):
 
 
 class CalldataGasCalculator(Protocol):
-    """A protocol to calculate the transaction gas cost of calldata for a given fork."""
+    """A protocol to calculate the transaction gas cost of calldata at a given fork."""
 
     def __call__(self, *, data: BytesConvertible, floor: bool = False) -> int:
         """Return the transaction gas cost of calldata given its contents."""
@@ -46,7 +46,7 @@ class TransactionDataFloorCostCalculator(Protocol):
 
 
 class TransactionIntrinsicCostCalculator(Protocol):
-    """A protocol to calculate the intrinsic gas cost of a transaction for a given fork."""
+    """A protocol to calculate the intrinsic gas cost of a transaction at a given fork."""
 
     def __call__(
         self,
@@ -75,6 +75,29 @@ class TransactionIntrinsicCostCalculator(Protocol):
             Gas cost of a transaction
 
         """
+        pass
+
+
+class BlobGasPriceCalculator(Protocol):
+    """A protocol to calculate the blob gas price given the excess blob gas at a given fork."""
+
+    def __call__(self, *, excess_blob_gas: int) -> int:
+        """Return the blob gas price given the excess blob gas."""
+        pass
+
+
+class ExcessBlobGasCalculator(Protocol):
+    """A protocol to calculate the excess blob gas for a block at a given fork."""
+
+    def __call__(
+        self,
+        *,
+        parent_excess_blob_gas: int | None = None,
+        parent_excess_blobs: int | None = None,
+        parent_blob_gas_used: int | None = None,
+        parent_blob_count: int | None = None,
+    ) -> int:
+        """Return the excess blob gas given the parent's excess blob gas and blob gas used."""
         pass
 
 
@@ -171,19 +194,21 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
 
     @classmethod
     @abstractmethod
-    def header_beacon_root_required(cls, block_number: int, timestamp: int) -> bool:
+    def header_beacon_root_required(cls, block_number: int = 0, timestamp: int = 0) -> bool:
         """Return true if the header must contain parent beacon block root."""
         pass
 
     @classmethod
     @abstractmethod
-    def header_requests_required(cls, block_number: int, timestamp: int) -> bool:
+    def header_requests_required(cls, block_number: int = 0, timestamp: int = 0) -> bool:
         """Return true if the header must contain beacon chain requests."""
         pass
 
     @classmethod
     @abstractmethod
-    def header_target_blobs_per_block_required(cls, block_number: int, timestamp: int) -> bool:
+    def header_target_blobs_per_block_required(
+        cls, block_number: int = 0, timestamp: int = 0
+    ) -> bool:
         """Return true if the header must contain target blobs per block."""
         pass
 
@@ -232,20 +257,48 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
 
     @classmethod
     @abstractmethod
-    def blob_gas_per_blob(cls, block_number: int, timestamp: int) -> int:
-        """Return amount of blob gas used per blob for a given fork."""
+    def blob_gas_price_calculator(
+        cls, block_number: int = 0, timestamp: int = 0
+    ) -> BlobGasPriceCalculator:
+        """Return a callable that calculates the blob gas price at a given fork."""
         pass
 
     @classmethod
     @abstractmethod
-    def target_blobs_per_block(cls, block_number: int, timestamp: int) -> int:
-        """Return target blobs per block for a given fork."""
+    def excess_blob_gas_calculator(
+        cls, block_number: int = 0, timestamp: int = 0
+    ) -> ExcessBlobGasCalculator:
+        """Return a callable that calculates the excess blob gas for a block at a given fork."""
         pass
 
     @classmethod
     @abstractmethod
-    def max_blobs_per_block(cls, block_number: int, timestamp: int) -> int:
-        """Return max blobs per block for a given fork."""
+    def min_base_fee_per_blob_gas(cls, block_number: int = 0, timestamp: int = 0) -> int:
+        """Return the minimum base fee per blob gas at a given fork."""
+        pass
+
+    @classmethod
+    @abstractmethod
+    def blob_gas_per_blob(cls, block_number: int = 0, timestamp: int = 0) -> int:
+        """Return the amount of blob gas used per blob at a given fork."""
+        pass
+
+    @classmethod
+    @abstractmethod
+    def blob_base_fee_update_fraction(cls, block_number: int = 0, timestamp: int = 0) -> int:
+        """Return the blob base fee update fraction at a given fork."""
+        pass
+
+    @classmethod
+    @abstractmethod
+    def target_blobs_per_block(cls, block_number: int = 0, timestamp: int = 0) -> int:
+        """Return the target blobs per block at a given fork."""
+        pass
+
+    @classmethod
+    @abstractmethod
+    def max_blobs_per_block(cls, block_number: int = 0, timestamp: int = 0) -> int:
+        """Return the max blobs per block at a given fork."""
         pass
 
     @classmethod

--- a/src/ethereum_test_forks/base_fork.py
+++ b/src/ethereum_test_forks/base_fork.py
@@ -181,6 +181,12 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
         """Return true if the header must contain beacon chain requests."""
         pass
 
+    @classmethod
+    @abstractmethod
+    def header_target_blobs_per_block_required(cls, block_number: int, timestamp: int) -> bool:
+        """Return true if the header must contain target blobs per block."""
+        pass
+
     # Gas related abstract methods
 
     @classmethod
@@ -222,12 +228,6 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
         cls, block_number: int = 0, timestamp: int = 0
     ) -> TransactionIntrinsicCostCalculator:
         """Return callable that calculates the intrinsic gas cost of a transaction for the fork."""
-        pass
-
-    @classmethod
-    @abstractmethod
-    def header_target_blobs_per_block_required(cls, block_number: int, timestamp: int) -> bool:
-        """Return true if the header must contain target blobs per block."""
         pass
 
     @classmethod

--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -14,23 +14,18 @@ from ethereum_test_vm import EVMCodeType, Opcodes
 
 from ..base_fork import (
     BaseFork,
+    BlobGasPriceCalculator,
     CalldataGasCalculator,
+    ExcessBlobGasCalculator,
     MemoryExpansionGasCalculator,
     TransactionDataFloorCostCalculator,
     TransactionIntrinsicCostCalculator,
 )
 from ..gas_costs import GasCosts
+from .helpers import ceiling_division, fake_exponential
 
 CURRENT_FILE = Path(realpath(__file__))
 CURRENT_FOLDER = CURRENT_FILE.parent
-
-
-def ceiling_division(a: int, b: int) -> int:
-    """
-    Calculate the ceil without using floating point.
-    Used by many of the EVM's formulas.
-    """
-    return -(a // -b)
 
 
 # All forks must be listed here !!! in the order they were introduced !!!
@@ -215,22 +210,46 @@ class Frontier(BaseFork, solc_name="homestead"):
         return fn
 
     @classmethod
-    def blob_gas_per_blob(cls, block_number: int, timestamp: int) -> int:
-        """Return amount of blob gas used per blob for a given fork."""
-        return 0
+    def blob_gas_price_calculator(
+        cls, block_number: int = 0, timestamp: int = 0
+    ) -> BlobGasPriceCalculator:
+        """Return a callable that calculates the blob gas price at a given fork."""
+        raise NotImplementedError("Blob gas price calculator is not supported in Frontier")
 
     @classmethod
-    def target_blobs_per_block(cls, block_number: int, timestamp: int) -> int:
-        """Return target number of blobs per block for a given fork."""
-        return 0
+    def excess_blob_gas_calculator(
+        cls, block_number: int = 0, timestamp: int = 0
+    ) -> ExcessBlobGasCalculator:
+        """Return a callable that calculates the excess blob gas for a block at a given fork."""
+        raise NotImplementedError("Excess blob gas calculator is not supported in Frontier")
 
     @classmethod
-    def max_blobs_per_block(cls, block_number: int, timestamp: int) -> int:
-        """Return max number of blobs per block for a given fork."""
-        return 0
+    def min_base_fee_per_blob_gas(cls, block_number: int = 0, timestamp: int = 0) -> int:
+        """Return the amount of blob gas used per blob at a given fork."""
+        raise NotImplementedError("Base fee per blob gas is not supported in Frontier")
 
     @classmethod
-    def header_requests_required(cls, block_number: int, timestamp: int) -> bool:
+    def blob_base_fee_update_fraction(cls, block_number: int = 0, timestamp: int = 0) -> int:
+        """Return the blob base fee update fraction at a given fork."""
+        raise NotImplementedError("Blob base fee update fraction is not supported in Frontier")
+
+    @classmethod
+    def blob_gas_per_blob(cls, block_number: int = 0, timestamp: int = 0) -> int:
+        """Return the amount of blob gas used per blob at a given fork."""
+        raise NotImplementedError("Blob gas per blob is not supported in Frontier")
+
+    @classmethod
+    def target_blobs_per_block(cls, block_number: int = 0, timestamp: int = 0) -> int:
+        """Return the target number of blobs per block at a given fork."""
+        raise NotImplementedError("Target blobs per block is not supported in Frontier")
+
+    @classmethod
+    def max_blobs_per_block(cls, block_number: int = 0, timestamp: int = 0) -> int:
+        """Return the max number of blobs per block at a given fork."""
+        raise NotImplementedError("Max blobs per block is not supported in Frontier")
+
+    @classmethod
+    def header_requests_required(cls, block_number: int = 0, timestamp: int = 0) -> bool:
         """At genesis, header must not contain beacon chain requests."""
         return False
 
@@ -858,17 +877,73 @@ class Cancun(Shanghai):
         return True
 
     @classmethod
-    def blob_gas_per_blob(cls, block_number: int, timestamp: int) -> int:
+    def blob_gas_price_calculator(
+        cls, block_number: int = 0, timestamp: int = 0
+    ) -> BlobGasPriceCalculator:
+        """Return a callable that calculates the blob gas price at Cancun."""
+        min_base_fee_per_blob_gas = cls.min_base_fee_per_blob_gas(block_number, timestamp)
+        blob_base_fee_update_fraction = cls.blob_base_fee_update_fraction(block_number, timestamp)
+
+        def fn(*, excess_blob_gas) -> int:
+            return fake_exponential(
+                min_base_fee_per_blob_gas,
+                excess_blob_gas,
+                blob_base_fee_update_fraction,
+            )
+
+        return fn
+
+    @classmethod
+    def excess_blob_gas_calculator(
+        cls, block_number: int = 0, timestamp: int = 0
+    ) -> ExcessBlobGasCalculator:
+        """Return a callable that calculates the excess blob gas for a block at Cancun."""
+        target_blobs_per_block = cls.target_blobs_per_block(block_number, timestamp)
+        blob_gas_per_blob = cls.blob_gas_per_blob(block_number, timestamp)
+        target_blob_gas_per_block = target_blobs_per_block * blob_gas_per_blob
+
+        def fn(
+            *,
+            parent_excess_blob_gas: int | None = None,
+            parent_excess_blobs: int | None = None,
+            parent_blob_gas_used: int | None = None,
+            parent_blob_count: int | None = None,
+        ) -> int:
+            if parent_excess_blob_gas is None:
+                assert parent_excess_blobs is not None, "Parent excess blobs are required"
+                parent_excess_blob_gas = parent_excess_blobs * blob_gas_per_blob
+            if parent_blob_gas_used is None:
+                assert parent_blob_count is not None, "Parent blob count is required"
+                parent_blob_gas_used = parent_blob_count * blob_gas_per_blob
+            if parent_excess_blob_gas + parent_blob_gas_used < target_blob_gas_per_block:
+                return 0
+            else:
+                return parent_excess_blob_gas + parent_blob_gas_used - target_blob_gas_per_block
+
+        return fn
+
+    @classmethod
+    def min_base_fee_per_blob_gas(cls, block_number: int = 0, timestamp: int = 0) -> int:
+        """Return the minimum base fee per blob gas for Cancun."""
+        return 1
+
+    @classmethod
+    def blob_base_fee_update_fraction(cls, block_number: int = 0, timestamp: int = 0) -> int:
+        """Return the blob base fee update fraction for Cancun."""
+        return 3338477
+
+    @classmethod
+    def blob_gas_per_blob(cls, block_number: int = 0, timestamp: int = 0) -> int:
         """Blobs are enabled starting from Cancun."""
         return 2**17
 
     @classmethod
-    def target_blobs_per_block(cls, block_number: int, timestamp: int) -> int:
+    def target_blobs_per_block(cls, block_number: int = 0, timestamp: int = 0) -> int:
         """Blobs are enabled starting from Cancun, with a static target of 3 blobs."""
         return 3
 
     @classmethod
-    def max_blobs_per_block(cls, block_number: int, timestamp: int) -> int:
+    def max_blobs_per_block(cls, block_number: int = 0, timestamp: int = 0) -> int:
         """Blobs are enabled starting from Cancun, with a static max of 6 blobs."""
         return 6
 
@@ -1074,6 +1149,26 @@ class Prague(Cancun):
         return fn
 
     @classmethod
+    def min_base_fee_per_blob_gas(cls, block_number: int = 0, timestamp: int = 0) -> int:
+        """Return the minimum base fee per blob gas for Prague."""
+        return 2**25
+
+    @classmethod
+    def blob_base_fee_update_fraction(cls, block_number: int = 0, timestamp: int = 0) -> int:
+        """Return the blob base fee update fraction for Prague."""
+        return 5007716
+
+    @classmethod
+    def target_blobs_per_block(cls, block_number: int = 0, timestamp: int = 0) -> int:
+        """Target blob count of 6 for Prague."""
+        return 6
+
+    @classmethod
+    def max_blobs_per_block(cls, block_number: int = 0, timestamp: int = 0) -> int:
+        """Max blob count of 9 for Prague."""
+        return 9
+
+    @classmethod
     def pre_allocation_blockchain(cls) -> Mapping:
         """
         Prague requires pre-allocation of the beacon chain deposit contract for EIP-6110,
@@ -1136,7 +1231,7 @@ class Prague(Cancun):
         return new_allocation | super(Prague, cls).pre_allocation_blockchain()  # type: ignore
 
     @classmethod
-    def header_requests_required(cls, block_number: int, timestamp: int) -> bool:
+    def header_requests_required(cls, block_number: int = 0, timestamp: int = 0) -> bool:
         """
         Prague requires that the execution layer header contains the beacon
         chain requests hash.

--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -1149,11 +1149,6 @@ class Prague(Cancun):
         return fn
 
     @classmethod
-    def min_base_fee_per_blob_gas(cls, block_number: int = 0, timestamp: int = 0) -> int:
-        """Return the minimum base fee per blob gas for Prague."""
-        return 2**25
-
-    @classmethod
     def blob_base_fee_update_fraction(cls, block_number: int = 0, timestamp: int = 0) -> int:
         """Return the blob base fee update fraction for Prague."""
         return 5007716

--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -236,7 +236,7 @@ class Frontier(BaseFork, solc_name="homestead"):
     @classmethod
     def blob_gas_per_blob(cls, block_number: int = 0, timestamp: int = 0) -> int:
         """Return the amount of blob gas used per blob at a given fork."""
-        raise NotImplementedError("Blob gas per blob is not supported in Frontier")
+        return 0
 
     @classmethod
     def target_blobs_per_block(cls, block_number: int = 0, timestamp: int = 0) -> int:

--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -1144,27 +1144,8 @@ class Prague(Cancun):
         return True
 
     @classmethod
-    def header_target_blobs_per_block_required(
-        cls,
-        block_number: int = 0,
-        timestamp: int = 0,
-    ) -> bool:
-        """
-        Prague requires that the execution layer header contains the beacon
-        chain target blobs per block.
-        """
-        return True
-
-    @classmethod
     def engine_new_payload_requests(cls, block_number: int = 0, timestamp: int = 0) -> bool:
         """From Prague, new payloads include the requests hash as a parameter."""
-        return True
-
-    @classmethod
-    def engine_new_payload_target_blobs_per_block(
-        cls, block_number: int = 0, timestamp: int = 0
-    ) -> bool:
-        """From Prague, new payloads include the target blobs per block as a parameter."""
         return True
 
     @classmethod
@@ -1175,18 +1156,11 @@ class Prague(Cancun):
         return 4
 
     @classmethod
-    def engine_payload_attribute_target_blobs_per_block(
+    def engine_forkchoice_updated_version(
         cls, block_number: int = 0, timestamp: int = 0
-    ) -> bool:
-        """From Prague, payload attributes include the target blobs per block."""
-        return True
-
-    @classmethod
-    def engine_payload_attribute_max_blobs_per_block(
-        cls, block_number: int = 0, timestamp: int = 0
-    ) -> bool:
-        """From Prague, payload attributes include the max blobs per block."""
-        return True
+    ) -> Optional[int]:
+        """At Prague, version number of NewPayload and ForkchoiceUpdated diverge."""
+        return 3
 
 
 class CancunEIP7692(  # noqa: SC200

--- a/src/ethereum_test_forks/forks/helpers.py
+++ b/src/ethereum_test_forks/forks/helpers.py
@@ -1,20 +1,16 @@
-"""
-Helpers used to return fork-specific values.
-"""
+"""Helpers used to return fork-specific values."""
 
 
 def ceiling_division(a: int, b: int) -> int:
     """
-    Calculates the ceil without using floating point.
-    Used by many of the EVM's formulas
+    Calculate the ceil without using floating point.
+    Used by many of the EVM's formulas.
     """
     return -(a // -b)
 
 
 def fake_exponential(factor: int, numerator: int, denominator: int) -> int:
-    """
-    Used to calculate the blob gas cost.
-    """
+    """Calculate the blob gas cost."""
     i = 1
     output = 0
     numerator_accumulator = factor * denominator

--- a/src/ethereum_test_forks/forks/helpers.py
+++ b/src/ethereum_test_forks/forks/helpers.py
@@ -1,0 +1,25 @@
+"""
+Helpers used to return fork-specific values.
+"""
+
+
+def ceiling_division(a: int, b: int) -> int:
+    """
+    Calculates the ceil without using floating point.
+    Used by many of the EVM's formulas
+    """
+    return -(a // -b)
+
+
+def fake_exponential(factor: int, numerator: int, denominator: int) -> int:
+    """
+    Used to calculate the blob gas cost.
+    """
+    i = 1
+    output = 0
+    numerator_accumulator = factor * denominator
+    while numerator_accumulator > 0:
+        output += numerator_accumulator
+        numerator_accumulator = (numerator_accumulator * numerator) // (denominator * i)
+        i += 1
+    return output // denominator

--- a/tests/cancun/eip4788_beacon_root/conftest.py
+++ b/tests/cancun/eip4788_beacon_root/conftest.py
@@ -6,9 +6,20 @@ from typing import Dict, Iterator, List
 import pytest
 
 from ethereum_test_forks import Fork
-from ethereum_test_tools import AccessList, Account, Address, Alloc, Bytecode, Environment, Hash
+from ethereum_test_tools import (
+    AccessList,
+    Account,
+    Address,
+    Alloc,
+    Bytecode,
+    Environment,
+    Hash,
+    Storage,
+    Transaction,
+    add_kzg_version,
+    keccak256,
+)
 from ethereum_test_tools import Opcodes as Op
-from ethereum_test_tools import Storage, Transaction, add_kzg_version, keccak256
 
 from .spec import Spec, SpecHelpers
 

--- a/tests/cancun/eip4788_beacon_root/conftest.py
+++ b/tests/cancun/eip4788_beacon_root/conftest.py
@@ -5,20 +5,10 @@ from typing import Dict, Iterator, List
 
 import pytest
 
-from ethereum_test_tools import (
-    AccessList,
-    Account,
-    Address,
-    Alloc,
-    Bytecode,
-    Environment,
-    Hash,
-    Storage,
-    Transaction,
-    add_kzg_version,
-    keccak256,
-)
-from ethereum_test_tools.vm.opcode import Opcodes as Op
+from ethereum_test_forks import Fork
+from ethereum_test_tools import AccessList, Account, Address, Alloc, Bytecode, Environment, Hash
+from ethereum_test_tools import Opcodes as Op
+from ethereum_test_tools import Storage, Transaction, add_kzg_version, keccak256
 
 from .spec import Spec, SpecHelpers
 
@@ -210,6 +200,7 @@ def tx_type() -> int:
 @pytest.fixture
 def tx(
     pre: Alloc,
+    fork: Fork,
     tx_to_address: Address,
     tx_data: bytes,
     tx_type: int,
@@ -230,7 +221,7 @@ def tx(
         kwargs["access_list"] = access_list
 
     if tx_type == 3:
-        kwargs["max_fee_per_blob_gas"] = 1
+        kwargs["max_fee_per_blob_gas"] = fork.min_base_fee_per_blob_gas()
         kwargs["blob_versioned_hashes"] = add_kzg_version([0], BLOB_COMMITMENT_VERSION_KZG)
 
     if tx_type > 3:

--- a/tests/cancun/eip4844_blobs/conftest.py
+++ b/tests/cancun/eip4844_blobs/conftest.py
@@ -10,36 +10,32 @@ from .spec import Spec
 
 @pytest.fixture
 def block_base_fee_per_gas() -> int:
-    """Default max fee per gas for transactions sent during test."""
+    """Return default max fee per gas for transactions sent during test."""
     return 7
 
 
 @pytest.fixture
 def target_blobs_per_block(fork: Fork) -> int:
-    """
-    Default number of blobs to be included in the block.
-    """
+    """Return default number of blobs to be included in the block."""
     return fork.target_blobs_per_block()
 
 
 @pytest.fixture
 def max_blobs_per_block(fork: Fork) -> int:
-    """
-    Default number of blobs to be included in the block.
-    """
+    """Return default number of blobs to be included in the block."""
     return fork.max_blobs_per_block()
 
 
 @pytest.fixture
 def blob_gas_per_blob(fork: Fork) -> int:
-    """Default blob gas cost per blob."""
+    """Return default blob gas cost per blob."""
     return fork.blob_gas_per_blob()
 
 
 @pytest.fixture(autouse=True)
 def parent_excess_blobs() -> int | None:
     """
-    Default excess blobs of the parent block.
+    Return default excess blobs of the parent block.
 
     Can be overloaded by a test case to provide a custom parent excess blob
     count.
@@ -50,7 +46,7 @@ def parent_excess_blobs() -> int | None:
 @pytest.fixture(autouse=True)
 def parent_blobs() -> int | None:
     """
-    Default data blobs of the parent blob.
+    Return default data blobs of the parent blob.
 
     Can be overloaded by a test case to provide a custom parent blob count.
     """
@@ -62,9 +58,7 @@ def parent_excess_blob_gas(
     parent_excess_blobs: int | None,
     blob_gas_per_blob: int,
 ) -> int | None:
-    """
-    Calculates the excess blob gas of the parent block from the excess blobs.
-    """
+    """Calculate the excess blob gas of the parent block from the excess blobs."""
     if parent_excess_blobs is None:
         return None
     assert parent_excess_blobs >= 0
@@ -78,7 +72,7 @@ def excess_blob_gas(
     parent_blobs: int | None,
 ) -> int | None:
     """
-    Calculates the excess blob gas of the block under test from the parent block.
+    Calculate the excess blob gas of the block under test from the parent block.
 
     Value can be overloaded by a test case to provide a custom excess blob gas.
     """
@@ -98,7 +92,7 @@ def correct_excess_blob_gas(
     parent_blobs: int | None,
 ) -> int:
     """
-    Calculates the correct excess blob gas of the block under test from the parent block.
+    Calculate the correct excess blob gas of the block under test from the parent block.
 
     Should not be overloaded by a test case.
     """
@@ -125,9 +119,7 @@ def blob_gas_price(
     fork: Fork,
     excess_blob_gas: int | None,
 ) -> int | None:
-    """
-    Blob gas price for the block of the test.
-    """
+    """Return blob gas price for the block of the test."""
     if excess_blob_gas is None:
         return None
 
@@ -144,9 +136,7 @@ def genesis_excess_blob_gas(
     target_blobs_per_block: int,
     blob_gas_per_blob: int,
 ) -> int:
-    """
-    Default excess blob gas for the genesis block.
-    """
+    """Return default excess blob gas for the genesis block."""
     excess_blob_gas = parent_excess_blob_gas if parent_excess_blob_gas else 0
     if parent_blobs:
         # We increase the excess blob gas of the genesis because
@@ -161,9 +151,7 @@ def env(
     block_base_fee_per_gas: int,
     genesis_excess_blob_gas: int,
 ) -> Environment:
-    """
-    Prepare the environment of the genesis block for all blockchain tests.
-    """
+    """Prepare the environment of the genesis block for all blockchain tests."""
     return Environment(
         excess_blob_gas=genesis_excess_blob_gas,
         blob_gas_used=0,
@@ -174,7 +162,7 @@ def env(
 @pytest.fixture
 def tx_value() -> int:
     """
-    Default value contained by the transactions sent during test.
+    Return default value contained by the transactions sent during test.
 
     Can be overloaded by a test case to provide a custom transaction value.
     """
@@ -183,7 +171,7 @@ def tx_value() -> int:
 
 @pytest.fixture
 def tx_calldata() -> bytes:
-    """Default calldata in transactions sent during test."""
+    """Return default calldata in transactions sent during test."""
     return b""
 
 
@@ -205,7 +193,7 @@ def tx_max_fee_per_gas(
 @pytest.fixture
 def tx_max_priority_fee_per_gas() -> int:
     """
-    Default max priority fee per gas for transactions sent during test.
+    Return default max priority fee per gas for transactions sent during test.
 
     Can be overloaded by a test case to provide a custom max priority fee per
     gas.
@@ -216,7 +204,7 @@ def tx_max_priority_fee_per_gas() -> int:
 @pytest.fixture
 def tx_max_fee_per_blob_gas_multiplier() -> int:
     """
-    Default max fee per blob gas multiplier for transactions sent during test.
+    Return default max fee per blob gas multiplier for transactions sent during test.
 
     Can be overloaded by a test case to provide a custom max fee per blob gas
     multiplier.
@@ -227,7 +215,7 @@ def tx_max_fee_per_blob_gas_multiplier() -> int:
 @pytest.fixture
 def tx_max_fee_per_blob_gas_delta() -> int:
     """
-    Default max fee per blob gas delta for transactions sent during test.
+    Return default max fee per blob gas delta for transactions sent during test.
 
     Can be overloaded by a test case to provide a custom max fee per blob gas
     delta.
@@ -242,7 +230,7 @@ def tx_max_fee_per_blob_gas(  # noqa: D103
     tx_max_fee_per_blob_gas_delta: int,
 ) -> int:
     """
-    Default max fee per blob gas for transactions sent during test.
+    Return default max fee per blob gas for transactions sent during test.
 
     By default, it is set to the blob gas price of the block.
 

--- a/tests/cancun/eip4844_blobs/conftest.py
+++ b/tests/cancun/eip4844_blobs/conftest.py
@@ -2,17 +2,268 @@
 
 import pytest
 
-from ethereum_test_tools import Alloc, Block, Hash, Transaction, add_kzg_version
+from ethereum_test_forks import Fork
+from ethereum_test_tools import Alloc, Block, Environment, Hash, Transaction, add_kzg_version
 
-from .spec import BlockHeaderBlobGasFields, Spec
+from .spec import Spec
+
+
+@pytest.fixture
+def block_base_fee_per_gas() -> int:
+    """Default max fee per gas for transactions sent during test."""
+    return 7
+
+
+@pytest.fixture
+def target_blobs_per_block(fork: Fork) -> int:
+    """
+    Default number of blobs to be included in the block.
+    """
+    return fork.target_blobs_per_block()
+
+
+@pytest.fixture
+def max_blobs_per_block(fork: Fork) -> int:
+    """
+    Default number of blobs to be included in the block.
+    """
+    return fork.max_blobs_per_block()
+
+
+@pytest.fixture
+def blob_gas_per_blob(fork: Fork) -> int:
+    """Default blob gas cost per blob."""
+    return fork.blob_gas_per_blob()
+
+
+@pytest.fixture(autouse=True)
+def parent_excess_blobs() -> int | None:
+    """
+    Default excess blobs of the parent block.
+
+    Can be overloaded by a test case to provide a custom parent excess blob
+    count.
+    """
+    return 10  # Defaults to a blob gas price of 1.
+
+
+@pytest.fixture(autouse=True)
+def parent_blobs() -> int | None:
+    """
+    Default data blobs of the parent blob.
+
+    Can be overloaded by a test case to provide a custom parent blob count.
+    """
+    return 0
+
+
+@pytest.fixture
+def parent_excess_blob_gas(
+    parent_excess_blobs: int | None,
+    blob_gas_per_blob: int,
+) -> int | None:
+    """
+    Calculates the excess blob gas of the parent block from the excess blobs.
+    """
+    if parent_excess_blobs is None:
+        return None
+    assert parent_excess_blobs >= 0
+    return parent_excess_blobs * blob_gas_per_blob
+
+
+@pytest.fixture
+def excess_blob_gas(
+    fork: Fork,
+    parent_excess_blobs: int | None,
+    parent_blobs: int | None,
+) -> int | None:
+    """
+    Calculates the excess blob gas of the block under test from the parent block.
+
+    Value can be overloaded by a test case to provide a custom excess blob gas.
+    """
+    if parent_excess_blobs is None or parent_blobs is None:
+        return None
+    excess_blob_gas = fork.excess_blob_gas_calculator()
+    return excess_blob_gas(
+        parent_excess_blobs=parent_excess_blobs,
+        parent_blob_count=parent_blobs,
+    )
+
+
+@pytest.fixture
+def correct_excess_blob_gas(
+    fork: Fork,
+    parent_excess_blobs: int | None,
+    parent_blobs: int | None,
+) -> int:
+    """
+    Calculates the correct excess blob gas of the block under test from the parent block.
+
+    Should not be overloaded by a test case.
+    """
+    if parent_excess_blobs is None or parent_blobs is None:
+        return 0
+    excess_blob_gas = fork.excess_blob_gas_calculator()
+    return excess_blob_gas(
+        parent_excess_blobs=parent_excess_blobs,
+        parent_blob_count=parent_blobs,
+    )
+
+
+@pytest.fixture
+def block_fee_per_blob_gas(  # noqa: D103
+    fork: Fork,
+    correct_excess_blob_gas: int,
+) -> int:
+    get_blob_gas_price = fork.blob_gas_price_calculator()
+    return get_blob_gas_price(excess_blob_gas=correct_excess_blob_gas)
+
+
+@pytest.fixture
+def blob_gas_price(
+    fork: Fork,
+    excess_blob_gas: int | None,
+) -> int | None:
+    """
+    Blob gas price for the block of the test.
+    """
+    if excess_blob_gas is None:
+        return None
+
+    get_blob_gas_price = fork.blob_gas_price_calculator()
+    return get_blob_gas_price(
+        excess_blob_gas=excess_blob_gas,
+    )
+
+
+@pytest.fixture
+def genesis_excess_blob_gas(
+    parent_excess_blob_gas: int | None,
+    parent_blobs: int,
+    target_blobs_per_block: int,
+    blob_gas_per_blob: int,
+) -> int:
+    """
+    Default excess blob gas for the genesis block.
+    """
+    excess_blob_gas = parent_excess_blob_gas if parent_excess_blob_gas else 0
+    if parent_blobs:
+        # We increase the excess blob gas of the genesis because
+        # we cannot include blobs in the genesis, so the
+        # test blobs are actually in block 1.
+        excess_blob_gas += target_blobs_per_block * blob_gas_per_blob
+    return excess_blob_gas
+
+
+@pytest.fixture
+def env(
+    block_base_fee_per_gas: int,
+    genesis_excess_blob_gas: int,
+) -> Environment:
+    """
+    Prepare the environment of the genesis block for all blockchain tests.
+    """
+    return Environment(
+        excess_blob_gas=genesis_excess_blob_gas,
+        blob_gas_used=0,
+        base_fee_per_gas=block_base_fee_per_gas,
+    )
+
+
+@pytest.fixture
+def tx_value() -> int:
+    """
+    Default value contained by the transactions sent during test.
+
+    Can be overloaded by a test case to provide a custom transaction value.
+    """
+    return 1
+
+
+@pytest.fixture
+def tx_calldata() -> bytes:
+    """Default calldata in transactions sent during test."""
+    return b""
+
+
+@pytest.fixture(autouse=True)
+def tx_max_fee_per_gas(
+    block_base_fee_per_gas: int,
+) -> int:
+    """
+    Max fee per gas value used by all transactions sent during test.
+
+    By default the max fee per gas is the same as the block fee per gas.
+
+    Can be overloaded by a test case to test rejection of transactions where
+    the max fee per gas is insufficient.
+    """
+    return block_base_fee_per_gas
+
+
+@pytest.fixture
+def tx_max_priority_fee_per_gas() -> int:
+    """
+    Default max priority fee per gas for transactions sent during test.
+
+    Can be overloaded by a test case to provide a custom max priority fee per
+    gas.
+    """
+    return 0
+
+
+@pytest.fixture
+def tx_max_fee_per_blob_gas_multiplier() -> int:
+    """
+    Default max fee per blob gas multiplier for transactions sent during test.
+
+    Can be overloaded by a test case to provide a custom max fee per blob gas
+    multiplier.
+    """
+    return 1
+
+
+@pytest.fixture
+def tx_max_fee_per_blob_gas_delta() -> int:
+    """
+    Default max fee per blob gas delta for transactions sent during test.
+
+    Can be overloaded by a test case to provide a custom max fee per blob gas
+    delta.
+    """
+    return 0
+
+
+@pytest.fixture
+def tx_max_fee_per_blob_gas(  # noqa: D103
+    blob_gas_price: int | None,
+    tx_max_fee_per_blob_gas_multiplier: int,
+    tx_max_fee_per_blob_gas_delta: int,
+) -> int:
+    """
+    Default max fee per blob gas for transactions sent during test.
+
+    By default, it is set to the blob gas price of the block.
+
+    Can be overloaded by a test case to test rejection of transactions where
+    the max fee per blob gas is insufficient.
+    """
+    if blob_gas_price is None:
+        # When fork transitioning, the default blob gas price is 1.
+        return 1
+    return (blob_gas_price * tx_max_fee_per_blob_gas_multiplier) + tx_max_fee_per_blob_gas_delta
 
 
 @pytest.fixture
 def non_zero_blob_gas_used_genesis_block(
     pre: Alloc,
     parent_blobs: int,
+    fork: Fork,
+    genesis_excess_blob_gas: int,
     parent_excess_blob_gas: int,
     tx_max_fee_per_gas: int,
+    target_blobs_per_block: int,
 ) -> Block | None:
     """
     For test cases with a non-zero blobGasUsed field in the
@@ -31,15 +282,18 @@ def non_zero_blob_gas_used_genesis_block(
     if parent_blobs == 0:
         return None
 
-    parent_excess_blob_gas += Spec.TARGET_BLOB_GAS_PER_BLOCK
-    excess_blob_gas = Spec.calc_excess_blob_gas(
-        BlockHeaderBlobGasFields(parent_excess_blob_gas, 0)
-    )
+    excess_blob_gas_calculator = fork.excess_blob_gas_calculator(block_number=1)
+    assert parent_excess_blob_gas == excess_blob_gas_calculator(
+        parent_excess_blob_gas=genesis_excess_blob_gas,
+        parent_blob_count=0,
+    ), "parent excess blob gas is not as expected for extra block"
 
     sender = pre.fund_eoa(10**27)
 
     # Address that contains no code, nor balance and is not a contract.
     empty_account_destination = pre.fund_eoa(0)
+
+    blob_gas_price_calculator = fork.blob_gas_price_calculator(block_number=1)
 
     return Block(
         txs=[
@@ -51,7 +305,9 @@ def non_zero_blob_gas_used_genesis_block(
                 gas_limit=21_000,
                 max_fee_per_gas=tx_max_fee_per_gas,
                 max_priority_fee_per_gas=0,
-                max_fee_per_blob_gas=Spec.get_blob_gasprice(excess_blob_gas=excess_blob_gas),
+                max_fee_per_blob_gas=blob_gas_price_calculator(
+                    excess_blob_gas=parent_excess_blob_gas
+                ),
                 access_list=[],
                 blob_versioned_hashes=add_kzg_version(
                     [Hash(x) for x in range(parent_blobs)],

--- a/tests/cancun/eip4844_blobs/test_blob_txs.py
+++ b/tests/cancun/eip4844_blobs/test_blob_txs.py
@@ -15,7 +15,6 @@ note: Adding a new test
 
 """  # noqa: E501
 
-import itertools
 from typing import List, Optional, Tuple
 
 import pytest
@@ -43,6 +42,7 @@ from ethereum_test_tools import (
     add_kzg_version,
 )
 from ethereum_test_tools import Opcodes as Op
+from pytest_plugins import fork_covariant_parametrize
 
 from .spec import Spec, SpecHelpers, ref_spec_4844
 
@@ -76,16 +76,6 @@ def destination_account(
 
 
 @pytest.fixture
-def tx_value() -> int:
-    """
-    Value contained by the transactions sent during test.
-
-    Can be overloaded by a test case to provide a custom transaction value.
-    """
-    return 1
-
-
-@pytest.fixture
 def tx_gas(
     fork: Fork,
     tx_calldata: bytes,
@@ -94,77 +84,6 @@ def tx_gas(
     """Gas allocated to transactions sent during test."""
     tx_intrinsic_cost_calculator = fork.transaction_intrinsic_cost_calculator()
     return tx_intrinsic_cost_calculator(calldata=tx_calldata, access_list=tx_access_list)
-
-
-@pytest.fixture
-def tx_calldata() -> bytes:
-    """Calldata in transactions sent during test."""
-    return b""
-
-
-@pytest.fixture
-def block_fee_per_gas() -> int:
-    """Max fee per gas for transactions sent during test."""
-    return 7
-
-
-@pytest.fixture(autouse=True)
-def parent_excess_blobs() -> Optional[int]:
-    """
-    Excess blobs of the parent block.
-
-    Can be overloaded by a test case to provide a custom parent excess blob
-    count.
-    """
-    return 10  # Defaults to a blob gas price of 1.
-
-
-@pytest.fixture(autouse=True)
-def parent_blobs() -> Optional[int]:
-    """
-    Blobs of the parent blob.
-
-    Can be overloaded by a test case to provide a custom parent blob count.
-    """
-    return 0
-
-
-@pytest.fixture
-def parent_excess_blob_gas(
-    parent_excess_blobs: Optional[int],
-) -> Optional[int]:
-    """Calculate excess blob gas of the parent block from the excess blobs."""
-    if parent_excess_blobs is None:
-        return None
-    return parent_excess_blobs * Spec.GAS_PER_BLOB
-
-
-@pytest.fixture
-def blob_gasprice(
-    parent_excess_blob_gas: Optional[int],
-    parent_blobs: Optional[int],
-) -> Optional[int]:
-    """Blob gas price for the block of the test."""
-    if parent_excess_blob_gas is None or parent_blobs is None:
-        return None
-
-    return Spec.get_blob_gasprice(
-        excess_blob_gas=SpecHelpers.calc_excess_blob_gas_from_blob_count(
-            parent_excess_blob_gas=parent_excess_blob_gas,
-            parent_blob_count=parent_blobs,
-        ),
-    )
-
-
-@pytest.fixture
-def tx_max_priority_fee_per_gas() -> int:
-    """
-    Max priority fee per gas for transactions sent during test.
-
-    Can be overloaded by a test case to provide a custom max priority fee per
-    gas.
-    """
-    return 0
 
 
 @pytest.fixture
@@ -200,6 +119,7 @@ def blob_hashes_per_tx(blobs_per_tx: List[int]) -> List[List[bytes]]:
 
 @pytest.fixture
 def total_account_minimum_balance(  # noqa: D103
+    blob_gas_per_blob: int,
     tx_gas: int,
     tx_value: int,
     tx_max_fee_per_gas: int,
@@ -212,7 +132,7 @@ def total_account_minimum_balance(  # noqa: D103
     """
     minimum_cost = 0
     for tx_blob_count in [len(x) for x in blob_hashes_per_tx]:
-        blob_cost = tx_max_fee_per_blob_gas * Spec.GAS_PER_BLOB * tx_blob_count
+        blob_cost = tx_max_fee_per_blob_gas * blob_gas_per_blob * tx_blob_count
         minimum_cost += (tx_gas * tx_max_fee_per_gas) + tx_value + blob_cost
     return minimum_cost
 
@@ -221,8 +141,9 @@ def total_account_minimum_balance(  # noqa: D103
 def total_account_transactions_fee(  # noqa: D103
     tx_gas: int,
     tx_value: int,
-    blob_gasprice: int,
-    block_fee_per_gas: int,
+    blob_gas_price: int,
+    block_base_fee_per_gas: int,
+    blob_gas_per_blob: int,
     tx_max_fee_per_gas: int,
     tx_max_priority_fee_per_gas: int,
     blob_hashes_per_tx: List[List[bytes]],
@@ -230,45 +151,14 @@ def total_account_transactions_fee(  # noqa: D103
     """Calculate actual fee for the blob transactions in the block of the test."""
     total_cost = 0
     for tx_blob_count in [len(x) for x in blob_hashes_per_tx]:
-        blob_cost = blob_gasprice * Spec.GAS_PER_BLOB * tx_blob_count
+        blob_cost = blob_gas_price * blob_gas_per_blob * tx_blob_count
         block_producer_fee = (
-            tx_max_fee_per_gas - block_fee_per_gas if tx_max_priority_fee_per_gas else 0
+            tx_max_fee_per_gas - block_base_fee_per_gas if tx_max_priority_fee_per_gas else 0
         )
-        total_cost += (tx_gas * (block_fee_per_gas + block_producer_fee)) + tx_value + blob_cost
+        total_cost += (
+            (tx_gas * (block_base_fee_per_gas + block_producer_fee)) + tx_value + blob_cost
+        )
     return total_cost
-
-
-@pytest.fixture(autouse=True)
-def tx_max_fee_per_gas(
-    block_fee_per_gas: int,
-) -> int:
-    """
-    Max fee per gas value used by all transactions sent during test.
-
-    By default the max fee per gas is the same as the block fee per gas.
-
-    Can be overloaded by a test case to test rejection of transactions where
-    the max fee per gas is insufficient.
-    """
-    return block_fee_per_gas
-
-
-@pytest.fixture
-def tx_max_fee_per_blob_gas(  # noqa: D103
-    blob_gasprice: Optional[int],
-) -> int:
-    """
-    Max fee per blob gas for transactions sent during test.
-
-    By default, it is set to the blob gas price of the block.
-
-    Can be overloaded by a test case to test rejection of transactions where
-    the max fee per blob gas is insufficient.
-    """
-    if blob_gasprice is None:
-        # When fork transitioning, the default blob gas price is 1.
-        return 1
-    return blob_gasprice
 
 
 @pytest.fixture
@@ -348,27 +238,8 @@ def account_balance_modifier() -> int:
 
 
 @pytest.fixture
-def env(
-    parent_excess_blob_gas: Optional[int],
-    parent_blobs: int,
-) -> Environment:
-    """Prepare the environment of the genesis block for all blockchain tests."""
-    excess_blob_gas = parent_excess_blob_gas if parent_excess_blob_gas else 0
-    if parent_blobs:
-        # We increase the excess blob gas of the genesis because
-        # we cannot include blobs in the genesis, so the
-        # test blobs are actually in block 1.
-        excess_blob_gas += Spec.TARGET_BLOB_GAS_PER_BLOCK
-    return Environment(
-        excess_blob_gas=excess_blob_gas,
-        blob_gas_used=0,
-    )
-
-
-@pytest.fixture
 def state_env(
-    parent_excess_blob_gas: Optional[int],
-    parent_blobs: int,
+    excess_blob_gas: Optional[int],
 ) -> Environment:
     """
     Prepare the environment for all state test cases.
@@ -378,10 +249,7 @@ def state_env(
     is not decreased by the target.
     """
     return Environment(
-        excess_blob_gas=SpecHelpers.calc_excess_blob_gas_from_blob_count(
-            parent_excess_blob_gas=parent_excess_blob_gas if parent_excess_blob_gas else 0,
-            parent_blob_count=parent_blobs,
-        ),
+        excess_blob_gas=excess_blob_gas if excess_blob_gas else 0,
     )
 
 
@@ -431,13 +299,17 @@ def expected_blob_gas_used(
         block_number=block_number, timestamp=block_timestamp
     ):
         return Header.EMPTY_FIELD
-    return sum([Spec.get_total_blob_gas(tx) for tx in txs])
+    blob_gas_per_blob = fork.blob_gas_per_blob(
+        block_number=block_number,
+        timestamp=block_timestamp,
+    )
+    return sum([Spec.get_total_blob_gas(tx=tx, blob_gas_per_blob=blob_gas_per_blob) for tx in txs])
 
 
 @pytest.fixture
 def expected_excess_blob_gas(
     fork: Fork,
-    parent_excess_blob_gas: Optional[int],
+    parent_excess_blobs: Optional[int],
     parent_blobs: Optional[int],
     block_number: int,
     block_timestamp: int,
@@ -447,8 +319,9 @@ def expected_excess_blob_gas(
         block_number=block_number, timestamp=block_timestamp
     ):
         return Header.EMPTY_FIELD
-    return SpecHelpers.calc_excess_blob_gas_from_blob_count(
-        parent_excess_blob_gas=parent_excess_blob_gas if parent_excess_blob_gas else 0,
+    excess_blob_gas = fork.excess_blob_gas_calculator()
+    return excess_blob_gas(
+        parent_excess_blobs=parent_excess_blobs if parent_excess_blobs else 0,
         parent_blob_count=parent_blobs if parent_blobs else 0,
     )
 
@@ -498,60 +371,9 @@ def block(
     )
 
 
-def all_valid_blob_combinations() -> List[Tuple[int, ...]]:
-    """
-    Return all valid blob tx combinations for a given block,
-    assuming the given MAX_BLOBS_PER_BLOCK.
-    """
-    all_combinations = [
-        seq
-        for i in range(
-            SpecHelpers.max_blobs_per_block(), 0, -1
-        )  # We can have from 1 to at most MAX_BLOBS_PER_BLOCK blobs per block
-        for seq in itertools.combinations_with_replacement(
-            range(1, SpecHelpers.max_blobs_per_block() + 1), i
-        )  # We iterate through all possible combinations
-        if sum(seq)
-        <= SpecHelpers.max_blobs_per_block()  # And we only keep the ones that are valid
-    ]
-    # We also add the reversed version of each combination, only if it's not
-    # already in the list. E.g. (2, 1, 1) is added from (1, 1, 2) but not
-    # (1, 1, 1) because its reversed version is identical.
-    all_combinations += [
-        tuple(reversed(x)) for x in all_combinations if tuple(reversed(x)) not in all_combinations
-    ]
-    return all_combinations
-
-
-def invalid_blob_combinations() -> List[Tuple[int, ...]]:
-    """
-    Return invalid blob tx combinations for a given block that use up to
-    MAX_BLOBS_PER_BLOCK+1 blobs.
-    """
-    all_combinations = [
-        seq
-        for i in range(
-            SpecHelpers.max_blobs_per_block() + 1, 0, -1
-        )  # We can have from 1 to at most MAX_BLOBS_PER_BLOCK blobs per block
-        for seq in itertools.combinations_with_replacement(
-            range(1, SpecHelpers.max_blobs_per_block() + 2), i
-        )  # We iterate through all possible combinations
-        if sum(seq)
-        == SpecHelpers.max_blobs_per_block() + 1  # And we only keep the ones that match the
-        # expected invalid blob count
-    ]
-    # We also add the reversed version of each combination, only if it's not
-    # already in the list. E.g. (4, 1) is added from (1, 4) but not
-    # (1, 1, 1, 1, 1) because its reversed version is identical.
-    all_combinations += [
-        tuple(reversed(x)) for x in all_combinations if tuple(reversed(x)) not in all_combinations
-    ]
-    return all_combinations
-
-
-@pytest.mark.parametrize(
-    "blobs_per_tx",
-    all_valid_blob_combinations(),
+@fork_covariant_parametrize(
+    parameter_names=["blobs_per_tx"],
+    fn=SpecHelpers.all_valid_blob_combinations,
 )
 @pytest.mark.valid_from("Cancun")
 def test_valid_blob_tx_combinations(
@@ -579,26 +401,70 @@ def test_valid_blob_tx_combinations(
     )
 
 
-@pytest.mark.parametrize(
-    "parent_excess_blobs,parent_blobs,tx_max_fee_per_blob_gas,tx_error",
-    [
-        # tx max_blob_gas_cost of the transaction is not enough
+def generate_invalid_tx_max_fee_per_blob_gas_tests(
+    fork: Fork,
+) -> List:
+    """
+    Return a list of tests for invalid blob transactions due to insufficient max fee per blob gas
+    parametrized for each different fork.
+    """
+    min_base_fee_per_blob_gas = fork.min_base_fee_per_blob_gas()
+    minimum_excess_blobs_for_first_increment = SpecHelpers.get_min_excess_blobs_for_blob_gas_price(
+        fork=fork,
+        blob_gas_price=min_base_fee_per_blob_gas + 1,
+    )
+    next_base_fee_per_blob_gas = fork.blob_gas_price_calculator()(
+        excess_blob_gas=minimum_excess_blobs_for_first_increment,
+    )
+
+    tests = []
+    tests.append(
         pytest.param(
-            SpecHelpers.get_min_excess_blobs_for_blob_gas_price(2) - 1,  # blob gas price is 1
-            SpecHelpers.target_blobs_per_block() + 1,  # blob gas cost increases to 2
-            1,  # tx max_blob_gas_cost is 1
+            minimum_excess_blobs_for_first_increment - 1,  # blob gas price is 1
+            fork.target_blobs_per_block() + 1,  # blob gas cost increases to above the minimum
+            min_base_fee_per_blob_gas,  # tx max_blob_gas_cost is the minimum
             TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS,
             id="insufficient_max_fee_per_blob_gas",
-        ),
-        # tx max_blob_gas_cost of the transaction is zero, which is invalid
+        )
+    )
+    if (next_base_fee_per_blob_gas - min_base_fee_per_blob_gas) > 1:
+        tests.append(
+            pytest.param(
+                minimum_excess_blobs_for_first_increment
+                - 1,  # blob gas price is one less than the minimum
+                fork.target_blobs_per_block() + 1,  # blob gas cost increases to above the minimum
+                next_base_fee_per_blob_gas
+                - 1,  # tx max_blob_gas_cost is one less than the minimum
+                TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS,
+                id="insufficient_max_fee_per_blob_gas_one_less_than_next",
+            )
+        )
+    if min_base_fee_per_blob_gas > 1:
+        tests.append(
+            pytest.param(
+                0,  # blob gas price is the minimum
+                0,  # blob gas cost stays put at 1
+                min_base_fee_per_blob_gas - 1,  # tx max_blob_gas_cost is one less than the minimum
+                TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS,
+                id="insufficient_max_fee_per_blob_gas_one_less_than_min",
+            )
+        )
+
+    tests.append(
         pytest.param(
-            0,  # blob gas price is 1
+            0,  # blob gas price is the minimum
             0,  # blob gas cost stays put at 1
             0,  # tx max_blob_gas_cost is 0
             TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS,
             id="invalid_max_fee_per_blob_gas",
-        ),
-    ],
+        )
+    )
+    return tests
+
+
+@fork_covariant_parametrize(
+    parameter_names="parent_excess_blobs,parent_blobs,tx_max_fee_per_blob_gas,tx_error",
+    fn=generate_invalid_tx_max_fee_per_blob_gas_tests,
 )
 @pytest.mark.parametrize(
     "account_balance_modifier",
@@ -630,26 +496,9 @@ def test_invalid_tx_max_fee_per_blob_gas(
     )
 
 
-@pytest.mark.parametrize(
-    "parent_excess_blobs,parent_blobs,tx_max_fee_per_blob_gas,tx_error",
-    [
-        # tx max_blob_gas_cost of the transaction is not enough
-        pytest.param(
-            SpecHelpers.get_min_excess_blobs_for_blob_gas_price(2) - 1,  # blob gas price is 1
-            SpecHelpers.target_blobs_per_block() + 1,  # blob gas cost increases to 2
-            1,  # tx max_blob_gas_cost is 1
-            TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS,
-            id="insufficient_max_fee_per_blob_gas",
-        ),
-        # tx max_blob_gas_cost of the transaction is zero, which is invalid
-        pytest.param(
-            0,  # blob gas price is 1
-            0,  # blob gas cost stays put at 1
-            0,  # tx max_blob_gas_cost is 0
-            TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS,
-            id="invalid_max_fee_per_blob_gas",
-        ),
-    ],
+@fork_covariant_parametrize(
+    parameter_names="parent_excess_blobs,parent_blobs,tx_max_fee_per_blob_gas,tx_error",
+    fn=generate_invalid_tx_max_fee_per_blob_gas_tests,
 )
 @pytest.mark.valid_from("Cancun")
 def test_invalid_tx_max_fee_per_blob_gas_state(
@@ -709,9 +558,9 @@ def test_invalid_normal_gas(
     )
 
 
-@pytest.mark.parametrize(
-    "blobs_per_tx",
-    invalid_blob_combinations(),
+@fork_covariant_parametrize(
+    parameter_names="blobs_per_tx",
+    fn=SpecHelpers.invalid_blob_combinations,
 )
 @pytest.mark.parametrize(
     "tx_error", [TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED], ids=[""]
@@ -752,7 +601,7 @@ def test_invalid_block_blob_count(
     [b"", b"\x00", b"\x01"],
     ids=["no_calldata", "single_zero_calldata", "single_one_calldata"],
 )
-@pytest.mark.parametrize("tx_max_fee_per_blob_gas", [1, 100, 10000])
+@pytest.mark.parametrize("tx_max_fee_per_blob_gas_multiplier", [1, 100, 10000])
 @pytest.mark.parametrize("account_balance_modifier", [-1], ids=["exact_balance_minus_1"])
 @pytest.mark.parametrize("tx_error", [TransactionException.INSUFFICIENT_ACCOUNT_FUNDS], ids=[""])
 @pytest.mark.valid_from("Cancun")
@@ -794,7 +643,7 @@ def test_insufficient_balance_blob_tx(
     [b"", b"\x00", b"\x01"],
     ids=["no_calldata", "single_zero_calldata", "single_one_calldata"],
 )
-@pytest.mark.parametrize("tx_max_fee_per_blob_gas", [1, 100, 10000])
+@pytest.mark.parametrize("tx_max_fee_per_blob_gas_multiplier", [1, 100, 10000])
 @pytest.mark.valid_from("Cancun")
 def test_sufficient_balance_blob_tx(
     state_test: StateTestFiller,
@@ -834,7 +683,7 @@ def test_sufficient_balance_blob_tx(
     [b"", b"\x00", b"\x01"],
     ids=["no_calldata", "single_zero_calldata", "single_one_calldata"],
 )
-@pytest.mark.parametrize("tx_max_fee_per_blob_gas", [1, 100, 10000])
+@pytest.mark.parametrize("tx_max_fee_per_blob_gas_multiplier", [1, 100, 10000])
 @pytest.mark.parametrize("sender_initial_balance", [0])
 @pytest.mark.valid_from("Cancun")
 def test_sufficient_balance_blob_tx_pre_fund_tx(
@@ -892,7 +741,7 @@ def test_sufficient_balance_blob_tx_pre_fund_tx(
     [b"", b"\x01"],
     ids=["no_calldata", "single_non_zero_byte_calldata"],
 )
-@pytest.mark.parametrize("tx_max_fee_per_blob_gas", [1, 100])
+@pytest.mark.parametrize("tx_max_fee_per_blob_gas_multiplier", [1, 100])
 @pytest.mark.parametrize(
     "tx_gas", [500_000], ids=[""]
 )  # Increase gas to account for contract code
@@ -948,9 +797,9 @@ def test_blob_gas_subtraction_tx(
     )
 
 
-@pytest.mark.parametrize(
-    "blobs_per_tx",
-    all_valid_blob_combinations(),
+@fork_covariant_parametrize(
+    parameter_names="blobs_per_tx",
+    fn=SpecHelpers.all_valid_blob_combinations,
 )
 @pytest.mark.parametrize("account_balance_modifier", [-1], ids=["exact_balance_minus_1"])
 @pytest.mark.parametrize("tx_error", [TransactionException.INSUFFICIENT_ACCOUNT_FUNDS], ids=[""])
@@ -975,16 +824,27 @@ def test_insufficient_balance_blob_tx_combinations(
     )
 
 
-@pytest.mark.parametrize(
-    "blobs_per_tx,tx_error",
-    [
-        ([0], TransactionException.TYPE_3_TX_ZERO_BLOBS),
-        (
-            [SpecHelpers.max_blobs_per_block() + 1],
-            TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED,
+def generate_invalid_tx_blob_count_tests(
+    fork: Fork,
+) -> List:
+    """Return a list of tests for invalid blob transactions due to invalid blob counts."""
+    return [
+        pytest.param(
+            [0],
+            TransactionException.TYPE_3_TX_ZERO_BLOBS,
+            id="too_few_blobs",
         ),
-    ],
-    ids=["too_few_blobs", "too_many_blobs"],
+        pytest.param(
+            [fork.max_blobs_per_block() + 1],
+            TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED,
+            id="too_many_blobs",
+        ),
+    ]
+
+
+@fork_covariant_parametrize(
+    parameter_names="blobs_per_tx,tx_error",
+    fn=generate_invalid_tx_blob_count_tests,
 )
 @pytest.mark.valid_from("Cancun")
 def test_invalid_tx_blob_count(
@@ -1145,9 +1005,9 @@ def test_invalid_blob_tx_contract_creation(
     )
 
 
-# ----------------------------------------
-# Opcode Tests in Blob Transaction Context
-# ----------------------------------------
+# # ----------------------------------------
+# # Opcode Tests in Blob Transaction Context
+# # ----------------------------------------
 
 
 @pytest.fixture
@@ -1155,7 +1015,7 @@ def opcode(
     request,
     sender: EOA,
     tx_calldata: bytes,
-    block_fee_per_gas: int,
+    block_base_fee_per_gas: int,
     tx_max_fee_per_gas: int,
     tx_max_priority_fee_per_gas: int,
     tx_value: int,
@@ -1192,12 +1052,12 @@ def opcode(
             {0: tx_calldata.ljust(32, b"\x00")},
         )
     elif request.param == Op.GASPRICE:
-        assert tx_max_fee_per_gas >= block_fee_per_gas
+        assert tx_max_fee_per_gas >= block_base_fee_per_gas
         return (
             Op.SSTORE(0, Op.GASPRICE),
             {
-                0: min(tx_max_priority_fee_per_gas, tx_max_fee_per_gas - block_fee_per_gas)
-                + block_fee_per_gas
+                0: min(tx_max_priority_fee_per_gas, tx_max_fee_per_gas - block_base_fee_per_gas)
+                + block_base_fee_per_gas
             },
         )
     raise Exception("Unknown opcode")
@@ -1379,8 +1239,8 @@ def test_blob_tx_attribute_calldata_opcodes(
 
 
 @pytest.mark.parametrize("tx_max_priority_fee_per_gas", [0, 2])  # always below data fee
-@pytest.mark.parametrize("tx_max_fee_per_blob_gas", [1, 3])  # normal and above priority fee
-@pytest.mark.parametrize("tx_max_fee_per_gas", [100])  # always above priority fee
+@pytest.mark.parametrize("tx_max_fee_per_blob_gas_delta", [0, 1])  # normal and above priority fee
+@pytest.mark.parametrize("tx_max_fee_per_gas", [100])  # always above priority fee (FOR CANCUN)
 @pytest.mark.parametrize("opcode", [Op.GASPRICE], indirect=True)
 @pytest.mark.parametrize("tx_gas", [500_000])
 @pytest.mark.valid_from("Cancun")

--- a/tests/cancun/eip4844_blobs/test_blob_txs.py
+++ b/tests/cancun/eip4844_blobs/test_blob_txs.py
@@ -630,6 +630,13 @@ def test_insufficient_balance_blob_tx(
     )
 
 
+@fork_covariant_parametrize(
+    parameter_names="blobs_per_tx",
+    fn=lambda fork: [
+        pytest.param([1], id="single_blob"),
+        pytest.param([fork.max_blobs_per_block()], id="max_blobs"),
+    ],
+)
 @pytest.mark.parametrize(
     "tx_access_list",
     [[], [AccessList(address=100, storage_keys=[100, 200])]],
@@ -670,6 +677,13 @@ def test_sufficient_balance_blob_tx(
     )
 
 
+@fork_covariant_parametrize(
+    parameter_names="blobs_per_tx",
+    fn=lambda fork: [
+        pytest.param([1], id="single_blob"),
+        pytest.param([fork.max_blobs_per_block()], id="max_blobs"),
+    ],
+)
 @pytest.mark.parametrize(
     "tx_access_list",
     [[], [AccessList(address=100, storage_keys=[100, 200])]],
@@ -728,6 +742,13 @@ def test_sufficient_balance_blob_tx_pre_fund_tx(
     )
 
 
+@fork_covariant_parametrize(
+    parameter_names="blobs_per_tx",
+    fn=lambda fork: [
+        pytest.param([1], id="single_blob"),
+        pytest.param([fork.max_blobs_per_block()], id="max_blobs"),
+    ],
+)
 @pytest.mark.parametrize(
     "tx_access_list",
     [[], [AccessList(address=100, storage_keys=[100, 200])]],

--- a/tests/cancun/eip4844_blobs/test_blob_txs.py
+++ b/tests/cancun/eip4844_blobs/test_blob_txs.py
@@ -20,7 +20,7 @@ from typing import List, Optional, Tuple
 
 import pytest
 
-from ethereum_test_forks import Fork, Prague
+from ethereum_test_forks import Fork
 from ethereum_test_tools import (
     EOA,
     AccessList,
@@ -282,24 +282,14 @@ def tx_access_list() -> List[AccessList]:
 
 
 @pytest.fixture
-def tx_error(
-    request: pytest.FixtureRequest,
-    fork: Fork,
-) -> Optional[TransactionException]:
+def tx_error() -> Optional[TransactionException]:
     """
     Error produced by the block transactions (no error).
 
     Can be overloaded on test cases where the transactions are expected
     to fail.
     """
-    if not hasattr(request, "param"):
-        return None
-    if fork >= Prague and request.param in [
-        TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED,
-        TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED,
-    ]:
-        return None
-    return request.param
+    return None
 
 
 @pytest.fixture
@@ -724,10 +714,7 @@ def test_invalid_normal_gas(
     invalid_blob_combinations(),
 )
 @pytest.mark.parametrize(
-    "tx_error",
-    [TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED],
-    ids=[""],
-    indirect=True,
+    "tx_error", [TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED], ids=[""]
 )
 @pytest.mark.valid_from("Cancun")
 def test_invalid_block_blob_count(
@@ -998,7 +985,6 @@ def test_insufficient_balance_blob_tx_combinations(
         ),
     ],
     ids=["too_few_blobs", "too_many_blobs"],
-    indirect=["tx_error"],
 )
 @pytest.mark.valid_from("Cancun")
 def test_invalid_tx_blob_count(

--- a/tests/cancun/eip4844_blobs/test_blob_txs.py
+++ b/tests/cancun/eip4844_blobs/test_blob_txs.py
@@ -42,7 +42,6 @@ from ethereum_test_tools import (
     add_kzg_version,
 )
 from ethereum_test_tools import Opcodes as Op
-from pytest_plugins import fork_covariant_parametrize
 
 from .spec import Spec, SpecHelpers, ref_spec_4844
 
@@ -371,9 +370,9 @@ def block(
     )
 
 
-@fork_covariant_parametrize(
-    parameter_names=["blobs_per_tx"],
-    fn=SpecHelpers.all_valid_blob_combinations,
+@pytest.mark.parametrize_by_fork(
+    "blobs_per_tx",
+    SpecHelpers.all_valid_blob_combinations,
 )
 @pytest.mark.valid_from("Cancun")
 def test_valid_blob_tx_combinations(
@@ -462,9 +461,9 @@ def generate_invalid_tx_max_fee_per_blob_gas_tests(
     return tests
 
 
-@fork_covariant_parametrize(
-    parameter_names="parent_excess_blobs,parent_blobs,tx_max_fee_per_blob_gas,tx_error",
-    fn=generate_invalid_tx_max_fee_per_blob_gas_tests,
+@pytest.mark.parametrize_by_fork(
+    "parent_excess_blobs,parent_blobs,tx_max_fee_per_blob_gas,tx_error",
+    generate_invalid_tx_max_fee_per_blob_gas_tests,
 )
 @pytest.mark.parametrize(
     "account_balance_modifier",
@@ -496,9 +495,9 @@ def test_invalid_tx_max_fee_per_blob_gas(
     )
 
 
-@fork_covariant_parametrize(
-    parameter_names="parent_excess_blobs,parent_blobs,tx_max_fee_per_blob_gas,tx_error",
-    fn=generate_invalid_tx_max_fee_per_blob_gas_tests,
+@pytest.mark.parametrize_by_fork(
+    "parent_excess_blobs,parent_blobs,tx_max_fee_per_blob_gas,tx_error",
+    generate_invalid_tx_max_fee_per_blob_gas_tests,
 )
 @pytest.mark.valid_from("Cancun")
 def test_invalid_tx_max_fee_per_blob_gas_state(
@@ -558,9 +557,9 @@ def test_invalid_normal_gas(
     )
 
 
-@fork_covariant_parametrize(
-    parameter_names="blobs_per_tx",
-    fn=SpecHelpers.invalid_blob_combinations,
+@pytest.mark.parametrize_by_fork(
+    "blobs_per_tx",
+    SpecHelpers.invalid_blob_combinations,
 )
 @pytest.mark.parametrize(
     "tx_error", [TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED], ids=[""]
@@ -630,9 +629,9 @@ def test_insufficient_balance_blob_tx(
     )
 
 
-@fork_covariant_parametrize(
-    parameter_names="blobs_per_tx",
-    fn=lambda fork: [
+@pytest.mark.parametrize_by_fork(
+    "blobs_per_tx",
+    lambda fork: [
         pytest.param([1], id="single_blob"),
         pytest.param([fork.max_blobs_per_block()], id="max_blobs"),
     ],
@@ -677,9 +676,9 @@ def test_sufficient_balance_blob_tx(
     )
 
 
-@fork_covariant_parametrize(
-    parameter_names="blobs_per_tx",
-    fn=lambda fork: [
+@pytest.mark.parametrize_by_fork(
+    "blobs_per_tx",
+    lambda fork: [
         pytest.param([1], id="single_blob"),
         pytest.param([fork.max_blobs_per_block()], id="max_blobs"),
     ],
@@ -742,9 +741,9 @@ def test_sufficient_balance_blob_tx_pre_fund_tx(
     )
 
 
-@fork_covariant_parametrize(
-    parameter_names="blobs_per_tx",
-    fn=lambda fork: [
+@pytest.mark.parametrize_by_fork(
+    "blobs_per_tx",
+    lambda fork: [
         pytest.param([1], id="single_blob"),
         pytest.param([fork.max_blobs_per_block()], id="max_blobs"),
     ],
@@ -818,9 +817,9 @@ def test_blob_gas_subtraction_tx(
     )
 
 
-@fork_covariant_parametrize(
-    parameter_names="blobs_per_tx",
-    fn=SpecHelpers.all_valid_blob_combinations,
+@pytest.mark.parametrize_by_fork(
+    "blobs_per_tx",
+    SpecHelpers.all_valid_blob_combinations,
 )
 @pytest.mark.parametrize("account_balance_modifier", [-1], ids=["exact_balance_minus_1"])
 @pytest.mark.parametrize("tx_error", [TransactionException.INSUFFICIENT_ACCOUNT_FUNDS], ids=[""])
@@ -863,9 +862,9 @@ def generate_invalid_tx_blob_count_tests(
     ]
 
 
-@fork_covariant_parametrize(
-    parameter_names="blobs_per_tx,tx_error",
-    fn=generate_invalid_tx_blob_count_tests,
+@pytest.mark.parametrize_by_fork(
+    "blobs_per_tx,tx_error",
+    generate_invalid_tx_blob_count_tests,
 )
 @pytest.mark.valid_from("Cancun")
 def test_invalid_tx_blob_count(

--- a/tests/cancun/eip4844_blobs/test_blob_txs_full.py
+++ b/tests/cancun/eip4844_blobs/test_blob_txs_full.py
@@ -8,6 +8,7 @@ from typing import List, Optional
 
 import pytest
 
+from ethereum_test_forks import Fork
 from ethereum_test_tools import (
     Address,
     Alloc,
@@ -19,6 +20,7 @@ from ethereum_test_tools import (
     Transaction,
     TransactionException,
 )
+from pytest_plugins import fork_covariant_parametrize
 
 from .common import INF_POINT, Blob
 from .spec import Spec, SpecHelpers, ref_spec_4844
@@ -55,12 +57,6 @@ def tx_calldata() -> bytes:
     return b""
 
 
-@pytest.fixture
-def block_fee_per_gas() -> int:
-    """Max fee per gas for transactions sent during test."""
-    return 7
-
-
 @pytest.fixture(autouse=True)
 def parent_excess_blobs() -> int:
     """
@@ -83,28 +79,6 @@ def parent_blobs() -> int:
 
 
 @pytest.fixture
-def parent_excess_blob_gas(
-    parent_excess_blobs: int,
-) -> int:
-    """Calculate excess blob gas of the parent block from the excess blobs."""
-    return parent_excess_blobs * Spec.GAS_PER_BLOB
-
-
-@pytest.fixture
-def blob_gasprice(
-    parent_excess_blob_gas: int,
-    parent_blobs: int,
-) -> int:
-    """Blob gas price for the block of the test."""
-    return Spec.get_blob_gasprice(
-        excess_blob_gas=SpecHelpers.calc_excess_blob_gas_from_blob_count(
-            parent_excess_blob_gas=parent_excess_blob_gas,
-            parent_blob_count=parent_blobs,
-        ),
-    )
-
-
-@pytest.fixture
 def tx_max_priority_fee_per_gas() -> int:
     """
     Max priority fee per gas for transactions sent during test.
@@ -123,7 +97,7 @@ def txs_versioned_hashes(txs_blobs: List[List[Blob]]) -> List[List[bytes]]:
 
 @pytest.fixture(autouse=True)
 def tx_max_fee_per_gas(
-    block_fee_per_gas: int,
+    block_base_fee_per_gas: int,
 ) -> int:
     """
     Max fee per gas value used by all transactions sent during test.
@@ -133,12 +107,12 @@ def tx_max_fee_per_gas(
     Can be overloaded by a test case to test rejection of transactions where
     the max fee per gas is insufficient.
     """
-    return block_fee_per_gas
+    return block_base_fee_per_gas
 
 
 @pytest.fixture
 def tx_max_fee_per_blob_gas(  # noqa: D103
-    blob_gasprice: Optional[int],
+    blob_gas_price: Optional[int],
 ) -> int:
     """
     Max fee per blob gas for transactions sent during test.
@@ -148,10 +122,10 @@ def tx_max_fee_per_blob_gas(  # noqa: D103
     Can be overloaded by a test case to test rejection of transactions where
     the max fee per blob gas is insufficient.
     """
-    if blob_gasprice is None:
+    if blob_gas_price is None:
         # When fork transitioning, the default blob gas price is 1.
         return 1
-    return blob_gasprice
+    return blob_gas_price
 
 
 @pytest.fixture
@@ -227,6 +201,7 @@ def env(
 def blocks(
     txs: List[Transaction],
     txs_wrapped_blobs: List[bool],
+    blob_gas_per_blob: int,
 ) -> List[Block]:
     """Prepare the list of blocks for all test cases."""
     header_blob_gas_used = 0
@@ -247,7 +222,7 @@ def blocks(
                     if tx.blob_versioned_hashes is not None
                 ]
             )
-            * Spec.GAS_PER_BLOB
+            * blob_gas_per_blob
         )
     return [
         Block(
@@ -256,59 +231,63 @@ def blocks(
     ]
 
 
-@pytest.mark.parametrize(
-    "txs_blobs,txs_wrapped_blobs",
-    [
-        (
+def generate_full_blob_tests(
+    fork: Fork,
+) -> List:
+    """
+    Return a list of tests for invalid blob transactions due to insufficient max fee per blob gas
+    parametrized for each different fork.
+    """
+    blob_size = Spec.FIELD_ELEMENTS_PER_BLOB * SpecHelpers.BYTES_PER_FIELD_ELEMENT
+    max_blobs = fork.max_blobs_per_block()
+    return [
+        pytest.param(
             [  # Txs
                 [  # Blobs per transaction
                     Blob(
-                        blob=bytes(
-                            Spec.FIELD_ELEMENTS_PER_BLOB * SpecHelpers.BYTES_PER_FIELD_ELEMENT
-                        ),
+                        blob=bytes(blob_size),
                         kzg_commitment=INF_POINT,
                         kzg_proof=INF_POINT,
                     ),
                 ]
             ],
             [True],
+            id="one_full_blob_one_tx",
         ),
-        (
+        pytest.param(
             [  # Txs
                 [  # Blobs per transaction
                     Blob(
-                        blob=bytes(
-                            Spec.FIELD_ELEMENTS_PER_BLOB * SpecHelpers.BYTES_PER_FIELD_ELEMENT
-                        ),
+                        blob=bytes(blob_size),
                         kzg_commitment=INF_POINT,
                         kzg_proof=INF_POINT,
                     )
                 ]
-                for _ in range(SpecHelpers.max_blobs_per_block())
+                for _ in range(max_blobs)
             ],
-            [True] + ([False] * (SpecHelpers.max_blobs_per_block() - 1)),
+            [True] + ([False] * (max_blobs - 1)),
+            id="one_full_blob_max_txs",
         ),
-        (
+        pytest.param(
             [  # Txs
                 [  # Blobs per transaction
                     Blob(
-                        blob=bytes(
-                            Spec.FIELD_ELEMENTS_PER_BLOB * SpecHelpers.BYTES_PER_FIELD_ELEMENT
-                        ),
+                        blob=bytes(blob_size),
                         kzg_commitment=INF_POINT,
                         kzg_proof=INF_POINT,
                     )
                 ]
-                for _ in range(SpecHelpers.max_blobs_per_block())
+                for _ in range(max_blobs)
             ],
-            ([False] * (SpecHelpers.max_blobs_per_block() - 1)) + [True],
+            ([False] * (max_blobs - 1)) + [True],
+            id="one_full_blob_at_the_end_max_txs",
         ),
-    ],
-    ids=[
-        "one_full_blob_one_tx",
-        "one_full_blob_max_txs",
-        "one_full_blob_at_the_end_max_txs",
-    ],
+    ]
+
+
+@fork_covariant_parametrize(
+    parameter_names="txs_blobs,txs_wrapped_blobs",
+    fn=generate_full_blob_tests,
 )
 @pytest.mark.valid_from("Cancun")
 def test_reject_valid_full_blob_in_block_rlp(

--- a/tests/cancun/eip4844_blobs/test_blob_txs_full.py
+++ b/tests/cancun/eip4844_blobs/test_blob_txs_full.py
@@ -20,7 +20,6 @@ from ethereum_test_tools import (
     Transaction,
     TransactionException,
 )
-from pytest_plugins import fork_covariant_parametrize
 
 from .common import INF_POINT, Blob
 from .spec import Spec, SpecHelpers, ref_spec_4844
@@ -285,9 +284,9 @@ def generate_full_blob_tests(
     ]
 
 
-@fork_covariant_parametrize(
-    parameter_names="txs_blobs,txs_wrapped_blobs",
-    fn=generate_full_blob_tests,
+@pytest.mark.parametrize_by_fork(
+    "txs_blobs,txs_wrapped_blobs",
+    generate_full_blob_tests,
 )
 @pytest.mark.valid_from("Cancun")
 def test_reject_valid_full_blob_in_block_rlp(

--- a/tests/cancun/eip4844_blobs/test_blobhash_opcode_contexts.py
+++ b/tests/cancun/eip4844_blobs/test_blobhash_opcode_contexts.py
@@ -5,8 +5,11 @@ abstract: Tests `BLOBHASH` opcode in [EIP-4844: Shard Blob Transactions](https:/
 
 """  # noqa: E501
 
+from typing import List
+
 import pytest
 
+from ethereum_test_forks import Fork
 from ethereum_test_tools import (
     Account,
     Block,
@@ -15,28 +18,16 @@ from ethereum_test_tools import (
     TestAddress,
     Transaction,
     YulCompiler,
+    add_kzg_version,
 )
 
-from .common import BlobhashContext, simple_blob_hashes
-from .spec import Spec, SpecHelpers, ref_spec_4844
+from .common import BlobhashContext
+from .spec import Spec, ref_spec_4844
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_4844.git_path
 REFERENCE_SPEC_VERSION = ref_spec_4844.version
 
 pytestmark = pytest.mark.valid_from("Cancun")
-
-
-# Blob transaction template
-tx_type_3 = Transaction(
-    ty=Spec.BLOB_TX_TYPE,
-    data=Hash(0),
-    gas_limit=3000000,
-    max_fee_per_gas=10,
-    max_priority_fee_per_gas=10,
-    max_fee_per_blob_gas=10,
-    access_list=[],
-    blob_versioned_hashes=simple_blob_hashes,
-)
 
 
 def create_opcode_context(pre, tx, post):
@@ -46,6 +37,35 @@ def create_opcode_context(pre, tx, post):
         "tx": tx,
         "post": post,
     }
+
+
+@pytest.fixture()
+def simple_blob_hashes(
+    max_blobs_per_block: int,
+) -> List[bytes]:
+    """Simple list of blob versioned hashes ranging from bytes32(1 to 4)"""
+    return add_kzg_version(
+        [(1 << x) for x in range(max_blobs_per_block)],
+        Spec.BLOB_COMMITMENT_VERSION_KZG,
+    )
+
+
+@pytest.fixture()
+def tx_type_3(
+    fork: Fork,
+    simple_blob_hashes: List[bytes],
+) -> Transaction:
+    """Blob transaction template."""
+    return Transaction(
+        ty=Spec.BLOB_TX_TYPE,
+        data=Hash(0),
+        gas_limit=3000000,
+        max_fee_per_gas=10,
+        max_priority_fee_per_gas=10,
+        max_fee_per_blob_gas=fork.min_base_fee_per_blob_gas() * 10,
+        access_list=[],
+        blob_versioned_hashes=simple_blob_hashes,
+    )
 
 
 @pytest.fixture(
@@ -63,7 +83,13 @@ def create_opcode_context(pre, tx, post):
         "on_type_0_tx",
     ]
 )
-def opcode_context(yul: YulCompiler, request):
+def opcode_context(
+    yul: YulCompiler,
+    request,
+    max_blobs_per_block: int,
+    simple_blob_hashes: List[bytes],
+    tx_type_3: Transaction,
+):
     """
     Fixture that is parameterized by each BLOBHASH opcode test case
     in order to return the corresponding constructed opcode context.
@@ -134,7 +160,7 @@ def opcode_context(yul: YulCompiler, request):
                 ),
             },
             tx_type_3.copy(
-                data=Hash(0) + Hash(SpecHelpers.max_blobs_per_block() - 1),
+                data=Hash(0) + Hash(max_blobs_per_block - 1),
                 to=BlobhashContext.address("delegatecall"),
             ),
             {
@@ -160,7 +186,7 @@ def opcode_context(yul: YulCompiler, request):
                 ),
             },
             tx_type_3.copy(
-                data=Hash(0) + Hash(SpecHelpers.max_blobs_per_block() - 1),
+                data=Hash(0) + Hash(max_blobs_per_block - 1),
                 to=BlobhashContext.address("staticcall"),
             ),
             {
@@ -182,7 +208,7 @@ def opcode_context(yul: YulCompiler, request):
                 ),
             },
             tx_type_3.copy(
-                data=Hash(0) + Hash(SpecHelpers.max_blobs_per_block() - 1),
+                data=Hash(0) + Hash(max_blobs_per_block - 1),
                 to=BlobhashContext.address("callcode"),
             ),
             {

--- a/tests/cancun/eip4844_blobs/test_blobhash_opcode_contexts.py
+++ b/tests/cancun/eip4844_blobs/test_blobhash_opcode_contexts.py
@@ -43,7 +43,7 @@ def create_opcode_context(pre, tx, post):
 def simple_blob_hashes(
     max_blobs_per_block: int,
 ) -> List[bytes]:
-    """Simple list of blob versioned hashes ranging from bytes32(1 to 4)"""
+    """Return a simple list of blob versioned hashes ranging from bytes32(1 to 4)."""
     return add_kzg_version(
         [(1 << x) for x in range(max_blobs_per_block)],
         Spec.BLOB_COMMITMENT_VERSION_KZG,

--- a/tests/cancun/eip4844_blobs/test_excess_blob_gas.py
+++ b/tests/cancun/eip4844_blobs/test_excess_blob_gas.py
@@ -22,10 +22,11 @@ note: Adding a new test
 """  # noqa: E501
 
 import itertools
-from typing import Dict, Iterator, List, Mapping, Optional, Tuple
+from typing import Callable, Dict, Iterator, List, Mapping, Optional, Tuple
 
 import pytest
 
+from ethereum_test_forks import Fork
 from ethereum_test_tools import (
     EOA,
     Account,
@@ -42,6 +43,7 @@ from ethereum_test_tools import (
     add_kzg_version,
 )
 from ethereum_test_tools import Opcodes as Op
+from pytest_plugins import fork_covariant_parametrize
 
 from .spec import Spec, SpecHelpers, ref_spec_4844
 
@@ -53,25 +55,9 @@ pytestmark = pytest.mark.valid_from("Cancun")
 
 
 @pytest.fixture
-def parent_excess_blobs() -> int:  # noqa: D103
+def parent_excess_blobs(fork: Fork) -> int:  # noqa: D103
     """By default we start with an intermediate value between the target and max."""
-    return (SpecHelpers.max_blobs_per_block() + SpecHelpers.target_blobs_per_block()) // 2 + 1
-
-
-@pytest.fixture
-def parent_excess_blob_gas(parent_excess_blobs: int) -> int:  # noqa: D103
-    return parent_excess_blobs * Spec.GAS_PER_BLOB
-
-
-@pytest.fixture
-def correct_excess_blob_gas(  # noqa: D103
-    parent_excess_blob_gas: int,
-    parent_blobs: int,
-) -> int:
-    return SpecHelpers.calc_excess_blob_gas_from_blob_count(
-        parent_excess_blob_gas=parent_excess_blob_gas,
-        parent_blob_count=parent_blobs,
-    )
+    return (fork.max_blobs_per_block() + fork.target_blobs_per_block()) // 2 + 1
 
 
 @pytest.fixture
@@ -89,10 +75,11 @@ def header_excess_blob_gas(  # noqa: D103
     correct_excess_blob_gas: int,
     header_excess_blobs_delta: Optional[int],
     header_excess_blob_gas_delta: Optional[int],
+    blob_gas_per_blob: int,
 ) -> Optional[int]:
     if header_excess_blobs_delta is not None:
         modified_excess_blob_gas = correct_excess_blob_gas + (
-            header_excess_blobs_delta * Spec.GAS_PER_BLOB
+            header_excess_blobs_delta * blob_gas_per_blob
         )
         if modified_excess_blob_gas < 0:
             modified_excess_blob_gas = 2**64 + (modified_excess_blob_gas)
@@ -103,58 +90,12 @@ def header_excess_blob_gas(  # noqa: D103
 
 
 @pytest.fixture
-def block_fee_per_blob_gas(  # noqa: D103
-    correct_excess_blob_gas: int,
-) -> int:
-    return Spec.get_blob_gasprice(excess_blob_gas=correct_excess_blob_gas)
-
-
-@pytest.fixture
-def block_base_fee() -> int:  # noqa: D103
-    return 7
-
-
-@pytest.fixture
-def env(  # noqa: D103
-    parent_excess_blob_gas: int,
-    block_base_fee: int,
-    parent_blobs: int,
-) -> Environment:
-    return Environment(
-        excess_blob_gas=(
-            parent_excess_blob_gas
-            if parent_blobs == 0
-            else parent_excess_blob_gas + Spec.TARGET_BLOB_GAS_PER_BLOCK
-        ),
-        base_fee_per_gas=block_base_fee,
-    )
-
-
-@pytest.fixture
-def tx_max_fee_per_gas(  # noqa: D103
-    block_base_fee: int,
-) -> int:
-    return block_base_fee
-
-
-@pytest.fixture
-def tx_max_fee_per_blob_gas(  # noqa: D103
-    block_fee_per_blob_gas: int,
-) -> int:
-    return block_fee_per_blob_gas
-
-
-@pytest.fixture
-def tx_data_cost(  # noqa: D103
+def tx_blob_data_cost(  # noqa: D103
     tx_max_fee_per_blob_gas: int,
     new_blobs: int,
+    blob_gas_per_blob: int,
 ) -> int:
-    return tx_max_fee_per_blob_gas * Spec.GAS_PER_BLOB * new_blobs
-
-
-@pytest.fixture
-def tx_value() -> int:  # noqa: D103
-    return 1
+    return tx_max_fee_per_blob_gas * blob_gas_per_blob * new_blobs
 
 
 @pytest.fixture
@@ -164,9 +105,9 @@ def tx_gas_limit() -> int:  # noqa: D103
 
 @pytest.fixture
 def tx_exact_cost(  # noqa: D103
-    tx_value: int, tx_max_fee_per_gas: int, tx_data_cost: int, tx_gas_limit: int
+    tx_value: int, tx_max_fee_per_gas: int, tx_blob_data_cost: int, tx_gas_limit: int
 ) -> int:
-    return (tx_gas_limit * tx_max_fee_per_gas) + tx_value + tx_data_cost
+    return (tx_gas_limit * tx_max_fee_per_gas) + tx_value + tx_blob_data_cost
 
 
 @pytest.fixture
@@ -190,11 +131,11 @@ def sender(pre: Alloc, tx_exact_cost: int) -> Address:  # noqa: D103
 
 @pytest.fixture
 def post(  # noqa: D103
-    destination_account: Address, tx_value: int, block_fee_per_blob_gas: int
+    destination_account: Address, tx_value: int, blob_gas_price: int
 ) -> Mapping[Address, Account]:
     return {
         destination_account: Account(
-            storage={0: block_fee_per_blob_gas},
+            storage={0: blob_gas_price},
             balance=tx_value,
         ),
     }
@@ -247,8 +188,9 @@ def header_blob_gas_used() -> Optional[int]:  # noqa: D103
 @pytest.fixture
 def correct_blob_gas_used(  # noqa: D103
     tx: Transaction,
+    blob_gas_per_blob: int,
 ) -> int:
-    return Spec.get_total_blob_gas(tx)
+    return Spec.get_total_blob_gas(tx=tx, blob_gas_per_blob=blob_gas_per_blob)
 
 
 @pytest.fixture
@@ -259,6 +201,8 @@ def blocks(  # noqa: D103
     correct_excess_blob_gas: int,
     correct_blob_gas_used: int,
     non_zero_blob_gas_used_genesis_block: Block,
+    max_blobs_per_block: int,
+    blob_gas_per_blob: int,
 ):
     blocks = (
         []
@@ -289,7 +233,7 @@ def blocks(  # noqa: D103
             exception_message=BlockException.INCORRECT_EXCESS_BLOB_GAS,
         )
     elif header_blob_gas_used is not None:
-        if header_blob_gas_used > Spec.MAX_BLOB_GAS_PER_BLOCK:
+        if header_blob_gas_used > (max_blobs_per_block * blob_gas_per_blob):
             add_block(
                 header_modifier={"blob_gas_used": header_blob_gas_used},
                 exception_message=[
@@ -308,8 +252,14 @@ def blocks(  # noqa: D103
     return blocks
 
 
-@pytest.mark.parametrize("parent_blobs", range(0, SpecHelpers.max_blobs_per_block() + 1))
-@pytest.mark.parametrize("parent_excess_blobs", range(0, SpecHelpers.target_blobs_per_block() + 1))
+@fork_covariant_parametrize(
+    parameter_names="parent_blobs",
+    fn=lambda fork: range(0, fork.max_blobs_per_block() + 1),
+)
+@fork_covariant_parametrize(
+    parameter_names="parent_excess_blobs",
+    fn=lambda fork: range(0, fork.target_blobs_per_block() + 1),
+)
 @pytest.mark.parametrize("new_blobs", [1])
 def test_correct_excess_blob_gas_calculation(
     blockchain_test: BlockchainTestFiller,
@@ -335,24 +285,42 @@ def test_correct_excess_blob_gas_calculation(
     )
 
 
-BLOB_GAS_COST_INCREASES = [
-    SpecHelpers.get_min_excess_blobs_for_blob_gas_price(i)
-    for i in [
-        2,  # First blob gas cost increase
-        2**32 // Spec.GAS_PER_BLOB,  # Data tx wei cost 2^32
-        2**32,  # blob gas cost 2^32
-        2**64 // Spec.GAS_PER_BLOB,  # Data tx wei cost 2^64
-        2**64,  # blob gas cost 2^64
-        (120_000_000 * (10**18) // Spec.GAS_PER_BLOB),  # Data tx wei is current total Ether supply
-    ]
-]
+def generate_blob_gas_cost_increases_tests(delta: int) -> Callable[[Fork], List[int]]:
+    """
+    Generate a list of block excess blob gas values where the blob gas price increases
+    based on fork properties.
+    """
+
+    def generator_function(fork: Fork) -> List[int]:
+        gas_per_blob = fork.blob_gas_per_blob()
+        return [
+            SpecHelpers.get_min_excess_blobs_for_blob_gas_price(
+                fork=fork, blob_gas_price=blob_gas_price
+            )
+            + delta
+            for blob_gas_price in [
+                2,  # First blob gas cost increase
+                2**32 // gas_per_blob,  # Data tx wei cost 2^32
+                2**32,  # blob gas cost 2^32
+                2**64 // gas_per_blob,  # Data tx wei cost 2^64
+                2**64,  # blob gas cost 2^64
+                (
+                    120_000_000 * (10**18) // gas_per_blob
+                ),  # Data tx wei is current total Ether supply
+            ]
+        ]
+
+    return generator_function
 
 
-@pytest.mark.parametrize(
-    "parent_excess_blobs",
-    [g - 1 for g in BLOB_GAS_COST_INCREASES],
+@fork_covariant_parametrize(
+    parameter_names="parent_excess_blobs",
+    fn=generate_blob_gas_cost_increases_tests(-1),
 )
-@pytest.mark.parametrize("parent_blobs", [SpecHelpers.target_blobs_per_block() + 1])
+@fork_covariant_parametrize(
+    parameter_names="parent_blobs",
+    fn=lambda fork: [fork.target_blobs_per_block() + 1],
+)
 @pytest.mark.parametrize("new_blobs", [1])
 def test_correct_increasing_blob_gas_costs(
     blockchain_test: BlockchainTestFiller,
@@ -382,11 +350,14 @@ def test_correct_increasing_blob_gas_costs(
     )
 
 
-@pytest.mark.parametrize(
-    "parent_excess_blobs",
-    list(BLOB_GAS_COST_INCREASES),
+@fork_covariant_parametrize(
+    parameter_names="parent_excess_blobs",
+    fn=generate_blob_gas_cost_increases_tests(0),
 )
-@pytest.mark.parametrize("parent_blobs", [SpecHelpers.target_blobs_per_block() - 1])
+@fork_covariant_parametrize(
+    parameter_names="parent_blobs",
+    fn=lambda fork: [fork.target_blobs_per_block() - 1],
+)
 @pytest.mark.parametrize("new_blobs", [1])
 def test_correct_decreasing_blob_gas_costs(
     blockchain_test: BlockchainTestFiller,
@@ -413,7 +384,10 @@ def test_correct_decreasing_blob_gas_costs(
 
 @pytest.mark.parametrize("header_excess_blob_gas", [0])
 @pytest.mark.parametrize("new_blobs", [0, 1])
-@pytest.mark.parametrize("parent_blobs", range(0, SpecHelpers.max_blobs_per_block() + 1))
+@fork_covariant_parametrize(
+    parameter_names="parent_blobs",
+    fn=lambda fork: range(0, fork.max_blobs_per_block() + 1),
+)
 def test_invalid_zero_excess_blob_gas_in_header(
     blockchain_test: BlockchainTestFiller,
     env: Environment,
@@ -447,18 +421,19 @@ def test_invalid_zero_excess_blob_gas_in_header(
     )
 
 
-def all_invalid_blob_gas_used_combinations() -> Iterator[Tuple[int, int]]:
+def all_invalid_blob_gas_used_combinations(fork: Fork) -> Iterator[Tuple[int, int]]:
     """Return all invalid blob gas used combinations."""
-    for new_blobs in range(0, SpecHelpers.max_blobs_per_block() + 1):
-        for header_blob_gas_used in range(0, SpecHelpers.max_blobs_per_block() + 1):
+    gas_per_blob = fork.blob_gas_per_blob()
+    for new_blobs in range(0, fork.max_blobs_per_block() + 1):
+        for header_blob_gas_used in range(0, fork.max_blobs_per_block() + 1):
             if new_blobs != header_blob_gas_used:
-                yield (new_blobs, header_blob_gas_used * Spec.GAS_PER_BLOB)
+                yield (new_blobs, header_blob_gas_used * gas_per_blob)
         yield (new_blobs, 2**64 - 1)
 
 
-@pytest.mark.parametrize(
-    "new_blobs,header_blob_gas_used",
-    all_invalid_blob_gas_used_combinations(),
+@fork_covariant_parametrize(
+    parameter_names="new_blobs,header_blob_gas_used",
+    fn=all_invalid_blob_gas_used_combinations,
 )
 @pytest.mark.parametrize("parent_blobs", [0])
 def test_invalid_blob_gas_used_in_header(
@@ -468,6 +443,7 @@ def test_invalid_blob_gas_used_in_header(
     blocks: List[Block],
     new_blobs: int,
     header_blob_gas_used: Optional[int],
+    blob_gas_per_blob: int,
 ):
     """
     Test rejection of blocks where the `blobGasUsed` in the header is invalid.
@@ -484,20 +460,24 @@ def test_invalid_blob_gas_used_in_header(
         genesis_environment=env,
         tag="-".join(
             [
-                f"correct:{hex(new_blobs * Spec.GAS_PER_BLOB)}",
+                f"correct:{hex(new_blobs * blob_gas_per_blob)}",
                 f"header:{hex(header_blob_gas_used)}",
             ]
         ),
     )
 
 
-@pytest.mark.parametrize(
-    "header_excess_blobs_delta,parent_blobs",
-    [
-        (-1, 0),
-        (+1, SpecHelpers.max_blobs_per_block()),
-    ],
-    ids=["zero_blobs_decrease_more_than_expected", "max_blobs_increase_more_than_expected"],
+def generate_invalid_excess_blob_gas_above_target_change_tests(fork: Fork) -> List:
+    """Return all invalid excess blob gas above target change tests."""
+    return [
+        pytest.param(-1, 0, id="zero_blobs_decrease_more_than_expected"),
+        pytest.param(+1, fork.max_blobs_per_block(), id="max_blobs_increase_more_than_expected"),
+    ]
+
+
+@fork_covariant_parametrize(
+    parameter_names="header_excess_blobs_delta,parent_blobs",
+    fn=generate_invalid_excess_blob_gas_above_target_change_tests,
 )
 @pytest.mark.parametrize("new_blobs", [1])
 def test_invalid_excess_blob_gas_above_target_change(
@@ -534,15 +514,15 @@ def test_invalid_excess_blob_gas_above_target_change(
     )
 
 
-@pytest.mark.parametrize(
-    "parent_blobs",
-    [
-        b
-        for b in range(0, SpecHelpers.max_blobs_per_block() + 1)
-        if b != SpecHelpers.target_blobs_per_block()
+@fork_covariant_parametrize(
+    parameter_names="parent_blobs",
+    fn=lambda fork: [
+        b for b in range(0, fork.max_blobs_per_block() + 1) if b != fork.target_blobs_per_block()
     ],
 )
-@pytest.mark.parametrize("parent_excess_blobs", [1, SpecHelpers.target_blobs_per_block()])
+@fork_covariant_parametrize(
+    parameter_names="parent_excess_blobs", fn=lambda fork: [1, fork.target_blobs_per_block()]
+)
 @pytest.mark.parametrize("new_blobs", [1])
 def test_invalid_static_excess_blob_gas(
     blockchain_test: BlockchainTestFiller,
@@ -575,8 +555,14 @@ def test_invalid_static_excess_blob_gas(
     )
 
 
-@pytest.mark.parametrize("header_excess_blobs_delta", range(1, SpecHelpers.max_blobs_per_block()))
-@pytest.mark.parametrize("parent_blobs", range(0, SpecHelpers.target_blobs_per_block() + 1))
+@fork_covariant_parametrize(
+    parameter_names="header_excess_blobs_delta",
+    fn=lambda fork: range(1, fork.max_blobs_per_block()),
+)
+@fork_covariant_parametrize(
+    parameter_names="parent_blobs",
+    fn=lambda fork: range(0, fork.target_blobs_per_block() + 1),
+)
 @pytest.mark.parametrize("parent_excess_blobs", [0])  # Start at 0
 @pytest.mark.parametrize("new_blobs", [1])
 def test_invalid_excess_blob_gas_target_blobs_increase_from_zero(
@@ -614,9 +600,9 @@ def test_invalid_excess_blob_gas_target_blobs_increase_from_zero(
 
 
 @pytest.mark.parametrize("header_excess_blob_gas", [0])
-@pytest.mark.parametrize(
-    "parent_blobs",
-    range(SpecHelpers.target_blobs_per_block() + 1, SpecHelpers.max_blobs_per_block() + 1),
+@fork_covariant_parametrize(
+    parameter_names="parent_blobs",
+    fn=lambda fork: range(fork.target_blobs_per_block() + 1, fork.max_blobs_per_block() + 1),
 )
 @pytest.mark.parametrize("parent_excess_blobs", [0])  # Start at 0
 @pytest.mark.parametrize("new_blobs", [1])
@@ -654,17 +640,15 @@ def test_invalid_static_excess_blob_gas_from_zero_on_blobs_above_target(
     )
 
 
-@pytest.mark.parametrize(
-    "parent_blobs,header_excess_blobs_delta",
-    itertools.product(
+@fork_covariant_parametrize(
+    parameter_names="parent_blobs,header_excess_blobs_delta",
+    fn=lambda fork: itertools.product(
         # parent_blobs
-        range(0, SpecHelpers.max_blobs_per_block() + 1),
+        range(0, fork.max_blobs_per_block() + 1),
         # header_excess_blobs_delta (from correct value)
         [
             x
-            for x in range(
-                -SpecHelpers.target_blobs_per_block(), SpecHelpers.target_blobs_per_block() + 1
-            )
+            for x in range(-fork.target_blobs_per_block(), fork.target_blobs_per_block() + 1)
             if x != 0
         ],
     ),
@@ -706,13 +690,21 @@ def test_invalid_excess_blob_gas_change(
     )
 
 
-@pytest.mark.parametrize(
-    "header_excess_blob_gas",
-    [(2**64 + (x * Spec.GAS_PER_BLOB)) for x in range(-SpecHelpers.target_blobs_per_block(), 0)],
+@fork_covariant_parametrize(
+    parameter_names="header_excess_blob_gas",
+    fn=lambda fork: [
+        (2**64 + (x * fork.blob_gas_per_blob())) for x in range(-fork.target_blobs_per_block(), 0)
+    ],
 )
-@pytest.mark.parametrize("parent_blobs", range(SpecHelpers.target_blobs_per_block()))
+@fork_covariant_parametrize(
+    parameter_names="parent_blobs",
+    fn=lambda fork: range(fork.target_blobs_per_block()),
+)
 @pytest.mark.parametrize("new_blobs", [1])
-@pytest.mark.parametrize("parent_excess_blobs", range(SpecHelpers.target_blobs_per_block()))
+@fork_covariant_parametrize(
+    parameter_names="parent_excess_blobs",
+    fn=lambda fork: range(fork.target_blobs_per_block()),
+)
 def test_invalid_negative_excess_blob_gas(
     blockchain_test: BlockchainTestFiller,
     env: Environment,
@@ -748,17 +740,20 @@ def test_invalid_negative_excess_blob_gas(
     )
 
 
-@pytest.mark.parametrize(
-    "parent_blobs,header_excess_blob_gas_delta",
-    [
-        (SpecHelpers.target_blobs_per_block() + 1, 1),
-        (SpecHelpers.target_blobs_per_block() + 1, Spec.GAS_PER_BLOB - 1),
-        (SpecHelpers.target_blobs_per_block() - 1, -1),
-        (SpecHelpers.target_blobs_per_block() - 1, -(Spec.GAS_PER_BLOB - 1)),
+@fork_covariant_parametrize(
+    parameter_names="parent_blobs,header_excess_blob_gas_delta",
+    fn=lambda fork: [
+        (fork.target_blobs_per_block() + 1, 1),
+        (fork.target_blobs_per_block() + 1, fork.blob_gas_per_blob() - 1),
+        (fork.target_blobs_per_block() - 1, -1),
+        (fork.target_blobs_per_block() - 1, -(fork.blob_gas_per_blob() - 1)),
     ],
 )
 @pytest.mark.parametrize("new_blobs", [1])
-@pytest.mark.parametrize("parent_excess_blobs", [SpecHelpers.target_blobs_per_block() + 1])
+@fork_covariant_parametrize(
+    parameter_names="parent_excess_blobs",
+    fn=lambda fork: [fork.target_blobs_per_block() + 1],
+)
 def test_invalid_non_multiple_excess_blob_gas(
     blockchain_test: BlockchainTestFiller,
     env: Environment,

--- a/tests/cancun/eip4844_blobs/test_excess_blob_gas.py
+++ b/tests/cancun/eip4844_blobs/test_excess_blob_gas.py
@@ -43,7 +43,6 @@ from ethereum_test_tools import (
     add_kzg_version,
 )
 from ethereum_test_tools import Opcodes as Op
-from pytest_plugins import fork_covariant_parametrize
 
 from .spec import Spec, SpecHelpers, ref_spec_4844
 
@@ -252,13 +251,13 @@ def blocks(  # noqa: D103
     return blocks
 
 
-@fork_covariant_parametrize(
-    parameter_names="parent_blobs",
-    fn=lambda fork: range(0, fork.max_blobs_per_block() + 1),
+@pytest.mark.parametrize_by_fork(
+    "parent_blobs",
+    lambda fork: range(0, fork.max_blobs_per_block() + 1),
 )
-@fork_covariant_parametrize(
-    parameter_names="parent_excess_blobs",
-    fn=lambda fork: range(0, fork.target_blobs_per_block() + 1),
+@pytest.mark.parametrize_by_fork(
+    "parent_excess_blobs",
+    lambda fork: range(0, fork.target_blobs_per_block() + 1),
 )
 @pytest.mark.parametrize("new_blobs", [1])
 def test_correct_excess_blob_gas_calculation(
@@ -313,13 +312,13 @@ def generate_blob_gas_cost_increases_tests(delta: int) -> Callable[[Fork], List[
     return generator_function
 
 
-@fork_covariant_parametrize(
-    parameter_names="parent_excess_blobs",
-    fn=generate_blob_gas_cost_increases_tests(-1),
+@pytest.mark.parametrize_by_fork(
+    "parent_excess_blobs",
+    generate_blob_gas_cost_increases_tests(-1),
 )
-@fork_covariant_parametrize(
-    parameter_names="parent_blobs",
-    fn=lambda fork: [fork.target_blobs_per_block() + 1],
+@pytest.mark.parametrize_by_fork(
+    "parent_blobs",
+    lambda fork: [fork.target_blobs_per_block() + 1],
 )
 @pytest.mark.parametrize("new_blobs", [1])
 def test_correct_increasing_blob_gas_costs(
@@ -350,13 +349,13 @@ def test_correct_increasing_blob_gas_costs(
     )
 
 
-@fork_covariant_parametrize(
-    parameter_names="parent_excess_blobs",
-    fn=generate_blob_gas_cost_increases_tests(0),
+@pytest.mark.parametrize_by_fork(
+    "parent_excess_blobs",
+    generate_blob_gas_cost_increases_tests(0),
 )
-@fork_covariant_parametrize(
-    parameter_names="parent_blobs",
-    fn=lambda fork: [fork.target_blobs_per_block() - 1],
+@pytest.mark.parametrize_by_fork(
+    "parent_blobs",
+    lambda fork: [fork.target_blobs_per_block() - 1],
 )
 @pytest.mark.parametrize("new_blobs", [1])
 def test_correct_decreasing_blob_gas_costs(
@@ -384,9 +383,9 @@ def test_correct_decreasing_blob_gas_costs(
 
 @pytest.mark.parametrize("header_excess_blob_gas", [0])
 @pytest.mark.parametrize("new_blobs", [0, 1])
-@fork_covariant_parametrize(
-    parameter_names="parent_blobs",
-    fn=lambda fork: range(0, fork.max_blobs_per_block() + 1),
+@pytest.mark.parametrize_by_fork(
+    "parent_blobs",
+    lambda fork: range(0, fork.max_blobs_per_block() + 1),
 )
 def test_invalid_zero_excess_blob_gas_in_header(
     blockchain_test: BlockchainTestFiller,
@@ -431,9 +430,9 @@ def all_invalid_blob_gas_used_combinations(fork: Fork) -> Iterator[Tuple[int, in
         yield (new_blobs, 2**64 - 1)
 
 
-@fork_covariant_parametrize(
-    parameter_names="new_blobs,header_blob_gas_used",
-    fn=all_invalid_blob_gas_used_combinations,
+@pytest.mark.parametrize_by_fork(
+    "new_blobs,header_blob_gas_used",
+    all_invalid_blob_gas_used_combinations,
 )
 @pytest.mark.parametrize("parent_blobs", [0])
 def test_invalid_blob_gas_used_in_header(
@@ -475,9 +474,9 @@ def generate_invalid_excess_blob_gas_above_target_change_tests(fork: Fork) -> Li
     ]
 
 
-@fork_covariant_parametrize(
-    parameter_names="header_excess_blobs_delta,parent_blobs",
-    fn=generate_invalid_excess_blob_gas_above_target_change_tests,
+@pytest.mark.parametrize_by_fork(
+    "header_excess_blobs_delta,parent_blobs",
+    generate_invalid_excess_blob_gas_above_target_change_tests,
 )
 @pytest.mark.parametrize("new_blobs", [1])
 def test_invalid_excess_blob_gas_above_target_change(
@@ -514,14 +513,14 @@ def test_invalid_excess_blob_gas_above_target_change(
     )
 
 
-@fork_covariant_parametrize(
-    parameter_names="parent_blobs",
-    fn=lambda fork: [
+@pytest.mark.parametrize_by_fork(
+    "parent_blobs",
+    lambda fork: [
         b for b in range(0, fork.max_blobs_per_block() + 1) if b != fork.target_blobs_per_block()
     ],
 )
-@fork_covariant_parametrize(
-    parameter_names="parent_excess_blobs", fn=lambda fork: [1, fork.target_blobs_per_block()]
+@pytest.mark.parametrize_by_fork(
+    "parent_excess_blobs", lambda fork: [1, fork.target_blobs_per_block()]
 )
 @pytest.mark.parametrize("new_blobs", [1])
 def test_invalid_static_excess_blob_gas(
@@ -555,13 +554,13 @@ def test_invalid_static_excess_blob_gas(
     )
 
 
-@fork_covariant_parametrize(
-    parameter_names="header_excess_blobs_delta",
-    fn=lambda fork: range(1, fork.max_blobs_per_block()),
+@pytest.mark.parametrize_by_fork(
+    "header_excess_blobs_delta",
+    lambda fork: range(1, fork.max_blobs_per_block()),
 )
-@fork_covariant_parametrize(
-    parameter_names="parent_blobs",
-    fn=lambda fork: range(0, fork.target_blobs_per_block() + 1),
+@pytest.mark.parametrize_by_fork(
+    "parent_blobs",
+    lambda fork: range(0, fork.target_blobs_per_block() + 1),
 )
 @pytest.mark.parametrize("parent_excess_blobs", [0])  # Start at 0
 @pytest.mark.parametrize("new_blobs", [1])
@@ -600,9 +599,9 @@ def test_invalid_excess_blob_gas_target_blobs_increase_from_zero(
 
 
 @pytest.mark.parametrize("header_excess_blob_gas", [0])
-@fork_covariant_parametrize(
-    parameter_names="parent_blobs",
-    fn=lambda fork: range(fork.target_blobs_per_block() + 1, fork.max_blobs_per_block() + 1),
+@pytest.mark.parametrize_by_fork(
+    "parent_blobs",
+    lambda fork: range(fork.target_blobs_per_block() + 1, fork.max_blobs_per_block() + 1),
 )
 @pytest.mark.parametrize("parent_excess_blobs", [0])  # Start at 0
 @pytest.mark.parametrize("new_blobs", [1])
@@ -640,9 +639,9 @@ def test_invalid_static_excess_blob_gas_from_zero_on_blobs_above_target(
     )
 
 
-@fork_covariant_parametrize(
-    parameter_names="parent_blobs,header_excess_blobs_delta",
-    fn=lambda fork: itertools.product(
+@pytest.mark.parametrize_by_fork(
+    "parent_blobs,header_excess_blobs_delta",
+    lambda fork: itertools.product(
         # parent_blobs
         range(0, fork.max_blobs_per_block() + 1),
         # header_excess_blobs_delta (from correct value)
@@ -690,20 +689,20 @@ def test_invalid_excess_blob_gas_change(
     )
 
 
-@fork_covariant_parametrize(
-    parameter_names="header_excess_blob_gas",
-    fn=lambda fork: [
+@pytest.mark.parametrize_by_fork(
+    "header_excess_blob_gas",
+    lambda fork: [
         (2**64 + (x * fork.blob_gas_per_blob())) for x in range(-fork.target_blobs_per_block(), 0)
     ],
 )
-@fork_covariant_parametrize(
-    parameter_names="parent_blobs",
-    fn=lambda fork: range(fork.target_blobs_per_block()),
+@pytest.mark.parametrize_by_fork(
+    "parent_blobs",
+    lambda fork: range(fork.target_blobs_per_block()),
 )
 @pytest.mark.parametrize("new_blobs", [1])
-@fork_covariant_parametrize(
-    parameter_names="parent_excess_blobs",
-    fn=lambda fork: range(fork.target_blobs_per_block()),
+@pytest.mark.parametrize_by_fork(
+    "parent_excess_blobs",
+    lambda fork: range(fork.target_blobs_per_block()),
 )
 def test_invalid_negative_excess_blob_gas(
     blockchain_test: BlockchainTestFiller,
@@ -740,9 +739,9 @@ def test_invalid_negative_excess_blob_gas(
     )
 
 
-@fork_covariant_parametrize(
-    parameter_names="parent_blobs,header_excess_blob_gas_delta",
-    fn=lambda fork: [
+@pytest.mark.parametrize_by_fork(
+    "parent_blobs,header_excess_blob_gas_delta",
+    lambda fork: [
         (fork.target_blobs_per_block() + 1, 1),
         (fork.target_blobs_per_block() + 1, fork.blob_gas_per_blob() - 1),
         (fork.target_blobs_per_block() - 1, -1),
@@ -750,9 +749,9 @@ def test_invalid_negative_excess_blob_gas(
     ],
 )
 @pytest.mark.parametrize("new_blobs", [1])
-@fork_covariant_parametrize(
-    parameter_names="parent_excess_blobs",
-    fn=lambda fork: [fork.target_blobs_per_block() + 1],
+@pytest.mark.parametrize_by_fork(
+    "parent_excess_blobs",
+    lambda fork: [fork.target_blobs_per_block() + 1],
 )
 def test_invalid_non_multiple_excess_blob_gas(
     blockchain_test: BlockchainTestFiller,

--- a/tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py
+++ b/tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py
@@ -8,6 +8,7 @@ from typing import List, Mapping
 
 import pytest
 
+from ethereum_test_forks import Cancun, Fork
 from ethereum_test_tools import (
     Account,
     Address,
@@ -55,10 +56,10 @@ def pre_fork_blocks():
 
 
 @pytest.fixture
-def post_fork_block_count() -> int:
+def post_fork_block_count(fork: Fork) -> int:
     """Amount of blocks to produce with the post-fork rules."""
-    return SpecHelpers.get_min_excess_blobs_for_blob_gas_price(2) // (
-        SpecHelpers.max_blobs_per_block() - SpecHelpers.target_blobs_per_block()
+    return SpecHelpers.get_min_excess_blobs_for_blob_gas_price(fork=fork, blob_gas_price=2) // (
+        fork.max_blobs_per_block() - fork.target_blobs_per_block()
     )
 
 
@@ -218,13 +219,13 @@ def test_invalid_post_fork_block_without_blob_fields(
     "post_fork_block_count,blob_count_per_block",
     [
         (
-            SpecHelpers.get_min_excess_blobs_for_blob_gas_price(2)
-            // (SpecHelpers.max_blobs_per_block() - SpecHelpers.target_blobs_per_block())
+            SpecHelpers.get_min_excess_blobs_for_blob_gas_price(fork=Cancun, blob_gas_price=2)
+            // (Cancun.max_blobs_per_block() - Cancun.target_blobs_per_block())
             + 2,
-            SpecHelpers.max_blobs_per_block(),
+            Cancun.max_blobs_per_block(),
         ),
         (10, 0),
-        (10, SpecHelpers.target_blobs_per_block()),
+        (10, Cancun.target_blobs_per_block()),
     ],
     ids=["max_blobs", "no_blobs", "target_blobs"],
 )

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -2722,6 +2722,7 @@ def test_eoa_tx_after_set_code(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
     tx_type: int,
+    fork: Fork,
     evm_code_type: EVMCodeType,
 ):
     """Test sending a transaction from an EOA after code has been set to the account."""
@@ -2807,7 +2808,7 @@ def test_eoa_tx_after_set_code(
                     value=0,
                     max_fee_per_gas=1_000,
                     max_priority_fee_per_gas=1_000,
-                    max_fee_per_blob_gas=1_000,
+                    max_fee_per_blob_gas=fork.min_base_fee_per_blob_gas() * 10,
                     blob_versioned_hashes=add_kzg_version(
                         [Hash(1)],
                         Spec4844.BLOB_COMMITMENT_VERSION_KZG,


### PR DESCRIPTION
## 🗒️ Description

This PR removes activation of EIP-7742 at Prague, but leaves the framework changes.

Adds [EIP-7691 Blob throughput increase](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7691.md) by making a refactor of EIP-4844 tests to accept dynamic parameters during test generation.

 This PR requires https://github.com/ethereum/execution-spec-tests/pull/1019.

## 🔗 Related Issues
#956

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
