### PR TITLE
fix(tests): fix address padding in extcall tests

### DIFF
--- a/tests/osaka/eip7692_eof_v1/eip7069_extcall/test_address_space_extension.py
+++ b/tests/osaka/eip7692_eof_v1/eip7069_extcall/test_address_space_extension.py
@@ -69,7 +69,7 @@ def test_address_space_extension(
     env = Environment()
 
     ase_address = len(target_address) > 20
-    stripped_address = target_address[-20:] if ase_address else target_address
+    stripped_address = Address(target_address[-20:], left_padding=True)
     if ase_address and target_address[0] == b"00":
         raise ValueError("Test instrumentation requires target addresses trim leading zeros")
 
@@ -125,16 +125,16 @@ def test_address_space_extension(
             # add no account
             pass
         case "EOA":
-            pre.fund_address(Address(stripped_address), 10**18)
+            pre.fund_address(stripped_address, 10**18)
             # TODO: we could use pre.fund_eoa here with nonce!=0.
         case "LegacyContract":
-            pre[Address(stripped_address)] = Account(
+            pre[stripped_address] = Account(
                 code=Op.MSTORE(0, Op.ADDRESS) + Op.RETURN(0, 32),
                 balance=0,
                 nonce=0,
             )
         case "EOFContract":
-            pre[Address(stripped_address)] = Account(
+            pre[stripped_address] = Account(
                 code=Container(
                     sections=[
                         Section.Code(


### PR DESCRIPTION
## 🗒️ Description
Simplify and properly convert bytes to `Address` using `left_padding`.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
