### PR TITLE
feat(clis,specs): Tests marked as `slow` have greater t8n server `timeout`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -63,6 +63,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Add the `eest make env` command that generates a default env file (`env.yaml`)([#996](https://github.com/ethereum/execution-spec-tests/pull/996)).
 - ✨ Generate Transaction Test type ([#933](https://github.com/ethereum/execution-spec-tests/pull/933)).
 - ✨ Add a default location for evm logs (`--evm-dump-dir`) when filling tests ([#999](https://github.com/ethereum/execution-spec-tests/pull/999)).
+- ✨ Slow tests now have greater timeout when making a request to the T8N server ([#1037](https://github.com/ethereum/execution-spec-tests/pull/1037)).
 
 ### 🔧 EVM Tools
 

--- a/src/ethereum_clis/clis/besu.py
+++ b/src/ethereum_clis/clis/besu.py
@@ -109,6 +109,7 @@ class BesuTransitionTool(TransitionTool):
         eips: Optional[List[int]] = None,
         debug_output_path: str = "",
         state_test: bool = False,
+        slow_request: bool = False,
     ) -> TransitionToolOutput:
         """
         Executes `evm t8n` with the specified arguments.

--- a/src/ethereum_test_specs/helpers.py
+++ b/src/ethereum_test_specs/helpers.py
@@ -1,9 +1,10 @@
 """
 Helper functions
 """
-
 from dataclasses import dataclass
 from typing import Dict, List
+
+import pytest
 
 from ethereum_clis import Result
 from ethereum_test_exceptions import ExceptionBase, ExceptionMapper, UndefinedException
@@ -150,3 +151,12 @@ def verify_transactions(
         verify_transaction_exception(exception_mapper=exception_mapper, info=info)
 
     return list(rejected_txs.keys())
+
+
+def is_slow_test(request: pytest.FixtureRequest) -> bool:
+    """
+    Check if the test is slow
+    """
+    if hasattr(request, "node"):
+        return request.node.get_closest_marker("slow") is not None
+    return False

--- a/src/ethereum_test_specs/state.py
+++ b/src/ethereum_test_specs/state.py
@@ -30,7 +30,7 @@ from ethereum_test_types import Alloc, Environment, Transaction
 from .base import BaseTest
 from .blockchain import Block, BlockchainTest, Header
 from .debugging import print_traces
-from .helpers import verify_transactions
+from .helpers import is_slow_test, verify_transactions
 
 TARGET_BLOB_GAS_PER_BLOCK = 393216
 
@@ -124,6 +124,7 @@ class StateTest(BaseTest):
         t8n: TransitionTool,
         fork: Fork,
         eips: Optional[List[int]] = None,
+        slow: bool = False,
     ) -> Fixture:
         """
         Create a fixture from the state test definition.
@@ -151,6 +152,7 @@ class StateTest(BaseTest):
             eips=eips,
             debug_output_path=self.get_next_transition_tool_output_path(),
             state_test=True,
+            slow_request=slow,
         )
 
         try:
@@ -199,7 +201,7 @@ class StateTest(BaseTest):
                 request=request, t8n=t8n, fork=fork, fixture_format=fixture_format, eips=eips
             )
         elif fixture_format == StateFixture:
-            return self.make_state_test_fixture(t8n, fork, eips)
+            return self.make_state_test_fixture(t8n, fork, eips, slow=is_slow_test(request))
 
         raise Exception(f"Unknown fixture format: {fixture_format}")
 


### PR DESCRIPTION
## 🗒️ Description

Allow tests marked as slow (with `@pytest.mark.slow`) to have a higher timeout when making a request to the t8n server.

I was writing a test to verify the maximum discount BLS multi-scalar-multiplication and it takes the t8n server 30 seconds to respond, which exceeds the 20 second timeout that is hard-coded by default.

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
