### PR TITLE
fix(specs): Fix verkle blockchain engine test generation

### DIFF
--- a/src/ethereum_test_specs/blockchain.py
+++ b/src/ethereum_test_specs/blockchain.py
@@ -20,11 +20,7 @@ from ethereum_test_base_types import (
     HexNumber,
     Number,
 )
-from ethereum_test_exceptions import (
-    BlockException,
-    EngineAPIError,
-    TransactionException,
-)
+from ethereum_test_exceptions import BlockException, EngineAPIError, TransactionException
 from ethereum_test_fixtures import (
     BaseFixture,
     BlockchainEngineFixture,
@@ -785,7 +781,7 @@ class BlockchainTest(BaseTest):
         vkt: Optional[VerkleTree] = None
 
         # Filling for verkle genesis tests
-        if fork is Verkle:
+        if fork >= Verkle:
             env.verkle_conversion_ended = True
             # convert alloc to vkt
             vkt = t8n.from_mpt_to_vkt(alloc)
@@ -807,16 +803,22 @@ class BlockchainTest(BaseTest):
                 # This is the most common case, the RLP needs to be constructed
                 # based on the transactions to be included in the block.
                 # Set the environment according to the block to execute.
-                new_env, header, txs, new_alloc, requests, new_vkt, witness = (
-                    self.generate_block_data(
-                        t8n=t8n,
-                        fork=fork,
-                        block=block,
-                        previous_env=env,
-                        previous_alloc=alloc,
-                        previous_vkt=vkt,
-                        eips=eips,
-                    )
+                (
+                    new_env,
+                    header,
+                    txs,
+                    new_alloc,
+                    requests,
+                    new_vkt,
+                    witness,
+                ) = self.generate_block_data(
+                    t8n=t8n,
+                    fork=fork,
+                    block=block,
+                    previous_env=env,
+                    previous_alloc=alloc,
+                    previous_vkt=vkt,
+                    eips=eips,
                 )
                 fixture_block = FixtureBlockBase(
                     header=header,
@@ -911,6 +913,12 @@ class BlockchainTest(BaseTest):
         env = environment_from_parent_header(genesis.header)
         head_hash = genesis.header.block_hash
         vkt: Optional[VerkleTree] = None
+
+        # Filling for verkle genesis tests
+        if fork >= Verkle:
+            env.verkle_conversion_ended = True
+            # convert alloc to vkt
+            vkt = t8n.from_mpt_to_vkt(alloc)
 
         # Hack for filling naive verkle transition tests
         if fork is EIP6800Transition:


### PR DESCRIPTION
## 🗒️ Description
The `vkt` object was not being properly initialized when generating a blockchain engine test.

This PR fixes it by copying the initialization lines from the normal blockchain test generation.

## 🔗 Related Issues
None

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
