### PR TITLE
new(tests): EOF - EIP-7069: Test EXTCALL creation gas charge

### DIFF
--- a/tests/osaka/eip7692_eof_v1/eip7069_extcall/test_gas.py
+++ b/tests/osaka/eip7692_eof_v1/eip7069_extcall/test_gas.py
@@ -5,10 +5,12 @@ abstract: Tests [EIP-7069: Revamped CALL instructions](https://eips.ethereum.org
 
 import pytest
 
+from ethereum_test_base_types import Address
 from ethereum_test_forks import Fork
 from ethereum_test_tools import Alloc, Environment, StateTestFiller
 from ethereum_test_tools.eof.v1 import Container
 from ethereum_test_tools.vm.opcode import Opcodes as Op
+from ethereum_test_vm import Bytecode
 
 from .. import EOF_FORK_NAME
 from ..gas_test import gas_test
@@ -183,5 +185,37 @@ def test_transfer_gas_is_cleared(
         warm_gas=2 * WARM_ACCOUNT_ACCESS_GAS
         + (CALL_WITH_VALUE_GAS if value > 0 else 0)
         + push_gas,
+        out_of_gas_testing=False,
+    )
+
+
+@pytest.mark.parametrize("opcode", [Op.EXTCALL, Op.EXTDELEGATECALL, Op.EXTSTATICCALL])
+def test_late_account_create(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    state_env: Environment,
+    opcode: Op,
+):
+    """
+    Test EXTCALL to a non-existent account after another EXT*CALL has called it and not created it.
+    """
+    empty_address = Address(0xDECAFC0DE)
+
+    push_gas = (opcode.popped_stack_items + Op.EXTCALL.popped_stack_items) * 3
+
+    gas_test(
+        state_test,
+        state_env,
+        pre,
+        setup_code=Bytecode(None),
+        subject_code=opcode(address=empty_address) + Op.EXTCALL(address=empty_address, value=1),
+        subject_balance=5,
+        tear_down_code=Op.STOP,
+        cold_gas=ACCOUNT_CREATION_GAS
+        + COLD_ACCOUNT_ACCESS_GAS
+        + WARM_ACCOUNT_ACCESS_GAS
+        + CALL_WITH_VALUE_GAS
+        + push_gas,
+        warm_gas=2 * WARM_ACCOUNT_ACCESS_GAS + CALL_WITH_VALUE_GAS + push_gas,
         out_of_gas_testing=False,
     )

--- a/tests/osaka/eip7692_eof_v1/eip7069_extcall/test_gas.py
+++ b/tests/osaka/eip7692_eof_v1/eip7069_extcall/test_gas.py
@@ -196,7 +196,8 @@ def test_late_account_create(
     opcode: Op,
 ):
     """
-    Test EXTCALL to a non-existent account after another EXT*CALL has called it and not created it.
+    Test EXTCALL to a non-existent account after another EXT*CALL has called it and not
+    created it.
     """
     empty_address = Address(0xDECAFC0DE)
 

--- a/tests/osaka/eip7692_eof_v1/gas_test.py
+++ b/tests/osaka/eip7692_eof_v1/gas_test.py
@@ -39,6 +39,8 @@ def gas_test(
     subject_balance: int = 0,
     oog_difference: int = 1,
     out_of_gas_testing: bool = True,
+    *,
+    prelude_code: Bytecode = Bytecode(None),
 ):
     """
     Creates a State Test to check the gas cost of a sequence of EOF code.
@@ -74,6 +76,8 @@ def gas_test(
         code=(
             # warm subject and baseline without executing
             (Op.BALANCE(address_subject) + Op.POP + Op.BALANCE(address_baseline) + Op.POP)
+            # run any "prelude" code that may have universal side effects
+            + prelude_code
             # Baseline gas run
             + (
                 Op.GAS

--- a/tests/osaka/eip7692_eof_v1/gas_test.py
+++ b/tests/osaka/eip7692_eof_v1/gas_test.py
@@ -40,7 +40,7 @@ def gas_test(
     oog_difference: int = 1,
     out_of_gas_testing: bool = True,
     *,
-    prelude_code: Bytecode = Bytecode(None),
+    prelude_code: Bytecode | None = None,
 ):
     """
     Creates a State Test to check the gas cost of a sequence of EOF code.


### PR DESCRIPTION

## 🗒️ Description
Test the creation gas charge of a contract when the contract was called and remained "empty."

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
