### PR TITLE
chore(tests): EIP-7702: update auth.chainid in set code txs to u256

### DIFF
--- a/tests/prague/eip7702_set_code_tx/spec.py
+++ b/tests/prague/eip7702_set_code_tx/spec.py
@@ -34,7 +34,7 @@ class Spec:
     DELEGATION_DESIGNATION_READING = Bytes("ef01")
     RESET_DELEGATION_ADDRESS = Address(0)
 
-    MAX_CHAIN_ID = 2**256 - 1
+    MAX_AUTH_CHAIN_ID = 2**256 - 1
     MAX_NONCE = 2**64 - 1
 
     @staticmethod

--- a/tests/prague/eip7702_set_code_tx/spec.py
+++ b/tests/prague/eip7702_set_code_tx/spec.py
@@ -34,7 +34,7 @@ class Spec:
     DELEGATION_DESIGNATION_READING = Bytes("ef01")
     RESET_DELEGATION_ADDRESS = Address(0)
 
-    MAX_CHAIN_ID = 2**64 - 1
+    MAX_CHAIN_ID = 2**256 - 1
     MAX_NONCE = 2**64 - 1
 
     @staticmethod

--- a/tests/prague/eip7702_set_code_tx/test_invalid_tx.py
+++ b/tests/prague/eip7702_set_code_tx/test_invalid_tx.py
@@ -104,8 +104,7 @@ def test_invalid_auth_signature(
 @pytest.mark.parametrize(
     "chain_id",
     [
-        pytest.param(Spec.MAX_CHAIN_ID + 1, id="chain_id=2**64"),
-        pytest.param(2**256, id="chain_id=2**256"),
+        pytest.param(Spec.MAX_CHAIN_ID + 1, id="chain_id=2**256"),
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/prague/eip7702_set_code_tx/test_invalid_tx.py
+++ b/tests/prague/eip7702_set_code_tx/test_invalid_tx.py
@@ -102,9 +102,9 @@ def test_invalid_auth_signature(
 
 
 @pytest.mark.parametrize(
-    "chain_id",
+    "auth_chain_id",
     [
-        pytest.param(Spec.MAX_AUTH_CHAIN_ID + 1, id="chain_id=2**256"),
+        pytest.param(Spec.MAX_AUTH_CHAIN_ID + 1, id="auth_chain_id=2**256"),
     ],
 )
 @pytest.mark.parametrize(
@@ -114,10 +114,10 @@ def test_invalid_auth_signature(
         pytest.param(Address(1), id="non_zero_address"),
     ],
 )
-def test_invalid_tx_invalid_chain_id(
+def test_invalid_tx_invalid_auth_chain_id(
     transaction_test: TransactionTestFiller,
     pre: Alloc,
-    chain_id: int,
+    auth_chain_id: int,
     delegate_address: Address,
 ):
     """
@@ -127,7 +127,7 @@ def test_invalid_tx_invalid_chain_id(
     authorization = AuthorizationTuple(
         address=delegate_address,
         nonce=0,
-        chain_id=chain_id,
+        chain_id=auth_chain_id,
         signer=pre.fund_eoa(auth_account_start_balance),
     )
 

--- a/tests/prague/eip7702_set_code_tx/test_invalid_tx.py
+++ b/tests/prague/eip7702_set_code_tx/test_invalid_tx.py
@@ -104,7 +104,7 @@ def test_invalid_auth_signature(
 @pytest.mark.parametrize(
     "chain_id",
     [
-        pytest.param(Spec.MAX_CHAIN_ID + 1, id="chain_id=2**256"),
+        pytest.param(Spec.MAX_AUTH_CHAIN_ID + 1, id="chain_id=2**256"),
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -2276,7 +2276,7 @@ def test_signature_s_out_of_range(
 @pytest.mark.parametrize(
     "chain_id",
     [
-        pytest.param(Spec.MAX_CHAIN_ID, id="chain_id=2**256-1"),
+        pytest.param(Spec.MAX_AUTH_CHAIN_ID, id="chain_id=2**256-1"),
         pytest.param(2, id="chain_id=2"),
     ],
 )

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -2274,16 +2274,16 @@ def test_signature_s_out_of_range(
 
 
 @pytest.mark.parametrize(
-    "chain_id",
+    "auth_chain_id",
     [
-        pytest.param(Spec.MAX_AUTH_CHAIN_ID, id="chain_id=2**256-1"),
+        pytest.param(Spec.MAX_AUTH_CHAIN_ID, id="auth_chain_id=2**256-1"),
         pytest.param(2, id="chain_id=2"),
     ],
 )
 def test_valid_tx_invalid_chain_id(
     state_test: StateTestFiller,
     pre: Alloc,
-    chain_id: int,
+    auth_chain_id: int,
 ):
     """
     Test sending a transaction where the chain id field does not match the current chain's id.
@@ -2299,7 +2299,7 @@ def test_valid_tx_invalid_chain_id(
     authorization = AuthorizationTuple(
         address=set_code_to_address,
         nonce=0,
-        chain_id=chain_id,
+        chain_id=auth_chain_id,
         signer=auth_signer,
     )
 

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -2276,7 +2276,7 @@ def test_signature_s_out_of_range(
 @pytest.mark.parametrize(
     "chain_id",
     [
-        pytest.param(Spec.MAX_CHAIN_ID, id="chain_id=2**64-1"),
+        pytest.param(Spec.MAX_CHAIN_ID, id="chain_id=2**256-1"),
         pytest.param(2, id="chain_id=2"),
     ],
 )


### PR DESCRIPTION
## 🗒️ Description
Updates the tests to use a u256 chain ID in 7702 set code txs.

## 🔗 Related Issues
- ethereum/EIPs#9143
- Note this counter proposal to #9143: ethereum/EIPs#9152
- ethereum/execution-specs#1057

## Filling
Fills using:
```
fill tests/prague/eip7702_set_code_tx/ --fork=Prague -n auto
```
with the eels resolutions file:
```json
{
    "Prague": {
        "git_url": "https://github.com/danceratopz/execution-specs.git",
        "branch": "eip-7702-chain_id-u256",
        "commit": "febb39764b8760715136981649773a1c48e98f8e"
    }
}
```

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.

