### PR TITLE
 Update github actions versions due to deprecation 

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -302,11 +302,12 @@ jobs:
           sudo chown -R $user:$user ${{ github.workspace }}/evmtest_coverage/coverage
 
       - name: Upload coverage results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ steps.changed-tests.outputs.tests_any_changed == 'true' }}
         with:
-          name: coverage-diff-native
+          name: coverage-diff-native-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ github.workspace }}/evmtest_coverage/coverage
+          compression-level: 6  # Default compression level for optimal balance
 
       - name: Verify coverage results
         uses: addnab/docker-run-action@v3


### PR DESCRIPTION
Artifact actions v3 will be closing down by January 30, 2025 and github is going to begin temporarily failing jobs that don't update before this deadline. The PR fixes the versions used. The migration docs [here](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md) were followed.