### PR TITLE
new(tests): add tests for DATALOADN validation and execution

### DIFF
--- a/converted-ethereum-tests.txt
+++ b/converted-ethereum-tests.txt
@@ -16,6 +16,7 @@ EOFTests/EIP3670/validInvalid.json
 EOFTests/EIP4200/validInvalid.json
 EOFTests/EIP4750/validInvalid.json
 EOFTests/efValidation/callf_into_nonreturning_.json
+EOFTests/efValidation/dataloadn_.json
 EOFTests/efValidation/EOF1_embedded_container_.json
 EOFTests/efValidation/EOF1_eofcreate_valid_.json
 EOFTests/efValidation/EOF1_callf_truncated_.json

--- a/tests/osaka/eip7692_eof_v1/eip7480_data_section/test_code_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip7480_data_section/test_code_validation.py
@@ -90,11 +90,70 @@ VALID: List[Container] = [
 
 INVALID: List[Container] = [
     Container(
+        name="DATALOADN_0_empty_data",
+        sections=[
+            Section.Code(
+                code=Op.DATALOADN[0] + Op.POP + Op.STOP,
+            ),
+        ],
+        validity_error=EOFException.INVALID_DATALOADN_INDEX,
+    ),
+    Container(
         name="DATALOADN_max_empty_data",
         sections=[
             Section.Code(
                 code=Op.DATALOADN[0xFFFF - 32] + Op.POP + Op.STOP,
             ),
+        ],
+        validity_error=EOFException.INVALID_DATALOADN_INDEX,
+    ),
+    Container(
+        name="DATALOADN_1_over_data",
+        sections=[
+            Section.Code(
+                code=Op.DATALOADN[1] + Op.POP + Op.STOP,
+            ),
+            Section.Data(b"\x00"),
+        ],
+        validity_error=EOFException.INVALID_DATALOADN_INDEX,
+    ),
+    Container(
+        name="DATALOADN_32_over_data",
+        sections=[
+            Section.Code(
+                code=Op.DATALOADN[32] + Op.POP + Op.STOP,
+            ),
+            Section.Data(b"\xda" * 32),
+        ],
+        validity_error=EOFException.INVALID_DATALOADN_INDEX,
+    ),
+    Container(
+        name="DATALOADN_0_data_31",
+        sections=[
+            Section.Code(
+                code=Op.DATALOADN[0] + Op.POP + Op.STOP,
+            ),
+            Section.Data(b"\xda" * 31),
+        ],
+        validity_error=EOFException.INVALID_DATALOADN_INDEX,
+    ),
+    Container(
+        name="DATALOADN_32_data_63",
+        sections=[
+            Section.Code(
+                code=Op.DATALOADN[32] + Op.POP + Op.STOP,
+            ),
+            Section.Data(b"\xda" * 63),
+        ],
+        validity_error=EOFException.INVALID_DATALOADN_INDEX,
+    ),
+    Container(
+        name="DATALOADN_max_imm",
+        sections=[
+            Section.Code(
+                code=Op.DATALOADN[0xFFFF] + Op.POP + Op.STOP,
+            ),
+            Section.Data(b"\xda" * 32),
         ],
         validity_error=EOFException.INVALID_DATALOADN_INDEX,
     ),
@@ -143,14 +202,11 @@ def container_name(c: Container):
     VALID,
     ids=container_name,
 )
-def test_legacy_initcode_valid_eof_v1_contract(
+def test_valid_containers_with_data_section(
     eof_test: EOFTestFiller,
     container: Container,
 ):
-    """
-    Test creating various types of valid EOF V1 contracts using legacy
-    initcode and a contract creating transaction.
-    """
+    """Test EOF validation of valid containers with data sections."""
     assert container.validity_error is None, (
         f"Valid container with validity error: {container.validity_error}"
     )
@@ -164,14 +220,11 @@ def test_legacy_initcode_valid_eof_v1_contract(
     INVALID,
     ids=container_name,
 )
-def test_legacy_initcode_invalid_eof_v1_contract(
+def test_invalid_containers_with_data_section(
     eof_test: EOFTestFiller,
     container: Container,
 ):
-    """
-    Test creating various types of valid EOF V1 contracts using legacy
-    initcode and a contract creating transaction.
-    """
+    """Test EOF validation of invalid containers with data sections."""
     assert container.validity_error is not None, "Invalid container without validity error"
     eof_test(
         container=container,

--- a/tests/osaka/eip7692_eof_v1/eof_tracker.md
+++ b/tests/osaka/eip7692_eof_v1/eof_tracker.md
@@ -354,10 +354,10 @@
 
 ### Validation
 
-- [ ] Valid DATALOADN with various offsets (ethereum/tests: src/EOFTestsFiller/efValidation/dataloadn_Copier.json)
+- [x] Valid DATALOADN with various offsets ([`tests/osaka/eip7692_eof_v1/eip7480_data_section/test_data_opcodes.py::test_dataloadn`](./eip7480_data_section/test_data_opcodes/test_dataloadn.md)
 - [x] Truncated DATALOADN immediate ([`tests/osaka/eip7692_eof_v1/eip7480_data_section/test_code_validation.py::test_dataloadn_truncated_immediate`](./eip7480_data_section/test_code_validation/test_dataloadn_truncated_immediate.md)
-- [ ] DATALOADN offset out of bounds (ethereum/tests: src/EOFTestsFiller/efValidation/dataloadn_Copier.json)
-- [ ] DATALOADN accessing not full word (ethereum/tests: src/EOFTestsFiller/efValidation/dataloadn_Copier.json)
+- [x] DATALOADN offset out of bounds ([`tests/osaka/eip7692_eof_v1/eip7480_data_section/test_code_validation.py::test_invalid_containers_with_data_section`](./eip7480_data_section/test_code_validation/test_invalid_containers_with_data_section.md)
+- [x] DATALOADN accessing not full word ([`tests/osaka/eip7692_eof_v1/eip7480_data_section/test_code_validation.py::test_invalid_containers_with_data_section`](./eip7480_data_section/test_code_validation/test_invalid_containers_with_data_section.md)
 
 ## EIP-663: SWAPN, DUPN and EXCHANGE instructions
 


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt). https://github.com/ethereum/tests/pull/1439
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
