### PR TITLE
fix(fw): fix Address padding options

### DIFF
--- a/src/ethereum_test_base_types/base_types.py
+++ b/src/ethereum_test_base_types/base_types.py
@@ -298,10 +298,14 @@ class Address(FixedSizeBytes[20]):  # type: ignore
     label: str | None = None
 
     def __new__(
-        cls, input_bytes: "FixedSizeBytesConvertible | Address", *, label: str | None = None
+        cls,
+        input_bytes: "FixedSizeBytesConvertible | Address",
+        *args,
+        label: str | None = None,
+        **kwargs,
     ):
         """Create a new Address object with an optional label."""
-        instance = super(Address, cls).__new__(cls, input_bytes)
+        instance = super(Address, cls).__new__(cls, input_bytes, *args, **kwargs)
         if isinstance(input_bytes, Address) and label is None:
             instance.label = input_bytes.label
         else:

--- a/src/ethereum_test_base_types/tests/test_base_types.py
+++ b/src/ethereum_test_base_types/tests/test_base_types.py
@@ -135,6 +135,16 @@ def test_comparisons(a: Any, b: Any, equal: bool):
         assert not a == b
 
 
+def test_hash_padding():
+    """Test Hash objects are padded correctly."""
+    assert Hash(b"\x01", left_padding=True) == (
+        "0x0000000000000000000000000000000000000000000000000000000000000001"
+    )
+    assert Hash(b"\x02", right_padding=True) == (
+        "0x0200000000000000000000000000000000000000000000000000000000000000"
+    )
+
+
 def test_address_padding():
     """Test that addresses are padded correctly."""
     assert Address(b"\x01", left_padding=True) == Address(

--- a/src/ethereum_test_base_types/tests/test_base_types.py
+++ b/src/ethereum_test_base_types/tests/test_base_types.py
@@ -135,6 +135,16 @@ def test_comparisons(a: Any, b: Any, equal: bool):
         assert not a == b
 
 
+def test_address_padding():
+    """Test that addresses are padded correctly."""
+    assert Address(b"\x01", left_padding=True) == Address(
+        "0x0000000000000000000000000000000000000001"
+    )
+    assert Address(b"\x80", right_padding=True) == Address(
+        "0x8000000000000000000000000000000000000000"
+    )
+
+
 @pytest.mark.parametrize(
     "s, expected",
     [


### PR DESCRIPTION
## 🗒️ Description

Pass all aguments to Address() to the super constructor. This fixes ability to create addresses out of shorter bytes, e.g. `Address(my_bytes, left_padding=True)`.

## 🔗 Related Issues
Solves an issue introduced by #1010.

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- ~~[ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~ skipped

