### PR TITLE
new(tests): tests for JUMPF invalid section index

### DIFF
--- a/tests/osaka/eip7692_eof_v1/eip6206_jumpf/test_jumpf_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip6206_jumpf/test_jumpf_validation.py
@@ -1,0 +1,58 @@
+"""EOF validation tests for JUMPF instruction."""
+
+import pytest
+
+from ethereum_test_tools import EOFException, EOFTestFiller
+from ethereum_test_tools.eof.v1 import Container, Section
+from ethereum_test_tools.vm.opcode import Opcodes as Op
+
+from .. import EOF_FORK_NAME
+
+REFERENCE_SPEC_GIT_PATH = "EIPS/eip-6206.md"
+REFERENCE_SPEC_VERSION = "2f365ea0cd58faa6e26013ea77ce6d538175f7d0"
+
+pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
+
+
+@pytest.mark.parametrize(
+    "container",
+    [
+        Container(
+            name="jumpf1",
+            sections=[
+                Section.Code(
+                    Op.JUMPF[1],
+                )
+            ],
+        ),
+        Container(
+            name="jumpf2",
+            sections=[
+                Section.Code(
+                    Op.JUMPF[2],
+                ),
+                Section.Code(
+                    Op.STOP,
+                ),
+            ],
+        ),
+        Container(
+            name="jumpf1_jumpf2",
+            sections=[
+                Section.Code(
+                    Op.JUMPF[1],
+                ),
+                Section.Code(
+                    Op.JUMPF[2],
+                ),
+            ],
+        ),
+    ],
+    ids=lambda container: container.name,
+)
+def test_invalid_code_section_index(
+    eof_test: EOFTestFiller,
+    container: Container,
+):
+    """Test cases for JUMPF instructions with invalid target code section index."""
+    eof_test(data=container, expect_exception=EOFException.INVALID_CODE_SECTION_INDEX)


### PR DESCRIPTION

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
