### PR TITLE
feat(github): Add devnet-6 definitions

### DIFF
--- a/.github/configs/evm.yaml
+++ b/.github/configs/evm.yaml
@@ -11,7 +11,7 @@ eip7692:
   repo: ethereum/evmone
   ref: master
   targets: ["evmone-t8n", "evmone-eofparse"]
-pectra-devnet-5:
+pectra-devnet-6:
   impl: eels
   repo: null
   ref: null  

--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -12,7 +12,7 @@ eip7692:
   fill-params: --fork=Osaka ./tests/osaka
   solc: 0.8.21
   eofwrap: true
-pectra-devnet-5:
-  evm-type: pectra-devnet-5
+pectra-devnet-6:
+  evm-type: pectra-devnet-6
   fill-params: --until=Prague -m "not eip_version_check"
   solc: 0.8.21


### PR DESCRIPTION
## 🗒️ Description
Changes devnet-5 to devnet-6 in all relevant CI config files.

## 🔗 Related Issues
#1108

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
