### PR TITLE
chore(all): add ethereum-rlp as a dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,12 +44,13 @@ dependencies = [
     "pyyaml>=6.0.2,<7",
     "types-pyyaml>=6.0.12.20240917,<7",
     "pytest-json-report>=1.5.0,<2",
-    # TODO: bump questionary to a newer release, when it becomes available. 
+    # TODO: bump questionary to a newer release, when it becomes available.
     # The current release questionary 2.0.1 requires `prompt_toolkit = ">=2.0,<=3.0.36"`.
     # This conflicts with ipython; while not an EEST dependency, ipython a very useful tool:
     # https://ethereum.github.io/execution-spec-tests/main/dev/interactive_usage/
     "questionary @ git+https://github.com/tmbo/questionary@ff22aeae1cd9c1c734f14329934e349bec7873bc",
-    "prompt_toolkit>=3.0.48,<4",  # ensure we have a new enough version for ipython
+    "prompt_toolkit>=3.0.48,<4", # ensure we have a new enough version for ipython
+    "ethereum-rlp==0.1.3",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -224,7 +224,7 @@ name = "click"
 version = "8.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
 wheels = [
@@ -496,6 +496,7 @@ dependencies = [
     { name = "coincurve" },
     { name = "colorlog" },
     { name = "ethereum" },
+    { name = "ethereum-rlp" },
     { name = "ethereum-spec-evm-resolver" },
     { name = "ethereum-types" },
     { name = "filelock" },
@@ -558,6 +559,7 @@ requires-dist = [
     { name = "coincurve", specifier = ">=20.0.0,<21" },
     { name = "colorlog", specifier = ">=6.7.0,<7" },
     { name = "ethereum", git = "https://github.com/ethereum/execution-specs" },
+    { name = "ethereum-rlp", specifier = "==0.1.3" },
     { name = "ethereum-spec-evm-resolver", git = "https://github.com/petertdavies/ethereum-spec-evm-resolver" },
     { name = "ethereum-types", specifier = ">=0.2.1,<0.3" },
     { name = "filelock", specifier = ">=3.15.1,<4" },
@@ -601,6 +603,19 @@ requires-dist = [
     { name = "types-pyyaml", specifier = ">=6.0.12.20240917,<7" },
     { name = "types-requests", marker = "extra == 'lint'" },
     { name = "types-setuptools" },
+]
+
+[[package]]
+name = "ethereum-rlp"
+version = "0.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ethereum-types" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cf/6c/b5545187ca81581ccc13370b2628d7e47392984b4a897720ce670afbb4c7/ethereum_rlp-0.1.3.tar.gz", hash = "sha256:3227d675e17b8d5a3b45569718e01827310822a1de069a3c9c840fb45432ccc2", size = 13113 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/1d/f2bffa0e94eda6e8bbb84e8e526dd4b821ce61ed964384e7a6efd635074a/ethereum_rlp-0.1.3-py3-none-any.whl", hash = "sha256:6c1d98b80b29307049ad301fcf1ffb36474c6962bef0f3fcbe44086163e7e48b", size = 9470 },
 ]
 
 [[package]]
@@ -947,7 +962,7 @@ version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "ghp-import" },
     { name = "jinja2" },
     { name = "markdown" },


### PR DESCRIPTION
## 🗒️ Description
Add https://pypi.org/project/ethereum-rlp/ as a dependency to address the recent fails in CI, cf #1083.

This also required bumping the version of `uv` used in CI to `0.5.20` to fix #1084.

## 🔗 Related Issues
Fixes #1083.

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] ~~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~ skipped

