### PR TITLE
refactor(tooling): modularize tox envs for better feedback and parallelization

### DIFF
--- a/.github/scripts/get_release_props.py
+++ b/.github/scripts/get_release_props.py
@@ -6,16 +6,17 @@
 # ]
 # ///
 """Extract the properties of a configured EEST release from a YAML file."""
+
 import sys
 
 import click
 import yaml
 
-RELEASE_PROPS_FILE = './.github/configs/feature.yaml'
+RELEASE_PROPS_FILE = "./.github/configs/feature.yaml"
 
 
 @click.command()
-@click.argument('release', required=True)
+@click.argument("release", required=True)
 def get_release_props(release):
     """Extract the properties from the YAML file for a given release."""
     with open(RELEASE_PROPS_FILE) as f:
@@ -24,6 +25,7 @@ def get_release_props(release):
         print(f"Error: Release {release} not found in {RELEASE_PROPS_FILE}.")
         sys.exit(1)
     print("\n".join(f"{key}={value}" for key, value in data[release].items()))
+
 
 if __name__ == "__main__":
     get_release_props()

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,13 +3,13 @@ repos:
     hooks:
       - id: tox
         name: tox
-        entry: tox run-parallel
+        entry: uvx --with=tox-uv tox --parallel -e lint
         language: system
         types: [python]
         pass_filenames: false
       - id: tox-docs
         name: tox-docs
-        entry: tox -e docs
+        entry: uvx --with=tox-uv tox --parallel -e spellcheck,markdownlint,mkdocs
         language: system
         files: \.md$
         pass_filenames: false

--- a/docs/dev/docs.md
+++ b/docs/dev/docs.md
@@ -8,19 +8,18 @@ The `execution-spec-tests` documentation is generated via [`mkdocs`](https://www
 uv sync --all-extras
 ```
 
-## Build the Documentation
+## Build and Verify the Documentation
 
-One time build:
+One time build in strict mode:
 
 ```console
-uv run mkdocs build
+uv run mkdocs build --strict
 ```
 
-Do a pre-commit check: One time build and lint/type checking:
+Perform all docs related checks via `tox` in parallel:
 
 ```console
-pip install tox-uv
-tox -e docs
+uvx --with=tox-uv tox -e spellcheck,markdownlint,mkdocs --parallel
 ```
 
 ### Local Deployment and Test

--- a/docs/writing_tests/test_markers.md
+++ b/docs/writing_tests/test_markers.md
@@ -352,7 +352,7 @@ In this example, the test will be marked as expected to fail when it is being ex
 
 ### `@pytest.mark.slow`
 
-This marker is used to mark tests that are slow to run. These tests are not run during tox testing, and are only run when a release is being prepared.
+This marker is used to mark tests that are slow to run. These tests are not run during [`tox` checks](./verifying_changes.md), and are only run when a release is being prepared.
 
 ### `@pytest.mark.pre_alloc_modify`
 

--- a/docs/writing_tests/verifying_changes.md
+++ b/docs/writing_tests/verifying_changes.md
@@ -1,15 +1,15 @@
 # Verifying Changes
 
-The `tox` tool can be executed locally to check that local changes won't cause Github Actions Checks to fail.
+The `tox` tool is used by execution-spec-tests to perform various checks on the codebase such as linting, type checking and spell-checking. The `tox` command can be executed locally to ensure that Github CI checks pass upon pushing to the repository.
 
-!!! note "Pre-commit"
-    Tox can be ran as a git pre-commit hook, see [Enabling Pre-Commit Checks](../dev/precommit.md).
+!!! note "Using automatic pre-commit checks"
+    Some `tox` environments can be ran as a git pre-commit hook, see [Enabling Pre-Commit Checks](../dev/precommit.md).
 
-## Executing `tox`
+## Running `tox`
 
 ### Execution
 
-Run `tox` and execute the defined environments (see `tox.ini`) in parallel with:
+Run all `tox` environments in parallel with:
 
 ```console
 uvx --with=tox-uv tox run-parallel
@@ -21,42 +21,48 @@ or, with sequential test environment execution and verbose output as:
 uvx --with=tox-uv tox
 ```
 
-This executes all the environments described in the next section.
+As some environments are rather slow, the next section describes how to run them individually.
 
 !!! note "Tox Virtual Environment"
     The checks performed by `tox` are sandboxed in their own virtual environments (which are created automatically in the `.tox/` subdirectory). These can be used to debug errors encountered during `tox` execution.
 
-    Whilst we create a virtual environment in the code snippet above, it's only to install the tox tool itself.
+### Listing the Available Environments
+
+Get a list of all the available `tox` environments:
+
+```console
+uvx --with=tox-uv tox -av
+```
 
 ## Executing `tox` Environments Individually
 
-There are three tox environments available:
-
-1. `framework`: Lint and test framework and libraries related code in `src/`.
-2. `tests`: Lint and test the test cases in `tests/` (runs `fill` on all forks deployed to mainnet).
-3. `docs`: Lint and spell-check markdown in `docs/`; build docs.
-
-For targeted tox runs locally, each environment can be ran separately as described below.
-
-### Test Case Verification: `tests`
-
-Verify:
+A selection of preferred environments may be executed via the `-e` flag:
 
 ```console
-uvx --with=tox-uv tox -e tests
+uvx --with=tox-uv tox -e lint,typecheck,spellcheck
 ```
 
-### Framework Verification: `framework`
-
-Verify:
+### Environments required for test case changes (`./tests/`)
 
 ```console
-uvx --with=tox-uv tox -e framework
+uvx --with=tox-uv tox -e lint,typecheck,spellcheck,tests-deployed
 ```
 
-### Documentation Verification: `docs`
+### Environments required for test framework and library changes (`./src/`)
 
-This environment runs `pyspelling` and `markdownlint-cli2` in a "soft fail" mode because they require external (non-python) packages. This allows developers who aren't working on documentation to execute tox locally without additional overhead. These commands are, however, ran as part of the checks in Github Actions.
+```console
+uvx --with=tox-uv tox -e lint,typecheck,spellcheck,pytest
+```
+
+### Environment required for documentation changes (`./docs/`)
+
+```console
+uvx --with=tox-uv tox -e spellcheck,markdownlint,mkdocs
+```
+
+### Additional Required Dependencies for `spellcheck` and `markdownlint`
+
+The `spellcheck` and `markdownlint` environments require external (non-python) packages. To avoid disruption to external contributors, these environments run in a "soft fail" mode if these dependencies are not available.
 
 Additional, optional prerequisites:
 
@@ -74,12 +80,6 @@ Additional, optional prerequisites:
     ```
 
     Or use a specific node version using `nvm`, for example.
-
-Verify:
-
-```console
-uvx --with=tox-uv tox -e docs
-```
 
 ### Verifying Fixture Changes
 

--- a/tox.ini
+++ b/tox.ini
@@ -67,14 +67,14 @@ eip7692 = Osaka
 [testenv:tests]
 description = Fill test cases in ./tests/ for deployed mainnet forks.
 commands_pre = solc-select use 0.8.24 --always-install
-commands = pytest -n auto -k "not slow"
+commands = pytest -n auto -k "not slow" --skip-evm-dump
 
 [testenv:tests-develop]
 description = Fill test cases in ./tests/ for deployed and development mainnet forks
 commands_pre = solc-select use 0.8.24 --always-install
-commands = pytest -n auto --until={[forks]develop} -k "not slow"
+commands = pytest -n auto --until={[forks]develop} -k "not slow" --skip-evm-dump
 
 [testenv:tests-eip7692]
 description = Fill test cases in ./tests/ for EIP-7692 (EOF) on Osaka
 commands_pre = solc-select use 0.8.24 --always-install
-commands =  pytest -n auto --evm-bin=evmone-t8n --fork={[forks]eip7692} -k "not slow" ./tests/osaka
+commands =  pytest -n auto --evm-bin=evmone-t8n --fork={[forks]eip7692} -k "not slow" ./tests/osaka --skip-evm-dump

--- a/tox.ini
+++ b/tox.ini
@@ -3,10 +3,10 @@
 env_list =
     lint
     typecheck
-    spellcheck
     markdownlint
-    framework
-    tests
+    spellcheck
+    pytest
+    tests-deployed
     mkdocs
 
 [testenv]
@@ -48,7 +48,7 @@ setenv =
     DYLD_FALLBACK_LIBRARY_PATH = /opt/homebrew/lib
 commands = mkdocs build --strict
 
-[testenv:framework]
+[testenv:pytest]
 description = Run library and framework unit tests (pytest)
 setenv =
     # Use custom EELS_RESOLUTIONS_FILE if it is set via the environment (eg, in CI)
@@ -64,17 +64,76 @@ commands =
 develop = Prague
 eip7692 = Osaka
 
-[testenv:tests]
+[testenv:tests-deployed]
 description = Fill test cases in ./tests/ for deployed mainnet forks.
-commands_pre = solc-select use 0.8.24 --always-install
+commands_pre = solc-select use {[testenv]solc_version} --always-install
 commands = pytest -n auto -k "not slow" --skip-evm-dump
 
 [testenv:tests-develop]
 description = Fill test cases in ./tests/ for deployed and development mainnet forks
-commands_pre = solc-select use 0.8.24 --always-install
+commands_pre = solc-select use {[testenv]solc_version} --always-install
 commands = pytest -n auto --until={[forks]develop} -k "not slow" --skip-evm-dump
 
 [testenv:tests-eip7692]
 description = Fill test cases in ./tests/ for EIP-7692 (EOF) on Osaka
-commands_pre = solc-select use 0.8.24 --always-install
+commands_pre = solc-select use {[testenv]solc_version} --always-install
 commands =  pytest -n auto --evm-bin=evmone-t8n --fork={[forks]eip7692} -k "not slow" ./tests/osaka --skip-evm-dump
+
+# ----------------------------------------------------------------------------------------------
+# ALIAS ENVIRONMENTS
+# ----------------------------------------------------------------------------------------------
+# For convenience/backwards compatibility. Using -e with a list of environments is preferred due
+# to clearer output and better parallelization, e.g.
+# uvx --with=tox-uv tox -e lint,typecheck,spellcheck,pytest
+# ----------------------------------------------------------------------------------------------
+
+# ALIAS that runs checks on ./src/: lint, typecheck, spellcheck, pytest
+# uvx --with=tox-uv tox -e lint,typecheck,spellcheck,pytest
+[testenv:framework]
+description = Alias that runs lint, typecheck, spellcheck, pytest.
+extras =
+    {[testenv:lint]extras}
+    {[testenv:typecheck]extras}
+    {[testenv:spellcheck]extras}
+    {[testenv:pytest]extras}
+setenv = 
+    {[testenv:pytest]setenv}
+commands_pre = 
+    {[testenv:pytest]:commands_pre}
+commands =
+    {[testenv:lint]commands}
+    {[testenv:typecheck]commands}
+    {[testenv:spellcheck]commands}
+    {[testenv:pytest]commands}
+
+# ALIAS that runs checks on ./tests/: lint, typecheck, spellcheck, tests-deployed
+# uvx --with=tox-uv tox -e lint,typecheck,spellcheck,tests-deployed
+[testenv:tests]
+description = Alias that runs lint, typecheck, spellcheck, tests-deployed
+extras =
+    {[testenv:lint]extras}
+    {[testenv:typecheck]extras}
+    {[testenv:spellcheck]extras}
+    {[testenv:tests-deployed]extras}
+commands_pre = 
+    {[testenv:tests-deployed]:commands_pre}    
+commands =
+    {[testenv:lint]commands}
+    {[testenv:typecheck]commands}
+    {[testenv:spellcheck]commands}
+    {[testenv:tests-deployed]commands}
+
+# ALIAS that runs checks on ./docs/: spellcheck, markdownlint, mkdocs
+# uvx --with=tox-uv tox -e spellcheck,markdownlint,mkdocs
+[testenv:docs]
+description = Alias that runs all documentation checks (spellcheck, markdownlint, mkdocs).
+extras =
+    {[testenv:spellcheck]extras}
+    {[testenv:markdownlint]extras}
+    {[testenv:mkdocs]extras}
+setenv =
+    {[testenv:mkdocs]setenv}
+commands =
+    {[testenv:spellcheck]commands}
+    {[testenv:markdownlint]commands}
+    {[testenv:mkdocs]commands}

--- a/tox.ini
+++ b/tox.ini
@@ -14,18 +14,19 @@ runner = uv-venv-lock-runner
 package = wheel
 wheel_build_env = .pkg
 solc_version = 0.8.24
+python_source_dirs = src tests docs .github/scripts
 
 [testenv:lint]
 description = Lint and code formatting checks (ruff)
 extras = lint
 commands =
-    ruff check --no-fix --show-fixes
-    ruff format --diff
+    ruff check --no-fix --show-fixes {[testenv]python_source_dirs}
+    ruff format --diff {[testenv]python_source_dirs}
 
 [testenv:typecheck]
 description = Run type checking (mypy)
 extras = lint
-commands = mypy src tests docs
+commands = mypy {[testenv]python_source_dirs}
 
 [testenv:spellcheck]
 description = Spellcheck documentation (pyspelling)

--- a/tox.ini
+++ b/tox.ini
@@ -1,105 +1,80 @@
 [tox]
+# Get a description of all available environments with `uvx --with=tox-uv tox -av`
 env_list =
+    lint
+    typecheck
+    spellcheck
+    markdownlint
     framework
     tests
-    docs
-
-[forks]
-develop = Prague
-eip7692 = Osaka
+    mkdocs
 
 [testenv]
 runner = uv-venv-lock-runner
 package = wheel
 wheel_build_env = .pkg
+solc_version = 0.8.24
 
-[testenv:framework]
-description = Run checks on helper libraries and test framework
-
-setenv =
-    # Only use EELS_RESOLUTIONS_FILE if it is set in the environment (eg, in CI)
-    EELS_RESOLUTIONS_FILE = {env:EELS_RESOLUTIONS_FILE:}
-
-extras =
-    test
-    lint
-
-src = src
-
-commands_pre = solc-select use 0.8.24 --always-install
-
+[testenv:lint]
+description = Lint and code formatting checks (ruff)
+extras = lint
 commands =
-    ruff check {[testenv:framework]src} --no-fix --show-fixes
-    ruff format {[testenv:framework]src} --diff
-    mypy {[testenv:framework]src}
-    pytest -c ./pytest-framework.ini -n auto -m "not run_in_serial"
-    pytest -c ./pytest-framework.ini -m run_in_serial
+    ruff check --no-fix --show-fixes
+    ruff format --diff
 
-[testenv:py3]
-description = An alias for the 'framework' tox environment
-deps = {[testenv:framework]deps}
-extras = {[testenv:framework]extras}
-allowlist_externals = {[testenv:framework]allowlist_externals}
-commands = {[testenv:framework]commands}
+[testenv:typecheck]
+description = Run type checking (mypy)
+extras = lint
+commands = mypy src tests docs
 
-[testenv:tests-base]
-extras =
-    test
-    lint
+[testenv:spellcheck]
+description = Spellcheck documentation (pyspelling)
+extras = docs
+commands = python -c "import src.cli.tox_helpers; src.cli.tox_helpers.pyspelling()"
 
-commands =
-    ruff check tests --no-fix --show-fixes
-    ruff format tests --diff
-    mypy tests
+[testenv:markdownlint]
+description = Lint markdown files (markdownlint)
+extras = docs
+commands = python -c "import src.cli.tox_helpers; src.cli.tox_helpers.markdownlint()"
 
-[testenv:tests]
-description = Execute test cases in tests/
-
-extras =
-    {[testenv:tests-base]extras}
-
-commands =
-    {[testenv:tests-base]commands}
-    pytest -n auto -k "not slow"
-
-[testenv:tests-develop]
-description = Execute test cases in tests/, including tests for development forks
-
-extras =
-    {[testenv:tests-base]extras}
-
-commands =
-    pytest -n auto --until={[forks]develop}  -k "not slow"
-
-[testenv:tests-eip7692]
-description = Execute test cases in tests/, including tests for EIP-7692 (EOF)
-
-extras =
-    {[testenv:tests-base]extras}
-
-commands =
-    pytest -n auto --evm-bin=evmone-t8n --fork={[forks]eip7692}  -k "not slow" ./tests/osaka
-
-[testenv:docs]
-description = Run documentation checks
-
-extras =
-    lint
-    docs
-
+[testenv:mkdocs]
+description = Build documentation in strict mode (mkdocs)
+extras = docs
 setenv =
     SPEC_TESTS_AUTO_GENERATE_FILES = true
     GEN_TEST_DOC_VERSION = "tox"
     # Required for `cairosvg` so tox can find `libcairo-2`.
     # https://squidfunk.github.io/mkdocs-material/plugins/requirements/image-processing/?h=cairo#cairo-library-was-not-found
     DYLD_FALLBACK_LIBRARY_PATH = /opt/homebrew/lib
+commands = mkdocs build --strict
 
-src = docs/gen_test_case_reference.py
-
+[testenv:framework]
+description = Run library and framework unit tests (pytest)
+setenv =
+    # Use custom EELS_RESOLUTIONS_FILE if it is set via the environment (eg, in CI)
+    EELS_RESOLUTIONS_FILE = {env:EELS_RESOLUTIONS_FILE:}
+extras = test
+commands_pre = solc-select use {[testenv]solc_version} --always-install
 commands =
-    ruff check {[testenv:docs]src} --no-fix --show-fixes
-    ruff format {[testenv:docs]src} --diff
-    mypy {[testenv:docs]src}
-    python -c "import src.cli.tox_helpers; src.cli.tox_helpers.pyspelling()"
-    python -c "import src.cli.tox_helpers; src.cli.tox_helpers.markdownlint()"
-    mkdocs build --strict
+    pytest -c ./pytest-framework.ini -n auto -m "not run_in_serial"
+    pytest -c ./pytest-framework.ini -m run_in_serial
+
+
+[forks]
+develop = Prague
+eip7692 = Osaka
+
+[testenv:tests]
+description = Fill test cases in ./tests/ for deployed mainnet forks.
+commands_pre = solc-select use 0.8.24 --always-install
+commands = pytest -n auto -k "not slow"
+
+[testenv:tests-develop]
+description = Fill test cases in ./tests/ for deployed and development mainnet forks
+commands_pre = solc-select use 0.8.24 --always-install
+commands = pytest -n auto --until={[forks]develop} -k "not slow"
+
+[testenv:tests-eip7692]
+description = Fill test cases in ./tests/ for EIP-7692 (EOF) on Osaka
+commands_pre = solc-select use 0.8.24 --always-install
+commands =  pytest -n auto --evm-bin=evmone-t8n --fork={[forks]eip7692} -k "not slow" ./tests/osaka

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -81,6 +81,7 @@ CLIs
 cli2
 cmd
 codeAddr
+codebase
 codecopy
 codesize
 coinbase


### PR DESCRIPTION
## 🗒️ Description
This PR:
- Splits the tox environments by tool rather than repo scope: There is now one env per tool (ruff, mypy, pyspelling, etc).
- Updates the pre-commit config to run `ruff` upon any commit on Python files.
- Updates the docs to reflect these changes.

Now, a `tox` execution will run the same checks in total, but as the 7 defined default environments (lint, typecheck, markdownlint, spellcheck, pytest, tests-deployed, mkdocs). Previously this was 3 environments (framework, tests, docs), which ran duplicate tools and even some duplicate checks across the environments.

Advantages:
1. The output provides clearer fails by type.
2. Faster feedback on individual tasks, in particular (but non limited to) parallel execution, e.g., with
    ```
    uvx --with=tox-uv tox --parallel
    ```
3. The `lint` env can be executed as a `pre-commit` hook (thanks to ruff, cf #922, it's now lightning fast!): 

Motivation: As a follow-up step, `tox_verify.yaml` can be split into a job per environment, which will make it faster to see check fails and easier log parsing.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] ~~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~ skipped
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
