### PR TITLE
fix(plugins/consume): Add `HIVE_TERMINAL_TOTAL_DIFFICULTY` to all pre-merge forks

### DIFF
--- a/src/pytest_plugins/consume/hive_simulators/ruleset.py
+++ b/src/pytest_plugins/consume/hive_simulators/ruleset.py
@@ -17,6 +17,7 @@ ruleset = {
         "HIVE_FORK_ISTANBUL": 2000,
         "HIVE_FORK_BERLIN": 2000,
         "HIVE_FORK_LONDON": 2000,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**64,
     },
     "Homestead": {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -29,6 +30,7 @@ ruleset = {
         "HIVE_FORK_ISTANBUL": 2000,
         "HIVE_FORK_BERLIN": 2000,
         "HIVE_FORK_LONDON": 2000,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**64,
     },
     "EIP150": {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -40,6 +42,7 @@ ruleset = {
         "HIVE_FORK_ISTANBUL": 2000,
         "HIVE_FORK_BERLIN": 2000,
         "HIVE_FORK_LONDON": 2000,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**64,
     },
     "EIP158": {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -51,6 +54,7 @@ ruleset = {
         "HIVE_FORK_ISTANBUL": 2000,
         "HIVE_FORK_BERLIN": 2000,
         "HIVE_FORK_LONDON": 2000,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**64,
     },
     "Byzantium": {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -62,6 +66,7 @@ ruleset = {
         "HIVE_FORK_ISTANBUL": 2000,
         "HIVE_FORK_BERLIN": 2000,
         "HIVE_FORK_LONDON": 2000,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**64,
     },
     "Constantinople": {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -73,6 +78,7 @@ ruleset = {
         "HIVE_FORK_ISTANBUL": 2000,
         "HIVE_FORK_BERLIN": 2000,
         "HIVE_FORK_LONDON": 2000,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**64,
     },
     "ConstantinopleFix": {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -84,6 +90,7 @@ ruleset = {
         "HIVE_FORK_ISTANBUL": 2000,
         "HIVE_FORK_BERLIN": 2000,
         "HIVE_FORK_LONDON": 2000,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**64,
     },
     "Istanbul": {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -95,6 +102,7 @@ ruleset = {
         "HIVE_FORK_ISTANBUL": 0,
         "HIVE_FORK_BERLIN": 2000,
         "HIVE_FORK_LONDON": 2000,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**64,
     },
     "Berlin": {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -106,6 +114,7 @@ ruleset = {
         "HIVE_FORK_ISTANBUL": 0,
         "HIVE_FORK_BERLIN": 0,
         "HIVE_FORK_LONDON": 2000,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**64,
     },
     "FrontierToHomesteadAt5": {
         "HIVE_FORK_HOMESTEAD": 5,
@@ -118,6 +127,7 @@ ruleset = {
         "HIVE_FORK_ISTANBUL": 2000,
         "HIVE_FORK_BERLIN": 2000,
         "HIVE_FORK_LONDON": 2000,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**64,
     },
     "HomesteadToEIP150At5": {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -130,6 +140,7 @@ ruleset = {
         "HIVE_FORK_ISTANBUL": 2000,
         "HIVE_FORK_BERLIN": 2000,
         "HIVE_FORK_LONDON": 2000,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**64,
     },
     "HomesteadToDaoAt5": {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -142,6 +153,7 @@ ruleset = {
         "HIVE_FORK_ISTANBUL": 2000,
         "HIVE_FORK_BERLIN": 2000,
         "HIVE_FORK_LONDON": 2000,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**64,
     },
     "EIP158ToByzantiumAt5": {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -154,6 +166,7 @@ ruleset = {
         "HIVE_FORK_ISTANBUL": 2000,
         "HIVE_FORK_BERLIN": 2000,
         "HIVE_FORK_LONDON": 2000,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**64,
     },
     "ByzantiumToConstantinopleAt5": {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -166,6 +179,7 @@ ruleset = {
         "HIVE_FORK_ISTANBUL": 2000,
         "HIVE_FORK_BERLIN": 2000,
         "HIVE_FORK_LONDON": 2000,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**64,
     },
     "ByzantiumToConstantinopleFixAt5": {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -178,6 +192,7 @@ ruleset = {
         "HIVE_FORK_ISTANBUL": 2000,
         "HIVE_FORK_BERLIN": 2000,
         "HIVE_FORK_LONDON": 2000,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**64,
     },
     "ConstantinopleFixToIstanbulAt5": {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -190,6 +205,7 @@ ruleset = {
         "HIVE_FORK_ISTANBUL": 5,
         "HIVE_FORK_BERLIN": 2000,
         "HIVE_FORK_LONDON": 2000,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**64,
     },
     "IstanbulToBerlinAt5": {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -202,6 +218,7 @@ ruleset = {
         "HIVE_FORK_ISTANBUL": 0,
         "HIVE_FORK_BERLIN": 5,
         "HIVE_FORK_LONDON": 2000,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**64,
     },
     "BerlinToLondonAt5": {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -214,6 +231,7 @@ ruleset = {
         "HIVE_FORK_ISTANBUL": 0,
         "HIVE_FORK_BERLIN": 0,
         "HIVE_FORK_LONDON": 5,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**64,
     },
     "London": {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -225,6 +243,7 @@ ruleset = {
         "HIVE_FORK_ISTANBUL": 0,
         "HIVE_FORK_BERLIN": 0,
         "HIVE_FORK_LONDON": 0,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**64,
     },
     "ArrowGlacierToMergeAtDiffC0000": {
         "HIVE_FORK_HOMESTEAD": 0,

--- a/src/pytest_plugins/consume/hive_simulators/ruleset.py
+++ b/src/pytest_plugins/consume/hive_simulators/ruleset.py
@@ -17,7 +17,7 @@ ruleset = {
         "HIVE_FORK_ISTANBUL": 2000,
         "HIVE_FORK_BERLIN": 2000,
         "HIVE_FORK_LONDON": 2000,
-        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**64,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**32,
     },
     "Homestead": {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -30,7 +30,7 @@ ruleset = {
         "HIVE_FORK_ISTANBUL": 2000,
         "HIVE_FORK_BERLIN": 2000,
         "HIVE_FORK_LONDON": 2000,
-        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**64,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**32,
     },
     "EIP150": {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -42,7 +42,7 @@ ruleset = {
         "HIVE_FORK_ISTANBUL": 2000,
         "HIVE_FORK_BERLIN": 2000,
         "HIVE_FORK_LONDON": 2000,
-        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**64,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**32,
     },
     "EIP158": {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -54,7 +54,7 @@ ruleset = {
         "HIVE_FORK_ISTANBUL": 2000,
         "HIVE_FORK_BERLIN": 2000,
         "HIVE_FORK_LONDON": 2000,
-        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**64,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**32,
     },
     "Byzantium": {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -66,7 +66,7 @@ ruleset = {
         "HIVE_FORK_ISTANBUL": 2000,
         "HIVE_FORK_BERLIN": 2000,
         "HIVE_FORK_LONDON": 2000,
-        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**64,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**32,
     },
     "Constantinople": {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -78,7 +78,7 @@ ruleset = {
         "HIVE_FORK_ISTANBUL": 2000,
         "HIVE_FORK_BERLIN": 2000,
         "HIVE_FORK_LONDON": 2000,
-        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**64,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**32,
     },
     "ConstantinopleFix": {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -90,7 +90,7 @@ ruleset = {
         "HIVE_FORK_ISTANBUL": 2000,
         "HIVE_FORK_BERLIN": 2000,
         "HIVE_FORK_LONDON": 2000,
-        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**64,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**32,
     },
     "Istanbul": {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -102,7 +102,7 @@ ruleset = {
         "HIVE_FORK_ISTANBUL": 0,
         "HIVE_FORK_BERLIN": 2000,
         "HIVE_FORK_LONDON": 2000,
-        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**64,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**32,
     },
     "Berlin": {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -114,7 +114,7 @@ ruleset = {
         "HIVE_FORK_ISTANBUL": 0,
         "HIVE_FORK_BERLIN": 0,
         "HIVE_FORK_LONDON": 2000,
-        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**64,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**32,
     },
     "FrontierToHomesteadAt5": {
         "HIVE_FORK_HOMESTEAD": 5,
@@ -127,7 +127,7 @@ ruleset = {
         "HIVE_FORK_ISTANBUL": 2000,
         "HIVE_FORK_BERLIN": 2000,
         "HIVE_FORK_LONDON": 2000,
-        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**64,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**32,
     },
     "HomesteadToEIP150At5": {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -140,7 +140,7 @@ ruleset = {
         "HIVE_FORK_ISTANBUL": 2000,
         "HIVE_FORK_BERLIN": 2000,
         "HIVE_FORK_LONDON": 2000,
-        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**64,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**32,
     },
     "HomesteadToDaoAt5": {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -153,7 +153,7 @@ ruleset = {
         "HIVE_FORK_ISTANBUL": 2000,
         "HIVE_FORK_BERLIN": 2000,
         "HIVE_FORK_LONDON": 2000,
-        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**64,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**32,
     },
     "EIP158ToByzantiumAt5": {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -166,7 +166,7 @@ ruleset = {
         "HIVE_FORK_ISTANBUL": 2000,
         "HIVE_FORK_BERLIN": 2000,
         "HIVE_FORK_LONDON": 2000,
-        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**64,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**32,
     },
     "ByzantiumToConstantinopleAt5": {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -179,7 +179,7 @@ ruleset = {
         "HIVE_FORK_ISTANBUL": 2000,
         "HIVE_FORK_BERLIN": 2000,
         "HIVE_FORK_LONDON": 2000,
-        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**64,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**32,
     },
     "ByzantiumToConstantinopleFixAt5": {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -192,7 +192,7 @@ ruleset = {
         "HIVE_FORK_ISTANBUL": 2000,
         "HIVE_FORK_BERLIN": 2000,
         "HIVE_FORK_LONDON": 2000,
-        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**64,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**32,
     },
     "ConstantinopleFixToIstanbulAt5": {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -205,7 +205,7 @@ ruleset = {
         "HIVE_FORK_ISTANBUL": 5,
         "HIVE_FORK_BERLIN": 2000,
         "HIVE_FORK_LONDON": 2000,
-        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**64,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**32,
     },
     "IstanbulToBerlinAt5": {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -218,7 +218,7 @@ ruleset = {
         "HIVE_FORK_ISTANBUL": 0,
         "HIVE_FORK_BERLIN": 5,
         "HIVE_FORK_LONDON": 2000,
-        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**64,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**32,
     },
     "BerlinToLondonAt5": {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -231,7 +231,7 @@ ruleset = {
         "HIVE_FORK_ISTANBUL": 0,
         "HIVE_FORK_BERLIN": 0,
         "HIVE_FORK_LONDON": 5,
-        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**64,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**32,
     },
     "London": {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -243,7 +243,7 @@ ruleset = {
         "HIVE_FORK_ISTANBUL": 0,
         "HIVE_FORK_BERLIN": 0,
         "HIVE_FORK_LONDON": 0,
-        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**64,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 2**32,
     },
     "ArrowGlacierToMergeAtDiffC0000": {
         "HIVE_FORK_HOMESTEAD": 0,


### PR DESCRIPTION
## 🗒️ Description

Adds `HIVE_TERMINAL_TOTAL_DIFFICULTY` equal to `2**32` to all pre-merge fork rulesets.

Fixes most hive tests for go-ethereum when running using `consume rlp`.

cc @lightclient 

## 🔗 Related Issues

None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] ~~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~ Skipped
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.