### PR TITLE
fix(fill,fw,ci): use t8n fork name in eels resolutions keys

### DIFF
--- a/.github/configs/eels_resolutions.json
+++ b/.github/configs/eels_resolutions.json
@@ -24,7 +24,7 @@
     "London": {
         "path": "../../execution-specs/src/ethereum/london"
     },
-    "Paris": {
+    "Merge": {
         "path": "../../execution-specs/src/ethereum/paris"
     },
     "Shanghai": {

--- a/.github/configs/eels_resolutions.json
+++ b/.github/configs/eels_resolutions.json
@@ -1,8 +1,4 @@
 {
-    "EELSMaster": {
-        "git_url": "https://github.com/ethereum/execution-specs.git",
-        "branch": "master"
-    },
     "Frontier": {
         "path": "../../execution-specs/src/ethereum/frontier"
     },

--- a/eels_resolutions.json
+++ b/eels_resolutions.json
@@ -25,7 +25,7 @@
     "London": {
         "same_as": "EELSMaster"
     },
-    "Paris": {
+    "Merge": {
         "same_as": "EELSMaster"
     },
     "Shanghai": {


### PR DESCRIPTION
## 🗒️ Description

Update the eels resolutions keys for the Paris fork from `Paris` to `Merge` (and remove `EELSMaster` from the CI resolution file).

## 🔗 Related Issues
This PR resolves (one of) the underlying reasons for this fail, see [this comment](https://github.com/ethereum/execution-spec-tests/issues/1083#issuecomment-2595249139) in from the following ticket for more details.
- #1083

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] ~~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~ skipped

