### PR TITLE
Add blob schedule docs

### DIFF
--- a/docs/consuming_tests/blockchain_test.md
+++ b/docs/consuming_tests/blockchain_test.md
@@ -80,6 +80,10 @@ Hash of the last valid block, or the genesis block hash if the list of blocks is
 
 Account allocation for verification after all the blocks have been processed.
 
+#### - `blobSchedule`: [`BlobSchedule`](./common_types.md#blobschedule-mappingforkforkblobschedule)
+
+Optional; present from Cancun on. Maps forks to their blob schedule configurations as defined by [EIP-7840](https://eips.ethereum.org/EIPS/eip-7840).
+
 #### - `sealEngine`: `str`
 
 Deprecated: Seal engine used to mine the blocks.

--- a/docs/consuming_tests/blockchain_test_engine.md
+++ b/docs/consuming_tests/blockchain_test_engine.md
@@ -63,9 +63,17 @@ Version of the `engine_forkchoiceUpdatedVX` directive to use to set the head of 
 
 Starting account allocation for the test. State root calculated from this allocation must match the one in the genesis block.
 
+#### - `lastblockhash`: [`Hash`](./common_types.md#hash)
+
+Hash of the last valid block, or the genesis block hash if the list of blocks is empty, or contains a single invalid block.
+
 #### - `post`: [`Alloc`](./common_types.md#alloc-mappingaddressaccount)
 
 Account allocation for verification after all the blocks have been processed.
+
+#### - `blobSchedule`: [`BlobSchedule`](./common_types.md#blobschedule-mappingforkforkblobschedule)
+
+Optional; present from Cancun on. Maps forks to their blob schedule configurations as defined by [EIP-7840](https://eips.ethereum.org/EIPS/eip-7840).
 
 ### `FixtureEngineNewPayload`
 

--- a/docs/consuming_tests/common_types.md
+++ b/docs/consuming_tests/common_types.md
@@ -82,6 +82,26 @@ Storage of the account.
 
 State allocation represented as a JSON object, where the keys are the addresses of the accounts, and the values are the accounts.
 
+### `BlobSchedule`: [`Mapping`](#mapping)`[`[`Fork`](#fork)`,`[`ForkBlobSchedule`](#forkblobschedule)`]`
+
+Maps forks to blob schedule configurations as defined by [EIP-7840](https://eips.ethereum.org/EIPS/eip-7840).
+
+### `ForkBlobSchedule`
+
+A fork blob schedule as defined by [EIP-7840](https://eips.ethereum.org/EIPS/eip-7840) as a JSON dictionary with the following entries:
+
+#### - `target`: [`ZeroPaddedHexNumber`](#zeropaddedhexnumber)
+
+The target blob count for a block.
+
+#### - `max`: [`ZeroPaddedHexNumber`](#zeropaddedhexnumber)
+
+The maximum possible blob count for a block.
+
+#### - `base_fee_update_fraction`: [`ZeroPaddedHexNumber`](#zeropaddedhexnumber)
+
+The blob base fee update fraction (adjusts the responsiveness of blob gas pricing per fork).
+
 ## Fork
 
 Fork type is represented as a JSON string that can be set to one of the following values:

--- a/docs/consuming_tests/state_test.md
+++ b/docs/consuming_tests/state_test.md
@@ -60,6 +60,10 @@ Transaction to be executed.
 
 Mapping of lists of post for verification per fork, where each element represents a single possible outcome of the transaction execution after being applied to the `pre`.
 
+#### - `blobSchedule`: [`BlobSchedule`](./common_types.md#blobschedule-mappingforkforkblobschedule)
+
+Optional; present from Cancun on. Maps forks to their blob schedule configurations as defined by [EIP-7840](https://eips.ethereum.org/EIPS/eip-7840).
+
 ### `FixtureEnvironment`
 
 #### - `currentCoinbase`: [`Address`](./common_types.md#address)


### PR DESCRIPTION
Adds the blob schedule types to the consume section of the docs that describe our fixture formats.
