### PR TITLE
feat(fw): allow adding verbatim bytes to Bytecode

### DIFF
--- a/src/ethereum_test_vm/bytecode.py
+++ b/src/ethereum_test_vm/bytecode.py
@@ -118,7 +118,7 @@ class Bytecode:
                 and self.max_stack_height == other.max_stack_height
                 and self.min_stack_height == other.min_stack_height
             )
-        if isinstance(other, SupportsBytes):
+        if isinstance(other, SupportsBytes) or isinstance(other, bytes):
             return bytes(self) == bytes(other)
         raise NotImplementedError(f"Unsupported type for comparison: {type(other)}")
 

--- a/src/ethereum_test_vm/bytecode.py
+++ b/src/ethereum_test_vm/bytecode.py
@@ -134,11 +134,18 @@ class Bytecode:
             )
         )
 
-    def __add__(self, other: "Bytecode | int | None") -> "Bytecode":
+    def __add__(self, other: "Bytecode | bytes | int | None") -> "Bytecode":
         """Concatenate the bytecode representation with another bytecode object."""
         if other is None or (isinstance(other, int) and other == 0):
             # Edge case for sum() function
             return self
+
+        if isinstance(other, bytes):
+            c = Bytecode(self)
+            c._bytes_ += other
+            c._name_ = ""
+            return c
+
         assert isinstance(other, Bytecode), "Can only concatenate Bytecode instances"
         # Figure out the stack height after executing the two opcodes.
         a_pop, a_push = self.popped_stack_items, self.pushed_stack_items

--- a/src/ethereum_test_vm/tests/test_vm.py
+++ b/src/ethereum_test_vm/tests/test_vm.py
@@ -413,15 +413,17 @@ def test_opcode_comparison():
     assert Op.ADD != Op.STOP
     assert Op.ADD > Op.STOP
 
-def test_bytecode_concatenation_with_bytes():
-    """Test that the bytecode can be concatenated with bytes.
-    Bytes work as verbatim code and don't affect the bytecode properties."""
 
-    base = Op.PUSH1[0xff] + Op.NOT
+def test_bytecode_concatenation_with_bytes():
+    """
+    Test that the bytecode can be concatenated with bytes.
+    Bytes work as verbatim code and don't affect the bytecode properties.
+    """
+    base = Op.PUSH1[0xFF] + Op.NOT
     assert str(base) == ""
 
     code = base + b"\x01\x02"
-    assert code == bytes([0x60, 0xff, 0x19, 0x01, 0x02])
+    assert code == bytes([0x60, 0xFF, 0x19, 0x01, 0x02])
 
     assert str(code) == ""
     assert code.popped_stack_items == code.popped_stack_items

--- a/src/ethereum_test_vm/tests/test_vm.py
+++ b/src/ethereum_test_vm/tests/test_vm.py
@@ -412,3 +412,20 @@ def test_opcode_comparison():
     assert Op.ADD == Op.ADD
     assert Op.ADD != Op.STOP
     assert Op.ADD > Op.STOP
+
+def test_bytecode_concatenation_with_bytes():
+    """Test that the bytecode can be concatenated with bytes.
+    Bytes work as verbatim code and don't affect the bytecode properties."""
+
+    base = Op.PUSH1[0xff] + Op.NOT
+    assert str(base) == ""
+
+    code = base + b"\x01\x02"
+    assert code == bytes([0x60, 0xff, 0x19, 0x01, 0x02])
+
+    assert str(code) == ""
+    assert code.popped_stack_items == code.popped_stack_items
+    assert code.pushed_stack_items == code.pushed_stack_items
+    assert code.max_stack_height == code.max_stack_height
+    assert code.min_stack_height == code.min_stack_height
+    assert code.terminating == code.terminating

--- a/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjump.py
+++ b/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjump.py
@@ -116,7 +116,7 @@ def test_rjump_truncated_rjump_2(
 ):
     """EOF1I4200_0002 (Invalid) EOF code containing truncated RJUMP."""
     eof_test(
-        data=Container.Code(Op.RJUMP + Op.STOP),
+        data=Container.Code(Op.RJUMP + b"\x00"),
         expect_exception=EOFException.TRUNCATED_INSTRUCTION,
     )
 

--- a/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpi.py
+++ b/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpi.py
@@ -300,7 +300,7 @@ def test_rjumpi_truncated_2(
         data=Container(
             sections=[
                 Section.Code(
-                    code=Op.PUSH1(0) + Op.RJUMPI + Op.STOP,
+                    code=Op.PUSH1(0) + Op.RJUMPI + b"\x00",
                 )
             ],
         ),


### PR DESCRIPTION
## 🗒️ Description

This provides a basic requested feature to allow concatenating `Bytecode` with verbatim `bytes`.
This implementation overload the `__add__` and make the basic use case work.
However, this is not very consistent. E.g. 
- `code + b"\x00"` means something different than `code + Bytecode(b"\x00")`
- `Bytecode() + b"\x00"` works in places where `Bytecode()` is expected but `b"\x00"` don't.

The reason this is not a complete solution is that `Bytecode()` already has a constructor from `bytes` but its purpose is different and unknown to me. We should consider changing the semantic of conversion from bytes to `Bytecode()` by just copying the bytes.

There is one more option for handling truncated opcode immediate bytes: take verbatim bytes from `[]`, e.g. `Op.PUSH3[b"\x00"]`. This currently compiles, but `Bytecode` also tries to be smart here and extends the provided bytes to the desired length. I'm not 100% sure what it does but I couldn't built a code with truncated immediates this way. However, there is one example that seems to be working: https://github.com/ethereum/execution-spec-tests/blob/ca912404cf7d8e95c7b06c3a5adcac4d37d7fbce/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py#L273

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
