### PR TITLE
fix(plugins/consume-engine): Fix Engine API error check

### DIFF
--- a/src/ethereum_test_rpc/rpc.py
+++ b/src/ethereum_test_rpc/rpc.py
@@ -82,8 +82,7 @@ class BaseRPC:
         response_json = response.json()
 
         if "error" in response_json:
-            exception = JSONRPCError(**response_json["error"])
-            raise exception.exception(method)
+            raise JSONRPCError(**response_json["error"])
 
         assert "result" in response_json, "RPC response didn't contain a result field"
         result = response_json["result"]

--- a/src/ethereum_test_rpc/types.py
+++ b/src/ethereum_test_rpc/types.py
@@ -10,21 +10,20 @@ from ethereum_test_fixtures.blockchain import FixtureExecutionPayload
 from ethereum_test_types import Withdrawal
 
 
-class JSONRPCError(CamelModel):
+class JSONRPCError(Exception):
     """Model to parse a JSON RPC error response."""
 
     code: int
     message: str
 
+    def __init__(self, code: int | str, message: str, **kwargs):
+        """Initialize the JSONRPCError."""
+        self.code = int(code)
+        self.message = message
+
     def __str__(self) -> str:
         """Return string representation of the JSONRPCError."""
         return f"JSONRPCError(code={self.code}, message={self.message})"
-
-    def exception(self, method) -> Exception:
-        """Return exception representation of the JSONRPCError."""
-        return Exception(
-            f"Error calling JSON RPC {method}, code: {self.code}, " f"message: {self.message}"
-        )
 
 
 class TransactionByHashResponse(CamelModel):


### PR DESCRIPTION
## 🗒️ Description
Fixes the `consume engine` from failing a test when the correct and expected Engine API error code is returned.

Thanks to the Reth team for raising this issue!

## 🔗 Related Issues
None

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
