### PR TITLE
feat(fill): make fork cli args case-insensitive

### DIFF
--- a/src/pytest_plugins/forks/forks.py
+++ b/src/pytest_plugins/forks/forks.py
@@ -440,7 +440,7 @@ def pytest_configure(config: pytest.Config):
             return set()
         forks_str = config_str.split(",")
         for i in range(len(forks_str)):
-            forks_str[i] = forks_str[i].strip()
+            forks_str[i] = forks_str[i].strip().capitalize()
             if forks_str[i] == "Merge":
                 forks_str[i] = "Paris"
 


### PR DESCRIPTION
## 🗒️ Description
Previously, `fill` required capitalized fork names on the command-line, e.g.,
```
fill --from=London --until=Merge
```
Any deviation in case was considered an invalid fork.

This small change now allows users to specify:
```
fill --from=london --until=merge
fill --from=LONDON --until=merge
```

## 🔗 Related Issues
Came to mind while reviewing the fork logic in #1081.

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] ~~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~ skipped

