### PR TITLE
new(tests): Identity precompile test

### DIFF
--- a/tests/homestead/identity_precompile/__init__.py
+++ b/tests/homestead/identity_precompile/__init__.py
@@ -1,0 +1,1 @@
+"""abstract: EIP-2: Homestead Precompile Identity Test Cases."""

--- a/tests/homestead/identity_precompile/test_identity.py
+++ b/tests/homestead/identity_precompile/test_identity.py
@@ -1,0 +1,98 @@
+"""abstract: EIP-2: Homestead Identity Precompile Test Cases."""
+
+import pytest
+
+from ethereum_test_tools import (
+    Account,
+    Alloc,
+    Environment,
+    StateTestFiller,
+    Transaction,
+    keccak256,
+)
+from ethereum_test_tools import Opcodes as Op
+
+
+@pytest.mark.with_all_call_opcodes()
+@pytest.mark.valid_from("Byzantium")
+def test_identity_return_overwrite(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    call_opcode: Op,
+):
+    """Test the return data of the identity precompile overwriting its input."""
+    code = (
+        sum(Op.MSTORE8(offset=i, value=(i + 1)) for i in range(4))  # memory = [1, 2, 3, 4]
+        + call_opcode(
+            address=4,
+            args_offset=0,
+            args_size=4,  # args = [1, 2, 3, 4]
+            ret_offset=1,
+            ret_size=4,
+        )  # memory = [1, 1, 2, 3, 4]
+        + Op.RETURNDATACOPY(
+            dest_offset=0, offset=0, size=Op.RETURNDATASIZE()
+        )  # memory correct = [1, 2, 3, 4, 4], corrupt = [1, 1, 2, 3, 4]
+        + Op.SSTORE(1, Op.SHA3(offset=0, size=Op.MSIZE))
+    )
+    contract_address = pre.deploy_contract(
+        code=code,
+    )
+    tx = Transaction(
+        sender=pre.fund_eoa(),
+        to=contract_address,
+        gas_limit=100_000,
+    )
+
+    post = {
+        contract_address: Account(
+            storage={
+                1: keccak256(bytes([1, 2, 3, 4, 4]).ljust(32, b"\0")),
+            },
+        ),
+    }
+
+    state_test(pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.with_all_call_opcodes()
+@pytest.mark.valid_from("Byzantium")
+def test_identity_return_buffer_modify(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    call_opcode: Op,
+):
+    """Test the modification of the input range to attempt to modify the return buffer."""
+    env = Environment()
+    code = (
+        sum(Op.MSTORE8(offset=i, value=(i + 1)) for i in range(4))  # memory = [1, 2, 3, 4]
+        + call_opcode(
+            address=4,
+            args_offset=0,
+            args_size=4,  # args = [1, 2, 3, 4]
+        )  # memory = [1, 2, 3, 4]
+        + Op.MSTORE8(offset=0, value=5)  # memory = [5, 2, 3, 4]
+        + Op.MSTORE8(offset=4, value=5)  # memory = [5, 2, 3, 4, 5]
+        + Op.RETURNDATACOPY(
+            dest_offset=0, offset=0, size=Op.RETURNDATASIZE()
+        )  # memory correct = [1, 2, 3, 4, 5], corrupt = [5, 2, 3, 4, 5]
+        + Op.SSTORE(1, Op.SHA3(offset=0, size=Op.MSIZE))
+    )
+    contract_address = pre.deploy_contract(
+        code=code,
+    )
+    tx = Transaction(
+        sender=pre.fund_eoa(),
+        to=contract_address,
+        gas_limit=100_000,
+    )
+
+    post = {
+        contract_address: Account(
+            storage={
+                1: keccak256(bytes([1, 2, 3, 4, 5]).ljust(32, b"\0")),
+            },
+        ),
+    }
+
+    state_test(env=env, pre=pre, post=post, tx=tx)


### PR DESCRIPTION
## 🗒️ Description

Adds a test for the identity precompile based on this https://github.com/ethereum/go-ethereum/blob/master/docs/postmortems/2021-08-22-split-postmortem.md

Also adds a new variant that can be filled for EOF `EXT*CALL` opcodes .

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
