### PR TITLE
feat(t8n,filler): Append EELS resolution information to ``_info`` for generate test jsons

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -104,6 +104,7 @@ Release tarball changes:
 - ✨ Use self-hosted runners for fixture building in CI ([#1051](https://github.com/ethereum/execution-spec-tests/pull/1051)).
 - ✨ Release tarballs now contain fixtures filled for all forks, not only the fork under active development and the fork currently deployed on mainnet ([#1053](https://github.com/ethereum/execution-spec-tests/pull/1053)).
 - ✨ `StateTest` fixture format now contains `state` field in each network post result, containing the decoded post allocation that results from the transaction execution ([#1064](https://github.com/ethereum/execution-spec-tests/pull/1064)).
+- ✨ Include EELS fork resolution information in filled json test fixtures ([#1123](https://github.com/ethereum/execution-spec-tests/pull/1123)).
 
 ### 💥 Breaking Change
 

--- a/src/ethereum_clis/transition_tool.py
+++ b/src/ethereum_clis/transition_tool.py
@@ -72,6 +72,7 @@ class TransitionTool(EthereumCLI, FixtureVerifier):
         self.exception_mapper = exception_mapper
         super().__init__(binary=binary)
         self.trace = trace
+        self._info_metadata: Optional[Dict[str, Any]] = {}
 
     def __init_subclass__(cls):
         """Register all subclasses of TransitionTool as possible tools."""
@@ -342,7 +343,12 @@ class TransitionTool(EthereumCLI, FixtureVerifier):
         response = self._server_post(
             data=request_data_json, url_args=self._generate_post_args(t8n_data), timeout=timeout
         )
-        output: TransitionToolOutput = TransitionToolOutput.model_validate(response.json())
+        response_json = response.json()
+
+        # pop optional test ``_info`` metadata from response, if present
+        self._info_metadata = response_json.pop("_info_metadata", {})
+
+        output: TransitionToolOutput = TransitionToolOutput.model_validate(response_json)
 
         if debug_output_path:
             response_info = (

--- a/src/ethereum_test_base_types/reference_spec/git_reference_spec.py
+++ b/src/ethereum_test_base_types/reference_spec/git_reference_spec.py
@@ -96,7 +96,7 @@ class GitReferenceSpec(ReferenceSpec):
         """
         return self.SpecVersion != ""
 
-    def write_info(self, info: Dict[str, str]):
+    def write_info(self, info: Dict[str, Dict[str, Any] | str]):
         """
         Write info about the reference specification used into the output
         fixture.

--- a/src/ethereum_test_base_types/reference_spec/reference_spec.py
+++ b/src/ethereum_test_base_types/reference_spec/reference_spec.py
@@ -63,7 +63,7 @@ class ReferenceSpec:
         pass
 
     @abstractmethod
-    def write_info(self, info: Dict[str, str]):
+    def write_info(self, info: Dict[str, Dict[str, Any] | str]):
         """Write info about the reference specification used into the output fixture."""
         pass
 

--- a/src/ethereum_test_fixtures/base.py
+++ b/src/ethereum_test_fixtures/base.py
@@ -14,7 +14,7 @@ from ethereum_test_forks import Fork
 class BaseFixture(CamelModel):
     """Represents a base Ethereum test fixture of any type."""
 
-    info: Dict[str, str] = Field(default_factory=dict, alias="_info")
+    info: Dict[str, Dict[str, Any] | str] = Field(default_factory=dict, alias="_info")
 
     # Fixture format properties
     fixture_format_name: ClassVar[str] = "unset"
@@ -52,6 +52,7 @@ class BaseFixture(CamelModel):
         test_case_description: str,
         fixture_source_url: str,
         ref_spec: ReferenceSpec | None,
+        _info_metadata: Dict[str, Any],
     ):
         """Fill the info field for this fixture."""
         if "comment" not in self.info:
@@ -62,6 +63,8 @@ class BaseFixture(CamelModel):
         self.info["fixture_format"] = self.fixture_format_name
         if ref_spec is not None:
             ref_spec.write_info(self.info)
+        if _info_metadata:
+            self.info.update(_info_metadata)
 
     def get_fork(self) -> str | None:
         """Return fork of the fixture as a string."""

--- a/src/pytest_plugins/filler/filler.py
+++ b/src/pytest_plugins/filler/filler.py
@@ -736,6 +736,7 @@ def base_test_parametrizer(cls: Type[BaseTest]):
                     test_case_description,
                     fixture_source_url=fixture_source_url,
                     ref_spec=reference_spec,
+                    _info_metadata=t8n._info_metadata,
                 )
 
                 fixture_path = fixture_collector.add_fixture(


### PR DESCRIPTION
## 🗒️ Description

This PR consumes the metadata passed on from the `ethereum-spec-evm-resolver` and appends this information to the ``_info`` section in generated test jsons.

## 🔗 Related Issues

- `ethereum-spec-evm-resolver` PR: https://github.com/petertdavies/ethereum-spec-evm-resolver/pull/8

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] ~~Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).~~
- [x] ~~Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.~~
- [x] ~~Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.~~
- [x] ~~Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.~~
