### PR TITLE
new(tests): add one more CALLF execution test

### DIFF
--- a/tests/osaka/eip7692_eof_v1/eip4750_functions/test_callf_execution.py
+++ b/tests/osaka/eip7692_eof_v1/eip4750_functions/test_callf_execution.py
@@ -158,6 +158,39 @@ def test_callf_fibonacci(eof_state_test: EOFStateTestFiller, n, result):
                 ),
             ],
         ),
+        Container(
+            name="multiple_sections_of_different_types",  # EOF1V4750_0005
+            sections=[
+                Section.Code(
+                    Op.PUSH0
+                    + Op.CALLF[1]
+                    + Op.CALLF[2]
+                    + Op.PUSH0
+                    + Op.CALLF[3]
+                    + Op.SSTORE
+                    + Op.STOP,
+                    max_stack_height=4,
+                ),
+                Section.Code(
+                    Op.POP + Op.RETF,
+                    code_inputs=1,
+                    code_outputs=0,
+                    max_stack_height=1,
+                ),
+                Section.Code(
+                    Op.PUSH2[value_code_worked] + Op.RETF,
+                    code_inputs=0,
+                    code_outputs=1,
+                    max_stack_height=1,
+                ),
+                Section.Code(
+                    Op.DUP2 + Op.PUSH2[slot_code_worked] + Op.RETF,
+                    code_inputs=2,
+                    code_outputs=4,
+                    max_stack_height=4,
+                ),
+            ],
+        ),
     ),
     ids=lambda x: x.name,
 )


### PR DESCRIPTION
## 🗒️ Description
This case is ported from a valid EOF validation test in ethereum/tests.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
