### PR TITLE
feat(tests): EIP-7691: Fork transition tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,7 +28,7 @@ Release tarball changes:
 - 🔀 Update EIP-7251 according to [spec updates](https://github.com/ethereum/EIPs/pull/9127) ([#1024](https://github.com/ethereum/execution-spec-tests/pull/1024)).
 - 🔀 Update EIP-7002 according to [spec updates](https://github.com/ethereum/EIPs/pull/9119) ([#1024](https://github.com/ethereum/execution-spec-tests/pull/1024)).
 - 🔀 Update EIP-2935 according to [spec updates](https://github.com/ethereum/EIPs/pull/9144) ([#1046](https://github.com/ethereum/execution-spec-tests/pull/1046))
-- ✨ [EIP-7691](https://eips.ethereum.org/EIPS/eip-7691) Blob throughput increase tests by parametrization of existing EIP-4844 tests ([#1023](https://github.com/ethereum/execution-spec-tests/pull/1023))
+- ✨ [EIP-7691](https://eips.ethereum.org/EIPS/eip-7691) Blob throughput increase tests by parametrization of existing EIP-4844 tests ([#1023](https://github.com/ethereum/execution-spec-tests/pull/1023), [#1082](https://github.com/ethereum/execution-spec-tests/pull/1082))
 
 ### 🛠️ Framework
 

--- a/tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py
+++ b/tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py
@@ -24,7 +24,6 @@ from ethereum_test_tools import (
     Transaction,
     add_kzg_version,
 )
-from ethereum_test_tools import Opcodes as Op
 
 from .spec import Spec, SpecHelpers, ref_spec_4844
 


### PR DESCRIPTION
## 🗒️ Description

Implements fork transition tests for the blob target and max increment by EIP-7691 that occurs on the Prague activation.

Test expectation: At the first block of Prague, we use the`TARGET_BLOB_GAS_PER_BLOCK`,`MAX_BLOB_GAS_PER_BLOCK` and `BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE` constants in EIP-7691, just the same as we use for subsequent blocks for Prague:
```
tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py::test_fork_transition_excess_blob_gas_at_blob_genesis[fork_ShanghaiToCancunAtTime15k-max_blobs-blockchain_test]
tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py::test_fork_transition_excess_blob_gas_at_blob_genesis[fork_ShanghaiToCancunAtTime15k-max_blobs-blockchain_test_engine]
tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py::test_fork_transition_excess_blob_gas_at_blob_genesis[fork_ShanghaiToCancunAtTime15k-no_blobs-blockchain_test]
tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py::test_fork_transition_excess_blob_gas_at_blob_genesis[fork_ShanghaiToCancunAtTime15k-no_blobs-blockchain_test_engine]
tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py::test_fork_transition_excess_blob_gas_at_blob_genesis[fork_ShanghaiToCancunAtTime15k-target_blobs-blockchain_test]
tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py::test_fork_transition_excess_blob_gas_at_blob_genesis[fork_ShanghaiToCancunAtTime15k-target_blobs-blockchain_test_engine]
tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py::test_fork_transition_excess_blob_gas_post_blob_genesis[fork_CancunToPragueAtTime15k-max_blobs-blockchain_test]
tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py::test_fork_transition_excess_blob_gas_post_blob_genesis[fork_CancunToPragueAtTime15k-max_blobs-blockchain_test_engine]
tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py::test_fork_transition_excess_blob_gas_post_blob_genesis[fork_CancunToPragueAtTime15k-no_blobs_before-blockchain_test]
tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py::test_fork_transition_excess_blob_gas_post_blob_genesis[fork_CancunToPragueAtTime15k-no_blobs_before-blockchain_test_engine]
tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py::test_fork_transition_excess_blob_gas_post_blob_genesis[fork_CancunToPragueAtTime15k-no_blobs_after-blockchain_test]
tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py::test_fork_transition_excess_blob_gas_post_blob_genesis[fork_CancunToPragueAtTime15k-no_blobs_after-blockchain_test_engine]
tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py::test_fork_transition_excess_blob_gas_post_blob_genesis[fork_CancunToPragueAtTime15k-target_blobs-blockchain_test]
tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py::test_fork_transition_excess_blob_gas_post_blob_genesis[fork_CancunToPragueAtTime15k-target_blobs-blockchain_test_engine]
tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py::test_fork_transition_excess_blob_gas_post_blob_genesis[fork_CancunToPragueAtTime15k-single_blob_to_max_blobs-blockchain_test]
tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py::test_fork_transition_excess_blob_gas_post_blob_genesis[fork_CancunToPragueAtTime15k-single_blob_to_max_blobs-blockchain_test_engine]
tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py::test_fork_transition_excess_blob_gas_post_blob_genesis[fork_CancunToPragueAtTime15k-max_blobs_to_single_blob-blockchain_test]
tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py::test_fork_transition_excess_blob_gas_post_blob_genesis[fork_CancunToPragueAtTime15k-max_blobs_to_single_blob-blockchain_test_engi
```
(output generated with `fill --until Prague -k test_fork_transition_excess_blob_gas --collect-only -q`)

~~Requires #1081~~ Merged

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
