### PR TITLE
Add docs to #1131

### DIFF
--- a/docs/consuming_tests/blockchain_test.md
+++ b/docs/consuming_tests/blockchain_test.md
@@ -98,6 +98,10 @@ Chain configuration object to be applied to the client running the blockchain te
 
 Fork configuration for the test. It is guaranteed that this field contains the same value as the root field `network`.
 
+#### - `chainid`: `int`
+
+Chain ID configuration for the test.
+
 #### - `blobSchedule`: [`BlobSchedule`](./common_types.md#blobschedule-mappingforkforkblobschedule)
 
 Optional; present from Cancun on. Maps forks to their blob schedule configurations as defined by [EIP-7840](https://eips.ethereum.org/EIPS/eip-7840).

--- a/docs/consuming_tests/state_test.md
+++ b/docs/consuming_tests/state_test.md
@@ -66,7 +66,13 @@ Chain configuration object.
 
 ### `FixtureConfig`
 
-At the moment this object can contain only the `blobSchedule` that is necessary to apply the correct cap to the maximum amount of blobs that a transaction can have. Otherwise, in forks prior to Cancun for example, it will be an empty JSON object.
+#### - `network`: [`Fork`](./common_types.md#fork)
+
+Fork configuration for the test. It is guaranteed that this field contains the same value as the sole key of the [`post`](#-post-mappingforklist-fixtureforkpost) object.
+
+#### - `chainid`: `int`
+
+Chain ID configuration for the test.
 
 #### - `blobSchedule`: [`BlobSchedule`](./common_types.md#blobschedule-mappingforkforkblobschedule)
 

--- a/src/cli/check_fixtures.py
+++ b/src/cli/check_fixtures.py
@@ -48,10 +48,12 @@ def check_json(json_file_path: Path):
                 message=f"Fixture hash attributes do not match for {fixture_name}",
             )
         if "hash" in fixture.info and fixture.info["hash"] != original_hash:
+            info_hash = fixture.info["hash"]
             raise HashMismatchExceptionError(
                 original_hash,
                 fixture.info["hash"],
-                message=f"Fixture info['hash'] does not match calculated hash for {fixture_name}",
+                message=f"Fixture info['hash'] does not match calculated hash for {fixture_name}:"
+                f"'{info_hash}' != '{original_hash}'",
             )
 
 

--- a/src/ethereum_test_fixtures/blockchain.py
+++ b/src/ethereum_test_fixtures/blockchain.py
@@ -401,6 +401,7 @@ class FixtureConfig(CamelModel):
     """Chain configuration for a fixture."""
 
     fork: str = Field(..., alias="network")
+    chain_id: int = Field(1, alias="chainid")
     blob_schedule: FixtureBlobSchedule | None = None
 
 

--- a/src/ethereum_test_fixtures/state.py
+++ b/src/ethereum_test_fixtures/state.py
@@ -98,6 +98,8 @@ class FixtureConfig(CamelModel):
     """Chain configuration for a fixture."""
 
     blob_schedule: FixtureBlobSchedule | None = None
+    chain_id: int = Field(1, alias="chainid")
+    fork: str = Field(..., alias="network")
 
 
 class StateFixture(BaseFixture):

--- a/src/ethereum_test_specs/blockchain.py
+++ b/src/ethereum_test_specs/blockchain.py
@@ -588,6 +588,7 @@ class BlockchainTest(BaseTest):
             config=FixtureConfig(
                 fork=network_info,
                 blob_schedule=FixtureBlobSchedule.from_blob_schedule(fork.blob_schedule()),
+                chain_id=self.chain_id,
             ),
         )
 

--- a/src/ethereum_test_specs/blockchain.py
+++ b/src/ethereum_test_specs/blockchain.py
@@ -687,6 +687,7 @@ class BlockchainTest(BaseTest):
             last_block_hash=head_hash,
             config=FixtureConfig(
                 fork=network_info,
+                chain_id=self.chain_id,
                 blob_schedule=FixtureBlobSchedule.from_blob_schedule(fork.blob_schedule()),
             ),
         )

--- a/src/ethereum_test_specs/state.py
+++ b/src/ethereum_test_specs/state.py
@@ -178,6 +178,8 @@ class StateTest(BaseTest):
             transaction=FixtureTransaction.from_transaction(tx),
             config=FixtureConfig(
                 blob_schedule=FixtureBlobSchedule.from_blob_schedule(fork.blob_schedule()),
+                fork=fork.blockchain_test_network_name(),
+                chain_id=self.chain_id,
             ),
         )
 

--- a/src/ethereum_test_specs/tests/fixtures/blockchain_london_invalid_filled.json
+++ b/src/ethereum_test_specs/tests/fixtures/blockchain_london_invalid_filled.json
@@ -1,7 +1,7 @@
 {
     "000/my_blockchain_test/London": {
         "_info": {
-            "hash": "0x76838b666ca44a330fcf031ae20392647c3251ad54f29e995890bd608948b915",
+            "hash": "0xd537e9737bcce3ebb8f0f12850f60cebf920994faf9a796001b2c9c87d67cb6f",
             "fixture_format": "blockchain_test"
         },
         "network": "London",
@@ -541,7 +541,8 @@
         },
         "sealEngine": "NoProof",
         "config": {
-            "network": "London"
+            "network": "London",
+            "chainid": 1
         }
     }
 }

--- a/src/ethereum_test_specs/tests/fixtures/blockchain_london_valid_filled.json
+++ b/src/ethereum_test_specs/tests/fixtures/blockchain_london_valid_filled.json
@@ -1,7 +1,7 @@
 {
     "000/my_blockchain_test/London": {
         "_info": {
-            "hash": "0x7694748a5d5e0ea1e5e914210fb8db7c8077f070dd29ffcb13774d526aee35de",
+            "hash": "0x4a02b0c78673fab329cbc4aff10f527ef08ab3ad0e451cdc843959aa152595f9",
             "fixture_format": "blockchain_test"
         },
         "network": "London",
@@ -419,7 +419,8 @@
         },
         "sealEngine": "NoProof",
         "config": {
-            "network": "London"
+            "network": "London",
+            "chainid": 1
         }
     }
 }

--- a/src/ethereum_test_specs/tests/fixtures/blockchain_shanghai_invalid_filled_engine.json
+++ b/src/ethereum_test_specs/tests/fixtures/blockchain_shanghai_invalid_filled_engine.json
@@ -1,7 +1,7 @@
 {
     "000/my_blockchain_test/Shanghai": {
         "_info": {
-            "hash": "0x75f8ac4dbd5bfee6046a0edd5bec5448e23d1f249c10025a47bfb46ff7dab303",
+            "hash": "0x5193a74de3854a143ddc0e82c31c0678b91c8cf743866d69b70d000b6c250af5",
             "fixture_format": "blockchain_test_engine"
         },
         "lastblockhash": "0xfc75f11c05ec814a890141bef919bb7c20dd29245e37e9bcea66008dfde98526",
@@ -314,7 +314,8 @@
             }
         },
         "config": {
-            "network": "Shanghai"
+            "network": "Shanghai",
+            "chainid": 1
         }
     }
 }

--- a/src/ethereum_test_specs/tests/fixtures/blockchain_shanghai_valid_filled_engine.json
+++ b/src/ethereum_test_specs/tests/fixtures/blockchain_shanghai_valid_filled_engine.json
@@ -1,7 +1,7 @@
 {
     "000/my_blockchain_test/Shanghai": {
         "_info": {
-            "hash": "0xe0738285cd63c07ce0dbc7801ad9d91962d25edcca544bc8475d88a86cab4a15",
+            "hash": "0x715db66feb482dc3968ab277d8b2b31e5d3c44e7142e46fcbd1f251f98a977f4",
             "fixture_format": "blockchain_test_engine"
         },
         "lastblockhash": "0xfc75f11c05ec814a890141bef919bb7c20dd29245e37e9bcea66008dfde98526",
@@ -260,7 +260,8 @@
             }
         },
         "config": {
-            "network": "Shanghai"
+            "network": "Shanghai",
+            "chainid": 1
         }
     }
 }

--- a/src/ethereum_test_specs/tests/fixtures/chainid_cancun_blockchain_test.json
+++ b/src/ethereum_test_specs/tests/fixtures/chainid_cancun_blockchain_test.json
@@ -1,7 +1,7 @@
 {
     "000/my_chain_id_test/Cancun": {
         "_info": {
-            "hash": "0xdc67839b9bbea740321a4ce4cd9124e14387e74627761cf65ff425bc44d56c1e",
+            "hash": "0xe53839d3e47bdfcef1ece21e61a5685160a6f4b9171522c3a2e258220181d8f1",
             "fixture_format": "blockchain_test"
         },
         "network": "Cancun",
@@ -130,6 +130,7 @@
         "sealEngine": "NoProof",
         "config": {
             "network": "Cancun",
+            "chainid": 1,
             "blobSchedule": {
                 "Cancun": {
                     "max": "0x06",

--- a/src/ethereum_test_specs/tests/fixtures/chainid_cancun_blockchain_test_engine.json
+++ b/src/ethereum_test_specs/tests/fixtures/chainid_cancun_blockchain_test_engine.json
@@ -1,7 +1,7 @@
 {
     "000/my_chain_id_test/Cancun": {
         "_info": {
-            "hash": "0x66186573da8dc65698bed9544ccbe25c13a1ff1039320609531e134473e7210c",
+            "hash": "0xb1727871136c6d0971fd796eabb7a5e6cab6859aaa2b07d4313a30bbab2d2cec",
             "fixture_format": "blockchain_test_engine"
         },
         "network": "Cancun",
@@ -112,6 +112,7 @@
         },
         "config": {
             "network": "Cancun",
+            "chainid": 1,
             "blobSchedule": {
                 "Cancun": {
                     "max": "0x06",

--- a/src/ethereum_test_specs/tests/fixtures/chainid_cancun_state_test.json
+++ b/src/ethereum_test_specs/tests/fixtures/chainid_cancun_state_test.json
@@ -1,7 +1,7 @@
 {
     "000/my_chain_id_test/Cancun": {
         "_info": {
-            "hash": "0x85756178b1a4315d675dd7a25ca319b61dd1f86a665baf8d51ba7faf7f3cb444",
+            "hash": "0x5397e9cc1a15367788e117b74f6a99dc5b90f64f0067e7ea924328a1171c7686",
             "fixture_format": "state_test"
         },
         "env": {
@@ -15,6 +15,8 @@
             "currentExcessBlobGas": "0x00"
         },
         "config": {
+            "network": "Cancun",
+            "chainid": 1,
             "blobSchedule": {
                 "Cancun": {
                     "max": "0x06",

--- a/src/ethereum_test_specs/tests/fixtures/chainid_istanbul_blockchain_test.json
+++ b/src/ethereum_test_specs/tests/fixtures/chainid_istanbul_blockchain_test.json
@@ -1,7 +1,7 @@
 {
     "000/my_chain_id_test/Istanbul": {
         "_info": {
-            "hash": "0x523fefcabce674d5b2ef4d99a151dabac431d61aff3e44f42d6d3b8a910a464b",
+            "hash": "0xa325abdcb4f795610017350dc84df3707f07fc81bd9a1f5dd8e5710dda0860fb",
             "fixture_format": "blockchain_test"
         },
         "network": "Istanbul",
@@ -104,7 +104,8 @@
         },
         "sealEngine": "NoProof",
         "config": {
-            "network": "Istanbul"
+            "network": "Istanbul",
+            "chainid": 1
         }
     }
 }

--- a/src/ethereum_test_specs/tests/fixtures/chainid_london_blockchain_test.json
+++ b/src/ethereum_test_specs/tests/fixtures/chainid_london_blockchain_test.json
@@ -1,7 +1,7 @@
 {
     "000/my_chain_id_test/London": {
         "_info": {
-            "hash": "0xb0d368cde0d719d6d0652854133631267760c0c41a88d12144c1d8845f677088",
+            "hash": "0xf7c6e189f9b3221c3dc86b0ec7e05b4ab9048ac0f01b2101a8e2ecf002bb2584",
             "fixture_format": "blockchain_test"
         },
         "network": "London",
@@ -106,7 +106,8 @@
         },
         "sealEngine": "NoProof",
         "config": {
-            "network": "London"
+            "network": "London",
+            "chainid": 1
         }
     }
 }

--- a/src/ethereum_test_specs/tests/fixtures/chainid_paris_blockchain_test_engine.json
+++ b/src/ethereum_test_specs/tests/fixtures/chainid_paris_blockchain_test_engine.json
@@ -1,7 +1,7 @@
 {
     "000/my_chain_id_test/Paris": {
         "_info": {
-            "hash": "0x72d0f1b29136f637f4e7cc22e990911fed6f9cdbd5f1987f1351cfc4efb4673b",
+            "hash": "0x308811e437a9d2da44a46f198a92fff76786a3febe5622c5de99f3b9cf45d0b6",
             "fixture_format": "blockchain_test_engine"
         },
         "network": "Paris",
@@ -88,7 +88,8 @@
             }
         },
         "config": {
-            "network": "Paris"
+            "network": "Paris",
+            "chainid": 1
         }
     }
 }

--- a/src/ethereum_test_specs/tests/fixtures/chainid_paris_state_test.json
+++ b/src/ethereum_test_specs/tests/fixtures/chainid_paris_state_test.json
@@ -1,7 +1,7 @@
 {
     "000/my_chain_id_test/Paris": {
         "_info": {
-            "hash": "0x1384e915045d477e8d6d0b26fa32f27cc0d30ec2b05f3b166d48d4134017e071",
+            "hash": "0x24bc1cdb1ba223ddf5f72efd852837b6659e1e7cb601e85d8e006144f08f59e8",
             "fixture_format": "state_test"
         },
         "env": {
@@ -79,6 +79,9 @@
                 }
             ]
         },
-        "config": {}
+        "config": {
+            "network": "Paris",
+            "chainid": 1
+        }
     }
 }

--- a/src/ethereum_test_specs/tests/fixtures/chainid_shanghai_blockchain_test_engine.json
+++ b/src/ethereum_test_specs/tests/fixtures/chainid_shanghai_blockchain_test_engine.json
@@ -1,7 +1,7 @@
 {
     "000/my_chain_id_test/Shanghai": {
         "_info": {
-            "hash": "0x0853409d8524239ae79581d1fcf8d2da12dc98cd7c1cfd7d730d33ec75e0c56e",
+            "hash": "0x2190cc0ce6c0a1bc02ff4b9bceb1a90f09b70a3a5d7eb95097387bc0a055b0b0",
             "fixture_format": "blockchain_test_engine"
         },
         "lastblockhash": "0x9c10141361e180632f7973f4f3a0aed2baa5ebb776bae84caafdcc07a24933e8",
@@ -90,7 +90,8 @@
             }
         },
         "config": {
-            "network": "Shanghai"
+            "network": "Shanghai",
+            "chainid": 1
         }
     }
 }

--- a/src/ethereum_test_specs/tests/fixtures/chainid_shanghai_state_test.json
+++ b/src/ethereum_test_specs/tests/fixtures/chainid_shanghai_state_test.json
@@ -1,7 +1,7 @@
 {
     "000/my_chain_id_test/Shanghai": {
         "_info": {
-            "hash": "0x2f1baaa3821157d4bc534b6a0f6908a9900839261b7e6347d3dc5206b8a333b3",
+            "hash": "0x3675a37e94b317cb8eb80e8af99f0da73101bed01e61b2c08fac76139e8dfdd0",
             "fixture_format": "state_test"
         },
         "env": {
@@ -79,6 +79,9 @@
                 }
             ]
         },
-        "config": {}
+        "config": {
+            "network": "Shanghai",
+            "chainid": 1
+        }
     }
 }


### PR DESCRIPTION
## 🗒️ Description
Adds documentation for #1131.

If we decide to change the format of the `chainid` field to `HexNumber` or `ZeroPaddedHexNumber`, these changes should also be updated.