### PR TITLE
Add check live port as dedicated fixture

### DIFF
--- a/src/pytest_plugins/consume/hive_simulators/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/conftest.py
@@ -2,7 +2,7 @@
 
 import io
 import json
-from typing import Generator, List, cast
+from typing import Generator, List, Literal, cast
 
 import pytest
 import rich
@@ -123,7 +123,21 @@ def client_genesis(blockchain_fixture: BlockchainFixtureCommon) -> dict:
 
 
 @pytest.fixture(scope="function")
-def environment(blockchain_fixture: BlockchainFixtureCommon) -> dict:
+def check_live_port(test_suite_name: str) -> Literal[8545, 8551]:
+    """Port used by hive to check for liveness of the client."""
+    if test_suite_name == "eest/consume-rlp":
+        return 8545
+    elif test_suite_name == "eest/consume-engine":
+        return 8551
+    raise ValueError(
+        f"Unexpected test suite name '{test_suite_name}' while setting HIVE_CHECK_LIVE_PORT."
+    )
+
+
+@pytest.fixture(scope="function")
+def environment(
+    blockchain_fixture: BlockchainFixtureCommon, check_live_port: Literal[8545, 8551]
+) -> dict:
     """Define the environment that hive will start the client with."""
     assert (
         blockchain_fixture.fork in ruleset
@@ -132,6 +146,7 @@ def environment(blockchain_fixture: BlockchainFixtureCommon) -> dict:
         "HIVE_CHAIN_ID": "1",
         "HIVE_FORK_DAO_VOTE": "1",
         "HIVE_NODETYPE": "full",
+        "HIVE_CHECK_LIVE_PORT": str(check_live_port),
         **{k: f"{v:d}" for k, v in ruleset[blockchain_fixture.fork].items()},
     }
 

--- a/src/pytest_plugins/consume/hive_simulators/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/conftest.py
@@ -64,8 +64,7 @@ def eest_consume_commands(
     hive_dev = f"./hive --dev --client-file configs/prague.yaml --client {client_type.name}"
     input_source = request.config.getoption("fixture_source")
     consume = (
-        f'consume {test_suite_name.split("-")[-1]} -v --input={input_source} -k '
-        f'"{test_case.id}"'
+        f'consume {test_suite_name.split("-")[-1]} -v --input={input_source} -k "{test_case.id}"'
     )
     return [hive_dev, consume]
 
@@ -89,13 +88,13 @@ def test_case_description(
     else:
         description += f"\n\n{blockchain_fixture.info['description']}"
     description += (
-        f"\n\nCommand to reproduce entirely in hive:" f"\n<code>{hive_consume_command}</code>"
+        f"\n\nCommand to reproduce entirely in hive:\n<code>{hive_consume_command}</code>"
     )
     eest_commands = "\n".join(
-        f"{i+1}. <code>{cmd}</code>" for i, cmd in enumerate(eest_consume_commands)
+        f"{i + 1}. <code>{cmd}</code>" for i, cmd in enumerate(eest_consume_commands)
     )
     description += (
-        "\n\nCommands to reproduce within EEST using a hive dev back-end:" f"\n{eest_commands}"
+        f"\n\nCommands to reproduce within EEST using a hive dev back-end:\n{eest_commands}"
     )
     description = description.replace("\n", "<br/>")
     return description

--- a/src/pytest_plugins/consume/hive_simulators/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/conftest.py
@@ -124,10 +124,7 @@ def client_genesis(blockchain_fixture: BlockchainFixtureCommon) -> dict:
 
 @pytest.fixture(scope="function")
 def environment(blockchain_fixture: BlockchainFixtureCommon) -> dict:
-    """
-    Define the environment that hive will start the client with using the fork
-    rules specific for the simulator.
-    """
+    """Define the environment that hive will start the client with."""
     assert (
         blockchain_fixture.fork in ruleset
     ), f"fork '{blockchain_fixture.fork}' missing in hive ruleset"
@@ -141,10 +138,7 @@ def environment(blockchain_fixture: BlockchainFixtureCommon) -> dict:
 
 @pytest.fixture(scope="function")
 def buffered_genesis(client_genesis: dict) -> io.BufferedReader:
-    """
-    Create a buffered reader for the genesis block header of the current test
-    fixture.
-    """
+    """Create a buffered reader for the genesis block header of the current test fixture."""
     genesis_json = json.dumps(client_genesis)
     genesis_bytes = genesis_json.encode("utf-8")
     return io.BufferedReader(cast(io.RawIOBase, io.BytesIO(genesis_bytes)))

--- a/src/pytest_plugins/consume/hive_simulators/engine/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/engine/conftest.py
@@ -6,7 +6,7 @@ Configures the hive back-end & EL clients for each individual test execution.
 
 import io
 from pathlib import Path
-from typing import Dict, Mapping
+from typing import Mapping
 
 import pytest
 from hive.client import Client
@@ -18,19 +18,6 @@ from ethereum_test_rpc import EngineRPC
 from pytest_plugins.consume.consume import JsonSource
 
 TestCase = TestCaseIndexFile | TestCaseStream
-
-
-@pytest.fixture(scope="function")
-def environment(request: pytest.FixtureRequest) -> Dict:
-    """
-    For the Engine API simulations, we need that the port 8551 is ready on the client's side,
-    instead of the default 8545, because the first request is a forkchoice update.
-
-    We signal this to hive by adding the "HIVE_CHECK_LIVE_PORT" environment variable.
-    """
-    environment: Dict = request.getfixturevalue("environment")
-    environment["HIVE_CHECK_LIVE_PORT"] = "8551"
-    return environment
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
This is a suggestion for #1095. 

It adds the check live as a dedicated fixture alongside the existing `environment` fixture in order to keep the hive client  config in one place.

I verified that the variable is correctly propagated locally for #1095 and for this PR.