### PR TITLE
export fork and chain id fixture config

### DIFF
--- a/src/ethereum_test_fixtures/blockchain.py
+++ b/src/ethereum_test_fixtures/blockchain.py
@@ -401,6 +401,7 @@ class FixtureConfig(CamelModel):
     """Chain configuration for a fixture."""
 
     fork: str = Field(..., alias="network")
+    chain_id: int = Field(1, alias="chainid")
     blob_schedule: FixtureBlobSchedule | None = None
 
 

--- a/src/ethereum_test_fixtures/state.py
+++ b/src/ethereum_test_fixtures/state.py
@@ -98,6 +98,8 @@ class FixtureConfig(CamelModel):
     """Chain configuration for a fixture."""
 
     blob_schedule: FixtureBlobSchedule | None = None
+    chain_id: int = Field(1, alias="chainid")
+    fork: str = Field(..., alias="network")
 
 
 class StateFixture(BaseFixture):

--- a/src/ethereum_test_specs/blockchain.py
+++ b/src/ethereum_test_specs/blockchain.py
@@ -588,6 +588,7 @@ class BlockchainTest(BaseTest):
             config=FixtureConfig(
                 fork=network_info,
                 blob_schedule=FixtureBlobSchedule.from_blob_schedule(fork.blob_schedule()),
+                chain_id=self.chain_id,
             ),
         )
 

--- a/src/ethereum_test_specs/state.py
+++ b/src/ethereum_test_specs/state.py
@@ -178,6 +178,8 @@ class StateTest(BaseTest):
             transaction=FixtureTransaction.from_transaction(tx),
             config=FixtureConfig(
                 blob_schedule=FixtureBlobSchedule.from_blob_schedule(fork.blob_schedule()),
+                fork=fork.blockchain_test_network_name(),
+                chain_id=self.chain_id,
             ),
         )
 


### PR DESCRIPTION
## 🗒️ Description
export chain id and network to the test config field so it won't be empty in state tests

## 🔗 Related Issues


## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
