### PR TITLE
new(tests): EIP-2537: Add G2 MSM test for max discount

### DIFF
--- a/src/ethereum_clis/clis/besu.py
+++ b/src/ethereum_clis/clis/besu.py
@@ -109,6 +109,7 @@ class BesuTransitionTool(TransitionTool):
         eips: Optional[List[int]] = None,
         debug_output_path: str = "",
         state_test: bool = False,
+        slow_request: bool = False,
     ) -> TransitionToolOutput:
         """
         Executes `evm t8n` with the specified arguments.

--- a/src/ethereum_test_specs/helpers.py
+++ b/src/ethereum_test_specs/helpers.py
@@ -1,9 +1,10 @@
 """
 Helper functions
 """
-
 from dataclasses import dataclass
 from typing import Dict, List
+
+import pytest
 
 from ethereum_clis import Result
 from ethereum_test_exceptions import ExceptionBase, ExceptionMapper, UndefinedException
@@ -150,3 +151,12 @@ def verify_transactions(
         verify_transaction_exception(exception_mapper=exception_mapper, info=info)
 
     return list(rejected_txs.keys())
+
+
+def is_slow_test(request: pytest.FixtureRequest) -> bool:
+    """
+    Check if the test is slow
+    """
+    if hasattr(request, "node"):
+        return request.node.get_closest_marker("slow") is not None
+    return False

--- a/src/ethereum_test_specs/state.py
+++ b/src/ethereum_test_specs/state.py
@@ -30,7 +30,7 @@ from ethereum_test_types import Alloc, Environment, Transaction
 from .base import BaseTest
 from .blockchain import Block, BlockchainTest, Header
 from .debugging import print_traces
-from .helpers import verify_transactions
+from .helpers import is_slow_test, verify_transactions
 
 TARGET_BLOB_GAS_PER_BLOCK = 393216
 
@@ -124,6 +124,7 @@ class StateTest(BaseTest):
         t8n: TransitionTool,
         fork: Fork,
         eips: Optional[List[int]] = None,
+        slow: bool = False,
     ) -> Fixture:
         """
         Create a fixture from the state test definition.
@@ -151,6 +152,7 @@ class StateTest(BaseTest):
             eips=eips,
             debug_output_path=self.get_next_transition_tool_output_path(),
             state_test=True,
+            slow_request=slow,
         )
 
         try:
@@ -199,7 +201,7 @@ class StateTest(BaseTest):
                 request=request, t8n=t8n, fork=fork, fixture_format=fixture_format, eips=eips
             )
         elif fixture_format == StateFixture:
-            return self.make_state_test_fixture(t8n, fork, eips)
+            return self.make_state_test_fixture(t8n, fork, eips, slow=is_slow_test(request))
 
         raise Exception(f"Unknown fixture format: {fixture_format}")
 

--- a/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g2msm.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g2msm.py
@@ -21,7 +21,24 @@ pytestmark = [
 ]
 
 
-@pytest.mark.parametrize("input,expected_output", vectors_from_file("multiexp_G2_bls.json"))
+@pytest.mark.parametrize(
+    "input,expected_output",
+    vectors_from_file("multiexp_G2_bls.json")
+    + [
+        pytest.param(
+            (Spec.P2 + Scalar(Spec.Q)) * (len(Spec.G2MSM_DISCOUNT_TABLE) - 1),
+            Spec.INF_G2,
+            id="max_discount",
+            marks=pytest.mark.slow,
+        ),
+        pytest.param(
+            (Spec.P2 + Scalar(Spec.Q)) * len(Spec.G2MSM_DISCOUNT_TABLE),
+            Spec.INF_G2,
+            id="max_discount_plus_1",
+            marks=pytest.mark.slow,
+        ),
+    ],
+)
 def test_valid(
     state_test: StateTestFiller,
     pre: Alloc,


### PR DESCRIPTION
## 🗒️ Description
Adds a test that should use the full discount table for G2 MSM.

Requires #1037

## 🔗 Related Issues
None

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
