### PR TITLE
new(tests): EOF - EIP-7834 - metadata section (draft)

### DIFF
--- a/src/ethereum_test_types/eof/v1/__init__.py
+++ b/src/ethereum_test_types/eof/v1/__init__.py
@@ -41,6 +41,7 @@ class SectionKind(IntEnum):
     CODE = 2
     CONTAINER = 3
     DATA = 4
+    METADATA = 5
 
     def __str__(self) -> str:
         """Return string representation of the section kind."""
@@ -281,6 +282,12 @@ class Section(CopyValidateModel):
         kwargs.pop("kind", None)
         return cls(kind=SectionKind.DATA, data=data, **kwargs)
 
+    @classmethod
+    def Metadata(cls, data: BytesConvertible = b"", **kwargs) -> "Section":  # noqa: N802
+        """Create new metadata section with the specified data."""
+        kwargs.pop("kind", None)
+        return cls(kind=SectionKind.METADATA, data=data, **kwargs)
+
 
 class Container(CopyValidateModel):
     """Class that represents an EOF V1 container."""
@@ -324,10 +331,8 @@ class Container(CopyValidateModel):
     auto_sort_sections: AutoSection = AutoSection.AUTO
     """
     Automatically sort sections for the header and body:
-    Headers: type section first, all code sections, container sections, last
-                data section(s)
-    Body: type section first, all code sections, data section(s), last
-                container sections
+    Order: type section first, all code sections, container sections, metadata section,
+                last data section
     """
     skip_join_concurrent_sections_in_header: bool = False
     """

--- a/tests/osaka/eip7692_eof_v1/eip7834_metadata_section/__init__.py
+++ b/tests/osaka/eip7692_eof_v1/eip7834_metadata_section/__init__.py
@@ -1,0 +1,5 @@
+"""
+abstract: Test cases for [EIP-7834: Separate Metadata Section for EOF](https://eips.ethereum.org/EIPS/eip-7834)
+    EIP-7834 Introduces a new separate metadata section to the Ethereum Object Format (EOF) that
+    is unreachable by the code, and any changes to which does not affect the code.
+"""  # noqa: E501

--- a/tests/osaka/eip7692_eof_v1/eip7834_metadata_section/test_code_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip7834_metadata_section/test_code_validation.py
@@ -1,0 +1,353 @@
+"""EOF V1 Code Validation tests."""
+
+from typing import List
+
+import pytest
+
+from ethereum_test_tools import EOFException, EOFTestFiller
+from ethereum_test_tools.eof.v1 import AutoSection, Container, Section, SectionKind
+from ethereum_test_tools.eof.v1.constants import MAX_INITCODE_SIZE
+from ethereum_test_tools.vm.opcode import Opcodes as Op
+
+from .. import EOF_FORK_NAME
+
+REFERENCE_SPEC_GIT_PATH = "EIPS/eip-7834.md"
+REFERENCE_SPEC_VERSION = "821ffeb8c424b038984be2b7d373a5ef2eb33fa2"
+
+pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
+
+smallest_runtime_subcontainer = Container(
+    name="Runtime Subcontainer",
+    sections=[
+        Section.Code(code=Op.STOP),
+    ],
+)
+
+VALID: List[Container] = [
+    Container(
+        name="small_metadata_section",
+        sections=[
+            Section.Code(
+                code=Op.STOP,
+            ),
+            Section.Metadata(data="1122334455667788" * 4),
+        ],
+        # TODO: workaround until data section becomes kind 0xff
+        auto_sort_sections=AutoSection.NONE,
+    ),
+    Container(
+        name="large_data_section",
+        sections=[
+            Section.Code(
+                code=Op.STOP,
+            ),
+            Section.Metadata(data="1122334455667788" * 3 * 1024),
+        ],
+        # TODO: workaround until data section becomes kind 0xff
+        auto_sort_sections=AutoSection.NONE,
+    ),
+    Container(
+        name="max_data_section",
+        sections=[
+            Section.Code(code=Op.STOP),
+            # Hits the 49152 bytes limit for the entire container
+            # Need to subtract an empty header size for the metadata section
+            Section.Metadata(
+                data=b"\x00" * (MAX_INITCODE_SIZE - len(smallest_runtime_subcontainer) - 3)
+            ),
+        ],
+        # TODO: workaround until data section becomes kind 0xff
+        auto_sort_sections=AutoSection.NONE,
+    ),
+    Container(
+        name="DATALOADN_zero",
+        sections=[
+            Section.Code(
+                code=Op.DATALOADN[0] + Op.POP + Op.STOP,
+            ),
+            Section.Metadata(data="aaffcc" * 16),
+            Section.Data(data="1122334455667788" * 16),
+        ],
+        # TODO: workaround until data section becomes kind 0xff
+        auto_sort_sections=AutoSection.NONE,
+    ),
+    Container(
+        name="DATALOADN_middle",
+        sections=[
+            Section.Code(
+                code=Op.DATALOADN[16] + Op.POP + Op.STOP,
+            ),
+            Section.Metadata(data="aaffcc" * 16),
+            Section.Data(data="1122334455667788" * 16),
+        ],
+        # TODO: workaround until data section becomes kind 0xff
+        auto_sort_sections=AutoSection.NONE,
+    ),
+    Container(
+        name="DATALOADN_edge",
+        sections=[
+            Section.Code(
+                code=Op.DATALOADN[128 - 32] + Op.POP + Op.STOP,
+            ),
+            Section.Metadata(data="aaffcc" * 16),
+            Section.Data(data="1122334455667788" * 16),
+        ],
+        # TODO: workaround until data section becomes kind 0xff
+        auto_sort_sections=AutoSection.NONE,
+    ),
+]
+
+INVALID: List[Container] = [
+    Container(
+        name="empty_metadata_section",
+        sections=[
+            Section.Code(
+                code=Op.STOP,
+            ),
+            Section.Metadata(data=""),
+        ],
+        # TODO: workaround until data section becomes kind 0xff
+        auto_sort_sections=AutoSection.NONE,
+        validity_error=EOFException.ZERO_SECTION_SIZE,
+    ),
+    Container(
+        name="empty_metadata_section_declared_with_size",
+        sections=[
+            Section.Code(
+                code=Op.STOP,
+            ),
+            Section.Metadata(data="", custom_size=1),
+        ],
+        # TODO: workaround until data section becomes kind 0xff
+        auto_sort_sections=AutoSection.NONE,
+        validity_error=EOFException.INVALID_SECTION_BODIES_SIZE,
+    ),
+    Container(
+        name="nonempty_metadata_section_declared_with_0_size",
+        sections=[
+            Section.Code(
+                code=Op.STOP,
+            ),
+            Section.Metadata(data="11", custom_size=0),
+        ],
+        # TODO: workaround until data section becomes kind 0xff
+        auto_sort_sections=AutoSection.NONE,
+        validity_error=EOFException.ZERO_SECTION_SIZE,
+    ),
+    Container(
+        name="DATALOADN_max_empty_data",
+        sections=[
+            Section.Code(
+                code=Op.DATALOADN[0xFFFF - 32] + Op.POP + Op.STOP,
+            ),
+            Section.Metadata(data="aaffcc" * 16),
+        ],
+        # TODO: workaround until data section becomes kind 0xff
+        auto_sort_sections=AutoSection.NONE,
+        validity_error=EOFException.INVALID_DATALOADN_INDEX,
+    ),
+    Container(
+        name="DATALOADN_max_small_data",
+        sections=[
+            Section.Code(
+                code=Op.DATALOADN[0xFFFF - 32] + Op.POP + Op.STOP,
+            ),
+            Section.Metadata(data="aaffcc" * 16),
+            Section.Data(data="1122334455667788" * 16),
+        ],
+        # TODO: workaround until data section becomes kind 0xff
+        auto_sort_sections=AutoSection.NONE,
+        validity_error=EOFException.INVALID_DATALOADN_INDEX,
+    ),
+    Container(
+        name="DATALOADN_max_half_data",
+        sections=[
+            Section.Code(
+                code=Op.DATALOADN[0xFFFF - 32] + Op.POP + Op.STOP,
+            ),
+            Section.Metadata(data="aaffcc" * 16),
+            Section.Data(data=("1122334455667788" * 4 * 1024)[2:]),
+        ],
+        # TODO: workaround until data section becomes kind 0xff
+        auto_sort_sections=AutoSection.NONE,
+        validity_error=EOFException.INVALID_DATALOADN_INDEX,
+    ),
+    Container(
+        name="data_section_over_container_limit",
+        sections=[
+            Section.Code(code=Op.STOP),
+            # Over the 49152 bytes limit for the entire container
+            # Need to subtract an empty header size for the metadata section
+            Section.Metadata(
+                data=(b"12345678" * 6 * 1024)[len(smallest_runtime_subcontainer) + 3 - 1 :]
+            ),
+        ],
+        # TODO: workaround until data section becomes kind 0xff
+        auto_sort_sections=AutoSection.NONE,
+        validity_error=EOFException.CONTAINER_SIZE_ABOVE_LIMIT,
+    ),
+    Container(
+        name="missing_data_section",
+        sections=[
+            Section.Code(
+                code=Op.STOP,
+            ),
+            Section.Metadata(data="11"),
+        ],
+        auto_data_section=False,
+        auto_sort_sections=AutoSection.NONE,
+        validity_error=EOFException.MISSING_DATA_SECTION,
+    ),
+    Container(
+        name="missing_data_section_with_subcontainer",
+        sections=[
+            Section.Code(
+                code=Op.STOP,
+            ),
+            Section.Metadata(data="11"),
+            Section.Container(container=Container()),
+        ],
+        auto_data_section=False,
+        auto_sort_sections=AutoSection.NONE,
+        validity_error=EOFException.MISSING_DATA_SECTION,
+    ),
+    Container(
+        name="missing_code_section",
+        sections=[
+            Section(kind=SectionKind.TYPE, data="0004"),
+            Section.Metadata(data="11"),
+        ],
+        auto_sort_sections=AutoSection.NONE,
+        validity_error=EOFException.MISSING_CODE_HEADER,
+    ),
+    Container(
+        name="missing_type_section",
+        sections=[
+            Section.Code(
+                code=Op.STOP,
+            ),
+            Section.Metadata(data="11"),
+        ],
+        auto_type_section=AutoSection.NONE,
+        auto_sort_sections=AutoSection.NONE,
+        validity_error=EOFException.MISSING_TYPE_HEADER,
+    ),
+    Container(
+        name="metadata_at_pos_0",
+        sections=[
+            Section.Metadata(data="11"),
+            Section(kind=SectionKind.TYPE, data="0004"),
+            Section.Code(
+                code=Op.STOP,
+            ),
+        ],
+        auto_type_section=AutoSection.NONE,
+        auto_sort_sections=AutoSection.NONE,
+        validity_error=EOFException.MISSING_TYPE_HEADER,
+    ),
+    Container(
+        name="metadata_at_pos_1",
+        sections=[
+            Section(kind=SectionKind.TYPE, data="0004"),
+            Section.Metadata(data="11"),
+            Section.Code(
+                code=Op.STOP,
+            ),
+        ],
+        auto_type_section=AutoSection.NONE,
+        auto_sort_sections=AutoSection.NONE,
+        validity_error=EOFException.MISSING_CODE_HEADER,
+    ),
+    Container(
+        name="metadata_before_subcontainer",
+        sections=[
+            Section.Code(
+                code=Op.STOP,
+            ),
+            Section.Metadata(data="11"),
+            Section.Container(container=Container()),
+        ],
+        auto_sort_sections=AutoSection.NONE,
+        validity_error=EOFException.MISSING_DATA_SECTION,
+    ),
+    Container(
+        name="metadata_last",
+        sections=[
+            Section(kind=SectionKind.TYPE, data="0004"),
+            Section.Code(
+                code=Op.STOP,
+            ),
+            Section.Data(data=""),
+            Section.Metadata(data="11"),
+        ],
+        auto_data_section=False,
+        auto_sort_sections=AutoSection.NONE,
+        validity_error=EOFException.MISSING_TERMINATOR,
+    ),
+    Container(
+        name="metadata_last_with_subcontainer",
+        sections=[
+            Section.Code(
+                code=Op.STOP,
+            ),
+            Section.Container(container=Container()),
+            Section.Data(data=""),
+            Section.Metadata(data="11"),
+        ],
+        auto_data_section=False,
+        auto_sort_sections=AutoSection.NONE,
+        validity_error=EOFException.MISSING_TERMINATOR,
+    ),
+]
+
+# FIXME: subcontainers (valid), multi code section, multi subcontainers, metadata in subcontainer
+# FIXME: multiple metadata section headers
+
+
+def container_name(c: Container):
+    """Return the name of the container for use in pytest ids."""
+    if hasattr(c, "name"):
+        return c.name
+    else:
+        return c.__class__.__name__
+
+
+@pytest.mark.parametrize(
+    "container",
+    VALID,
+    ids=container_name,
+)
+def test_legacy_initcode_valid_eof_v1_contract(
+    eof_test: EOFTestFiller,
+    container: Container,
+):
+    """
+    Test creating various types of valid EOF V1 contracts using legacy
+    initcode and a contract creating transaction.
+    """
+    assert (
+        container.validity_error is None
+    ), f"Valid container with validity error: {container.validity_error}"
+    eof_test(
+        data=container,
+    )
+
+
+@pytest.mark.parametrize(
+    "container",
+    INVALID,
+    ids=container_name,
+)
+def test_legacy_initcode_invalid_eof_v1_contract(
+    eof_test: EOFTestFiller,
+    container: Container,
+):
+    """
+    Test creating various types of valid EOF V1 contracts using legacy
+    initcode and a contract creating transaction.
+    """
+    assert container.validity_error is not None, "Invalid container without validity error"
+    eof_test(
+        data=container,
+        expect_exception=container.validity_error,
+    )

--- a/tests/osaka/eip7692_eof_v1/eip7834_metadata_section/test_data_opcodes.py
+++ b/tests/osaka/eip7692_eof_v1/eip7834_metadata_section/test_data_opcodes.py
@@ -1,0 +1,130 @@
+"""Execution of DATA* opcodes within EOF V1 containers tests _containing metadata_."""
+
+# IMPORTANT NOTICE: it is preferred for execution tests concerning the metadata section be
+# generated automatically via a test marker, since the presence of a metadata section doesn't
+# impact code execution in almost any way (exception being gas consumed and limits observed when
+# metadata is part of initcode/deployed code).
+
+# TODO: remove this test once the marker is functional.
+
+import pytest
+
+from ethereum_test_tools import Account, Alloc, Environment, StateTestFiller, Transaction
+from ethereum_test_tools.eof.v1 import AutoSection, Container, Section
+from ethereum_test_tools.vm.opcode import Opcodes as Op
+
+from .. import EOF_FORK_NAME
+
+REFERENCE_SPEC_GIT_PATH = "EIPS/eip-7834.md"
+REFERENCE_SPEC_VERSION = "821ffeb8c424b038984be2b7d373a5ef2eb33fa2"
+
+pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
+
+
+def create_data_test(offset: int, datasize: int):
+    """Generate data load operators test cases based on load offset and data section size."""
+    data = b"".join(i.to_bytes(length=2, byteorder="big") for i in range(1, datasize // 2 + 1))
+    assert len(data) == datasize
+    overhang = min(32, offset + 32 - datasize)
+    answer = data[offset : offset + 32] if overhang <= 0 else data[offset:] + b"\x00" * overhang
+    dataloadn_op = Op.DATALOADN[offset] if overhang <= 0 else Op.PUSH32[answer]
+
+    return (
+        Container(
+            sections=[
+                Section.Code(
+                    code=(
+                        Op.CALLF[1]
+                        + Op.CALLF[2]
+                        + Op.CALLF[3]
+                        + Op.CALLF[4]
+                        + Op.SSTORE(0, 1)
+                        + Op.STOP
+                    ),
+                ),
+                Section.Code(
+                    code=(Op.DATALOAD(offset) + Op.PUSH1(1) + Op.SSTORE + Op.RETF),
+                    code_inputs=0,
+                    code_outputs=0,
+                ),
+                Section.Code(
+                    code=(dataloadn_op + Op.PUSH1(2) + Op.SSTORE + Op.RETF),
+                    code_inputs=0,
+                    code_outputs=0,
+                ),
+                Section.Code(
+                    code=(Op.DATASIZE + Op.PUSH1(3) + Op.SSTORE + Op.RETF),
+                    code_inputs=0,
+                    code_outputs=0,
+                ),
+                Section.Code(
+                    code=(Op.DATACOPY(0, offset, 32) + Op.SSTORE(4, Op.MLOAD(0)) + Op.RETF),
+                    code_inputs=0,
+                    code_outputs=0,
+                ),
+                Section.Metadata(data="1e1e4b4bef"),
+                Section.Data(data),
+            ],
+            # TODO: workaround until data section becomes kind 0xff
+            auto_sort_sections=AutoSection.NONE,
+        ),
+        {0: 1, 1: answer, 2: answer, 3: datasize, 4: answer},
+    )
+
+
+@pytest.mark.parametrize(
+    ["offset", "datasize"],
+    [
+        pytest.param(0, 0, id="empty_zero"),
+        pytest.param(0, 2, id="short_zero"),
+        pytest.param(0, 32, id="exact_zero"),
+        pytest.param(0, 64, id="large_zero"),
+        pytest.param(32, 0, id="empty_32"),
+        pytest.param(32, 34, id="short_32"),
+        pytest.param(32, 64, id="exact_32"),
+        pytest.param(32, 96, id="large_32"),
+        pytest.param(0x5BFE, 0, id="empty_23k"),
+        pytest.param(0x5BFE, 0x5C00, id="short_23k"),
+        pytest.param(0x5BE0, 0x5D00, id="exact_23k"),
+        pytest.param(0x2345, 0x5C00, id="large_23k"),
+        pytest.param(2**16 - 1, 32, id="u16_max"),
+        pytest.param(2**16, 32, id="u16_max_plus_1"),
+        pytest.param(2**32 - 1, 32, id="u32_max"),
+        pytest.param(2**32, 32, id="u32_max_plus_1"),
+        pytest.param(2**64 - 1, 32, id="u64_max"),
+        pytest.param(2**64, 32, id="u64_max_plus_1"),
+    ],
+)
+def test_data_section_succeed(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    offset: int,
+    datasize: int,
+):
+    """Test simple contracts that are simply expected to succeed on call."""
+    env = Environment()
+
+    (container, expected_storage) = create_data_test(offset, datasize)
+    callee_contract = pre.deploy_contract(code=container)
+    entry_point = pre.deploy_contract(
+        Op.SSTORE(0, Op.DELEGATECALL(Op.GAS, callee_contract, 0, 0, 0, 0)) + Op.STOP()
+    )
+    sender = pre.fund_eoa()
+
+    tx = Transaction(
+        to=entry_point,
+        gas_limit=50000000,
+        gas_price=10,
+        protected=False,
+        data="",
+        sender=sender,
+    )
+
+    post = {entry_point: Account(storage=expected_storage)}
+
+    state_test(
+        env=env,
+        pre=pre,
+        post=post,
+        tx=tx,
+    )


### PR DESCRIPTION
## 🗒️ Description

A couple of example tests for the proposed https://eips.ethereum.org/EIPS/eip-7834 - metadata sections. Not intended to merge but just for future reference.

As discussed on the EOF call, the plan would be to mass-add execution tests by adding a special marker which injects a metadata section into containers, which should not impact execution and the test can proceed as it originally did.

Paired with a spike in `evmone`, which I'll have gh reference :point_down:  soon.

## 🔗 Related Issues
NA

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
