### PR TITLE
fix(tests): [eip6780] avoid call fund address for unexpected triggering contract in execute mode

### DIFF
--- a/tests/cancun/eip6780_selfdestruct/test_selfdestruct.py
+++ b/tests/cancun/eip6780_selfdestruct/test_selfdestruct.py
@@ -693,14 +693,14 @@ def test_selfdestruct_pre_existing(
         - Different send-all recipient addresses: single, multiple, including self
         - Different initial balances for the self-destructing contract
     """
-    selfdestruct_contract_address = pre.deploy_contract(selfdestruct_code)
+    selfdestruct_contract_address = pre.deploy_contract(
+        selfdestruct_code, balance=selfdestruct_contract_initial_balance
+    )
     entry_code_storage = Storage()
 
     for i in range(len(sendall_recipient_addresses)):
         if sendall_recipient_addresses[i] == SELF_ADDRESS:
             sendall_recipient_addresses[i] = selfdestruct_contract_address
-    if selfdestruct_contract_initial_balance > 0:
-        pre.fund_address(selfdestruct_contract_address, selfdestruct_contract_initial_balance)
 
     # Create a dict to record the expected final balances
     sendall_final_balances = dict(
@@ -788,13 +788,6 @@ def test_selfdestruct_pre_existing(
             balance=balance,
             storage={0: call_times},
         )
-        # If the selfdestruct_contract_initial_balance > 0, means that the contract was called one
-        # more time, so the storage slot 0 should be more than 1
-        if selfdestruct_contract_initial_balance > 0:
-            post[selfdestruct_contract_address] = Account(
-                balance=balance,
-                storage={0: call_times + 1},
-            )
     else:
         post[selfdestruct_contract_address] = Account.NONEXISTENT  # type: ignore
 

--- a/tests/cancun/eip6780_selfdestruct/test_selfdestruct.py
+++ b/tests/cancun/eip6780_selfdestruct/test_selfdestruct.py
@@ -788,6 +788,13 @@ def test_selfdestruct_pre_existing(
             balance=balance,
             storage={0: call_times},
         )
+        # If the selfdestruct_contract_initial_balance > 0, means that the contract was called one
+        # more time, so the storage slot 0 should be more than 1
+        if selfdestruct_contract_initial_balance > 0:
+            post[selfdestruct_contract_address] = Account(
+                balance=balance,
+                storage={0: call_times + 1},
+            )
     else:
         post[selfdestruct_contract_address] = Account.NONEXISTENT  # type: ignore
 


### PR DESCRIPTION
## 🗒️ Description
```   
 if selfdestruct_contract_initial_balance > 0:
        pre.fund_address(selfdestruct_contract_address, selfdestruct_contract_initial_balance)
```
when selfdestruct_contract_initial_balance is >0, the contract will be called one time which make comparision when slot 0 is wrong. 

```
============================================================= test session starts ==============================================================
platform darwin -- Python 3.13.1, pytest-7.4.4, pluggy-1.5.0 -- /Users/son.ho/Backend/ronin-execution-spec-tests/.venv/bin/python
Generating fixtures for: Cancun
Only generating fixtures with stable/deployed forks: Specify an upcoming fork via --until=fork to add forks under development.
solc: 0.8.24
Start seed for EOA: 0xaf83d2077ff7e87fc12a8f0e5e10003e17313b130f84ae008a2ea682c54a6a40
cachedir: .pytest_cache
metadata: {'Python': '3.13.1', 'Platform': 'macOS-14.7.2-arm64-arm-64bit-Mach-O', 'Packages': {'pytest': '7.4.4', 'pluggy': '1.5.0'}, 'Plugins': {'html': '4.1.1', 'json-report': '1.5.0', 'metadata': '3.1.1', 'cov': '4.1.0', 'custom-report': '1.0.1', 'xdist': '3.6.1', 'typeguard': '4.3.0'}, 'Command-line args': '<code>fill -c pytest-execute.ini --fork=Cancun --rpc-endpoint=http://34.30.122.240:8545 --rpc-seed-key 0x7ca3c559a80bd88737050131609b57b88725b5aa3616b6561febedbc8a1fa8d1 --rpc-chain-id 2020 tests/cancun/eip6780_selfdestruct/test_selfdestruct.py::test_selfdestruct_pre_existing -s -v</code>', 'Tools': {'solc': '0.8.24'}, 'Senders': {}}
rootdir: /Users/son.ho/Backend/ronin-execution-spec-tests
configfile: pytest-execute.ini
plugins: html-4.1.1, json-report-1.5.0, metadata-3.1.1, cov-4.1.0, custom-report-1.0.1, xdist-3.6.1, typeguard-4.3.0
collected 9 items / 1 deselected / 8 selected

tests/cancun/eip6780_selfdestruct/test_selfdestruct.py::test_selfdestruct_pre_existing[fork_Cancun-transaction_post-selfdestruct_contract_initial_balance_100000-single_call] Starting EOA index: 0xaf83d2077ff7e87fc12a8f0e5e10003e17313b130f84ae008a2ea682c54a6a40
Deploying contract with gas limit: 153758
Deploying contract with gas limit: 122180
PASSEDUsed balance=0.000369696000100000

tests/cancun/eip6780_selfdestruct/test_selfdestruct.py::test_selfdestruct_pre_existing[fork_Cancun-transaction_post-selfdestruct_contract_initial_balance_100000-single_call_self] Deploying contract with gas limit: 113534
PASSEDUsed balance=0.000303658000100000

tests/cancun/eip6780_selfdestruct/test_selfdestruct.py::test_selfdestruct_pre_existing[fork_Cancun-transaction_post-selfdestruct_contract_initial_balance_100000-multiple_calls_single_sendall_recipient] Deploying contract with gas limit: 153758
Deploying contract with gas limit: 122180

PASSEDUsed balance=0.000407395000100001```
## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

