### PR TITLE
new(tests): extend tests for CALLF invalid section index

### DIFF
--- a/tests/osaka/eip7692_eof_v1/eip4750_functions/test_code_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip4750_functions/test_code_validation.py
@@ -130,19 +130,6 @@ INVALID: List[Container] = [
         validity_error=EOFException.INVALID_MAX_STACK_HEIGHT,
     ),
     Container(
-        name="oob_callf_1",
-        sections=[
-            Section.Code(
-                code=(Op.CALLF[2] + Op.STOP),
-            ),
-            Section.Code(
-                code=(Op.RETF),
-                code_outputs=0,
-            ),
-        ],
-        validity_error=EOFException.INVALID_CODE_SECTION_INDEX,
-    ),
-    Container(
         name="overflow_code_sections_1",
         sections=[
             Section.Code(
@@ -186,6 +173,52 @@ def test_eof_validity(
 ):
     """Test EOF container validation for features around EIP-4750 / Functions / Code Sections."""
     eof_test(data=container)
+
+
+@pytest.mark.parametrize(
+    "container",
+    [
+        Container(
+            name="callf1",  # EOF1I4750_0010
+            sections=[
+                Section.Code(
+                    Op.CALLF[1] + Op.STOP,
+                )
+            ],
+        ),
+        Container(
+            name="callf2",  # EOF1I0011
+            sections=[
+                Section.Code(
+                    Op.CALLF[2] + Op.STOP,
+                ),
+                Section.Code(
+                    Op.RETF,
+                    code_outputs=0,
+                ),
+            ],
+        ),
+        Container(
+            name="callf1_callf2",
+            sections=[
+                Section.Code(
+                    Op.CALLF[1] + Op.STOP,
+                ),
+                Section.Code(
+                    Op.CALLF[2] + Op.RETF,
+                    code_outputs=0,
+                ),
+            ],
+        ),
+    ],
+    ids=container_name,
+)
+def test_invalid_code_section_index(
+    eof_test: EOFTestFiller,
+    container: Container,
+):
+    """Test cases for CALLF instructions with invalid target code section index."""
+    eof_test(data=container, expect_exception=EOFException.INVALID_CODE_SECTION_INDEX)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## 🗒️ Description

It takes a single test case for `CALLF`'s invalid code section index to separate more specific test and add 2 more cases (one from ethereum/tests).

The same test case are going to be done later for `JUMPF`.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
