### PR TITLE
transaction test failure

### DIFF
--- a/tests/frontier/transactions/test_transactions.py
+++ b/tests/frontier/transactions/test_transactions.py
@@ -1,0 +1,47 @@
+"""Test address field in transaction rlp."""
+
+from typing import Optional, Union
+
+import pytest
+from pydantic import Field
+
+from ethereum_test_base_types import Bytes
+from ethereum_test_tools import (
+    Address,
+    Alloc,
+    Transaction,
+    TransactionException,
+    TransactionTestFiller,
+)
+
+REFERENCE_SPEC_GIT_PATH = None
+REFERENCE_SPEC_VERSION = None
+
+pytestmark = pytest.mark.valid_from("Frontier")
+
+
+class TestTransaction(Transaction):
+    """Test version of the Transaction class where 'to' accepts Bytes."""
+
+    to: Optional[Union[Bytes, Address, None]] = Field(Bytes(bytes.fromhex("00")))
+
+
+def test_tx_address_less_than_20(
+    transaction_test: TransactionTestFiller,
+    pre: Alloc,
+):
+    """Test sending a transaction with an empty authorization list."""
+    tx = TestTransaction(
+        gas_limit=100_000,
+        to=bytes.fromhex("0011"),
+        value=0,
+        error=TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED,
+        sender=pre.fund_eoa(),
+    )
+    tx = tx.with_signature_and_sender()
+    hash = tx.hash
+
+    transaction_test(
+        pre=pre,
+        tx=tx,
+    )


### PR DESCRIPTION
## 🗒️ Description
transaction is failing with signature undefined
Debug shows that such tx unable to provide it's hash value.

also we wold need mock transaction class that will override it's standard behavior. 
like allowing fields to be of incorrect size to be able to produce invalid rlp's. 
overwrite signature bytes and so on. 


## 🔗 Related Issues
[<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->](https://github.com/ethereum/execution-spec-tests/issues/1089)

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
