### PR TITLE
fix(github): Features for legacy forks

### DIFF
--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -1,14 +1,11 @@
-legacy:
-  evm-type: stable
-  fill-params: --until=Shanghai
-  solc: 0.8.21
+# Unless filling for special features, all features should fill for previous forks (starting from Frontier) too
 stable:
   evm-type: stable
-  fill-params: --fork=Cancun
+  fill-params: --until=Cancun
   solc: 0.8.21
 develop:
   evm-type: develop
-  fill-params: --from=Cancun --until=Prague
+  fill-params: --until=Prague
   solc: 0.8.21
 eip7692:
   evm-type: eip7692
@@ -17,5 +14,5 @@ eip7692:
   eofwrap: true
 pectra-devnet-5:
   evm-type: pectra-devnet-5
-  fill-params: --fork=Prague -m "not eip_version_check"
+  fill-params: --until=Prague -m "not eip_version_check"
   solc: 0.8.21


### PR DESCRIPTION
## 🗒️ Description

- All features now do `--until` instead of `--fork`, to include filled tests for legacy forks too.
- The `legacy` feature is now removed since `stable` now includes all forks starting from `Frontier`.
- Added a comment to encourage not filling only for a single fork on features and include previous forks too.

This issue was raised by some teams who would like to have all tests in the same package for their QA procedures.

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.