### PR TITLE
fix(tests): EIP-6110: Add `slow` marker to `many_deposits` test

### DIFF
--- a/tests/prague/eip6110_deposits/test_deposits.py
+++ b/tests/prague/eip6110_deposits/test_deposits.py
@@ -301,6 +301,7 @@ pytestmark = pytest.mark.valid_from("Prague")
                 ),
             ],
             id="many_deposits_from_contract",
+            marks=pytest.mark.slow,
         ),
         pytest.param(
             [
@@ -472,6 +473,7 @@ pytestmark = pytest.mark.valid_from("Prague")
                 ),
             ],
             id="many_deposits_from_contract_oog",
+            marks=pytest.mark.slow,
         ),
         pytest.param(
             [


### PR DESCRIPTION
## 🗒️ Description
Mark the `many_deposits` tests as slow due to timeouts that have been happening when filling using max parallelism.

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] ~~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~ Skip.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.