### PR TITLE
fix(consume/engine): check if client fails to raise an expected Engine API error

### DIFF
--- a/src/pytest_plugins/consume/hive_simulators/engine/test_via_engine.py
+++ b/src/pytest_plugins/consume/hive_simulators/engine/test_via_engine.py
@@ -62,6 +62,11 @@ def test_via_engine(
                             if payload.valid()
                             else PayloadStatusEnum.INVALID
                         ), f"unexpected status: {payload_response}"
+                        if payload.error_code is not None:
+                            raise Exception(
+                                "Client failed to raise expected Engine API error code: "
+                                f"{payload.error_code}"
+                            )
                     except JSONRPCError as e:
                         if payload.error_code is None:
                             raise Exception(f"unexpected error: {e.code} - {e.message}") from e


### PR DESCRIPTION
## 🗒️ Description
This PR adds a missing check for the case of Engine API exceptions.

If the fixture specifies a payload `errorCode`, then check that it is indeed raised by the client. If not, fail the test.

## 🔗 Related Issues
Small follow-up to #1133.

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.

