### PR TITLE
Refactor `left_pad_zeros_up_to_size` to a parameter in the `FixedSizeBytes` constructor

### DIFF
--- a/src/ethereum_test_base_types/base_types.py
+++ b/src/ethereum_test_base_types/base_types.py
@@ -242,12 +242,24 @@ class FixedSizeBytes(Bytes):
         Sized._sized_ = Sized
         return Sized
 
-    def __new__(cls, input_bytes: FixedSizeBytesConvertible | T):
+    def __new__(
+        cls,
+        input_bytes: FixedSizeBytesConvertible | T,
+        *,
+        left_padding: bool = False,
+        right_padding: bool = False,
+    ):
         """Create a new FixedSizeBytes object."""
         if type(input_bytes) is cls:
             return input_bytes
         return super(FixedSizeBytes, cls).__new__(
-            cls, to_fixed_size_bytes(input_bytes, cls.byte_length)
+            cls,
+            to_fixed_size_bytes(
+                input_bytes,
+                cls.byte_length,
+                left_padding=left_padding,
+                right_padding=right_padding,
+            ),
         )
 
     def __hash__(self) -> int:

--- a/src/ethereum_test_base_types/conversions.py
+++ b/src/ethereum_test_base_types/conversions.py
@@ -50,29 +50,38 @@ def to_bytes(input_bytes: BytesConvertible) -> bytes:
     raise Exception("invalid type for `bytes`")
 
 
-def to_fixed_size_bytes(input_bytes: FixedSizeBytesConvertible, size: int) -> bytes:
-    """Convert multiple types into fixed-size bytes."""
+def to_fixed_size_bytes(
+    input_bytes: FixedSizeBytesConvertible,
+    size: int,
+    *,
+    left_padding: bool = False,
+    right_padding: bool = False,
+) -> bytes:
+    """
+    Convert multiple types into fixed-size bytes.
+
+    :param input_bytes: The input data to convert.
+    :param size: The size of the output bytes.
+    :param left_padding: Whether to allow left-padding of the input data bytes using zeros. If the
+        input data is an integer, padding is always performed.
+    :param right_padding: Whether to allow right-padding of the input data bytes using zeros. If
+        the input data is an integer, padding is always performed.
+    """
     if isinstance(input_bytes, int):
         return int.to_bytes(input_bytes, length=size, byteorder="big", signed=input_bytes < 0)
     input_bytes = to_bytes(input_bytes)
     if len(input_bytes) > size:
         raise Exception(f"input is too large for fixed size bytes: {len(input_bytes)} > {size}")
-    return bytes(input_bytes).rjust(size, b"\x00")
-
-
-def left_pad_zeros_up_to_size(input_bytes: bytes, size: int) -> bytes:
-    """
-    Pad the given data to fit into a size-byte bytes. If the data is longer than
-    size bytes, it raises a ValueError. If it is shorter, it left pads with zero bytes.
-
-    :param data: The input data to pad.
-    :return: A Hash object of exactly size bytes.
-    """
-    input_bytes = to_bytes(input_bytes)
-    if len(input_bytes) > size:
-        raise ValueError(f"Data cannot be longer than {size} bytes.")
-    padded_data = bytes(input_bytes).rjust(size, b"\x00")
-    return bytes(padded_data)
+    if len(input_bytes) < size:
+        if left_padding:
+            return bytes(input_bytes).rjust(size, b"\x00")
+        if right_padding:
+            return bytes(input_bytes).ljust(size, b"\x00")
+        raise Exception(
+            f"input is too small for fixed size bytes: {len(input_bytes)} < {size}\n"
+            "Use `left_padding=True` or `right_padding=True` to allow padding."
+        )
+    return input_bytes
 
 
 def to_hex(input_bytes: BytesConvertible) -> str:
@@ -89,8 +98,3 @@ def to_number(input_number: NumberConvertible) -> int:
     if isinstance(input_number, bytes) or isinstance(input_number, SupportsBytes):
         return int.from_bytes(input_number, byteorder="big")
     raise Exception("invalid type for `number`")
-
-
-def to_fixed_size_hex(input_bytes: FixedSizeBytesConvertible, size: int) -> str:
-    """Convert multiple types into a bytes hex string."""
-    return "0x" + to_fixed_size_bytes(input_bytes, size).hex()

--- a/src/ethereum_test_types/types.py
+++ b/src/ethereum_test_types/types.py
@@ -594,28 +594,8 @@ class TransactionGeneric(BaseModel, Generic[NumberBoundTypeVar]):
     sender: EOA | None = None
 
 
-class TransactionFixtureConverter(CamelModel):
-    """Handler for serializing and validating the `to` field as an empty string."""
-
-    @model_validator(mode="before")
-    @classmethod
-    def validate_to_as_empty_string(cls, data: Any) -> Any:
-        """If the `to` field is an empty string, set the model value to None."""
-        if isinstance(data, dict) and "to" in data and data["to"] == "":
-            data["to"] = None
-        return data
-
-    @model_serializer(mode="wrap", when_used="json-unless-none")
-    def serialize_to_as_empty_string(self, serializer):
-        """Serialize the `to` field as the empty string if the model value is None."""
-        default = serializer(self)
-        if default is not None and "to" not in default:
-            default["to"] = ""
-        return default
-
-
-class TransactionTransitionToolConverter(CamelModel):
-    """Handler for serializing and validating the `to` field as an empty string."""
+class TransactionValidateToAsEmptyString(CamelModel):
+    """Handler to validate the `to` field from an empty string."""
 
     @model_validator(mode="before")
     @classmethod
@@ -629,6 +609,22 @@ class TransactionTransitionToolConverter(CamelModel):
         ):
             data["to"] = None
         return data
+
+
+class TransactionFixtureConverter(TransactionValidateToAsEmptyString):
+    """Handler for serializing and validating the `to` field as an empty string."""
+
+    @model_serializer(mode="wrap", when_used="json-unless-none")
+    def serialize_to_as_empty_string(self, serializer):
+        """Serialize the `to` field as the empty string if the model value is None."""
+        default = serializer(self)
+        if default is not None and "to" not in default:
+            default["to"] = ""
+        return default
+
+
+class TransactionTransitionToolConverter(TransactionValidateToAsEmptyString):
+    """Handler for serializing and validating the `to` field as an empty string."""
 
     @model_serializer(mode="wrap", when_used="json-unless-none")
     def serialize_to_as_none(self, serializer):

--- a/tests/cancun/eip1153_tstore/test_tstorage_execution_contexts.py
+++ b/tests/cancun/eip1153_tstore/test_tstorage_execution_contexts.py
@@ -8,13 +8,13 @@ from typing import Dict, Mapping
 
 import pytest
 
-from ethereum_test_base_types.conversions import left_pad_zeros_up_to_size
 from ethereum_test_tools import (
     Account,
     Address,
     Alloc,
     Bytecode,
     Environment,
+    Hash,
     StateTestFiller,
     Transaction,
 )
@@ -308,7 +308,7 @@ def tx(pre: Alloc, caller_address: Address, callee_address: Address) -> Transact
     return Transaction(
         sender=pre.fund_eoa(),
         to=caller_address,
-        data=left_pad_zeros_up_to_size(callee_address, 32),
+        data=Hash(callee_address, left_padding=True),
         gas_limit=1_000_000,
     )
 

--- a/tests/cancun/eip1153_tstore/test_tstorage_selfdestruct.py
+++ b/tests/cancun/eip1153_tstore/test_tstorage_selfdestruct.py
@@ -9,13 +9,13 @@ from typing import Dict
 
 import pytest
 
-from ethereum_test_base_types.conversions import left_pad_zeros_up_to_size
 from ethereum_test_tools import (
     Account,
     Alloc,
     Bytecode,
     CalldataCase,
     Environment,
+    Hash,
     Initcode,
     StateTestFiller,
     Switch,
@@ -233,7 +233,7 @@ def test_reentrant_selfdestructing_call(
     data: bytes | Bytecode
     if pre_existing_contract:
         callee_address = pre.deploy_contract(code=callee_bytecode)
-        data = left_pad_zeros_up_to_size(callee_address, 32)
+        data = Hash(callee_address, left_padding=True)
     else:
         callee_address = compute_create_address(address=caller_address, nonce=1)
         data = Initcode(deploy_code=callee_bytecode)

--- a/tests/shanghai/eip4895_withdrawals/test_withdrawals.py
+++ b/tests/shanghai/eip4895_withdrawals/test_withdrawals.py
@@ -10,7 +10,6 @@ from typing import Dict, List, Mapping
 import pytest
 
 from ethereum_clis import TransitionTool
-from ethereum_test_base_types.conversions import left_pad_zeros_up_to_size
 from ethereum_test_forks import Cancun, Fork
 from ethereum_test_tools import (
     EOA,
@@ -19,6 +18,7 @@ from ethereum_test_tools import (
     Alloc,
     Block,
     BlockchainTestFiller,
+    Hash,
     Transaction,
     TransactionException,
     Withdrawal,
@@ -201,7 +201,7 @@ def test_balance_within_block(blockchain_test: BlockchainTestFiller, pre: Alloc)
                     sender=sender,
                     gas_limit=100000,
                     to=contract_address,
-                    data=left_pad_zeros_up_to_size(recipient, 32),
+                    data=Hash(recipient, left_padding=True),
                 )
             ],
             withdrawals=[
@@ -219,7 +219,7 @@ def test_balance_within_block(blockchain_test: BlockchainTestFiller, pre: Alloc)
                     sender=sender,
                     gas_limit=100000,
                     to=contract_address,
-                    data=left_pad_zeros_up_to_size(recipient, 32),
+                    data=Hash(recipient, left_padding=True),
                 )
             ]
         ),
@@ -373,7 +373,7 @@ def test_self_destructing_account(
         sender=sender,
         gas_limit=100000,
         to=self_destruct_contract_address,
-        data=left_pad_zeros_up_to_size(recipient, 32),
+        data=Hash(recipient, left_padding=True),
     )
 
     withdrawal = Withdrawal(


### PR DESCRIPTION
Changes `left_pad_zeros_up_to_size` to be instead an optional parameter in all classes that inherit `FixedSizeBytes`.

So for example `Hash(left_pad_zeros_up_to_size("0x00", 32))` is equivalent to `Hash("0x00", left_padding=True)`.

If neither `left_padding` or `right_padding` are specified, and the input is shorter than the expected size, an exception is raised.