### PR TITLE
feat(consume/hive): add `HIVE_PRAGUE_BLOB_BASE_FEE_UPDATE_FRACTION`

### DIFF
--- a/src/pytest_plugins/consume/hive_simulators/ruleset.py
+++ b/src/pytest_plugins/consume/hive_simulators/ruleset.py
@@ -339,6 +339,7 @@ ruleset = {
         "HIVE_PRAGUE_TIMESTAMP": 0,
         "HIVE_PRAGUE_BLOB_TARGET": 6,
         "HIVE_PRAGUE_BLOB_MAX": 9,
+        "HIVE_PRAGUE_BLOB_BASE_FEE_UPDATE_FRACTION": 5007716,
     },
     "CancunToPragueAtTime15k": {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -357,5 +358,6 @@ ruleset = {
         "HIVE_PRAGUE_TIMESTAMP": 15000,
         "HIVE_PRAGUE_BLOB_TARGET": 6,
         "HIVE_PRAGUE_BLOB_MAX": 9,
+        "HIVE_PRAGUE_BLOB_BASE_FEE_UPDATE_FRACTION": 5007716,
     },
 }


### PR DESCRIPTION
Adds `HIVE_PRAGUE_BLOB_BASE_FEE_UPDATE_FRACTION` to the ruleset.

## 🗒️ Description
Based on this hive PR: https://github.com/ethereum/hive/pull/1215

## 🔗 Related Issues
None

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
