### PR TITLE
new(tests): CALLF with truncated immediate bytes

### DIFF
--- a/converted-ethereum-tests.txt
+++ b/converted-ethereum-tests.txt
@@ -16,6 +16,7 @@ EOFTests/EIP3670/validInvalid.json
 EOFTests/EIP4200/validInvalid.json
 EOFTests/efValidation/EOF1_embedded_container_.json
 EOFTests/efValidation/EOF1_eofcreate_valid_.json
+EOFTests/efValidation/EOF1_callf_truncated_.json
 EOFTests/efValidation/EOF1_valid_rjump_.json
 EOFTests/efValidation/EOF1_valid_rjumpi_.json
 EOFTests/efValidation/EOF1_valid_rjumpv_.json

--- a/tests/osaka/eip7692_eof_v1/eip4750_functions/test_code_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip4750_functions/test_code_validation.py
@@ -179,6 +179,59 @@ def test_eof_validity(
     "container",
     [
         Container(
+            name="imm0",
+            sections=[
+                Section.Code(
+                    code=Op.CALLF,
+                )
+            ],
+            validity_error=EOFException.TRUNCATED_INSTRUCTION,
+        ),
+        Container(
+            name="imm1",
+            sections=[
+                Section.Code(
+                    code=Op.CALLF + Op.STOP,
+                )
+            ],
+            validity_error=EOFException.TRUNCATED_INSTRUCTION,
+        ),
+        Container(
+            name="imm_from_next_section",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0 + Op.PUSH0 + Op.CALLF[1] + Op.STOP,
+                ),
+                Section.Code(
+                    code=Op.CALLF + Op.STOP,  # would be valid with "02" + Op.RETF.
+                    code_inputs=2,
+                    code_outputs=1,
+                    max_stack_height=2,
+                ),
+                Section.Code(
+                    code=Op.SUB + Op.RETF,  # SUB (0x02) can be confused with CALLF[2].
+                    code_inputs=2,
+                    code_outputs=1,
+                    max_stack_height=2,
+                ),
+            ],
+            validity_error=EOFException.TRUNCATED_INSTRUCTION,
+        ),
+    ],
+    ids=container_name,
+)
+def test_callf_truncated_immediate(
+    eof_test: EOFTestFiller,
+    container: Container,
+):
+    """Test cases for CALLF instructions with truncated immediate bytes."""
+    eof_test(data=container, expect_exception=EOFException.TRUNCATED_INSTRUCTION)
+
+
+@pytest.mark.parametrize(
+    "container",
+    [
+        Container(
             name="callf1",  # EOF1I4750_0010
             sections=[
                 Section.Code(

--- a/tests/osaka/eip7692_eof_v1/eof_tracker.md
+++ b/tests/osaka/eip7692_eof_v1/eof_tracker.md
@@ -151,7 +151,7 @@
 
 - [ ] Valid CALLFs  (ethereum/tests: ./src/EOFTestsFiller/efExample/validInvalidFiller.yml)
 - [ ] CALLFs to non-existing sections  (ethereum/tests: ./src/EOFTestsFiller/efExample/validInvalidFiller.yml src/EOFTestsFiller/efValidation/callf_invalid_code_section_index_Copier.json src/EOFTestsFiller/EIP4750/validInvalidFiller.yml)
-- [ ] Truncated CALLF immediate (ethereum/tests: ./src/EOFTestsFiller/efValidation/EOF1_callf_truncated_Copier.json src/EOFTestsFiller/EIP4750/validInvalidFiller.yml)
+- [x] Truncated CALLF immediate ([`tests/osaka/eip7692_eof_v1/eip4750_functions/test_code_validation.py::test_callf_truncated_immediate`](./eip4750_functions/test_code_validation/test_callf_truncated_immediate.md))
 - [ ] Unreachable code sections (ethereum/tests: src/EOFTestsFiller/efValidation/unreachable_code_sections_Copier.json)
 - [ ] Sections reachable from other sections, but not reachable from section 0 (ethereum/tests: src/EOFTestsFiller/efValidation/unreachable_code_sections_Copier.json)
 - [ ] Unreachable code section that calls itself with JUMPF


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
