### PR TITLE
feat(specs): verify intermidiate block state in blockchain test

### DIFF
--- a/src/ethereum_test_specs/blockchain.py
+++ b/src/ethereum_test_specs/blockchain.py
@@ -634,6 +634,12 @@ class BlockchainTest(BaseTest):
                     alloc = new_alloc
                     env = apply_new_parent(env, header)
                     head_hash = header.block_hash
+
+            if block.expected_post_state:
+                self.verify_post_state(
+                    t8n, t8n_state=alloc, expected_state=block.expected_post_state
+                )
+
         fcu_version = fork.engine_forkchoice_updated_version(header.number, header.timestamp)
         assert (
             fcu_version is not None

--- a/tests/frontier/examples/__init__.py
+++ b/tests/frontier/examples/__init__.py
@@ -1,0 +1,1 @@
+"""Test examples, patterns, templates to use in .py tests."""

--- a/tests/frontier/examples/test_block_intermediate_state.py
+++ b/tests/frontier/examples/test_block_intermediate_state.py
@@ -19,8 +19,8 @@ def test_block_intermidiate_state(blockchain_test: BlockchainTestFiller, pre: Al
     env = Environment()
     sender = pre.fund_eoa()
 
-    tx = Transaction(gas_limit=100_000, to=None, data=b"", sender=sender)
-    tx_2 = Transaction(gas_limit=100_000, to=None, data=b"", sender=sender)
+    tx = Transaction(gas_limit=100_000, to=None, data=b"", sender=sender, protected=False)
+    tx_2 = Transaction(gas_limit=100_000, to=None, data=b"", sender=sender, protected=False)
 
     block_1 = Block(
         txs=[tx],

--- a/tests/frontier/examples/test_block_intermidiate_state.py
+++ b/tests/frontier/examples/test_block_intermidiate_state.py
@@ -1,0 +1,50 @@
+"""Test the SELFDESTRUCT opcode."""
+
+import pytest
+
+from ethereum_test_tools import (
+    Account,
+    Alloc,
+    Block,
+    BlockchainTestFiller,
+    Environment,
+    Transaction,
+)
+
+
+@pytest.mark.valid_from("Frontier")
+@pytest.mark.valid_until("Homestead")
+def test_block_intermidiate_state(blockchain_test: BlockchainTestFiller, pre: Alloc):
+    """Verify intermidiate block states."""
+    env = Environment()
+    sender = pre.fund_eoa()
+
+    tx = Transaction(gas_limit=100_000, to=None, data=b"", sender=sender)
+    tx_2 = Transaction(gas_limit=100_000, to=None, data=b"", sender=sender)
+
+    block_1 = Block(
+        txs=[tx],
+        expected_post_state={
+            sender: Account(
+                nonce=1,
+            ),
+        },
+    )
+
+    block_2 = Block(txs=[])
+
+    block_3 = Block(
+        txs=[tx_2],
+        expected_post_state={
+            sender: Account(
+                nonce=2,
+            ),
+        },
+    )
+
+    blockchain_test(
+        genesis_environment=env,
+        pre=pre,
+        post=block_3.expected_post_state,
+        blocks=[block_1, block_2, block_3],
+    )

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -253,6 +253,7 @@ isort
 isort's
 ispkg
 itemName
+intermidiate
 javascripts
 jimporter
 joinpath


### PR DESCRIPTION
## 🗒️ Description
Allow verification of individual block states in blockchain test

## 🔗 Related Issues
https://github.com/ethereum/execution-spec-tests/issues/1033

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
