### PR TITLE
feat(tests): EIP-7702: Invalid block test

### DIFF
--- a/src/ethereum_clis/clis/execution_specs.py
+++ b/src/ethereum_clis/clis/execution_specs.py
@@ -179,6 +179,14 @@ class ExecutionSpecsExceptionMapper(ExceptionMapper):
                 TransactionException.PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS,
                 "nsaction: ",
             ),
+            ExceptionMessage(
+                TransactionException.NONCE_MISMATCH_TOO_HIGH,
+                "saction: ",
+            ),
+            ExceptionMessage(
+                TransactionException.NONCE_MISMATCH_TOO_LOW,
+                "action: ",
+            ),
             # TODO EVMONE needs to differentiate when the section is missing in the header or body
             ExceptionMessage(EOFException.MISSING_STOP_OPCODE, "err: no_terminating_instruction"),
             ExceptionMessage(EOFException.MISSING_CODE_HEADER, "err: code_section_missing"),

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -3394,7 +3394,8 @@ def test_invalid_transaction_after_authorization(
             ],
         ),
         Transaction(
-            sender=auth_signer,  # Nonce is not bumped by the authorization, so it is still 0
+            sender=auth_signer,
+            nonce=0,
             gas_limit=21_000,
             to=Address(0),
             value=1,
@@ -3429,6 +3430,7 @@ def test_authorization_reusing_nonce(
     txs = [
         Transaction(
             sender=auth_signer,
+            nonce=0,
             gas_limit=21_000,
             to=Address(0),
             value=1,

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -3367,3 +3367,93 @@ def test_many_delegations(
         tx=tx,
         post=post,
     )
+
+
+def test_invalid_transaction_after_authorization(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+):
+    """
+    Test an invalid block due to a transaction reusing the same nonce as an authorization
+    included in a prior transaction.
+    """
+    auth_signer = pre.fund_eoa()
+
+    txs = [
+        Transaction(
+            sender=pre.fund_eoa(),
+            gas_limit=500_000,
+            to=Address(0),
+            value=0,
+            authorization_list=[
+                AuthorizationTuple(
+                    address=Address(1),
+                    nonce=0,
+                    signer=auth_signer,
+                ),
+            ],
+        ),
+        Transaction(
+            sender=auth_signer,  # Nonce is not bumped by the authorization, so it is still 0
+            gas_limit=21_000,
+            to=Address(0),
+            value=1,
+            error=TransactionException.NONCE_MISMATCH_TOO_LOW,
+        ),
+    ]
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=txs,
+                exception=TransactionException.NONCE_MISMATCH_TOO_LOW,
+            )
+        ],
+        post={
+            Address(0): None,
+        },
+    )
+
+
+def test_authorization_reusing_nonce(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+):
+    """
+    Test an authorization reusing the same nonce as a prior transaction included in the same
+    block.
+    """
+    auth_signer = pre.fund_eoa()
+    sender = pre.fund_eoa()
+    txs = [
+        Transaction(
+            sender=auth_signer,
+            gas_limit=21_000,
+            to=Address(0),
+            value=1,
+        ),
+        Transaction(
+            sender=sender,
+            gas_limit=500_000,
+            to=Address(0),
+            value=0,
+            authorization_list=[
+                AuthorizationTuple(
+                    address=Address(1),
+                    nonce=0,
+                    signer=auth_signer,
+                ),
+            ],
+        ),
+    ]
+
+    blockchain_test(
+        pre=pre,
+        blocks=[Block(txs=txs)],
+        post={
+            Address(0): Account(balance=1),
+            auth_signer: Account(nonce=1, code=b""),
+            sender: Account(nonce=1),
+        },
+    )


### PR DESCRIPTION
## 🗒️ Description
Adds two tests where either the authorization reuses the same nonce as a prior transaction (valid block), or a transaction reuses the nonce of an authorization included in a prior transaction (invalid block).

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.