### PR TITLE
fix(tests): Typo in `tests/osaka/eip7692_eof_v1/eip7069_extcall/test_gas.py`

### DIFF
--- a/tests/osaka/eip7692_eof_v1/eip7069_extcall/test_gas.py
+++ b/tests/osaka/eip7692_eof_v1/eip7069_extcall/test_gas.py
@@ -1,6 +1,6 @@
 """
 abstract: Tests [EIP-7069: Revamped CALL instructions](https://eips.ethereum.org/EIPS/eip-7069)
-    Tests gas comsumption.
+    Tests gas consumption.
 """  # noqa: E501
 
 import pytest


### PR DESCRIPTION
# Pull Request Title  
**Fix Typo in `test_gas.py`**

## Description  
This pull request corrects a typo in the `test_gas.py` file. Specifically, the word "comsumption" was corrected to "consumption" in the comment section.

### Changes Made:
- **File Modified:** `tests/osaka/eip7692_eof_v1/eip7069_extcall/test_gas.py`
- **Summary of Changes:**
  - Corrected the typo in the comment from "comsumption" to "consumption" for better clarity.

## Checklist  
- [x] Fixed the typo in the comment.
- [x] Verified that no functionality was impacted by this change.

## Additional Notes  
This typo correction improves the readability and accuracy of the comment regarding the purpose of the tests.

---

**Allow edits by maintainers:** [x]
