### PR TITLE
test(fill): remove test for `phil`

### DIFF
--- a/src/cli/tests/test_pytest_fill_command.py
+++ b/src/cli/tests/test_pytest_fill_command.py
@@ -9,7 +9,7 @@ from click.testing import CliRunner
 
 import pytest_plugins.filler.filler
 
-from ..pytest_commands.fill import fill, phil
+from ..pytest_commands.fill import fill
 
 
 @pytest.fixture
@@ -159,11 +159,3 @@ class TestHtmlReportFlags:
         assert result.exit_code == pytest.ExitCode.OK
         assert html_path.exists()
         assert (output_dir / "state_tests").exists(), "No fixtures in output directory"
-
-
-def test_phil_default_output_options(runner):
-    """A simple sanity test for phil."""
-    fill_args = ["-k", "test_dup and state_test-DUP16 and LEGACY", "--fork", "Frontier"]
-    result = runner.invoke(phil, fill_args)
-    assert result.exit_code == pytest.ExitCode.OK
-    assert "🦄" in result.output


### PR DESCRIPTION
## 🗒️ Description
Running `phil` in the framework tests "sometimes" caused `phil`'s pytest-custom-report (emoji) config to leak out into the framework pytest session terminal results and unsettling unfamiliar users.

## 🔗 Related Issues


## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
