### PR TITLE
feat(plugins/consume): Check port 8551 on Engine API tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -78,6 +78,7 @@ Release tarball changes:
 - 🐞 fix(consume): allow absolute paths with `--evm-bin` ([#1052](https://github.com/ethereum/execution-spec-tests/pull/1052)).
 - ✨ Disable EIP-7742 framework changes for Prague ([#1023](https://github.com/ethereum/execution-spec-tests/pull/1023)).
 - ✨ Allow verification of the transaction receipt on executed test transactions ([#1068](https://github.com/ethereum/execution-spec-tests/pull/1068)).
+- 🐞 fix(consume): use `"HIVE_CHECK_LIVE_PORT"` to signal hive to wait for port 8551 (Engine API port) instead of the 8545 port when running `consume engine` ([#1095](https://github.com/ethereum/execution-spec-tests/pull/1095)).
 
 ### 🔧 EVM Tools
 

--- a/src/pytest_plugins/consume/hive_simulators/engine/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/engine/conftest.py
@@ -6,7 +6,7 @@ Configures the hive back-end & EL clients for each individual test execution.
 
 import io
 from pathlib import Path
-from typing import Dict, Mapping
+from typing import Mapping
 
 import pytest
 from hive.client import Client
@@ -18,19 +18,6 @@ from ethereum_test_rpc import EngineRPC
 from pytest_plugins.consume.consume import JsonSource
 
 TestCase = TestCaseIndexFile | TestCaseStream
-
-
-@pytest.fixture(scope="function")
-def environment(request: pytest.FixtureRequest) -> Dict:
-    """
-    For the Engine API simulations, we need that the port 8551 is ready on the client's side,
-    instead of the default 8545, because the first request is a forkchoice update.
-
-    We signal this to hive by adding the "HIVE_CHECK_LIVE_PORT" environment variable.
-    """
-    environment: Dict = request.getfixturevalue("environment")
-    environment["HIVE_CHECK_LIVE_PORT"] = "8551"
-    return environment
 
 
 @pytest.fixture(scope="function")

--- a/src/pytest_plugins/consume/hive_simulators/engine/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/engine/conftest.py
@@ -6,7 +6,7 @@ Configures the hive back-end & EL clients for each individual test execution.
 
 import io
 from pathlib import Path
-from typing import Mapping
+from typing import Dict, Mapping
 
 import pytest
 from hive.client import Client
@@ -18,6 +18,19 @@ from ethereum_test_rpc import EngineRPC
 from pytest_plugins.consume.consume import JsonSource
 
 TestCase = TestCaseIndexFile | TestCaseStream
+
+
+@pytest.fixture(scope="function")
+def environment(request: pytest.FixtureRequest) -> Dict:
+    """
+    For the Engine API simulations, we need that the port 8551 is ready on the client's side,
+    instead of the default 8545, because the first request is a forkchoice update.
+
+    We signal this to hive by adding the "HIVE_CHECK_LIVE_PORT" environment variable.
+    """
+    environment: Dict = request.getfixturevalue("environment")
+    environment["HIVE_CHECK_LIVE_PORT"] = "8551"
+    return environment
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
## 🗒️ Description
Use the [`"HIVE_CHECK_LIVE_PORT"` client environment value](https://github.com/ethereum/hive/blob/7910caeacba62a7172fd98dbe73322724c146297/internal/libhive/api.go#L265-L275) when starting a client for an Engine API test in the `consume` command.

This seems to be a recurrent issue when instantiating parallel client containers for hive runs, as it can be seen in https://hive.pectra-devnet-5.ethpandaops.io/suite.html?suiteid=1737336360-cdc9f3b55f2e828c17ab8b6c364934e8.json&suitename=eest%2Fconsume-engine#

The solution suggested by this PR is to signal hive to wait for the Engine API port (8551) instead of the RPC port (8545) before returning the client to the simulator (`consume`).

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.