### PR TITLE
fix(tests): fix unit tests and use Bytecode verbatim

### DIFF
--- a/src/ethereum_test_vm/tests/test_vm.py
+++ b/src/ethereum_test_vm/tests/test_vm.py
@@ -426,8 +426,8 @@ def test_bytecode_concatenation_with_bytes():
     assert code == bytes([0x60, 0xFF, 0x19, 0x01, 0x02])
 
     assert str(code) == ""
-    assert code.popped_stack_items == code.popped_stack_items
-    assert code.pushed_stack_items == code.pushed_stack_items
-    assert code.max_stack_height == code.max_stack_height
-    assert code.min_stack_height == code.min_stack_height
-    assert code.terminating == code.terminating
+    assert code.popped_stack_items == base.popped_stack_items
+    assert code.pushed_stack_items == base.pushed_stack_items
+    assert code.max_stack_height == base.max_stack_height
+    assert code.min_stack_height == base.min_stack_height
+    assert code.terminating == base.terminating

--- a/tests/osaka/eip7692_eof_v1/eip4750_functions/test_code_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip4750_functions/test_code_validation.py
@@ -190,7 +190,7 @@ def test_eof_validity(
             name="imm1",
             sections=[
                 Section.Code(
-                    code=Op.CALLF + Op.STOP,
+                    code=Op.CALLF + b"\x00",
                 )
             ],
         ),
@@ -201,7 +201,7 @@ def test_eof_validity(
                     code=Op.PUSH0 + Op.PUSH0 + Op.CALLF[1] + Op.STOP,
                 ),
                 Section.Code(
-                    code=Op.CALLF + Op.STOP,  # would be valid with "02" + Op.RETF.
+                    code=Op.CALLF + b"\x00",  # would be valid with "02" + Op.RETF.
                     code_inputs=2,
                     code_outputs=1,
                     max_stack_height=2,

--- a/tests/osaka/eip7692_eof_v1/eip7480_data_section/test_code_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip7480_data_section/test_code_validation.py
@@ -192,7 +192,7 @@ def test_legacy_initcode_invalid_eof_v1_contract(
         Container(
             name="imm1",
             sections=[
-                Section.Code(Op.DATALOADN + Op.STOP),
+                Section.Code(Op.DATALOADN + b"\x00"),
                 Section.Data(b"\xff" * 32),
             ],
         ),
@@ -204,7 +204,7 @@ def test_legacy_initcode_invalid_eof_v1_contract(
                     max_stack_height=1,
                 ),
                 Section.Code(
-                    Op.DATALOADN + Op.STOP,
+                    Op.DATALOADN + b"\x00",
                     code_outputs=1,
                 ),
                 Section.Code(


### PR DESCRIPTION
## 🗒️ Description

The https://github.com/ethereum/execution-spec-tests/pull/1119 had incorrect unit test. This fixes the unit tests and uses the verbatim bytes in tests added in the mean time.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
