### PR TITLE
 fix(eof): eofwrap.py to ignore invalid blocks 

### DIFF
--- a/src/cli/eofwrap.py
+++ b/src/cli/eofwrap.py
@@ -91,6 +91,8 @@ class EofWrapper:
     FIXTURES_CANT_WRAP = "fixtures_cant_wrap"
     # Test fixtures with EOF code but test doesn't pass and generation fails
     FIXTURES_CANT_GENERATE = "fixtures_cant_generate"
+    # Invalid blocks in fixtures skipped
+    INVALID_BLOCKS_SKIPPED = "invalid_blocks_skipped"
     # State accounts with code wrapped into valid EOF
     ACCOUNTS_WRAPPED = "accounts_wrapped"
     # State accounts with code wrapped into valid unique EOF
@@ -111,6 +113,7 @@ class EofWrapper:
             self.FIXTURES_GENERATED: 0,
             self.FIXTURES_CANT_WRAP: 0,
             self.FIXTURES_CANT_GENERATE: 0,
+            self.INVALID_BLOCKS_SKIPPED: 0,
             self.ACCOUNTS_WRAPPED: 0,
             self.UNIQUE_ACCOUNTS_WRAPPED: 0,
             self.ACCOUNTS_INVALID_EOF: 0,
@@ -283,15 +286,15 @@ class EofWrapper:
                         **fixture_tx_dump,
                     )
                     block.txs.append(tx)
+
+                test.blocks.append(block)
             elif isinstance(fixture_block, InvalidFixtureBlock):
-                block = Block(
-                    rlp=fixture_block.rlp,
-                    exception=fixture_block.expect_exception,
-                )
+                # Skip - invalid blocks are not supported. Reason: FixtureTransaction doesn't
+                # support expected exception. But we can continue and test the remaining
+                # blocks.
+                self.metrics[self.INVALID_BLOCKS_SKIPPED] += 1
             else:
                 raise TypeError("not a FixtureBlock")
-
-            test.blocks.append(block)
 
         result = test.generate(
             request=None,  # type: ignore


### PR DESCRIPTION
## 🗒️ Description

There is no support for invalid FixtureTransactions to be read from JSON, so we cannot include invalid blocks easily. However as this is not central to the behavior eofwrap tests are intended to test, we can just skip these invalid blocks with the same end effect on the test.

~Unfortunately, the fix isn't limited to that. It seems like the fix to requests serialization/hashing (#990) missed a detail when the `requests_lists` is used to construct requests (like from t8n output). Please double check carefully if this fix is fine.~

~Note also that for devnet-5 this would be partially hidden by the fact, that we don't include empty requests in the commitment anymore, meaning that all empty requests will not trigger the problem~

EDIT: request handling remains unchanged, see thread below

## 🔗 Related Issues

NA

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
