### PR TITLE
fix(tests): fixes to get tests running in external testnets

### DIFF
--- a/tests/prague/eip2537_bls_12_381_precompiles/conftest.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/conftest.py
@@ -135,7 +135,7 @@ def call_contract_address(pre: Alloc, call_contract_code: Bytecode) -> Address:
 @pytest.fixture
 def sender(pre: Alloc) -> EOA:
     """Sender of the transaction."""
-    return pre.fund_eoa(20_000_000_000_000_000)
+    return pre.fund_eoa(1_000_000_000_000_000_000)
 
 
 @pytest.fixture
@@ -151,7 +151,7 @@ def post(call_contract_address: Address, call_contract_post_storage: Storage):
 @pytest.fixture
 def tx_gas_limit(precompile_gas: int) -> int:
     """Transaction gas limit used for the test (Can be overridden in the test)."""
-    return 200_000 + precompile_gas
+    return 10_000_000 + precompile_gas
 
 
 @pytest.fixture

--- a/tests/prague/eip2537_bls_12_381_precompiles/conftest.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/conftest.py
@@ -135,7 +135,7 @@ def call_contract_address(pre: Alloc, call_contract_code: Bytecode) -> Address:
 @pytest.fixture
 def sender(pre: Alloc) -> EOA:
     """Sender of the transaction."""
-    return pre.fund_eoa(1_000_000_000_000_000)
+    return pre.fund_eoa(20_000_000_000_000_000)
 
 
 @pytest.fixture
@@ -151,7 +151,7 @@ def post(call_contract_address: Address, call_contract_post_storage: Storage):
 @pytest.fixture
 def tx_gas_limit(precompile_gas: int) -> int:
     """Transaction gas limit used for the test (Can be overridden in the test)."""
-    return 10_000_000 + precompile_gas
+    return 200_000 + precompile_gas
 
 
 @pytest.fixture

--- a/tests/prague/eip7002_el_triggerable_withdrawals/helpers.py
+++ b/tests/prague/eip7002_el_triggerable_withdrawals/helpers.py
@@ -60,7 +60,7 @@ class WithdrawalRequest(WithdrawalRequestBase):
 class WithdrawalRequestInteractionBase:
     """Base class for all types of withdrawal transactions we want to test."""
 
-    sender_balance: int = 32_000_000_000_000_000_000 * 100
+    sender_balance: int = 1_000_000_000_000_000_000
     """
     Balance of the account that sends the transaction.
     """
@@ -96,7 +96,7 @@ class WithdrawalRequestTransaction(WithdrawalRequestInteractionBase):
         return [
             Transaction(
                 gas_limit=request.gas_limit,
-                gas_price=0x07,
+                gas_price=1_000_000_000,
                 to=request.interaction_contract_address,
                 value=request.value,
                 data=request.calldata,
@@ -128,7 +128,7 @@ class WithdrawalRequestContract(WithdrawalRequestInteractionBase):
     Gas limit for the transaction.
     """
 
-    contract_balance: int = 32_000_000_000_000_000_000 * 100
+    contract_balance: int = 1_000_000_000_000_000_000
     """
     Balance of the contract that will make the call to the pre-deploy contract.
     """
@@ -181,7 +181,7 @@ class WithdrawalRequestContract(WithdrawalRequestInteractionBase):
         return [
             Transaction(
                 gas_limit=self.tx_gas_limit,
-                gas_price=0x07,
+                gas_price=1_000_000_000,
                 to=self.entry_address,
                 value=0,
                 data=b"".join(r.calldata for r in self.requests),

--- a/tests/prague/eip7251_consolidations/helpers.py
+++ b/tests/prague/eip7251_consolidations/helpers.py
@@ -58,7 +58,7 @@ class ConsolidationRequest(ConsolidationRequestBase):
 class ConsolidationRequestInteractionBase:
     """Base class for all types of consolidation transactions we want to test."""
 
-    sender_balance: int = 32_000_000_000_000_000_000 * 100
+    sender_balance: int = 1_000_000_000_000_000_000
     """
     Balance of the account that sends the transaction.
     """
@@ -94,7 +94,7 @@ class ConsolidationRequestTransaction(ConsolidationRequestInteractionBase):
         return [
             Transaction(
                 gas_limit=request.gas_limit,
-                gas_price=0x07,
+                gas_price=1_000_000_000,
                 to=request.interaction_contract_address,
                 value=request.value,
                 data=request.calldata,
@@ -126,7 +126,7 @@ class ConsolidationRequestContract(ConsolidationRequestInteractionBase):
     Gas limit for the transaction.
     """
 
-    contract_balance: int = 32_000_000_000_000_000_000 * 100
+    contract_balance: int = 1_000_000_000_000_000_000
     """
     Balance of the contract that will make the call to the pre-deploy contract.
     """
@@ -179,7 +179,7 @@ class ConsolidationRequestContract(ConsolidationRequestInteractionBase):
         return [
             Transaction(
                 gas_limit=self.tx_gas_limit,
-                gas_price=0x07,
+                gas_price=1_000_000_000,
                 to=self.entry_address,
                 value=0,
                 data=b"".join(r.calldata for r in self.requests),

--- a/tests/prague/eip7702_set_code_tx/test_gas.py
+++ b/tests/prague/eip7702_set_code_tx/test_gas.py
@@ -712,7 +712,7 @@ def test_gas_cost(
     test_code_address = pre.deploy_contract(test_code)
 
     tx_gas_limit = intrinsic_gas + execution_gas
-    tx_max_fee_per_gas = 7
+    tx_max_fee_per_gas = 1_000_000_000
     tx_exact_cost = tx_gas_limit * tx_max_fee_per_gas
 
     # EIP-3529


### PR DESCRIPTION
## 🗒️ Description
various small fixed to make tests work in external testnets

I've got most of these prague tests running:
- eip2537_bls_12_381_precompiles (except all tests in test_bls12_variable_length_input_contracts.py with manual 100M gas limit attribute)
- eip7002_el_triggerable_withdrawals
- eip7251_consolidations
- eip7623_increase_calldata_cost
- eip7702_set_code_tx

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
