### PR TITLE
fix(tests): EIP-7685: Return Engine API error code for invalid params

### DIFF
--- a/tests/prague/eip7685_general_purpose_el_requests/conftest.py
+++ b/tests/prague/eip7685_general_purpose_el_requests/conftest.py
@@ -5,7 +5,15 @@ from typing import List, SupportsBytes
 import pytest
 
 from ethereum_test_forks import Fork
-from ethereum_test_tools import Alloc, Block, BlockException, Bytes, Header, Requests
+from ethereum_test_tools import (
+    Alloc,
+    Block,
+    BlockException,
+    Bytes,
+    EngineAPIError,
+    Header,
+    Requests,
+)
 
 from ..eip6110_deposits.helpers import DepositInteractionBase, DepositRequest
 from ..eip7002_el_triggerable_withdrawals.helpers import (
@@ -51,6 +59,26 @@ def exception() -> BlockException | None:
 
 
 @pytest.fixture
+def engine_api_error_code(
+    block_body_override_requests: List[Bytes | SupportsBytes] | None,
+) -> EngineAPIError | None:
+    """Engine API error code if any."""
+    if block_body_override_requests is None:
+        return None
+    block_body_override_requests_bytes = [bytes(r) for r in block_body_override_requests]
+    if any(len(r) <= 1 for r in block_body_override_requests_bytes):
+        return EngineAPIError.InvalidParams
+
+    last_type: int = -1
+    for r in block_body_override_requests_bytes:
+        if r[0] <= last_type:
+            return EngineAPIError.InvalidParams
+        last_type = r[0]
+
+    return None
+
+
+@pytest.fixture
 def blocks(
     fork: Fork,
     pre: Alloc,
@@ -59,10 +87,11 @@ def blocks(
         | WithdrawalRequestInteractionBase
         | ConsolidationRequestInteractionBase
     ],
-    block_body_override_requests: (List[Bytes | SupportsBytes] | None),
+    block_body_override_requests: List[Bytes | SupportsBytes] | None,
     block_body_extra_requests: List[SupportsBytes],
     correct_requests_hash_in_header: bool,
     exception: BlockException | None,
+    engine_api_error_code: EngineAPIError | None,
 ) -> List[Block]:
     """List of blocks that comprise the test."""
     valid_requests_list: List[DepositRequest | WithdrawalRequest | ConsolidationRequest] = []
@@ -95,5 +124,6 @@ def blocks(
             requests=block_body_override_requests,
             exception=exception,
             rlp_modifier=rlp_modifier,
+            engine_api_error_code=engine_api_error_code,
         )
     ]

--- a/tests/prague/eip7685_general_purpose_el_requests/conftest.py
+++ b/tests/prague/eip7685_general_purpose_el_requests/conftest.py
@@ -69,11 +69,11 @@ def engine_api_error_code(
     if any(len(r) <= 1 for r in block_body_override_requests_bytes):
         return EngineAPIError.InvalidParams
 
-    last_type: int = -1
-    for r in block_body_override_requests_bytes:
-        if r[0] <= last_type:
-            return EngineAPIError.InvalidParams
-        last_type = r[0]
+    def is_monotonically_increasing(requests: List[bytes]) -> bool:
+        return all(x[0] < y[0] for x, y in zip(requests, requests[1:], strict=False))
+
+    if not is_monotonically_increasing(block_body_override_requests_bytes):
+        return EngineAPIError.InvalidParams
 
     return None
 

--- a/tests/prague/eip7685_general_purpose_el_requests/test_deposits_withdrawals_consolidations.py
+++ b/tests/prague/eip7685_general_purpose_el_requests/test_deposits_withdrawals_consolidations.py
@@ -331,6 +331,8 @@ def invalid_requests_block_combinations(fork: Fork) -> List[Any]:
 
     In the event of a new request type, the `all_request_types` dictionary should be updated
     with the new request type and its corresponding request-generating transaction.
+
+    Returned parameters are: requests, block_body_override_requests, exception
     """
     assert fork.max_request_type() == 2, "Test update is needed for new request types"
 

--- a/tests/prague/eip7685_general_purpose_el_requests/test_request_types.py
+++ b/tests/prague/eip7685_general_purpose_el_requests/test_request_types.py
@@ -29,7 +29,11 @@ pytestmark = pytest.mark.valid_from("Prague")
 
 @pytest.fixture
 def block_body_extra_requests(fork: Fork, invalid_request_data: bytes) -> List[bytes]:
-    """List of requests that overwrite the requests in the header. None by default."""
+    """
+    Create a request with an invalid type for the fork.
+
+    This overrides the default fixture and its behavior defined in conftest.py.
+    """
     invalid_request_type = fork.max_request_type() + 1
     return [bytes([invalid_request_type]) + invalid_request_data]
 


### PR DESCRIPTION
## 🗒️ Description
Updates EIP-7685 to take into account the following execution-apis PRs:

- https://github.com/ethereum/execution-apis/pull/622
- https://github.com/ethereum/execution-apis/pull/623 (Not yet merged)

## 🔗 Related Issues
#1094

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.