### PR TITLE
uv.lock: Upgrade ethereum-types to 0.2.3

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -637,14 +637,14 @@ dependencies = [
 
 [[package]]
 name = "ethereum-types"
-version = "0.2.1"
+version = "0.2.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/a8/053c5fcc8581fe599a87b86431a50b7df5b84a88242a6ba33ab1138a2a34/ethereum_types-0.2.1.tar.gz", hash = "sha256:2b53c5f08aff52004d7a49cdb09e70163482b55a41e274a95a8d27d194c5d146", size = 14935 }
+sdist = { url = "https://files.pythonhosted.org/packages/65/23/cb6fdde984cc3632b478d68daaad9b8faccb3f83338882d3060e8cb2999e/ethereum_types-0.2.3.tar.gz", hash = "sha256:9cdbfda64052102ff57e6119464493d070f67126c2596081f6c791da90e834cd", size = 15216 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/76/3bbd13a9637287388f23c0c4094c81adf2d1467e314f8974ea0c61d2fc94/ethereum_types-0.2.1-py3-none-any.whl", hash = "sha256:6f6c51b239c231c6e33c10451b8fffb2fc168c6a7f0975cac3893d7e38e9c3e9", size = 10288 },
+    { url = "https://files.pythonhosted.org/packages/f3/0e/d327da9d255b030f8eee252cac85602982c30b87263a4b553e780154fe84/ethereum_types-0.2.3-py3-none-any.whl", hash = "sha256:a09a0d53a82cb9e3df734302d5b7eb92e01f524b81eb9d5b1240c77b796add5d", size = 10381 },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🗒️ Description
Upgrades ethereum-types to the latest version: 0.2.3

Fixes issue when running the resolver:
```
Traceback (most recent call last):
  File "/home/marioevz/Development/Eth/execution-spec-tests/.venv/bin/ethereum-spec-evm-resolver", line 8, in <module>
    sys.exit(main())
  File "/home/marioevz/Development/Eth/execution-spec-tests/.venv/lib/python3.10/site-packages/ethereum_spec_evm_resolver/main.py", line 53, in main
    from ethereum_spec_tools.evm_tools import Daemon as Daemon_
  File "/home/marioevz/Development/Eth/z-execution-specs/src/ethereum_spec_tools/evm_tools/__init__.py", line 12, in <module>
    from .b11r import B11R, b11r_arguments
  File "/home/marioevz/Development/Eth/z-execution-specs/src/ethereum_spec_tools/evm_tools/b11r/__init__.py", line 15, in <module>
    from .b11r_types import Body, Header
  File "/home/marioevz/Development/Eth/z-execution-specs/src/ethereum_spec_tools/evm_tools/b11r/b11r_types.py", line 12, in <module>
    from ethereum.utils.hexadecimal import hex_to_bytes, hex_to_bytes8
  File "/home/marioevz/Development/Eth/z-execution-specs/src/ethereum/utils/hexadecimal.py", line 15, in <module>
    from ethereum_types.numeric import U8, U64, U256, Uint
ImportError: cannot import name 'U8' from 'ethereum_types.numeric' (/home/marioevz/Development/Eth/execution-spec-tests/.venv/lib/python3.10/site-packages/ethereum_types/numeric.py)
```

## 🔗 Related Issues
None

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
