### PR TITLE
fix(execute): fix selected forks incompatibility

### DIFF
--- a/src/pytest_plugins/execute/execute.py
+++ b/src/pytest_plugins/execute/execute.py
@@ -95,10 +95,18 @@ def pytest_configure(config):
     command_line_args = "fill " + " ".join(config.invocation_params.args)
     config.stash[metadata_key]["Command-line args"] = f"<code>{command_line_args}</code>"
 
-    if len(config.selected_fork_set) != 1:
+    selected_fork_set = config.selected_fork_set
+
+    # remove the transition forks from the selected forks
+    for fork in set(selected_fork_set):
+        if hasattr(fork, "transitions_to"):
+            selected_fork_set.remove(fork)
+
+    if len(selected_fork_set) != 1:
         pytest.exit(
             f"""
-            Expected exactly one fork to be specified, got {len(config.selected_fork_set)}.
+            Expected exactly one fork to be specified, got {len(selected_fork_set)}
+            ({selected_fork_set}).
             Make sure to specify exactly one fork using the --fork command line argument.
             """,
             returncode=pytest.ExitCode.USAGE_ERROR,


### PR DESCRIPTION
## 🗒️ Description
Fixes an issue when using `uv run execute` where now the `config.selected_forks` variable that is prepared by the forks plugin also contains the transition forks, which resulted in the `execute` command always failing to start.

## 🔗 Related Issues
Bug introduced in fork plugin refactor in:
- #1081

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
