### PR TITLE
feat(tests): EOF - EIP-7620: verify RETURNCONTRACT does not overwrite containing contract

### DIFF
--- a/tests/osaka/eip7692_eof_v1/eip7620_eof_create/helpers.py
+++ b/tests/osaka/eip7692_eof_v1/eip7620_eof_create/helpers.py
@@ -18,12 +18,14 @@ slot_returndata_size = next(_slot)
 slot_max_depth = next(_slot)
 slot_call_or_create = next(_slot)
 slot_counter = next(_slot)
+slot_data_load = next(_slot)
 
 slot_last_slot = next(_slot)
 
 value_code_worked = 0x2015
 value_canary_should_not_change = 0x2019
 value_canary_to_be_overwritten = 0x2009
+value_long_value = b'abcdefghijklmnopqrstuvwxyz123456'
 
 smallest_runtime_subcontainer = Container.Code(code=Op.STOP, name="Runtime Subcontainer")
 

--- a/tests/osaka/eip7692_eof_v1/eip7620_eof_create/helpers.py
+++ b/tests/osaka/eip7692_eof_v1/eip7620_eof_create/helpers.py
@@ -25,7 +25,7 @@ slot_last_slot = next(_slot)
 value_code_worked = 0x2015
 value_canary_should_not_change = 0x2019
 value_canary_to_be_overwritten = 0x2009
-value_long_value = b'abcdefghijklmnopqrstuvwxyz123456'
+value_long_value = b"abcdefghijklmnopqrstuvwxyz123456"
 
 smallest_runtime_subcontainer = Container.Code(code=Op.STOP, name="Runtime Subcontainer")
 

--- a/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_eofcreate.py
+++ b/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_eofcreate.py
@@ -24,13 +24,13 @@ from .helpers import (
     slot_calldata,
     slot_code_worked,
     slot_create_address,
+    slot_data_load,
     slot_last_slot,
     slot_returndata_size,
     smallest_initcode_subcontainer,
     smallest_runtime_subcontainer,
     value_canary_to_be_overwritten,
     value_code_worked,
-    slot_data_load,
     value_long_value,
 )
 from .spec import EOFCREATE_FAILURE
@@ -99,9 +99,9 @@ def test_eofcreate_then_dataload(
                     + Op.STOP,
                 ),
                 Section.Container(
-                    container= small_auxdata_container,
+                    container=small_auxdata_container,
                 ),
-                Section.Data(data=value_long_value)
+                Section.Data(data=value_long_value),
             ],
         ),
         storage={slot_data_load: value_canary_to_be_overwritten},

--- a/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_eofcreate.py
+++ b/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_eofcreate.py
@@ -30,6 +30,8 @@ from .helpers import (
     smallest_runtime_subcontainer,
     value_canary_to_be_overwritten,
     value_code_worked,
+    slot_data_load,
+    value_long_value,
 )
 from .spec import EOFCREATE_FAILURE
 
@@ -54,7 +56,6 @@ def test_simple_eofcreate(
                 ),
                 Section.Container(container=smallest_initcode_subcontainer),
             ],
-            data=b"abcdef",
         ),
         storage={0: 0xB17D},  # a canary to be overwritten
     )
@@ -63,6 +64,54 @@ def test_simple_eofcreate(
         contract_address: Account(
             storage={
                 0: compute_eofcreate_address(contract_address, 0, smallest_initcode_subcontainer)
+            }
+        )
+    }
+    tx = Transaction(
+        to=contract_address,
+        gas_limit=10_000_000,
+        gas_price=10,
+        protected=False,
+        sender=sender,
+    )
+    state_test(env=env, pre=pre, post=post, tx=tx)
+
+
+def test_eofcreate_then_dataload(
+    state_test: StateTestFiller,
+    pre: Alloc,
+):
+    """Verifies that a contract returned with auxdata does not overwrite the parent data."""
+    env = Environment()
+    sender = pre.fund_eoa()
+    small_auxdata_container = Container(
+        sections=[
+            Section.Code(code=Op.RETURNCONTRACT[0](0, 32)),
+            Section.Container(container=smallest_runtime_subcontainer),
+        ],
+    )
+    contract_address = pre.deploy_contract(
+        code=Container(
+            sections=[
+                Section.Code(
+                    code=Op.SSTORE(0, Op.EOFCREATE[0](0, 0, 0, 0))
+                    + Op.SSTORE(slot_data_load, Op.DATALOAD(0))
+                    + Op.STOP,
+                ),
+                Section.Container(
+                    container= small_auxdata_container,
+                ),
+                Section.Data(data=value_long_value)
+            ],
+        ),
+        storage={slot_data_load: value_canary_to_be_overwritten},
+    )
+
+    post = {
+        contract_address: Account(
+            storage={
+                0: compute_eofcreate_address(contract_address, 0, small_auxdata_container),
+                slot_data_load: value_long_value,
             }
         )
     }


### PR DESCRIPTION

## 🗒️ Description
Test the case where adding auxdata to a subcontainer could result in the parent containers data section if the subcontainer were not copied.

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
