### PR TITLE
chore(consume): add blob schedule rules to hive ruleset

### DIFF
--- a/src/pytest_plugins/consume/hive_simulators/ruleset.py
+++ b/src/pytest_plugins/consume/hive_simulators/ruleset.py
@@ -337,6 +337,8 @@ ruleset = {
         "HIVE_SHANGHAI_TIMESTAMP": 0,
         "HIVE_CANCUN_TIMESTAMP": 0,
         "HIVE_PRAGUE_TIMESTAMP": 0,
+        "HIVE_PRAGUE_BLOB_TARGET": 6,
+        "HIVE_PRAGUE_BLOB_MAX": 9,
     },
     "CancunToPragueAtTime15k": {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -353,5 +355,7 @@ ruleset = {
         "HIVE_SHANGHAI_TIMESTAMP": 0,
         "HIVE_CANCUN_TIMESTAMP": 0,
         "HIVE_PRAGUE_TIMESTAMP": 15000,
+        "HIVE_PRAGUE_BLOB_TARGET": 6,
+        "HIVE_PRAGUE_BLOB_MAX": 9,
     },
 }


### PR DESCRIPTION
## 🗒️ Description
Adds the Prague blob schedules (EIP-7840) to the hive simulator ruleset (as done in https://github.com/ethereum/hive/pull/1207)

## 🔗 Related Issues
- https://github.com/ethereum/EIPs/pull/9129
- https://github.com/ethereum/hive/pull/1207

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] ~~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~ skipped

