### PR TITLE
feat/adapt eip6780 selfdestruct revert & reentrancy_selfdestruct to execute mode

### DIFF
--- a/tests/cancun/eip6780_selfdestruct/conftest.py
+++ b/tests/cancun/eip6780_selfdestruct/conftest.py
@@ -1,0 +1,25 @@
+"""Pytest (plugin) definitions local to EIP-6780 tests."""
+
+import random
+
+import pytest
+
+from ethereum_test_tools import EOA, Address, Alloc, Environment
+
+
+@pytest.fixture
+def sender(pre: Alloc) -> EOA:
+    """EOA that will be used to send transactions."""
+    return pre.fund_eoa()
+
+
+@pytest.fixture
+def env() -> Environment:
+    """Environment for all tests."""
+    return Environment()
+
+
+@pytest.fixture
+def selfdestruct_recipient_address() -> Address:
+    """Address that can receive a SELFDESTRUCT operation."""
+    return Address("0x" + "".join(["{:02x}".format(random.randint(0, 255)) for _ in range(20)]))

--- a/tests/cancun/eip6780_selfdestruct/conftest.py
+++ b/tests/cancun/eip6780_selfdestruct/conftest.py
@@ -1,7 +1,5 @@
 """Pytest (plugin) definitions local to EIP-6780 tests."""
 
-import random
-
 import pytest
 
 from ethereum_test_tools import EOA, Address, Alloc, Environment
@@ -20,6 +18,6 @@ def env() -> Environment:
 
 
 @pytest.fixture
-def selfdestruct_recipient_address() -> Address:
+def selfdestruct_recipient_address(pre: Alloc) -> Address:
     """Address that can receive a SELFDESTRUCT operation."""
-    return Address("0x" + "".join(["{:02x}".format(random.randint(0, 255)) for _ in range(20)]))
+    return pre.fund_eoa(amount=0)

--- a/tests/cancun/eip6780_selfdestruct/test_reentrancy_selfdestruct_revert.py
+++ b/tests/cancun/eip6780_selfdestruct/test_reentrancy_selfdestruct_revert.py
@@ -3,16 +3,19 @@ Suicide scenario requested test
 https://github.com/ethereum/tests/issues/1325.
 """
 
+from typing import SupportsBytes
+
 import pytest
 
 from ethereum_test_forks import Cancun, Fork
 from ethereum_test_tools import (
+    EOA,
     Account,
     Address,
+    Alloc,
+    Bytecode,
     Environment,
     StateTestFiller,
-    TestAddress,
-    TestAddress2,
     Transaction,
 )
 from ethereum_test_tools.vm.opcode import Opcodes as Op
@@ -21,26 +24,123 @@ REFERENCE_SPEC_GIT_PATH = "EIPS/eip-6780.md"
 REFERENCE_SPEC_VERSION = "2f8299df31bb8173618901a03a8366a3183479b0"
 
 
+def construct_call_op(call_type: Op, money: int, address_to: Address):
+    """Return call op based on call_type and address_to."""
+    if call_type in [Op.CALLCODE, Op.CALL]:
+        return call_type(Op.GAS, address_to, money, 0, 0, 0, 0)
+    else:
+        return call_type(Op.GAS, address_to, money, 0, 0, 0)
+
+
 @pytest.fixture
-def env():  # noqa: D103
-    return Environment(
-        fee_recipient="0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
-        difficulty=0x020000,
-        gas_limit=71794957647893862,
-        number=1,
-        timestamp=1000,
+def selfdestruct_contract_bytecode(selfdestruct_recipient_address: Address) -> Bytecode:
+    """Contract code that performs a SELFDESTRUCT operation."""
+    return Op.SELFDESTRUCT(selfdestruct_recipient_address)
+
+
+@pytest.fixture
+def selfdestruct_contract_init_balance() -> int:  # noqa: D103
+    return 300_000
+
+
+@pytest.fixture
+def selfdestruct_contract_address(
+    pre: Alloc, selfdestruct_contract_bytecode: Bytecode, selfdestruct_contract_init_balance: int
+) -> Address:
+    """Address of the selfdestruct contract."""
+    return pre.deploy_contract(
+        code=selfdestruct_contract_bytecode, balance=selfdestruct_contract_init_balance
     )
+
+
+@pytest.fixture
+def executor_contract_bytecode(
+    first_suicide: Op,
+    revert_contract_address: Address,
+    selfdestruct_contract_address: Address,
+) -> Bytecode:
+    """Contract code that performs a selfdestruct call then revert."""
+    return (
+        Op.SSTORE(1, construct_call_op(first_suicide, 0, selfdestruct_contract_address))
+        + Op.SSTORE(2, Op.CALL(Op.GAS, revert_contract_address, 0, 0, 0, 0, 0))
+        + Op.RETURNDATACOPY(0, 0, Op.RETURNDATASIZE())
+        + Op.SSTORE(3, Op.MLOAD(0))
+    )
+
+
+@pytest.fixture
+def executor_contract_init_storage() -> (  # noqa: D103
+    dict[str | bytes | SupportsBytes | int, str | bytes | SupportsBytes | int]
+):
+    return {0x01: 0x0100, 0x02: 0x0100, 0x03: 0x0100}
+
+
+@pytest.fixture
+def executor_contract_init_balance() -> int:  # noqa: D103
+    return 100_000
+
+
+@pytest.fixture
+def executor_contract_address(
+    pre: Alloc,
+    executor_contract_bytecode: Bytecode,
+    executor_contract_init_balance: int,
+    executor_contract_init_storage: dict[
+        str | bytes | SupportsBytes | int, str | bytes | SupportsBytes | int
+    ],
+) -> Address:
+    """Address of the executor contract."""
+    return pre.deploy_contract(
+        executor_contract_bytecode,
+        balance=executor_contract_init_balance,
+        storage=executor_contract_init_storage,
+    )
+
+
+@pytest.fixture
+def revert_contract_bytecode(
+    second_suicide: Op,
+    selfdestruct_contract_address: Address,
+) -> Bytecode:
+    """Contract code that performs a call and then reverts."""
+    call_op = construct_call_op(second_suicide, 100, selfdestruct_contract_address)
+    return Op.MSTORE(0, Op.ADD(15, call_op)) + Op.REVERT(0, 32)
+
+
+@pytest.fixture
+def revert_contract_init_balance() -> int:  # noqa: D103
+    return 500_000
+
+
+@pytest.fixture
+def revert_contract_address(
+    pre: Alloc,
+    revert_contract_bytecode: Bytecode,
+    revert_contract_init_balance: int,
+) -> Address:
+    """Address of the revert contract."""
+    return pre.deploy_contract(revert_contract_bytecode, balance=revert_contract_init_balance)
 
 
 @pytest.mark.valid_from("Paris")
 @pytest.mark.parametrize("first_suicide", [Op.CALL, Op.CALLCODE, Op.DELEGATECALL])
 @pytest.mark.parametrize("second_suicide", [Op.CALL, Op.CALLCODE, Op.DELEGATECALL])
 def test_reentrancy_selfdestruct_revert(
+    pre: Alloc,
     env: Environment,
+    sender: EOA,
     fork: Fork,
     first_suicide: Op,
     second_suicide: Op,
     state_test: StateTestFiller,
+    selfdestruct_contract_bytecode: Bytecode,
+    selfdestruct_contract_address: Address,
+    selfdestruct_contract_init_balance: int,
+    revert_contract_address: Address,
+    revert_contract_init_balance: int,
+    executor_contract_address: Address,
+    executor_contract_init_balance: int,
+    selfdestruct_recipient_address: Address,
 ):
     """
     Suicide reentrancy scenario.
@@ -53,58 +153,15 @@ def test_reentrancy_selfdestruct_revert(
     R reverts (including the effects of the second selfdestruct).
     It is expected the S is self destructed after the transaction.
     """
-    address_to = TestAddress2
-    address_s = Address(0x1000000000000000000000000000000000000001)
-    address_r = Address(0x1000000000000000000000000000000000000002)
-    suicide_d = Address(0x03E8)
-
-    def construct_call_s(call_type: Op, money: int):
-        if call_type in [Op.CALLCODE, Op.CALL]:
-            return call_type(Op.GAS, address_s, money, 0, 0, 0, 0)
-        else:
-            return call_type(Op.GAS, address_s, money, 0, 0, 0)
-
-    pre = {
-        address_to: Account(
-            balance=1000000000000000000,
-            nonce=0,
-            code=Op.SSTORE(1, construct_call_s(first_suicide, 0))
-            + Op.SSTORE(2, Op.CALL(Op.GAS, address_r, 0, 0, 0, 0, 0))
-            + Op.RETURNDATACOPY(0, 0, Op.RETURNDATASIZE())
-            + Op.SSTORE(3, Op.MLOAD(0)),
-            storage={0x01: 0x0100, 0x02: 0x0100, 0x03: 0x0100},
-        ),
-        address_s: Account(
-            balance=3000000000000000000,
-            nonce=0,
-            code=Op.SELFDESTRUCT(1000),
-            storage={},
-        ),
-        address_r: Account(
-            balance=5000000000000000000,
-            nonce=0,
-            # Send money when calling it suicide second time to make sure the funds not transferred
-            code=Op.MSTORE(0, Op.ADD(15, construct_call_s(second_suicide, 100)))
-            + Op.REVERT(0, 32),
-            storage={},
-        ),
-        TestAddress: Account(
-            balance=7000000000000000000,
-            nonce=0,
-            code="0x",
-            storage={},
-        ),
-    }
-
     post = {
         # Second caller unchanged as call gets reverted
-        address_r: Account(balance=5000000000000000000, storage={}),
+        revert_contract_address: Account(balance=revert_contract_init_balance, storage={}),
     }
 
     if first_suicide in [Op.CALLCODE, Op.DELEGATECALL]:
         if fork >= Cancun:
             # On Cancun even callcode/delegatecall does not remove the account, so the value remain
-            post[address_to] = Account(
+            post[executor_contract_address] = Account(
                 storage={
                     0x01: 0x01,  # First call to contract S->suicide success
                     0x02: 0x00,  # Second call to contract S->suicide reverted
@@ -113,18 +170,20 @@ def test_reentrancy_selfdestruct_revert(
             )
         else:
             # Callcode executed first suicide from sender. sender is deleted
-            post[address_to] = Account.NONEXISTENT  # type: ignore
+            post[executor_contract_address] = Account.NONEXISTENT  # type: ignore
 
         # Original suicide account remains in state
-        post[address_s] = Account(balance=3000000000000000000, storage={})
+        post[selfdestruct_contract_address] = Account(
+            balance=selfdestruct_contract_init_balance, storage={}
+        )
         # Suicide destination
-        post[suicide_d] = Account(
-            balance=1000000000000000000,
+        post[selfdestruct_recipient_address] = Account(
+            balance=executor_contract_init_balance,
         )
 
     # On Cancun suicide no longer destroys the account from state, just cleans the balance
     if first_suicide in [Op.CALL]:
-        post[address_to] = Account(
+        post[executor_contract_address] = Account(
             storage={
                 0x01: 0x01,  # First call to contract S->suicide success
                 0x02: 0x00,  # Second call to contract S->suicide reverted
@@ -133,22 +192,20 @@ def test_reentrancy_selfdestruct_revert(
         )
         if fork >= Cancun:
             # On Cancun suicide does not remove the account, just sends the balance
-            post[address_s] = Account(balance=0, code="0x6103e8ff", storage={})
+            post[selfdestruct_contract_address] = Account(
+                balance=0, code=selfdestruct_contract_bytecode, storage={}
+            )
         else:
-            post[address_s] = Account.NONEXISTENT  # type: ignore
+            post[selfdestruct_contract_address] = Account.NONEXISTENT  # type: ignore
 
         # Suicide destination
-        post[suicide_d] = Account(
-            balance=3000000000000000000,
+        post[selfdestruct_recipient_address] = Account(
+            balance=selfdestruct_contract_init_balance,
         )
 
     tx = Transaction(
-        ty=0x0,
-        chain_id=0x0,
-        nonce=0,
-        to=address_to,
-        gas_price=10,
-        protected=False,
+        sender=sender,
+        to=executor_contract_address,
         data="",
         gas_limit=500000,
         value=0,


### PR DESCRIPTION
```
plugins: html-4.1.1, json-report-1.5.0, metadata-3.1.1, custom-report-1.0.1, xdist-3.6.1, typeguard-4.3.0
collected 6 items / 1 deselected / 5 selected                                                                                                                                                                  

tests/cancun/eip6780_selfdestruct/test_selfdestruct_revert.py::test_selfdestruct_created_in_same_tx_with_revert[fork_Cancun-transaction_post-no_outer_selfdestruct-same_tx] Starting EOA index: 0x7e86ab011d54ff42e0187e246ce6a5900063147355b14f27feae79f32f533eef
Deploying contract with gas limit: 135602
Deploying contract with gas limit: 162902
PASSEDUsed balance=0.000429135000000003

tests/cancun/eip6780_selfdestruct/test_selfdestruct_revert.py::test_selfdestruct_created_in_same_tx_with_revert[fork_Cancun-transaction_post-outer_selfdestruct_before_inner_call-same_tx] Deploying contract with gas limit: 135626
Deploying contract with gas limit: 178028
PASSEDUsed balance=0.000448805000000003

tests/cancun/eip6780_selfdestruct/test_selfdestruct_revert.py::test_selfdestruct_created_in_same_tx_with_revert[fork_Cancun-transaction_post-outer_selfdestruct_after_inner_call-same_tx] Deploying contract with gas limit: 135626
Deploying contract with gas limit: 177596
PASSEDUsed balance=0.000498087000000003

tests/cancun/eip6780_selfdestruct/test_selfdestruct_revert.py::test_selfdestruct_not_created_in_same_tx_with_revert[fork_Cancun-transaction_post-no_outer_selfdestruct-not_same_tx-init_balance_2] Deploying contract with gas limit: 130922
Deploying contract with gas limit: 162902
PASSEDUsed balance=0.000360561000000002

tests/cancun/eip6780_selfdestruct/test_selfdestruct_revert.py::test_selfdestruct_not_created_in_same_tx_with_revert[fork_Cancun-transaction_post-outer_selfdestruct_before_inner_call-not_same_tx-init_balance_2] Deploying contract with gas limit: 130922
Deploying contract with gas limit: 178028
PASSEDUsed balance=0.000374958000000002

tests/cancun/eip6780_selfdestruct/test_selfdestruct_revert.py::test_selfdestruct_not_created_in_same_tx_with_revert[fork_Cancun-transaction_post-outer_selfdestruct_after_inner_call-not_same_tx-init_balance_2] Deploying contract with gas limit: 130922
Deploying contract with gas limit: 177596
PASSEDUsed balance=0.000429501000000002


=============================================================================================== warnings summary ===============================================================================================
tests/cancun/eip6780_selfdestruct/test_selfdestruct_revert.py::test_selfdestruct_created_in_same_tx_with_revert[fork_Cancun-transaction_post-no_outer_selfdestruct-same_tx]
tests/cancun/eip6780_selfdestruct/test_selfdestruct_revert.py::test_selfdestruct_created_in_same_tx_with_revert[fork_Cancun-transaction_post-outer_selfdestruct_before_inner_call-same_tx]
tests/cancun/eip6780_selfdestruct/test_selfdestruct_revert.py::test_selfdestruct_created_in_same_tx_with_revert[fork_Cancun-transaction_post-outer_selfdestruct_after_inner_call-same_tx]
tests/cancun/eip6780_selfdestruct/test_selfdestruct_revert.py::test_selfdestruct_not_created_in_same_tx_with_revert[fork_Cancun-transaction_post-no_outer_selfdestruct-not_same_tx-init_balance_2]
tests/cancun/eip6780_selfdestruct/test_selfdestruct_revert.py::test_selfdestruct_not_created_in_same_tx_with_revert[fork_Cancun-transaction_post-outer_selfdestruct_before_inner_call-not_same_tx-init_balance_2]
tests/cancun/eip6780_selfdestruct/test_selfdestruct_revert.py::test_selfdestruct_not_created_in_same_tx_with_revert[fork_Cancun-transaction_post-outer_selfdestruct_after_inner_call-not_same_tx-init_balance_2]
  /opt/homebrew/Cellar/python@3.13/3.13.1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/copy.py:152: DeprecationWarning: Pickle, copy, and deepcopy support will be removed from itertools in Python 3.14.
    rv = reductor(4)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================================================== 6 passed, 1 deselected, 6 warnings in 273.06s (0:04:33) ============================================================================
```
We reduced gas limit from 100.000.000 to 20.000.000 for avoiding maxblockgaslimit for some chains.