### PR TITLE
reafactor(specs,tests): Rename `EOFTest.data` -> `EOFTest.container`, rebase `EOFStateTest`

### DIFF
--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_all_opcodes_in_container.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_all_opcodes_in_container.py
@@ -113,7 +113,7 @@ def test_all_opcodes_in_container(
         eof_code = Container(sections=sections)
 
     eof_test(
-        data=eof_code,
+        container=eof_code,
         expect_exception=(
             None if opcode in valid_eof_opcodes else EOFException.UNDEFINED_INSTRUCTION
         ),
@@ -159,7 +159,7 @@ def test_invalid_opcodes_after_stop(
     )
 
     eof_test(
-        data=eof_code,
+        container=eof_code,
         expect_exception=EOFException.UNDEFINED_INSTRUCTION,
     )
 
@@ -204,7 +204,7 @@ def test_all_invalid_terminating_opcodes(
     sections += [Section.Data(b"\0" * 32)]
 
     eof_test(
-        data=Container(
+        container=Container(
             sections=sections,
         ),
         expect_exception=EOFException.MISSING_STOP_OPCODE,
@@ -253,7 +253,7 @@ def test_all_unreachable_terminating_opcodes_after_stop(
             raise NotImplementedError(f"Opcode {opcode} is not implemented")
 
     eof_test(
-        data=Container(
+        container=Container(
             sections=sections,
         ),
         expect_exception=EOFException.UNREACHABLE_INSTRUCTIONS
@@ -302,7 +302,7 @@ def test_all_unreachable_terminating_opcodes_before_stop(
             raise NotImplementedError(f"Opcode {opcode} is not implemented")
 
     eof_test(
-        data=Container(
+        container=Container(
             sections=sections,
         ),
         expect_exception=EOFException.UNREACHABLE_INSTRUCTIONS
@@ -365,7 +365,7 @@ def test_all_opcodes_stack_underflow(
     eof_code = Container(sections=sections)
 
     eof_test(
-        data=eof_code,
+        container=eof_code,
         expect_exception=EOFException.STACK_UNDERFLOW,
     )
 
@@ -415,7 +415,7 @@ def test_all_opcodes_stack_overflow(
     eof_code = Container(sections=sections)
 
     eof_test(
-        data=eof_code,
+        container=eof_code,
         expect_exception=exception,
     )
 
@@ -477,6 +477,6 @@ def test_truncated_data_portion_opcodes(
         ]
     )
     eof_test(
-        data=eof_code,
+        container=eof_code,
         expect_exception=EOFException.TRUNCATED_INSTRUCTION,
     )

--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_container_size.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_container_size.py
@@ -37,7 +37,7 @@ def test_max_size(
     )
     assert len(code) == MAX_INITCODE_SIZE + over_limit
     eof_test(
-        data=bytes(code),
+        container=bytes(code),
         expect_exception=None if over_limit == 0 else EOFException.CONTAINER_SIZE_ABOVE_LIMIT,
     )
 
@@ -53,7 +53,7 @@ def test_above_max_size_raw(
     """Verify EOF container invalid above maximum size, regardless of header contents."""
     code = Op.INVALID * size
     eof_test(
-        data=bytes(code),
+        container=bytes(code),
         expect_exception=EOFException.CONTAINER_SIZE_ABOVE_LIMIT,
     )
 
@@ -101,6 +101,6 @@ def test_section_after_end_of_container(
 ):
     """Verify EOF container is invalid if any of sections declares above container size."""
     eof_test(
-        data=bytes(code),
+        container=bytes(code),
         expect_exception=EOFException.INVALID_SECTION_BODIES_SIZE,
     )

--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py
@@ -144,7 +144,7 @@ def test_valid_containers(
         container.validity_error is None
     ), f"Valid container with validity error: {container.validity_error}"
     eof_test(
-        data=bytes(container),
+        container=bytes(container),
     )
 
 
@@ -1066,7 +1066,7 @@ def test_invalid_containers(
     """
     assert container.validity_error is not None, "Invalid container without validity error"
     eof_test(
-        data=bytes(container),
+        container=bytes(container),
         expect_exception=container.validity_error,
     )
 
@@ -1085,7 +1085,7 @@ def test_magic_validation(
     code[0] = magic_0
     code[1] = magic_1
     eof_test(
-        data=bytes(code),
+        container=bytes(code),
         expect_exception=None if magic_0 == 0xEF and magic_1 == 0 else EOFException.INVALID_MAGIC,
     )
 
@@ -1101,7 +1101,7 @@ def test_version_validation(
     code = bytearray(bytes(VALID_CONTAINER))
     code[2] = version
     eof_test(
-        data=bytes(code),
+        container=bytes(code),
         expect_exception=None if version == 1 else EOFException.INVALID_VERSION,
     )
 
@@ -1129,7 +1129,7 @@ def test_single_code_section(
     if plus_data:
         sections.append(Section.Data(data=b"\0"))
     eof_test(
-        data=Container(
+        container=Container(
             name="single_code_section",
             sections=sections,
             kind=ContainerKind.INITCODE if plus_container else ContainerKind.RUNTIME,
@@ -1170,7 +1170,7 @@ def test_max_code_sections(
     if plus_data:
         sections.append(Section.Data(data=b"\0"))
     eof_test(
-        data=Container(
+        container=Container(
             name="max_code_sections",
             sections=sections,
             kind=ContainerKind.INITCODE if plus_container else ContainerKind.RUNTIME,

--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_eof_example.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_eof_example.py
@@ -60,7 +60,7 @@ def test_eof_example(eof_test: EOFTestFiller):
     )
 
     eof_test(
-        data=eof_code,
+        container=eof_code,
         expect_exception=eof_code.validity_error,
     )
 
@@ -110,7 +110,7 @@ def test_eof_example_custom_fields(eof_test: EOFTestFiller):
     )
 
     eof_test(
-        data=eof_code,
+        container=eof_code,
         expect_exception=eof_code.validity_error,
     )
 
@@ -143,6 +143,6 @@ def test_eof_example_parameters(
     )
 
     eof_test(
-        data=eof_code,
+        container=eof_code,
         expect_exception=eof_code.validity_error,
     )

--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_migrated_valid_invalid.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_migrated_valid_invalid.py
@@ -303,6 +303,6 @@ def test_migrated_valid_invalid(
 ):
     """Verify EOF container construction and exception."""
     eof_test(
-        data=eof_code,
+        container=eof_code,
         expect_exception=exception,
     )

--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_section_header_body_mismatch.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_section_header_body_mismatch.py
@@ -136,6 +136,6 @@ def test_code_section_header_body_mismatch(
     assert bytes(eof_code).hex() == bytes.fromhex(expected_code).hex()
 
     eof_test(
-        data=eof_code,
+        container=eof_code,
         expect_exception=expected_exception,
     )

--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_section_order.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_section_order.py
@@ -215,7 +215,7 @@ def test_section_order(
     )
 
     eof_test(
-        data=eof_code,
+        container=eof_code,
         expect_exception=expected_exception,
     )
 
@@ -280,6 +280,6 @@ def test_container_section_order(
                 return EOFException.MISSING_TERMINATOR
 
     eof_test(
-        data=eof_code,
+        container=eof_code,
         expect_exception=get_expected_exception(),
     )

--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_section_size.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_section_size.py
@@ -163,7 +163,7 @@ def test_section_size(
     else:
         eof_code.sections.append(Section.Data("0x00aaaa"))
     eof_test(
-        data=eof_code,
+        container=eof_code,
         expect_exception=exception,
     )
 
@@ -191,7 +191,7 @@ def test_truncated_container_without_data(
     container = Container(sections=[Section.Code(Op.INVALID + Op.INVALID)])
     bytecode = bytes(container)
     eof_test(
-        data=bytecode[: len(bytecode) - truncation_len],
+        container=bytecode[: len(bytecode) - truncation_len],
         expect_exception=exception,
     )
 
@@ -221,6 +221,6 @@ def test_truncated_container_with_data(
         ]
     )
     eof_test(
-        data=container,
+        container=container,
         expect_exception=exception,
     )

--- a/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjump.py
+++ b/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjump.py
@@ -23,7 +23,7 @@ def test_rjump_negative(
 ):
     """Test for a forward RJUMPI and backward RJUMP."""
     eof_state_test(
-        data=Container.Code(
+        container=Container.Code(
             Op.PUSH1[1]
             + Op.RJUMPI[7]  # RJUMP cannot be used because of the backward jump restriction
             + Op.SSTORE(slot_code_worked, Op.MLOAD(0))
@@ -40,7 +40,7 @@ def test_rjump_positive_negative(
 ):
     """EOF1V4200_0001 (Valid) EOF code containing RJUMP (Positive, Negative)."""
     eof_state_test(
-        data=Container.Code(
+        container=Container.Code(
             Op.PUSH0
             + Op.RJUMPI[3]
             + Op.RJUMP[7]
@@ -57,7 +57,7 @@ def test_rjump_zero(
 ):
     """EOF1V4200_0002 (Valid) EOF code containing RJUMP (Zero)."""
     eof_state_test(
-        data=Container.Code(
+        container=Container.Code(
             Op.RJUMP[0] + Op.SSTORE(slot_code_worked, value_code_worked) + Op.STOP,
         ),
         container_post=Account(storage={slot_code_worked: value_code_worked}),
@@ -69,7 +69,7 @@ def test_rjump_maxes(
 ):
     """EOF1V4200_0003 EOF with RJUMP containing the max positive and negative offset (32767)."""
     eof_state_test(
-        data=Container.Code(
+        container=Container.Code(
             Op.PUSH0
             + Op.RJUMPI[RJUMP_LEN]  # The push/jumpi is to allow the NOOPs to be forward referenced
             + Op.RJUMP[0x7FFF]
@@ -98,7 +98,7 @@ def test_rjump_max_bytecode_size(
     )
     container = Container.Code(code)
     assert len(container) == MAX_BYTECODE_SIZE
-    eof_test(data=container)
+    eof_test(container=container)
 
 
 def test_rjump_truncated_rjump(
@@ -106,7 +106,7 @@ def test_rjump_truncated_rjump(
 ):
     """EOF1I4200_0001 (Invalid) EOF code containing truncated RJUMP."""
     eof_test(
-        data=Container.Code(Op.RJUMP),
+        container=Container.Code(Op.RJUMP),
         expect_exception=EOFException.TRUNCATED_INSTRUCTION,
     )
 
@@ -116,7 +116,7 @@ def test_rjump_truncated_rjump_2(
 ):
     """EOF1I4200_0002 (Invalid) EOF code containing truncated RJUMP."""
     eof_test(
-        data=Container.Code(Op.RJUMP + b"\x00"),
+        container=Container.Code(Op.RJUMP + b"\x00"),
         expect_exception=EOFException.TRUNCATED_INSTRUCTION,
     )
 
@@ -131,7 +131,7 @@ def test_rjump_into_header(
     (Jumping into header).
     """
     eof_test(
-        data=Container.Code(Op.RJUMP[offset]),
+        container=Container.Code(Op.RJUMP[offset]),
         expect_exception=EOFException.INVALID_RJUMP_DESTINATION,
     )
 
@@ -144,7 +144,7 @@ def test_rjump_before_header(
     (Jumping before code begin).
     """
     eof_test(
-        data=Container.Code(Op.RJUMP[-23]),
+        container=Container.Code(Op.RJUMP[-23]),
         expect_exception=EOFException.INVALID_RJUMP_DESTINATION,
     )
 
@@ -157,7 +157,7 @@ def test_rjump_into_data(
     (Jumping into data section).
     """
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(Op.RJUMP[2]),
                 Section.Data(data=b"\xaa\xbb\xcc"),
@@ -172,7 +172,7 @@ def test_rjump_outside_other_section_before(
 ):
     """EOF code containing RJUMP with target outside code bounds (prior code section)."""
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(code=Op.JUMPF[1]),
                 Section.Code(code=Op.RJUMP[-6]),
@@ -187,7 +187,7 @@ def test_rjump_outside_other_section_after(
 ):
     """EOF code containing RJUMP with target outside code bounds (Subsequent code section)."""
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(code=Op.JUMPF[1]),
                 Section.Code(code=Op.RJUMP[3] + Op.JUMPF[2]),
@@ -206,7 +206,7 @@ def test_rjump_after_container(
     (Jumping after code end).
     """
     eof_test(
-        data=Container.Code(Op.RJUMP[2]),
+        container=Container.Code(Op.RJUMP[2]),
         expect_exception=EOFException.INVALID_RJUMP_DESTINATION,
     )
 
@@ -219,7 +219,7 @@ def test_rjump_to_code_end(
     (Jumping to code end).
     """
     eof_test(
-        data=Container.Code(Op.RJUMP[1] + Op.STOP),
+        container=Container.Code(Op.RJUMP[1] + Op.STOP),
         expect_exception=EOFException.INVALID_RJUMP_DESTINATION,
     )
 
@@ -231,7 +231,7 @@ def test_rjump_into_self_data_portion(
 ):
     """EOF1I4200_0008 (Invalid) EOF code containing RJUMP with target self RJUMP immediate."""
     eof_test(
-        data=Container.Code(Op.RJUMP[-offset] + Op.STOP),
+        container=Container.Code(Op.RJUMP[-offset] + Op.STOP),
         expect_exception=EOFException.INVALID_RJUMP_DESTINATION,
     )
 
@@ -244,7 +244,7 @@ def test_rjump_into_self_remaining_code(
     unreachable code.
     """
     eof_test(
-        data=Container.Code(Op.RJUMP[-len(Op.RJUMP[0])] + Op.STOP),
+        container=Container.Code(Op.RJUMP[-len(Op.RJUMP[0])] + Op.STOP),
         expect_exception=EOFException.UNREACHABLE_INSTRUCTIONS,
     )
 
@@ -254,7 +254,7 @@ def test_rjump_into_self(
 ):
     """EOF code containing RJUMP with target self RJUMP."""
     eof_test(
-        data=Container.Code(Op.RJUMP[-len(Op.RJUMP[0])]),
+        container=Container.Code(Op.RJUMP[-len(Op.RJUMP[0])]),
     )
 
 
@@ -263,7 +263,7 @@ def test_rjump_into_self_pre_code(
 ):
     """EOF code containing RJUMP with target self RJUMP with non-zero stack before RJUMP."""
     eof_test(
-        data=Container.Code(Op.PUSH1(0) + Op.RJUMP[-len(Op.RJUMP[0])]),
+        container=Container.Code(Op.PUSH1(0) + Op.RJUMP[-len(Op.RJUMP[0])]),
     )
 
 
@@ -272,7 +272,7 @@ def test_rjump_into_stack_height_diff(
 ):
     """EOF code containing RJUMP with target instruction that causes stack height difference."""
     eof_test(
-        data=Container.Code(Op.PUSH1(0) + Op.RJUMP[-(len(Op.RJUMP[0]) + len(Op.PUSH1(0)))]),
+        container=Container.Code(Op.PUSH1(0) + Op.RJUMP[-(len(Op.RJUMP[0]) + len(Op.PUSH1(0)))]),
         expect_exception=EOFException.STACK_HEIGHT_MISMATCH,
     )
 
@@ -282,7 +282,9 @@ def test_rjump_into_stack_height_diff_2(
 ):
     """EOF code containing RJUMP with target instruction that cause stack height difference."""
     eof_test(
-        data=Container.Code(Op.PUSH1(0) + Op.POP + Op.RJUMP[-(len(Op.RJUMP[0]) + len(Op.POP))]),
+        container=Container.Code(
+            Op.PUSH1(0) + Op.POP + Op.RJUMP[-(len(Op.RJUMP[0]) + len(Op.POP))]
+        ),
         expect_exception=EOFException.STACK_HEIGHT_MISMATCH,
     )
 
@@ -292,7 +294,7 @@ def test_rjump_into_stack_underflow(
 ):
     """EOF code containing RJUMP with target instruction that cause stack underflow."""
     eof_test(
-        data=Container.Code(
+        container=Container.Code(
             Op.ORIGIN
             + Op.RJUMPI[len(Op.RJUMP[0])]
             + Op.RJUMP[len(Op.STOP)]
@@ -309,7 +311,7 @@ def test_rjump_into_rjump(
 ):
     """EOF1I4200_0009 (Invalid) EOF code containing RJUMP with target other RJUMP immediate."""
     eof_test(
-        data=Container.Code(Op.RJUMP[1] + Op.RJUMP[0]),
+        container=Container.Code(Op.RJUMP[1] + Op.RJUMP[0]),
         expect_exception=EOFException.INVALID_RJUMP_DESTINATION,
     )
 
@@ -319,7 +321,7 @@ def test_rjump_into_rjumpi(
 ):
     """EOF1I4200_0010 (Invalid) EOF code containing RJUMP with target RJUMPI immediate."""
     eof_test(
-        data=Container.Code(Op.RJUMP[5] + Op.STOP + Op.PUSH1(1) + Op.RJUMPI[-6] + Op.STOP),
+        container=Container.Code(Op.RJUMP[5] + Op.STOP + Op.PUSH1(1) + Op.RJUMPI[-6] + Op.STOP),
         expect_exception=EOFException.INVALID_RJUMP_DESTINATION,
     )
 
@@ -331,7 +333,7 @@ def test_rjump_into_push_1(eof_test: EOFTestFiller, jump: JumpDirection):
         Op.PUSH1[1] + Op.RJUMP[-4] if jump == JumpDirection.BACKWARD else Op.RJUMP[1] + Op.PUSH1[1]
     ) + Op.STOP
     eof_test(
-        data=Container.Code(code),
+        container=Container.Code(code),
         expect_exception=EOFException.INVALID_RJUMP_DESTINATION,
     )
 
@@ -393,7 +395,7 @@ def test_rjump_into_push_n(
         offset = -4 if data_portion_end else -4 - data_portion_length + 1
         code = opcode[0] + Op.RJUMP[offset]
     eof_test(
-        data=Container.Code(code),
+        container=Container.Code(code),
         expect_exception=EOFException.INVALID_RJUMP_DESTINATION,
     )
 
@@ -413,7 +415,7 @@ def test_rjump_into_rjumpv(
     invalid_destination = 4 + (2 * target_rjumpv_table_size) if data_portion_end else 4
     target_jump_table = [0 for _ in range(target_rjumpv_table_size)]
     eof_test(
-        data=Container.Code(
+        container=Container.Code(
             Op.RJUMP[invalid_destination]
             + Op.STOP
             + Op.PUSH1(1)
@@ -436,7 +438,7 @@ def test_rjump_into_callf(
     """EOF1I4200_0013 (Invalid) EOF code containing RJUMP with target CALLF immediate."""
     invalid_destination = 2 if data_portion_end else 1
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.RJUMP[invalid_destination] + Op.CALLF[1] + Op.STOP,
@@ -456,7 +458,7 @@ def test_rjump_into_dupn(
 ):
     """EOF code containing RJUMP with target DUPN immediate."""
     eof_test(
-        data=Container.Code(
+        container=Container.Code(
             Op.PUSH1(1) + Op.PUSH1(1) + Op.RJUMP[1] + Op.DUPN[1] + Op.SSTORE + Op.STOP,
         ),
         expect_exception=EOFException.INVALID_RJUMP_DESTINATION,
@@ -468,7 +470,7 @@ def test_rjump_into_swapn(
 ):
     """EOF code containing RJUMP with target SWAPN immediate."""
     eof_test(
-        data=Container.Code(
+        container=Container.Code(
             Op.PUSH1(1) + Op.PUSH1(1) + Op.RJUMP[1] + Op.SWAPN[1] + Op.SSTORE + Op.STOP,
         ),
         expect_exception=EOFException.INVALID_RJUMP_DESTINATION,
@@ -480,7 +482,7 @@ def test_rjump_into_exchange(
 ):
     """EOF code containing RJUMP with target EXCHANGE immediate."""
     eof_test(
-        data=Container.Code(
+        container=Container.Code(
             Op.PUSH1(1)
             + Op.PUSH1(2)
             + Op.PUSH1(3)
@@ -498,7 +500,7 @@ def test_rjump_into_eofcreate(
 ):
     """EOF code containing RJUMP with target EOFCREATE immediate."""
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH0 * 4 + Op.RJUMP[1] + Op.EOFCREATE[0] + Op.STOP,
@@ -526,7 +528,7 @@ def test_rjump_into_returncontract(
 ):
     """EOF code containing RJUMP with target RETURNCONTRACT immediate."""
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.EOFCREATE[0](0, 0, 0, 0) + Op.STOP,
@@ -555,7 +557,7 @@ def test_rjump_unreachable_code(
     """EOF code containing instructions skipped by RJUMP."""
     container = Container.Code(code=(Op.RJUMP[len(Op.STOP)] + Op.STOP + Op.STOP))
     eof_test(
-        data=container,
+        container=container,
         expect_exception=EOFException.UNREACHABLE_INSTRUCTIONS,
     )
 
@@ -568,7 +570,7 @@ def test_rjump_backwards_reference_only(
         code=(Op.RJUMP[RJUMP_LEN] + Op.RJUMP[RJUMP_LEN] + Op.RJUMP[-(2 * RJUMP_LEN)] + Op.STOP)
     )
     eof_test(
-        data=container,
+        container=container,
         expect_exception=EOFException.UNREACHABLE_INSTRUCTIONS,
     )
 
@@ -578,7 +580,7 @@ def test_rjump_backwards_illegal_stack_height(
 ):
     """Invalid backward jump, found via fuzzing coverage."""
     eof_test(
-        data=Container.Code(
+        container=Container.Code(
             code=(
                 Op.PUSH0
                 + Op.RJUMPI[3]
@@ -598,7 +600,7 @@ def test_rjump_backwards_infinite_loop(
 ):
     """Validate that a backwards RJUMP as terminal operation is valid."""
     eof_test(
-        data=Container(
+        container=Container(
             name="backwards_rjump_terminal",
             sections=[
                 Section.Code(

--- a/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpi.py
+++ b/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpi.py
@@ -159,7 +159,7 @@ def test_rjumpi_forwards(
 ):
     """EOF1V4200_0004 (Valid) EOF code containing RJUMPI (Positive)."""
     eof_state_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1)
@@ -181,7 +181,7 @@ def test_rjumpi_backwards(
 ):
     """EOF1V4200_0005 (Valid) EOF code containing RJUMPI (Negative)."""
     eof_state_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1)
@@ -203,7 +203,7 @@ def test_rjumpi_zero(
 ):
     """EOF1V4200_0006 (Valid) EOF code containing RJUMPI (Zero)."""
     eof_state_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1)
@@ -222,7 +222,7 @@ def test_rjumpi_max_forward(
 ):
     """EOF1V4200_0007 (Valid) EOF with RJUMPI containing the maximum offset (32767)."""
     eof_state_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1)
@@ -243,7 +243,7 @@ def test_rjumpi_max_backward(
     """EOF with RJUMPI containing the maximum negative offset (-32768)."""
     (
         eof_state_test(
-            data=Container(
+            container=Container(
                 sections=[
                     Section.Code(
                         code=Op.PUSH0
@@ -273,7 +273,7 @@ def test_rjumpi_max_bytecode_size(
     code = Op.RJUMPI[len(Op.NOOP) * noop_count](Op.ORIGIN) + (Op.NOOP * noop_count) + Op.STOP
     container = Container.Code(code=code)
     assert len(container) == MAX_BYTECODE_SIZE
-    eof_test(data=container)
+    eof_test(container=container)
 
 
 def test_rjumpi_truncated(
@@ -281,7 +281,7 @@ def test_rjumpi_truncated(
 ):
     """EOF1I4200_0014 (Invalid) EOF code containing truncated RJUMPI."""
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(0) + Op.RJUMPI,
@@ -297,7 +297,7 @@ def test_rjumpi_truncated_2(
 ):
     """EOF1I4200_0015 (Invalid) EOF code containing truncated RJUMPI."""
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(0) + Op.RJUMPI + b"\x00",
@@ -318,7 +318,7 @@ def test_rjumpi_into_header(
     (Jumping into header).
     """
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1) + Op.RJUMPI[offset] + Op.STOP,
@@ -337,7 +337,7 @@ def test_rjumpi_jump_before_header(
     (Jumping to before code begin).
     """
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1) + Op.RJUMPI[-25] + Op.STOP,
@@ -356,7 +356,7 @@ def test_rjumpi_into_data(
     (Jumping into data section).
     """
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1) + Op.RJUMPI[2] + Op.STOP,
@@ -376,7 +376,7 @@ def test_rjumpi_after_container(
     (Jumping to after code end).
     """
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1) + Op.RJUMPI[2] + Op.STOP,
@@ -395,7 +395,7 @@ def test_rjumpi_to_code_end(
     (Jumping to code end).
     """
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1) + Op.RJUMPI[1] + Op.STOP,
@@ -413,7 +413,7 @@ def test_rjumpi_into_self_data_portion(
 ):
     """EOF1I4200_0021 (Invalid) EOF code containing RJUMPI with target same RJUMPI immediate."""
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1) + Op.RJUMPI[-offset] + Op.STOP,
@@ -429,7 +429,7 @@ def test_rjumpi_into_self(
 ):
     """EOF1I4200_0021 (Invalid) EOF code containing RJUMPI with target same RJUMPI immediate."""
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1) + Op.RJUMPI[-len(Op.RJUMPI[0])] + Op.STOP,
@@ -445,7 +445,7 @@ def test_rjumpi_into_stack_height_diff(
 ):
     """EOF code containing RJUMPI with target instruction that causes stack height difference."""
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(0)
@@ -464,7 +464,7 @@ def test_rjumpi_into_stack_underflow(
 ):
     """EOF code containing RJUMPI with target instruction that cause stack underflow."""
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.ORIGIN + Op.RJUMPI[len(Op.STOP)] + Op.STOP + Op.POP + Op.STOP
@@ -480,7 +480,7 @@ def test_rjumpi_skips_stack_underflow(
 ):
     """EOF code containing RJUMPI where the default path produces a stack underflow."""
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(code=Op.ORIGIN + Op.RJUMPI[len(Op.POP)] + Op.POP + Op.STOP),
             ],
@@ -494,7 +494,7 @@ def test_rjumpi_into_rjump(
 ):
     """EOF1I4200_0023 (Invalid) EOF code containing RJUMPI with target RJUMP immediate."""
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1) + Op.RJUMPI[3] + Op.STOP + Op.RJUMP[-9],
@@ -510,7 +510,7 @@ def test_rjumpi_into_rjumpi(
 ):
     """EOF1I4200_0022 (Invalid) EOF code containing RJUMPI with target other RJUMPI immediate."""
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1)
@@ -538,7 +538,7 @@ def test_rjumpi_into_push_1(
         else Op.PUSH1[1] + Op.RJUMPI[1] + Op.PUSH1[1] + Op.POP
     ) + Op.STOP
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(code=code),
             ],
@@ -604,7 +604,7 @@ def test_rjumpi_into_push_n(
         offset = -4 if data_portion_end else -4 - data_portion_length + 1
         code = opcode[0] + Op.RJUMPI[offset] + Op.STOP
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(code=code),
             ],
@@ -628,7 +628,7 @@ def test_rjumpi_into_rjumpv(
     invalid_destination = 4 + (2 * target_rjumpv_table_size) if data_portion_end else 4
     target_jump_table = [0 for _ in range(target_rjumpv_table_size)]
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1)
@@ -656,7 +656,7 @@ def test_rjumpi_into_callf(
     """EOF1I4200_0026 (Invalid) EOF code containing RJUMPI with target CALLF immediate."""
     invalid_destination = 2 if data_portion_end else 1
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1) + Op.RJUMPI[invalid_destination] + Op.CALLF[1] + Op.STOP,
@@ -676,7 +676,7 @@ def test_rjumpi_into_dupn(
 ):
     """EOF code containing RJUMP with target DUPN immediate."""
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1)
@@ -698,7 +698,7 @@ def test_rjumpi_into_swapn(
 ):
     """EOF code containing RJUMP with target SWAPN immediate."""
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1)
@@ -720,7 +720,7 @@ def test_rjumpi_into_exchange(
 ):
     """EOF code containing RJUMP with target EXCHANGE immediate."""
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1)
@@ -743,7 +743,7 @@ def test_rjumpi_into_eofcreate(
 ):
     """EOF code containing RJUMPI with target EOFCREATE immediate."""
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH0 * 5 + Op.RJUMPI[1] + Op.EOFCREATE[0] + Op.STOP,
@@ -771,7 +771,7 @@ def test_rjumpi_into_returncontract(
 ):
     """EOF code containing RJUMPI with target RETURNCONTRACT immediate."""
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.EOFCREATE[0](0, 0, 0, 0) + Op.STOP,
@@ -808,7 +808,7 @@ def test_rjumpi_backwards_reference_only(
         )
     )
     eof_test(
-        data=container,
+        container=container,
         expect_exception=EOFException.UNREACHABLE_INSTRUCTIONS,
     )
 
@@ -823,7 +823,7 @@ def test_rjumpi_stack_validation(
     """
     container = Container.Code(code=Op.RJUMPI[1](1) + Op.ADDRESS + Op.NOOP + Op.STOP)
     eof_test(
-        data=container,
+        container=container,
         expect_exception=None,
     )
 
@@ -836,7 +836,7 @@ def test_rjumpi_at_the_end(
     This implies that the last instruction may be a terminating instruction or RJUMP.
     """
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(0) + Op.PUSH1(0) + Op.RJUMPI[1] + Op.STOP + Op.RJUMPI[-4],
@@ -866,7 +866,7 @@ def test_tangled_rjumpi(
         )
     )
     eof_test(
-        data=container,
+        container=container,
         expect_exception=EOFException.STACK_UNDERFLOW,
     )
 
@@ -880,7 +880,7 @@ def test_rjumpi_backwards_onto_dup(
         max_stack_height=2,
     )
     eof_test(
-        data=container,
+        container=container,
     )
 
 
@@ -901,7 +901,7 @@ def test_rjumpi_backwards_min_stack_wrong(
         max_stack_height=3,
     )
     eof_test(
-        data=container,
+        container=container,
         expect_exception=EOFException.STACK_HEIGHT_MISMATCH,
     )
 
@@ -923,7 +923,7 @@ def test_rjumpi_rjumpv_backwards_min_stack_wrong(
         max_stack_height=3,
     )
     eof_test(
-        data=container,
+        container=container,
         expect_exception=EOFException.STACK_HEIGHT_MISMATCH,
     )
 
@@ -945,7 +945,7 @@ def test_double_rjumpi_stack_underflow(
         max_stack_height=3,
     )
     eof_test(
-        data=container,
+        container=container,
         expect_exception=EOFException.STACK_UNDERFLOW,
     )
 
@@ -958,7 +958,7 @@ def test_double_rjumpi_stack_height_mismatch(
     targeted by two RJUMPIs with the non-uniform stack height range.
     """
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH0  # BEGIN: (0, 0)
@@ -982,7 +982,7 @@ def test_double_rjumpi_invalid_max_stack_height(
     targeted by two RJUMPIs with the non-uniform stack height range.
     """
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH0  # (0, 0)

--- a/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py
+++ b/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py
@@ -54,7 +54,7 @@ def test_rjumpv_condition(
     fall_through_case = Op.SSTORE(slot_conditional_result, value_fall_through) + Op.STOP
 
     eof_state_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH0
@@ -65,7 +65,7 @@ def test_rjumpv_condition(
                 )
             ]
         ),
-        tx_data=calldata.to_bytes(32, "big"),
+        data=calldata.to_bytes(32, "big"),
         container_post=Account(
             storage={
                 slot_conditional_result: calldata + value_base
@@ -81,7 +81,7 @@ def test_rjumpv_forwards(
 ):
     """EOF1V4200_0008 (Valid) EOF with RJUMPV table size 1 (Positive)."""
     eof_state_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(0)
@@ -103,7 +103,7 @@ def test_rjumpv_backwards(
 ):
     """EOF1V4200_0009 (Valid) EOF with RJUMPV table size 1 (Negative)."""
     eof_state_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(0)
@@ -129,7 +129,7 @@ def test_rjumpv_backwards_onto_dup(
         max_stack_height=2,
     )
     eof_test(
-        data=container,
+        container=container,
     )
 
 
@@ -146,7 +146,7 @@ def test_rjumpv_backwards_large_table(
         max_stack_height=1,
     )
     eof_test(
-        data=container,
+        container=container,
     )
 
 
@@ -155,7 +155,7 @@ def test_rjumpv_zero(
 ):
     """EOF1V4200_0010 (Valid) EOF with RJUMPV table size 1 (Zero)."""
     eof_state_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(0)
@@ -174,7 +174,7 @@ def test_rjumpv_size_3(
 ):
     """EOF1V4200_0011 (Valid) EOF with RJUMPV table size 3."""
     eof_state_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(0)
@@ -201,7 +201,7 @@ def test_rjumpv_full_table(
 ):
     """EOF1V4200_0012/13/14/15 (Valid) EOF with RJUMPV table size 256 (target parameterized)."""
     eof_state_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH2[target]
@@ -221,7 +221,7 @@ def test_rjumpv_max_forwards(
 ):
     """EOF1V4200_0016 (Valid) EOF with RJUMPV containing the maximum offset (32767)."""
     eof_state_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1)
@@ -241,7 +241,7 @@ def test_rjumpv_truncated_empty(
 ):
     """EOF1I4200_0027 (Invalid) EOF code containing RJUMPV with max_index 0 but no immediates."""
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1) + Op.RJUMPV,
@@ -270,7 +270,7 @@ def test_rjumpv_truncated(
     rjumpv_bytes += b"\0" * ((2 * (branches - 1)) + byte_count_last_branch)
 
     eof_test(
-        data=Container.Code(code=Op.PUSH1(1) + Op.RJUMPV[rjumpv_bytes]),
+        container=Container.Code(code=Op.PUSH1(1) + Op.RJUMPV[rjumpv_bytes]),
         expect_exception=EOFException.TRUNCATED_INSTRUCTION,
     )
 
@@ -296,7 +296,7 @@ def test_rjumpv_into_header(
     jump_table = [0 for _ in range(table_size)]
     jump_table[invalid_index] = invalid_destination
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1) + Op.RJUMPV[jump_table] + Op.STOP,
@@ -330,7 +330,7 @@ def test_rjumpv_before_container(
     jump_table = [0 for _ in range(table_size)]
     jump_table[invalid_index] = invalid_destination
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1) + Op.RJUMPV[jump_table] + Op.STOP,
@@ -362,7 +362,7 @@ def test_rjumpv_into_data(
     jump_table = [0 for _ in range(table_size)]
     jump_table[invalid_index] = invalid_destination
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1) + Op.RJUMPV[jump_table] + Op.STOP,
@@ -395,7 +395,7 @@ def test_rjumpv_after_container(
     jump_table = [0 for _ in range(table_size)]
     jump_table[invalid_index] = invalid_destination
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1) + Op.RJUMPV[jump_table] + Op.STOP,
@@ -427,7 +427,7 @@ def test_rjumpv_at_end(
     jump_table = [0 for _ in range(table_size)]
     jump_table[invalid_index] = invalid_destination
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1) + Op.RJUMPV[jump_table] + Op.STOP,
@@ -462,7 +462,7 @@ def test_rjumpv_into_self_data_portion(
     jump_table = [0 for _ in range(table_size)]
     jump_table[invalid_index] = invalid_destination
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1) + Op.RJUMPV[jump_table] + Op.STOP,
@@ -491,7 +491,7 @@ def test_rjumpv_into_self(
     jump_table[invalid_index] = -len(Op.RJUMPV[jump_table])
 
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1) + Op.RJUMPV[jump_table] + Op.STOP,
@@ -520,7 +520,7 @@ def test_rjumpv_into_stack_height_diff(
     jump_table[invalid_index] = -(len(Op.RJUMPV[jump_table]) + len(Op.PUSH1(0)) + len(Op.PUSH1(0)))
 
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(0) + Op.PUSH1(0) + Op.RJUMPV[jump_table] + Op.STOP,
@@ -548,7 +548,7 @@ def test_rjumpv_into_stack_underflow(
     jump_table = [0 for _ in range(table_size)]
     jump_table[invalid_index] = 1
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(code=Op.ORIGIN + Op.RJUMPV[jump_table] + Op.STOP + Op.POP + Op.STOP),
             ],
@@ -571,7 +571,7 @@ def test_rjumpv_skips_stack_underflow(
     """EOF code containing RJUMPV where the default path produces a stack underflow."""
     jump_table = [1 for _ in range(table_size)]
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(code=Op.ORIGIN + Op.RJUMPV[jump_table] + Op.POP + Op.STOP),
             ],
@@ -609,7 +609,7 @@ def test_rjumpv_into_rjump(
             valid_index += 1
         jump_table[valid_index] = 1
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1) + Op.RJUMPV[jump_table] + Op.STOP + Op.RJUMP[0] + Op.STOP,
@@ -649,7 +649,7 @@ def test_rjumpv_into_rjumpi(
             valid_index += 1
         jump_table[valid_index] = 1
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1)
@@ -700,7 +700,7 @@ def test_rjumpv_into_push_1(
         jump_table[invalid_index] = invalid_destination
         code = Op.PUSH1(1) + Op.RJUMPV[jump_table] + Op.STOP
     eof_test(
-        data=Container(
+        container=Container(
             sections=[Section.Code(code=code)],
         ),
         expect_exception=EOFException.INVALID_RJUMP_DESTINATION,
@@ -790,7 +790,7 @@ def test_rjumpv_into_push_n(
         jump_table[invalid_index] = invalid_destination
         code = opcode[1] + Op.RJUMPV[jump_table] + Op.STOP
     eof_test(
-        data=Container(
+        container=Container(
             sections=[Section.Code(code=code)],
         ),
         expect_exception=EOFException.INVALID_RJUMP_DESTINATION,
@@ -824,7 +824,7 @@ def test_rjumpv_into_rjumpv(
     source_jump_table[invalid_index] = invalid_destination
     target_jump_table = [0 for _ in range(target_table_size)]
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1)
@@ -864,7 +864,7 @@ def test_rjumpv_into_callf(
     jump_table = [0 for _ in range(table_size)]
     jump_table[invalid_index] = invalid_destination
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(0) + Op.RJUMPV[jump_table] + Op.CALLF[1] + Op.STOP,
@@ -897,7 +897,7 @@ def test_rjumpv_into_dupn(
     jump_table = [0 for _ in range(table_size)]
     jump_table[invalid_index] = invalid_destination
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1)
@@ -932,7 +932,7 @@ def test_rjumpv_into_swapn(
     jump_table = [0 for _ in range(table_size)]
     jump_table[invalid_index] = invalid_destination
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1)
@@ -967,7 +967,7 @@ def test_rjumpv_into_exchange(
     jump_table = [0 for _ in range(table_size)]
     jump_table[invalid_index] = invalid_destination
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1)
@@ -1003,7 +1003,7 @@ def test_rjumpv_into_eofcreate(
     jump_table = [0 for _ in range(table_size)]
     jump_table[invalid_index] = invalid_destination
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH0 * 5 + Op.RJUMPV[jump_table] + Op.EOFCREATE[0] + Op.STOP,
@@ -1044,7 +1044,7 @@ def test_rjumpv_into_returncontract(
     jump_table = [0 for _ in range(table_size)]
     jump_table[invalid_index] = invalid_destination
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.EOFCREATE[0](0, 0, 0, 0) + Op.STOP,
@@ -1082,7 +1082,7 @@ def test_rjumpv_backwards_reference_only(
         )
     )
     eof_test(
-        data=container,
+        container=container,
         expect_exception=EOFException.UNREACHABLE_INSTRUCTIONS,
     )
 
@@ -1095,7 +1095,7 @@ def test_rjumpv_at_the_end(
     This implies that the last instruction may be a terminating instruction or RJUMP.
     """
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(0) + Op.PUSH1(0) + Op.RJUMPI[1] + Op.STOP + Op.RJUMPV[-7](1),
@@ -1123,7 +1123,7 @@ def test_rjumpv_backwards_min_stack_wrong(
         max_stack_height=3,
     )
     eof_test(
-        data=container,
+        container=container,
         expect_exception=EOFException.STACK_HEIGHT_MISMATCH,
     )
 
@@ -1145,7 +1145,7 @@ def test_rjumpv_rjumpi_backwards_min_stack_wrong(
         max_stack_height=3,
     )
     eof_test(
-        data=container,
+        container=container,
         expect_exception=EOFException.STACK_HEIGHT_MISMATCH,
     )
 
@@ -1159,6 +1159,6 @@ def test_double_rjumpv(
         max_stack_height=3,
     )
     eof_test(
-        data=container,
+        container=container,
         expect_exception=EOFException.STACK_UNDERFLOW,
     )

--- a/tests/osaka/eip7692_eof_v1/eip4750_functions/test_callf_execution.py
+++ b/tests/osaka/eip7692_eof_v1/eip4750_functions/test_callf_execution.py
@@ -31,7 +31,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
 def test_callf_factorial(eof_state_test: EOFStateTestFiller, n, result):
     """Test factorial implementation with recursive CALLF instructions."""
     eof_state_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     Op.CALLDATALOAD(0) + Op.SSTORE(0, Op.CALLF[1]) + Op.STOP,
@@ -60,7 +60,7 @@ def test_callf_factorial(eof_state_test: EOFStateTestFiller, n, result):
                 ),
             ]
         ),
-        tx_data=Hash(n),
+        data=Hash(n),
         container_post=Account(storage={0: result}),
     )
 
@@ -72,7 +72,7 @@ def test_callf_factorial(eof_state_test: EOFStateTestFiller, n, result):
 def test_callf_fibonacci(eof_state_test: EOFStateTestFiller, n, result):
     """Test fibonacci sequence implementation with recursive CALLF instructions."""
     eof_state_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     Op.CALLDATALOAD(0) + Op.SSTORE(0, Op.CALLF[1]) + Op.STOP,
@@ -104,8 +104,8 @@ def test_callf_fibonacci(eof_state_test: EOFStateTestFiller, n, result):
                 ),
             ]
         ),
-        tx_gas_limit=15_000_000,
-        tx_data=Hash(n),
+        gas_limit=15_000_000,
+        data=Hash(n),
         container_post=Account(storage={0: result}),
     )
 
@@ -197,7 +197,7 @@ def test_callf_fibonacci(eof_state_test: EOFStateTestFiller, n, result):
 def test_callf(eof_state_test: EOFStateTestFiller, container: Container):
     """Test basic usage of CALLF and RETF instructions."""
     eof_state_test(
-        data=container,
+        container=container,
         container_post=Account(storage={slot_code_worked: value_code_worked}),
     )
 
@@ -392,7 +392,7 @@ def test_callf(eof_state_test: EOFStateTestFiller, container: Container):
 def test_callf_operand_stack_size_max(eof_state_test: EOFStateTestFiller, container: Container):
     """Test operand stack reaching 1024 items."""
     eof_state_test(
-        data=container,
+        container=container,
         container_post=Account(storage={slot_code_worked: value_code_worked}),
     )
 
@@ -474,7 +474,7 @@ def test_callf_operand_stack_size_max(eof_state_test: EOFStateTestFiller, contai
 def test_callf_operand_stack_overflow(eof_state_test: EOFStateTestFiller, container: Container):
     """Test stack overflowing 1024 items in called function."""
     eof_state_test(
-        data=container,
+        container=container,
         container_post=Account(storage={slot_code_worked: 0}),
     )
 

--- a/tests/osaka/eip7692_eof_v1/eip4750_functions/test_code_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip4750_functions/test_code_validation.py
@@ -172,7 +172,7 @@ def test_eof_validity(
     container: Container,
 ):
     """Test EOF container validation for features around EIP-4750 / Functions / Code Sections."""
-    eof_test(data=container)
+    eof_test(container=container)
 
 
 @pytest.mark.parametrize(
@@ -222,7 +222,7 @@ def test_callf_truncated_immediate(
     container: Container,
 ):
     """Test cases for CALLF instructions with truncated immediate bytes."""
-    eof_test(data=container, expect_exception=EOFException.TRUNCATED_INSTRUCTION)
+    eof_test(container=container, expect_exception=EOFException.TRUNCATED_INSTRUCTION)
 
 
 @pytest.mark.parametrize(
@@ -268,7 +268,7 @@ def test_invalid_code_section_index(
     container: Container,
 ):
     """Test cases for CALLF instructions with invalid target code section index."""
-    eof_test(data=container, expect_exception=EOFException.INVALID_CODE_SECTION_INDEX)
+    eof_test(container=container, expect_exception=EOFException.INVALID_CODE_SECTION_INDEX)
 
 
 @pytest.mark.parametrize(
@@ -432,7 +432,7 @@ def test_unreachable_code_sections(
     Test cases for EOF unreachable code sections
     (i.e. code sections not reachable from the code section 0).
     """
-    eof_test(data=container, expect_exception=EOFException.UNREACHABLE_CODE_SECTIONS)
+    eof_test(container=container, expect_exception=EOFException.UNREACHABLE_CODE_SECTIONS)
 
 
 @pytest.mark.parametrize("callee_outputs", [1, 2, MAX_CODE_OUTPUTS])
@@ -456,7 +456,7 @@ def test_callf_stack_height_limit_exceeded(eof_test, callee_outputs):
             ),
         ],
     )
-    eof_test(data=container, expect_exception=EOFException.MAX_STACK_HEIGHT_ABOVE_LIMIT)
+    eof_test(container=container, expect_exception=EOFException.MAX_STACK_HEIGHT_ABOVE_LIMIT)
 
 
 @pytest.mark.parametrize("callee_outputs", [1, 2, MAX_CODE_OUTPUTS - 1, MAX_CODE_OUTPUTS])
@@ -484,7 +484,7 @@ def test_callf_stack_overflow_by_outputs(eof_test, callee_outputs, max_stack_hei
             ),
         ],
     )
-    eof_test(data=container, expect_exception=EOFException.STACK_OVERFLOW)
+    eof_test(container=container, expect_exception=EOFException.STACK_OVERFLOW)
 
 
 @pytest.mark.parametrize(
@@ -511,4 +511,4 @@ def test_callf_stack_overflow_by_height(eof_test, callee_stack_height):
             ),
         ],
     )
-    eof_test(data=container, expect_exception=EOFException.STACK_OVERFLOW)
+    eof_test(container=container, expect_exception=EOFException.STACK_OVERFLOW)

--- a/tests/osaka/eip7692_eof_v1/eip5450_stack/test_code_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip5450_stack/test_code_validation.py
@@ -340,7 +340,7 @@ def test_rjumps_callf_retf(
     if container_has_section_0_retf:
         possible_exceptions.append(EOFException.INVALID_NON_RETURNING_FLAG)
 
-    eof_test(data=Container(sections=sections), expect_exception=possible_exceptions or None)
+    eof_test(container=Container(sections=sections), expect_exception=possible_exceptions or None)
 
 
 @pytest.mark.parametrize(
@@ -432,4 +432,4 @@ def test_rjumps_jumpf_nonreturning(
     if container_has_non_returning_retf:
         possible_exceptions.append(EOFException.INVALID_NON_RETURNING_FLAG)
 
-    eof_test(data=Container(sections=sections), expect_exception=possible_exceptions or None)
+    eof_test(container=Container(sections=sections), expect_exception=possible_exceptions or None)

--- a/tests/osaka/eip7692_eof_v1/eip6206_jumpf/test_jumpf_execution.py
+++ b/tests/osaka/eip7692_eof_v1/eip6206_jumpf/test_jumpf_execution.py
@@ -21,7 +21,7 @@ def test_jumpf_forward(
 ):
     """Test JUMPF jumping forward."""
     eof_state_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.JUMPF[1],
@@ -32,7 +32,7 @@ def test_jumpf_forward(
             ],
         ),
         container_post=Account(storage={slot_code_worked: value_code_worked}),
-        tx_data=b"\1",
+        data=b"\1",
     )
 
 
@@ -41,7 +41,7 @@ def test_jumpf_backward(
 ):
     """Tests JUMPF jumping backward."""
     eof_state_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.CALLF[2] + Op.SSTORE(slot_code_worked, value_code_worked) + Op.STOP,
@@ -57,7 +57,7 @@ def test_jumpf_backward(
             ],
         ),
         container_post=Account(storage={slot_code_worked: value_code_worked}),
-        tx_data=b"\1",
+        data=b"\1",
     )
 
 
@@ -66,7 +66,7 @@ def test_jumpf_to_self(
 ):
     """Tests JUMPF jumping to self."""
     eof_state_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.SLOAD(slot_code_worked)
@@ -79,7 +79,7 @@ def test_jumpf_to_self(
             ],
         ),
         container_post=Account(storage={slot_code_worked: value_code_worked}),
-        tx_data=b"\1",
+        data=b"\1",
     )
 
 
@@ -88,7 +88,7 @@ def test_jumpf_too_large(
 ):
     """Tests JUMPF jumping to a section outside the max section range."""
     eof_state_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.JUMPF[1025],
@@ -104,7 +104,7 @@ def test_jumpf_way_too_large(
 ):
     """Tests JUMPF jumping to uint64.MAX."""
     eof_state_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.JUMPF[0xFFFF],
@@ -120,7 +120,7 @@ def test_jumpf_to_nonexistent_section(
 ):
     """Tests JUMPF jumping to valid section number but where the section does not exist."""
     eof_state_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.JUMPF[5],
@@ -136,7 +136,7 @@ def test_callf_to_non_returning_section(
 ):
     """Tests CALLF into a non-returning section."""
     eof_state_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.CALLF[1],
@@ -156,7 +156,7 @@ def test_jumpf_stack_size_1024(
 ):
     """Test stack reaching 1024 items in target function of JUMPF."""
     eof_state_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH0 * 1022 + Op.JUMPF[1],
@@ -179,7 +179,7 @@ def test_jumpf_with_inputs_stack_size_1024(
 ):
     """Test stack reaching 1024 items in target function of JUMPF with inputs."""
     eof_state_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH0 * 1022 + Op.JUMPF[1],
@@ -202,7 +202,7 @@ def test_jumpf_stack_size_1024_at_push(
 ):
     """Test stack reaching 1024 items in JUMPF target function at PUSH0 instruction."""
     eof_state_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH0 * 1023
@@ -258,7 +258,7 @@ def test_jumpf_stack_overflow(
     `execution_overflow` - execution would overflow (but still blocked by reserved stack rule)
     """
     eof_state_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH0 * stack_height
@@ -303,7 +303,7 @@ def test_jumpf_with_inputs_stack_size_1024_at_push(
 ):
     """Test stack reaching 1024 items in JUMPF target function with inputs at PUSH0 instruction."""
     eof_state_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH0 * 1023
@@ -341,7 +341,7 @@ def test_jumpf_with_inputs_stack_overflow(
 ):
     """Test stack overflowing 1024 items in JUMPF target function with inputs."""
     eof_state_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH0 * 1023

--- a/tests/osaka/eip7692_eof_v1/eip6206_jumpf/test_jumpf_stack.py
+++ b/tests/osaka/eip7692_eof_v1/eip6206_jumpf/test_jumpf_stack.py
@@ -59,9 +59,9 @@ def test_jumpf_stack_non_returning_rules(
         container.validity_error = EOFException.STACK_UNDERFLOW
 
     eof_state_test(
-        data=container,
+        container=container,
         container_post=Account(storage={slot_code_worked: value_code_worked}),
-        tx_data=b"\1",
+        data=b"\1",
     )
 
 
@@ -129,9 +129,9 @@ def test_jumpf_stack_returning_rules(
         container.validity_error = EOFException.STACK_HIGHER_THAN_OUTPUTS
 
     eof_state_test(
-        data=container,
+        container=container,
         container_post=Account(storage={slot_code_worked: value_code_worked}),
-        tx_data=b"\1",
+        data=b"\1",
     )
 
 
@@ -162,7 +162,7 @@ def test_jumpf_incompatible_outputs(
     if (current_section_outputs + target_inputs - target_outputs) != stack_height:
         assert expected_exception is not None
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(Op.CALLF(1) + Op.STOP, max_stack_height=1),
                 Section.Code(
@@ -206,7 +206,7 @@ def test_jumpf_diff_max_stack_height(
     """Tests jumpf with a different max stack height."""
     current_section_outputs = 1
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(Op.CALLF(1) + Op.STOP, max_stack_height=1),
                 Section.Code(
@@ -254,7 +254,7 @@ def test_jumpf_diff_min_stack_height(
     """Tests jumpf with a different min stack height."""
     current_section_outputs = 1
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(Op.CALLF(1) + Op.STOP, max_stack_height=1),
                 Section.Code(

--- a/tests/osaka/eip7692_eof_v1/eip6206_jumpf/test_jumpf_target.py
+++ b/tests/osaka/eip7692_eof_v1/eip6206_jumpf/test_jumpf_target.py
@@ -105,9 +105,9 @@ def test_jumpf_target_rules(
         container.validity_error = EOFException.JUMPF_DESTINATION_INCOMPATIBLE_OUTPUTS
 
     eof_state_test(
-        data=container,
+        container=container,
         container_post=Account(storage={slot_code_worked: value_code_worked}),
-        tx_data=b"\1",
+        data=b"\1",
     )
 
 

--- a/tests/osaka/eip7692_eof_v1/eip6206_jumpf/test_jumpf_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip6206_jumpf/test_jumpf_validation.py
@@ -55,4 +55,4 @@ def test_invalid_code_section_index(
     container: Container,
 ):
     """Test cases for JUMPF instructions with invalid target code section index."""
-    eof_test(data=container, expect_exception=EOFException.INVALID_CODE_SECTION_INDEX)
+    eof_test(container=container, expect_exception=EOFException.INVALID_CODE_SECTION_INDEX)

--- a/tests/osaka/eip7692_eof_v1/eip6206_jumpf/test_nonreturning_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip6206_jumpf/test_nonreturning_validation.py
@@ -32,7 +32,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
 def test_first_section_returning(eof_test: EOFTestFiller, code_section: Section):
     """Test EOF validation failing because the first section is not non-returning."""
     eof_test(
-        data=Container(
+        container=Container(
             sections=[code_section], validity_error=EOFException.INVALID_FIRST_SECTION_TYPE
         )
     )
@@ -56,7 +56,7 @@ def test_first_section_returning(eof_test: EOFTestFiller, code_section: Section)
 def test_returning_section_not_returning(eof_test: EOFTestFiller, code_section: Section):
     """Test EOF validation failing due to returning section with no RETF or JUMPF-to-returning."""
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(Op.CALLF[1] + Op.STOP, max_stack_height=code_section.code_outputs),
                 code_section,
@@ -84,7 +84,7 @@ def test_returning_section_returncontract(eof_test: EOFTestFiller, code_section:
     RETURNCONTRACT version.
     """
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(Op.CALLF[1] + Op.INVALID, max_stack_height=code_section.code_outputs),
                 code_section,
@@ -115,7 +115,9 @@ def test_retf_in_nonreturning(eof_test: EOFTestFiller, first: bool, code_prefix:
     if not first:  # Prefix sections with additional valid JUMPF to invalid section
         sections = [Section.Code(Op.JUMPF[1])] + sections
     eof_test(
-        data=Container(sections=sections, validity_error=EOFException.INVALID_NON_RETURNING_FLAG)
+        container=Container(
+            sections=sections, validity_error=EOFException.INVALID_NON_RETURNING_FLAG
+        )
     )
 
 
@@ -133,7 +135,7 @@ def test_jumpf_in_nonreturning(eof_test: EOFTestFiller, first: bool, code_prefix
         sections = [Section.Code(Op.JUMPF[1])] + sections
 
     eof_test(
-        data=Container(
+        container=Container(
             sections=sections,
             validity_error=EOFException.INVALID_NON_RETURNING_FLAG,
         )
@@ -205,4 +207,4 @@ def test_jumpf_in_nonreturning(eof_test: EOFTestFiller, first: bool, code_prefix
 )
 def test_callf_to_nonreturning(eof_test: EOFTestFiller, container: Container):
     """Test EOF validation failing due to CALLF to non-returning section."""
-    eof_test(data=container, expect_exception=EOFException.CALLF_TO_NON_RETURNING)
+    eof_test(container=container, expect_exception=EOFException.CALLF_TO_NON_RETURNING)

--- a/tests/osaka/eip7692_eof_v1/eip663_dupn_swapn_exchange/test_dupn.py
+++ b/tests/osaka/eip7692_eof_v1/eip663_dupn_swapn_exchange/test_dupn.py
@@ -37,7 +37,7 @@ def test_dupn_all_valid_immediates(eof_state_test: EOFStateTestFiller):
 
     eof_state_test(
         tx_sender_funding_amount=1_000_000_000,
-        data=eof_code,
+        container=eof_code,
         container_post=post,
     )
 
@@ -71,7 +71,7 @@ def test_dupn_stack_underflow(
         ],
     )
     eof_test(
-        data=eof_code,
+        container=eof_code,
         expect_exception=EOFException.STACK_UNDERFLOW,
     )
 
@@ -104,6 +104,6 @@ def test_dupn_stack_overflow(
         ],
     )
     eof_test(
-        data=eof_code,
+        container=eof_code,
         expect_exception=expect_exception,
     )

--- a/tests/osaka/eip7692_eof_v1/eip663_dupn_swapn_exchange/test_exchange.py
+++ b/tests/osaka/eip7692_eof_v1/eip663_dupn_swapn_exchange/test_exchange.py
@@ -47,7 +47,7 @@ def test_exchange_all_valid_immediates(eof_state_test: EOFStateTestFiller):
 
     eof_state_test(
         tx_sender_funding_amount=1_000_000_000,
-        data=eof_code,
+        container=eof_code,
         container_post=post,
     )
 
@@ -86,6 +86,6 @@ def test_exchange_all_invalid_immediates(
     )
 
     eof_test(
-        data=eof_code,
+        container=eof_code,
         expect_exception=EOFException.STACK_UNDERFLOW,
     )

--- a/tests/osaka/eip7692_eof_v1/eip663_dupn_swapn_exchange/test_swapn.py
+++ b/tests/osaka/eip7692_eof_v1/eip663_dupn_swapn_exchange/test_swapn.py
@@ -38,7 +38,7 @@ def test_swapn_all_valid_immediates(eof_state_test: EOFStateTestFiller):
 
     eof_state_test(
         tx_sender_funding_amount=1_000_000_000,
-        data=eof_code,
+        container=eof_code,
         container_post=post,
     )
 
@@ -66,7 +66,7 @@ def test_swapn_on_max_stack(
         ],
     )
     eof_test(
-        data=eof_code,
+        container=eof_code,
     )
 
 
@@ -96,6 +96,6 @@ def test_swapn_stack_underflow(
         ],
     )
     eof_test(
-        data=eof_code,
+        container=eof_code,
         expect_exception=EOFException.STACK_UNDERFLOW,
     )

--- a/tests/osaka/eip7692_eof_v1/eip7480_data_section/test_code_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip7480_data_section/test_code_validation.py
@@ -155,7 +155,7 @@ def test_legacy_initcode_valid_eof_v1_contract(
         container.validity_error is None
     ), f"Valid container with validity error: {container.validity_error}"
     eof_test(
-        data=container,
+        container=container,
     )
 
 
@@ -174,7 +174,7 @@ def test_legacy_initcode_invalid_eof_v1_contract(
     """
     assert container.validity_error is not None, "Invalid container without validity error"
     eof_test(
-        data=container,
+        container=container,
         expect_exception=container.validity_error,
     )
 
@@ -221,4 +221,4 @@ def test_dataloadn_truncated_immediate(
     container: Container,
 ):
     """Test cases for DATALOADN instructions with truncated immediate bytes."""
-    eof_test(data=container, expect_exception=EOFException.TRUNCATED_INSTRUCTION)
+    eof_test(container=container, expect_exception=EOFException.TRUNCATED_INSTRUCTION)

--- a/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_eofcreate.py
+++ b/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_eofcreate.py
@@ -562,7 +562,7 @@ def test_eofcreate_invalid_index(
 ):
     """Referring to non-existent container section index."""
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.EOFCREATE[index](0, 0, 0, 0) + Op.STOP,

--- a/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_returncontract.py
+++ b/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_returncontract.py
@@ -29,7 +29,7 @@ def test_returncontract_valid_index_0(
     """Deploy container index 0."""
     eof_test(
         container_kind=ContainerKind.INITCODE,
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.RETURNCONTRACT[0](0, 0),
@@ -46,7 +46,7 @@ def test_returncontract_valid_index_1(
     """Deploy container index 1."""
     eof_test(
         container_kind=ContainerKind.INITCODE,
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.RJUMPI[6](0) + Op.RETURNCONTRACT[0](0, 0) + Op.RETURNCONTRACT[1](0, 0),
@@ -65,7 +65,7 @@ def test_returncontract_valid_index_255(
     """Deploy container index 255."""
     eof_test(
         container_kind=ContainerKind.INITCODE,
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     sum((Op.RJUMPI[6](0) + Op.RETURNCONTRACT[i](0, 0)) for i in range(256))
@@ -85,7 +85,7 @@ def test_returncontract_invalid_truncated_immediate(
     """Truncated immediate."""
     eof_test(
         container_kind=ContainerKind.INITCODE,
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH0 + Op.PUSH0 + Op.RETURNCONTRACT,
@@ -102,7 +102,7 @@ def test_returncontract_invalid_index_0(
     """Referring to non-existent container section index 0."""
     eof_test(
         container_kind=ContainerKind.INITCODE,
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.RETURNCONTRACT[0](0, 0),
@@ -119,7 +119,7 @@ def test_returncontract_invalid_index_1(
     """Referring to non-existent container section index 1."""
     eof_test(
         container_kind=ContainerKind.INITCODE,
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.RETURNCONTRACT[1](0, 0),
@@ -137,7 +137,7 @@ def test_returncontract_invalid_index_255(
     """Referring to non-existent container section index 255."""
     eof_test(
         container_kind=ContainerKind.INITCODE,
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.RETURNCONTRACT[255](0, 0),
@@ -155,7 +155,7 @@ def test_returncontract_terminating(
     """Unreachable code after RETURNCONTRACT."""
     eof_test(
         container_kind=ContainerKind.INITCODE,
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.RETURNCONTRACT[0](0, 0) + Op.REVERT(0, 0),

--- a/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
@@ -45,7 +45,7 @@ def test_simple_create_from_deployed(
 ):
     """Simple EOF creation from a deployed EOF container."""
     eof_state_test(
-        data=Container(
+        container=Container(
             sections=[
                 eofcreate_code_section,
                 returncontract_sub_container,
@@ -60,7 +60,7 @@ def test_simple_create_from_creation(
 ):
     """Simple EOF creation from a create transaction container."""
     eof_state_test(
-        data=Container(
+        container=Container(
             sections=[
                 returncontract_code_section,
                 stop_sub_container,
@@ -82,7 +82,7 @@ def test_reverting_container(
 ):
     """Test revert containers."""
     eof_state_test(
-        data=Container(
+        container=Container(
             sections=[
                 zero_section,
                 revert_sub_container,
@@ -119,7 +119,7 @@ def test_orphan_container(
 ):
     """Test orphaned containers."""
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 code_section,
                 first_sub_container,
@@ -174,7 +174,7 @@ def test_container_combos_valid(
 ):
     """Test valid subcontainer reference / opcode combos."""
     eof_state_test(
-        data=Container(
+        container=Container(
             sections=[
                 code_section,
                 sub_container,
@@ -216,7 +216,7 @@ def test_container_combos_invalid(
 ):
     """Test invalid subcontainer reference / opcode combos."""
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 code_section,
                 first_sub_container,
@@ -281,7 +281,7 @@ def test_container_combos_deeply_nested_valid(
             kind=ContainerKind.INITCODE,
         )
 
-    eof_test(data=container)
+    eof_test(container=container)
 
 
 @pytest.mark.parametrize(
@@ -329,7 +329,7 @@ def test_container_combos_deeply_nested_invalid(
         )
 
     eof_test(
-        data=container,
+        container=container,
         expect_exception=EOFException.INCOMPATIBLE_CONTAINER_KIND,
     )
 
@@ -377,7 +377,7 @@ def test_container_combos_non_first_code_sections_valid(
 ):
     """Test valid subcontainer reference / opcode combos in a non-first code section."""
     eof_test(
-        data=Container(
+        container=Container(
             sections=[Section.Code(Op.JUMPF[i]) for i in range(1, 1024)]
             + [code_section, first_sub_container],
             kind=container_kind,
@@ -416,7 +416,7 @@ def test_container_combos_non_first_code_sections_invalid(
 ):
     """Test invalid subcontainer reference / opcode combos in a non-first code section."""
     eof_test(
-        data=Container(
+        container=Container(
             sections=[Section.Code(Op.JUMPF[i]) for i in range(1, 1024)]
             + [code_section, first_sub_container],
             kind=container_kind,
@@ -428,7 +428,7 @@ def test_container_combos_non_first_code_sections_invalid(
 def test_container_both_kinds_same_sub(eof_test: EOFTestFiller):
     """Test subcontainer conflicts (both EOFCREATE and RETURNCONTRACT Reference)."""
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.EOFCREATE[0](0, 0, 0, 0) + Op.JUMPF[1],
@@ -446,7 +446,7 @@ def test_container_both_kinds_same_sub(eof_test: EOFTestFiller):
 def test_container_both_kinds_different_sub(eof_test: EOFTestFiller):
     """Test multiple kinds of subcontainer at the same level."""
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.EOFCREATE[0](0, 0, 0, 0) + Op.JUMPF[1],
@@ -465,7 +465,7 @@ def test_container_both_kinds_different_sub(eof_test: EOFTestFiller):
 def test_container_multiple_eofcreate_references(eof_test: EOFTestFiller):
     """Test multiple references to the same subcontainer from an EOFCREATE operation."""
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.EOFCREATE[0](0, 0, 0, 0) + Op.EOFCREATE[0](0, 0, 0, 0) + Op.STOP,
@@ -479,7 +479,7 @@ def test_container_multiple_eofcreate_references(eof_test: EOFTestFiller):
 def test_container_multiple_returncontract_references(eof_test: EOFTestFiller):
     """Test multiple references to the same subcontainer from a RETURNCONTACT operation."""
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH0
@@ -502,7 +502,7 @@ def test_subcontainer_wrong_eof_version(
 ):
     """Test a subcontainer with the incorrect EOF version."""
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=Op.EOFCREATE[0](0, 0, 0, 0) + Op.STOP,
@@ -526,7 +526,7 @@ def test_subcontainer_wrong_size(
 ):
     """Test a subcontainer with the incorrect size in the parent's header."""
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=(Op.EOFCREATE[0](0, 0, 0, 0) + Op.STOP)
@@ -586,7 +586,7 @@ def test_deep_container(
             ],
         )
 
-    eof_test(data=last_container, expect_exception=exception)
+    eof_test(container=last_container, expect_exception=exception)
 
 
 @pytest.mark.parametrize(
@@ -604,7 +604,7 @@ def test_wide_container(eof_test: EOFTestFiller, width: int, exception: EOFExcep
     for x in range(0, 256):
         create_code = Op.EOFCREATE[x](0, 0, 0, 0) + create_code
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 Section.Code(
                     code=create_code,
@@ -784,7 +784,7 @@ def test_wide_container(eof_test: EOFTestFiller, width: int, exception: EOFExcep
 )
 def test_migrated_eofcreate(eof_test: EOFTestFiller, container: Container):
     """Tests migrated from EOFTests/efValidation/EOF1_eofcreate_valid_.json."""
-    eof_test(data=container, expect_exception=container.validity_error)
+    eof_test(container=container, expect_exception=container.validity_error)
 
 
 def test_dangling_initcode_subcontainer_bytes(
@@ -792,7 +792,7 @@ def test_dangling_initcode_subcontainer_bytes(
 ):
     """Initcode mode EOF Subcontainer test with subcontainer containing dangling bytes."""
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 returncontract_code_section,
                 Section.Container(
@@ -812,7 +812,7 @@ def test_dangling_runtime_subcontainer_bytes(
 ):
     """Runtime mode EOF Subcontainer test with subcontainer containing dangling bytes."""
     eof_test(
-        data=Container(
+        container=Container(
             sections=[
                 eofcreate_code_section,
                 Section.Container(


### PR DESCRIPTION
## 🗒️ Description

### `EOFTest.data` -> `EOFTest.container` Rename

Renames the `data` field of `EOFTest` to a more appropriate name of `container`.

All EOF tests have been refactored to use the new name.

### `EOFStateTest` inheriting `Transaction`

`EOFStateTest` now inherits `Transaction` and the fields `tx_gas_limit` and `tx_data` have been deprecated in favor of the `Transaction.gas_limit` and `Transaction.data` fields. Tests using either of these fields have been modified to use the new fields.

Note that `EOFStateTest.gas_limit` is redefined to have a default of 10,000,000, since the `Transaction` default is 21,000, and some EOF tests relied on the higher limit.

Other `Transaction` fields such as `expected_receipt` are now available in the `EOFStateTest` object, and can be used automatically to make verifications in the state test.

### Test filling

Tests were filled before and after this change and the resulting hashes are identical:
```
(execution-spec-tests) marioevz@hive-simulations:~/Development/Eth/execution-spec-tests ((83228e6092...))$ hasher -r ../fixtures
0xc606e47771600234d26b2657ecf8332c7479cd998d733e5df3d8fc4aa31aa112
(execution-spec-tests) marioevz@hive-simulations:~/Development/Eth/execution-spec-tests ((83228e6092...))$ hasher -r ./fixtures
0xc606e47771600234d26b2657ecf8332c7479cd998d733e5df3d8fc4aa31aa112
```

## 🔗 Related Issues
None.

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
