### PR TITLE
chore(tests): EIP-2537: remove BLS MUL precompiles (MVP)

### DIFF
--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -1133,16 +1133,14 @@ class Prague(Cancun):
         At Prague, pre-compile for BLS operations are added:
 
         G1ADD = 0x0B
-        G1MUL = 0x0C
-        G1MSM = 0x0D
-        G2ADD = 0x0E
-        G2MUL = 0x0F
-        G2MSM = 0x10
-        PAIRING = 0x11
-        MAP_FP_TO_G1 = 0x12
-        MAP_FP2_TO_G2 = 0x13
+        G1MSM = 0x0C
+        G2ADD = 0x0D
+        G2MSM = 0x0E
+        PAIRING = 0x0F
+        MAP_FP_TO_G1 = 0x10
+        MAP_FP2_TO_G2 = 0x11
         """
-        return list(Address(i) for i in range(0xB, 0x13 + 1)) + super(Prague, cls).precompiles(
+        return list(Address(i) for i in range(0xB, 0x11 + 1)) + super(Prague, cls).precompiles(
             block_number, timestamp
         )
 

--- a/tests/prague/eip2537_bls_12_381_precompiles/spec.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/spec.py
@@ -116,14 +116,12 @@ class Spec:
 
     # Addresses
     G1ADD = 0x0B
-    G1MUL = 0x0C
-    G1MSM = 0x0D
-    G2ADD = 0x0E
-    G2MUL = 0x0F
-    G2MSM = 0x10
-    PAIRING = 0x11
-    MAP_FP_TO_G1 = 0x12
-    MAP_FP2_TO_G2 = 0x13
+    G1MSM = 0x0C
+    G2ADD = 0x0D
+    G2MSM = 0x0E
+    PAIRING = 0x0F
+    MAP_FP_TO_G1 = 0x10
+    MAP_FP2_TO_G2 = 0x11
 
     # Gas constants
     G1ADD_GAS = 375
@@ -288,10 +286,8 @@ def pairing_gas(input_length: int) -> int:
 
 GAS_CALCULATION_FUNCTION_MAP = {
     Spec.G1ADD: lambda _: Spec.G1ADD_GAS,
-    Spec.G1MUL: lambda _: Spec.G1MUL_GAS,
     Spec.G1MSM: msm_gas_func_gen(BLS12Group.G1, len(PointG1() + Scalar()), Spec.G1MUL_GAS),
     Spec.G2ADD: lambda _: Spec.G2ADD_GAS,
-    Spec.G2MUL: lambda _: Spec.G2MUL_GAS,
     Spec.G2MSM: msm_gas_func_gen(BLS12Group.G2, len(PointG2() + Scalar()), Spec.G2MUL_GAS),
     Spec.PAIRING: pairing_gas,
     Spec.MAP_FP_TO_G1: lambda _: Spec.MAP_FP_TO_G1_GAS,

--- a/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1mul.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1mul.py
@@ -17,7 +17,7 @@ REFERENCE_SPEC_VERSION = ref_spec_2537.version
 
 pytestmark = [
     pytest.mark.valid_from("Prague"),
-    pytest.mark.parametrize("precompile_address", [Spec.G1MUL], ids=[""]),
+    pytest.mark.parametrize("precompile_address", [Spec.G1MSM], ids=[""]),
 ]
 
 

--- a/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g2mul.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g2mul.py
@@ -17,7 +17,7 @@ REFERENCE_SPEC_VERSION = ref_spec_2537.version
 
 pytestmark = [
     pytest.mark.valid_from("Prague"),
-    pytest.mark.parametrize("precompile_address", [Spec.G2MUL], ids=[""]),
+    pytest.mark.parametrize("precompile_address", [Spec.G2MSM], ids=[""]),
 ]
 
 

--- a/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_precompiles_before_fork.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_precompiles_before_fork.py
@@ -30,11 +30,6 @@ pytestmark = pytest.mark.valid_at_transition_to("Prague")
             id="G1MSM",
         ),
         pytest.param(
-            Spec.G1MUL,
-            Spec.INF_G1 + Scalar(0),
-            id="G1MUL",
-        ),
-        pytest.param(
             Spec.G2ADD,
             Spec.INF_G2 + Spec.INF_G2,
             id="G2ADD",
@@ -43,11 +38,6 @@ pytestmark = pytest.mark.valid_at_transition_to("Prague")
             Spec.G2MSM,
             Spec.INF_G2 + Scalar(0),
             id="G2MSM",
-        ),
-        pytest.param(
-            Spec.G2MUL,
-            Spec.INF_G2 + Scalar(0),
-            id="G2MUL",
         ),
         pytest.param(
             Spec.PAIRING,


### PR DESCRIPTION
## 🗒️ Description

This is a set of minimal changes that removes the BLS G1/G2 MUL precompiles (EIP-2537). All existing tests for MULs are redirected to MSMs because these are ABI and gas equivalent (main reason for the spec change).

You can also notice that we had more tests for MULs than for MSMs meaning there were test cases missing for MSMs.

I have filled these tests with modified evmone.

## 🔗 Related Issues

EIP-2537 update: https://github.com/ethereum/EIPs/pull/8945

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
