### PR TITLE
fix(pytest): add `parametrize_by_fork` marker to pytest's ini config

### DIFF
--- a/src/pytest_plugins/forks/forks.py
+++ b/src/pytest_plugins/forks/forks.py
@@ -405,7 +405,13 @@ def pytest_configure(config: pytest.Config):
         "markers",
         "valid_until(fork): specifies until which fork a test case is valid",
     )
-
+    config.addinivalue_line(
+        "markers",
+        (
+            "parametrize_by_fork(names, values_fn): parametrize a test case by fork using the "
+            "specified names and values returned by the function values_fn(fork)"
+        ),
+    )
     for d in fork_covariant_decorators:
         config.addinivalue_line("markers", f"{d.marker_name}: {d.description}")
 


### PR DESCRIPTION
## 🗒️ Description
Fixes the warnings:
```
  ./tests/cancun/eip4844_blobs/test_blob_txs.py:373: PytestUnknownMarkWarning: Unknown pytest.mark.parametrize_by_fork - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.parametrize_by_fork
```

## 🔗 Related Issues
Fix for:
- #1057 (which forgot to register the marker explicitly in the pytest ini config).

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] ~~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~
