### PR TITLE
test(gentest): add `--skip-evm-dump` option to `fill`

### DIFF
--- a/src/cli/gentest/tests/test_cli.py
+++ b/src/cli/gentest/tests/test_cli.py
@@ -97,5 +97,5 @@ def test_generate_success(tmp_path, monkeypatch):
     assert gentest_result.exit_code == 0
 
     ## Fill ##
-    fill_result = runner.invoke(fill, ["-c", "pytest.ini", output_file])
+    fill_result = runner.invoke(fill, ["-c", "pytest.ini", "--skip-evm-dump", output_file])
     assert fill_result.exit_code == 0


### PR DESCRIPTION
This avoids running into #1149.

## 🔗 Related Issues
#999

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
