### PR TITLE
chore(deps): update ruff to version '0.9.4'.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -108,6 +108,7 @@ Release tarball changes:
 - ✨ Release tarballs now contain fixtures filled for all forks, not only the fork under active development and the fork currently deployed on mainnet ([#1053](https://github.com/ethereum/execution-spec-tests/pull/1053)).
 - ✨ `StateTest` fixture format now contains `state` field in each network post result, containing the decoded post allocation that results from the transaction execution ([#1064](https://github.com/ethereum/execution-spec-tests/pull/1064)).
 - ✨ Include EELS fork resolution information in filled json test fixtures ([#1123](https://github.com/ethereum/execution-spec-tests/pull/1123)).
+- 🔀 Updates ruff from version 0.8.2 to 0.9.4 ([#1168](https://github.com/ethereum/execution-spec-tests/pull/1168)).
 
 ### 💥 Breaking Change
 

--- a/docs/gen_test_case_reference.py
+++ b/docs/gen_test_case_reference.py
@@ -44,8 +44,7 @@ args = [
 
 runner = CliRunner()
 logger.info(
-    f"Generating documentation for test cases until {GENERATE_UNTIL_FORK} as "
-    f"fill {' '.join(args)}"
+    f"Generating documentation for test cases until {GENERATE_UNTIL_FORK} as fill {' '.join(args)}"
 )
 result = runner.invoke(fill, args)
 for line in result.output.split("\n"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ Changelog = "https://ethereum.github.io/execution-spec-tests/main/CHANGELOG/"
 [project.optional-dependencies]
 test = ["pytest-cov>=4.1.0,<5"]
 lint = [
-    "ruff==0.8.2",
+    "ruff==0.9.4",
     "mypy==0.991; implementation_name == 'cpython'",
     "types-requests"
 ]
@@ -115,7 +115,7 @@ line-length = 99
 [tool.ruff.lint]
 select = ["E", "F", "B", "W", "I", "A", "N", "D", "C"]
 fixable = ["I", "B", "E", "F", "W", "D", "C"]
-ignore = ["D205", "D203", "D212", "D415", "C901"] 
+ignore = ["D205", "D203", "D212", "D415", "C901", "A005"] 
 
 
 [tool.mypy]

--- a/src/cli/gentest/request_manager.py
+++ b/src/cli/gentest/request_manager.py
@@ -55,9 +55,9 @@ class RPCRequest:
         block_number = res.block_number
         assert block_number is not None, "Transaction does not seem to be included in any block"
 
-        assert (
-            res.ty == 0
-        ), f"Transaction has type {res.ty}: Currently only type 0 transactions are supported."
+        assert res.ty == 0, (
+            f"Transaction has type {res.ty}: Currently only type 0 transactions are supported."
+        )
 
         return RPCRequest.RemoteTransaction(
             block_number=block_number,

--- a/src/ethereum_clis/clis/besu.py
+++ b/src/ethereum_clis/clis/besu.py
@@ -50,7 +50,7 @@ class BesuTransitionTool(TransitionTool):
             result = subprocess.run(args, capture_output=True, text=True)
         except subprocess.CalledProcessError as e:
             raise Exception(
-                "evm process unexpectedly returned a non-zero status code: " f"{e}."
+                f"evm process unexpectedly returned a non-zero status code: {e}."
             ) from e
         except Exception as e:
             raise Exception(f"Unexpected exception calling evm tool: {e}.") from e

--- a/src/ethereum_clis/clis/geth.py
+++ b/src/ethereum_clis/clis/geth.py
@@ -46,7 +46,7 @@ class GethTransitionTool(TransitionTool):
             result = subprocess.run(args, capture_output=True, text=True)
         except subprocess.CalledProcessError as e:
             raise Exception(
-                "evm process unexpectedly returned a non-zero status code: " f"{e}."
+                f"evm process unexpectedly returned a non-zero status code: {e}."
             ) from e
         except Exception as e:
             raise Exception(f"Unexpected exception calling evm tool: {e}.") from e
@@ -67,7 +67,7 @@ class GethTransitionTool(TransitionTool):
             result = subprocess.run(args, capture_output=True, text=True)
         except subprocess.CalledProcessError as e:
             raise Exception(
-                "evm process unexpectedly returned a non-zero status code: " f"{e}."
+                f"evm process unexpectedly returned a non-zero status code: {e}."
             ) from e
         except Exception as e:
             raise Exception(f"Unexpected exception calling evm tool: {e}.") from e

--- a/src/ethereum_clis/clis/nimbus.py
+++ b/src/ethereum_clis/clis/nimbus.py
@@ -40,7 +40,7 @@ class NimbusTransitionTool(TransitionTool):
             result = subprocess.run(args, capture_output=True, text=True)
         except subprocess.CalledProcessError as e:
             raise Exception(
-                "evm process unexpectedly returned a non-zero status code: " f"{e}."
+                f"evm process unexpectedly returned a non-zero status code: {e}."
             ) from e
         except Exception as e:
             raise Exception(f"Unexpected exception calling evm tool: {e}.") from e

--- a/src/ethereum_test_exceptions/exception_mapper.py
+++ b/src/ethereum_test_exceptions/exception_mapper.py
@@ -27,12 +27,12 @@ class ExceptionMapper(ABC):
         # Ensure that the subclass has properly defined _mapping_data before accessing it
         assert self._mapping_data is not None, "_mapping_data must be defined in subclass"
 
-        assert len({entry.exception for entry in self._mapping_data}) == len(
-            self._mapping_data
-        ), "Duplicate exception in _mapping_data"
-        assert len({entry.message for entry in self._mapping_data}) == len(
-            self._mapping_data
-        ), "Duplicate message in _mapping_data"
+        assert len({entry.exception for entry in self._mapping_data}) == len(self._mapping_data), (
+            "Duplicate exception in _mapping_data"
+        )
+        assert len({entry.message for entry in self._mapping_data}) == len(self._mapping_data), (
+            "Duplicate message in _mapping_data"
+        )
         self.exception_to_message_map: frozenbidict = frozenbidict(
             {entry.exception: entry.message for entry in self._mapping_data}
         )

--- a/src/ethereum_test_exceptions/exceptions.py
+++ b/src/ethereum_test_exceptions/exceptions.py
@@ -45,9 +45,9 @@ class ExceptionBase(Enum):
             exception_class = _exception_classes[class_name]
         else:
             # Otherwise, use the class that the method is called on
-            assert (
-                cls.__name__ == class_name
-            ), f"Unexpected exception type: {class_name}, expected {cls.__name__}"
+            assert cls.__name__ == class_name, (
+                f"Unexpected exception type: {class_name}, expected {cls.__name__}"
+            )
             exception_class = cls
 
         exception = getattr(exception_class, enum_name, None)

--- a/src/ethereum_test_execution/transaction_post.py
+++ b/src/ethereum_test_execution/transaction_post.py
@@ -24,9 +24,9 @@ class TransactionPost(BaseExecute):
 
     def execute(self, eth_rpc: EthRPC):
         """Execute the format."""
-        assert not any(
-            tx.ty == 3 for tx in self.transactions
-        ), "Transaction type 3 is not supported in execute mode."
+        assert not any(tx.ty == 3 for tx in self.transactions), (
+            "Transaction type 3 is not supported in execute mode."
+        )
         if any(tx.error is not None for tx in self.transactions):
             for transaction in self.transactions:
                 if transaction.error is None:
@@ -49,17 +49,17 @@ class TransactionPost(BaseExecute):
                 assert nonce == 0, f"Nonce of {address} is {nonce}, expected 0."
             else:
                 if "balance" in account.model_fields_set:
-                    assert (
-                        balance == account.balance
-                    ), f"Balance of {address} is {balance}, expected {account.balance}."
+                    assert balance == account.balance, (
+                        f"Balance of {address} is {balance}, expected {account.balance}."
+                    )
                 if "code" in account.model_fields_set:
-                    assert (
-                        code == account.code
-                    ), f"Code of {address} is {code}, expected {account.code}."
+                    assert code == account.code, (
+                        f"Code of {address} is {code}, expected {account.code}."
+                    )
                 if "nonce" in account.model_fields_set:
-                    assert (
-                        nonce == account.nonce
-                    ), f"Nonce of {address} is {nonce}, expected {account.nonce}."
+                    assert nonce == account.nonce, (
+                        f"Nonce of {address} is {nonce}, expected {account.nonce}."
+                    )
                 if "storage" in account.model_fields_set:
                     for key, value in account.storage.items():
                         storage_value = eth_rpc.get_storage_at(address, Hash(key))

--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -196,9 +196,9 @@ class Frontier(BaseFork, solc_name="homestead"):
             return_cost_deducted_prior_execution: bool = False,
         ) -> int:
             assert access_list is None, f"Access list is not supported in {cls.name()}"
-            assert (
-                authorization_list_or_count is None
-            ), f"Authorizations are not supported in {cls.name()}"
+            assert authorization_list_or_count is None, (
+                f"Authorizations are not supported in {cls.name()}"
+            )
             intrinsic_cost: int = gas_costs.G_TRANSACTION
 
             if contract_creation:

--- a/src/ethereum_test_specs/blockchain.py
+++ b/src/ethereum_test_specs/blockchain.py
@@ -167,9 +167,9 @@ class Header(CamelModel):
                 assert baseline_value is not Header.REMOVE_FIELD, "invalid header"
                 value = getattr(target, field_name)
                 if baseline_value is Header.EMPTY_FIELD:
-                    assert (
-                        value is None
-                    ), f"invalid header field {field_name}, got {value}, want None"
+                    assert value is None, (
+                        f"invalid header field {field_name}, got {value}, want None"
+                    )
                     continue
                 assert value == baseline_value, (
                     f"invalid header field ({field_name}) value, "
@@ -301,12 +301,12 @@ class BlockchainTest(BaseTest):
     ) -> Tuple[Alloc, FixtureBlock]:
         """Create a genesis block from the blockchain test definition."""
         env = self.genesis_environment.set_fork_requirements(fork)
-        assert (
-            env.withdrawals is None or len(env.withdrawals) == 0
-        ), "withdrawals must be empty at genesis"
-        assert env.parent_beacon_block_root is None or env.parent_beacon_block_root == Hash(
-            0
-        ), "parent_beacon_block_root must be empty at genesis"
+        assert env.withdrawals is None or len(env.withdrawals) == 0, (
+            "withdrawals must be empty at genesis"
+        )
+        assert env.parent_beacon_block_root is None or env.parent_beacon_block_root == Hash(0), (
+            "parent_beacon_block_root must be empty at genesis"
+        )
 
         pre_alloc = Alloc.merge(
             Alloc.model_validate(fork.pre_allocation_blockchain()),
@@ -448,9 +448,9 @@ class BlockchainTest(BaseTest):
 
         requests_list: List[Bytes] | None = None
         if fork.header_requests_required(header.number, header.timestamp):
-            assert (
-                transition_tool_output.result.requests is not None
-            ), "Requests are required for this block"
+            assert transition_tool_output.result.requests is not None, (
+                "Requests are required for this block"
+            )
             requests = Requests(requests_lists=list(transition_tool_output.result.requests))
 
             if Hash(requests) != header.requests_hash:
@@ -639,19 +639,19 @@ class BlockchainTest(BaseTest):
                 )
 
         fcu_version = fork.engine_forkchoice_updated_version(header.number, header.timestamp)
-        assert (
-            fcu_version is not None
-        ), "A hive fixture was requested but no forkchoice update is defined. The framework should"
-        " never try to execute this test case."
+        assert fcu_version is not None, (
+            "A hive fixture was requested but no forkchoice update is defined."
+            " The framework should never try to execute this test case."
+        )
 
         self.verify_post_state(t8n, t8n_state=alloc)
 
         sync_payload: Optional[FixtureEngineNewPayload] = None
         if self.verify_sync:
             # Test is marked for syncing verification.
-            assert (
-                genesis.header.block_hash != head_hash
-            ), "Invalid payload tests negative test via sync is not supported yet."
+            assert genesis.header.block_hash != head_hash, (
+                "Invalid payload tests negative test via sync is not supported yet."
+            )
 
             # Most clients require the header to start the sync process, so we create an empty
             # block on top of the last block of the test to send it as new payload and trigger the

--- a/src/ethereum_test_specs/state.py
+++ b/src/ethereum_test_specs/state.py
@@ -55,9 +55,9 @@ class StateTest(BaseTest):
 
     def _generate_blockchain_genesis_environment(self, *, fork: Fork) -> Environment:
         """Generate the genesis environment for the BlockchainTest formatted test."""
-        assert (
-            self.env.number >= 1
-        ), "genesis block number cannot be negative, set state test env.number to 1"
+        assert self.env.number >= 1, (
+            "genesis block number cannot be negative, set state test env.number to 1"
+        )
 
         # Modify values to the proper values for the genesis block
         # TODO: All of this can be moved to a new method in `Fork`

--- a/src/ethereum_test_tools/code/generators.py
+++ b/src/ethereum_test_tools/code/generators.py
@@ -102,9 +102,9 @@ class Initcode(Bytecode):
         padding_bytes = bytes()
 
         if initcode_length is not None:
-            assert initcode_length >= len(
-                initcode_plus_deploy_code
-            ), "specified invalid length for initcode"
+            assert initcode_length >= len(initcode_plus_deploy_code), (
+                "specified invalid length for initcode"
+            )
 
             padding_bytes = bytes(
                 [padding_byte] * (initcode_length - len(initcode_plus_deploy_code))

--- a/src/ethereum_test_types/tests/test_helpers.py
+++ b/src/ethereum_test_types/tests/test_helpers.py
@@ -58,7 +58,7 @@ def test_address():
             "0x06012c8cf97bead5deae237070f9587f8e7a266d",
             id="large-nonce-0x-str-address",
             marks=pytest.mark.xfail(
-                reason="Nonce too large to convert with hard-coded to_bytes " "length of 1"
+                reason="Nonce too large to convert with hard-coded to_bytes length of 1"
             ),
         ),
     ],

--- a/src/pytest_plugins/consume/direct/conftest.py
+++ b/src/pytest_plugins/consume/direct/conftest.py
@@ -105,7 +105,7 @@ def fixture_path(test_case: TestCaseIndexFile | TestCaseStream, fixture_source):
     if fixture_source == "stdin":
         assert isinstance(test_case, TestCaseStream)
         temp_dir = tempfile.TemporaryDirectory()
-        fixture_path = Path(temp_dir.name) / f"{test_case.id.replace('/','_')}.json"
+        fixture_path = Path(temp_dir.name) / f"{test_case.id.replace('/', '_')}.json"
         fixtures = Fixtures({test_case.id: test_case.fixture})
         with open(fixture_path, "w") as f:
             json.dump(to_json(fixtures), f, indent=4)

--- a/src/pytest_plugins/consume/hive_simulators/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/conftest.py
@@ -139,9 +139,9 @@ def environment(
     blockchain_fixture: BlockchainFixtureCommon, check_live_port: Literal[8545, 8551]
 ) -> dict:
     """Define the environment that hive will start the client with."""
-    assert (
-        blockchain_fixture.fork in ruleset
-    ), f"fork '{blockchain_fixture.fork}' missing in hive ruleset"
+    assert blockchain_fixture.fork in ruleset, (
+        f"fork '{blockchain_fixture.fork}' missing in hive ruleset"
+    )
     return {
         "HIVE_CHAIN_ID": "1",
         "HIVE_FORK_DAO_VOTE": "1",

--- a/src/pytest_plugins/consume/hive_simulators/engine/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/engine/conftest.py
@@ -49,9 +49,9 @@ def blockchain_fixture(fixture_source: JsonSource, test_case: TestCase) -> Block
     """
     if fixture_source == "stdin":
         assert isinstance(test_case, TestCaseStream), "Expected a stream test case"
-        assert isinstance(
-            test_case.fixture, BlockchainEngineFixture
-        ), "Expected a blockchain engine test fixture"
+        assert isinstance(test_case.fixture, BlockchainEngineFixture), (
+            "Expected a blockchain engine test fixture"
+        )
         fixture = test_case.fixture
     else:
         assert isinstance(test_case, TestCaseIndexFile), "Expected an index file test case"

--- a/src/pytest_plugins/consume/hive_simulators/engine/test_via_engine.py
+++ b/src/pytest_plugins/consume/hive_simulators/engine/test_via_engine.py
@@ -36,9 +36,9 @@ def test_via_engine(
             payload_attributes=None,
             version=blockchain_fixture.payloads[0].forkchoice_updated_version,
         )
-        assert (
-            forkchoice_response.payload_status.status == PayloadStatusEnum.VALID
-        ), f"unexpected status on forkchoice updated to genesis: {forkchoice_response}"
+        assert forkchoice_response.payload_status.status == PayloadStatusEnum.VALID, (
+            f"unexpected status on forkchoice updated to genesis: {forkchoice_response}"
+        )
 
     with timing_data.time("Get genesis block"):
         genesis_block = eth_rpc.get_block_by_number(0)

--- a/src/pytest_plugins/consume/hive_simulators/rlp/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/rlp/conftest.py
@@ -38,9 +38,9 @@ def blockchain_fixture(fixture_source: JsonSource, test_case: TestCase) -> Block
     """
     if fixture_source == "stdin":
         assert isinstance(test_case, TestCaseStream), "Expected a stream test case"
-        assert isinstance(
-            test_case.fixture, BlockchainFixture
-        ), "Expected a blockchain test fixture"
+        assert isinstance(test_case.fixture, BlockchainFixture), (
+            "Expected a blockchain test fixture"
+        )
         fixture = test_case.fixture
     else:
         assert isinstance(test_case, TestCaseIndexFile), "Expected an index file test case"

--- a/src/pytest_plugins/consume/hive_simulators/rlp/test_via_rlp.py
+++ b/src/pytest_plugins/consume/hive_simulators/rlp/test_via_rlp.py
@@ -32,6 +32,6 @@ def test_via_rlp(
             )
     with timing_data.time("Get latest block"):
         block = eth_rpc.get_block_by_number("latest")
-        assert block["hash"] == str(
-            blockchain_fixture.last_block_hash
-        ), "hash mismatch in last block"
+        assert block["hash"] == str(blockchain_fixture.last_block_hash), (
+            "hash mismatch in last block"
+        )

--- a/src/pytest_plugins/execute/pre_alloc.py
+++ b/src/pytest_plugins/execute/pre_alloc.py
@@ -165,9 +165,9 @@ class Alloc(BaseAlloc):
             initcode_prefix += sum(Op.SSTORE(key, value) for key, value in storage.root.items())
             deploy_gas_limit += len(storage.root) * 22_600
 
-        assert isinstance(code, Bytecode) or isinstance(
-            code, Container
-        ), f"incompatible code type: {type(code)}"
+        assert isinstance(code, Bytecode) or isinstance(code, Container), (
+            f"incompatible code type: {type(code)}"
+        )
         code = self.code_pre_processor(code, evm_code_type=evm_code_type)
 
         assert len(code) <= MAX_BYTECODE_SIZE, f"code too large: {len(code)} > {MAX_BYTECODE_SIZE}"
@@ -184,9 +184,9 @@ class Alloc(BaseAlloc):
             memory_expansion_gas_calculator = self._fork.memory_expansion_gas_calculator()
             deploy_gas_limit += memory_expansion_gas_calculator(new_bytes=len(bytes(initcode)))
 
-        assert (
-            len(initcode) <= MAX_INITCODE_SIZE
-        ), f"initcode too large {len(initcode)} > {MAX_INITCODE_SIZE}"
+        assert len(initcode) <= MAX_INITCODE_SIZE, (
+            f"initcode too large {len(initcode)} > {MAX_INITCODE_SIZE}"
+        )
 
         calldata_gas_calculator = self._fork.calldata_gas_calculator()
         deploy_gas_limit += calldata_gas_calculator(data=initcode)

--- a/src/pytest_plugins/execute/rpc/hive.py
+++ b/src/pytest_plugins/execute/rpc/hive.py
@@ -203,12 +203,12 @@ def base_pre_genesis(
 ) -> Tuple[Alloc, FixtureHeader]:
     """Create a genesis block from the blockchain test definition."""
     env = Environment().set_fork_requirements(base_fork)
-    assert (
-        env.withdrawals is None or len(env.withdrawals) == 0
-    ), "withdrawals must be empty at genesis"
-    assert env.parent_beacon_block_root is None or env.parent_beacon_block_root == Hash(
-        0
-    ), "parent_beacon_block_root must be empty at genesis"
+    assert env.withdrawals is None or len(env.withdrawals) == 0, (
+        "withdrawals must be empty at genesis"
+    )
+    assert env.parent_beacon_block_root is None or env.parent_beacon_block_root == Hash(0), (
+        "parent_beacon_block_root must be empty at genesis"
+    )
 
     pre_alloc = Alloc.merge(
         Alloc.model_validate(base_fork.pre_allocation_blockchain()),
@@ -574,9 +574,9 @@ class EthRPC(BaseEthRPC):
                     head_block_hash=base_genesis_header.block_hash,
                 )
                 forkchoice_version = self.fork.engine_forkchoice_updated_version()
-                assert (
-                    forkchoice_version is not None
-                ), "Fork does not support engine forkchoice_updated"
+                assert forkchoice_version is not None, (
+                    "Fork does not support engine forkchoice_updated"
+                )
                 for _ in range(initial_forkchoice_update_retries):
                     response = self.engine_rpc.forkchoice_updated(
                         forkchoice_state,
@@ -618,9 +618,9 @@ class EthRPC(BaseEthRPC):
             ),
         )
         forkchoice_updated_version = self.fork.engine_forkchoice_updated_version()
-        assert (
-            forkchoice_updated_version is not None
-        ), "Fork does not support engine forkchoice_updated"
+        assert forkchoice_updated_version is not None, (
+            "Fork does not support engine forkchoice_updated"
+        )
         response = self.engine_rpc.forkchoice_updated(
             forkchoice_state,
             payload_attributes,

--- a/src/pytest_plugins/filler/tests/test_filler.py
+++ b/src/pytest_plugins/filler/tests/test_filler.py
@@ -575,13 +575,13 @@ def test_fixture_output_based_on_command_line_args(
     all_fixtures = [file for file in all_files if file.name not in expected_additional_files]
     for fixture_file, fixture_count in zip(expected_fixture_files, expected_fixture_counts):
         assert fixture_file.exists(), f"{fixture_file} does not exist"
-        assert fixture_count == count_keys_in_fixture(
-            fixture_file
-        ), f"Fixture count mismatch for {fixture_file}"
+        assert fixture_count == count_keys_in_fixture(fixture_file), (
+            f"Fixture count mismatch for {fixture_file}"
+        )
 
-    assert set(all_fixtures) == set(
-        expected_fixture_files
-    ), f"Unexpected files in directory: {set(all_fixtures) - set(expected_fixture_files)}"
+    assert set(all_fixtures) == set(expected_fixture_files), (
+        f"Unexpected files in directory: {set(all_fixtures) - set(expected_fixture_files)}"
+    )
 
     assert ini_file is not None, f"No {expected_ini_file} file was found in {meta_dir}"
     config = configparser.ConfigParser()

--- a/src/pytest_plugins/forks/forks.py
+++ b/src/pytest_plugins/forks/forks.py
@@ -613,8 +613,7 @@ class ValidityMarker(ABC):
             fork_names |= set(fork_names_list)
             if len(fork_names) != expected_length_after_append:
                 pytest.fail(
-                    f"'{self.test_name}': Duplicate argument specified in "
-                    f"'{self.marker_name}'."
+                    f"'{self.test_name}': Duplicate argument specified in '{self.marker_name}'."
                 )
         forks: Set[Fork] = set()
         for fork_name in fork_names:
@@ -815,14 +814,12 @@ class ValidAtTransitionTo(ValidityMarker, mutually_exclusive=True):
         )
         if len(forks) == 0:
             pytest.fail(
-                f"'{self.test_name}': Missing fork argument with 'valid_at_transition_to' "
-                "marker."
+                f"'{self.test_name}': Missing fork argument with 'valid_at_transition_to' marker."
             )
 
         if len(forks) > 1:
             pytest.fail(
-                f"'{self.test_name}': Too many forks specified to 'valid_at_transition_to' "
-                "marker."
+                f"'{self.test_name}': Too many forks specified to 'valid_at_transition_to' marker."
             )
 
         resulting_set: Set[Fork] = set()

--- a/src/pytest_plugins/shared/execute_fill.py
+++ b/src/pytest_plugins/shared/execute_fill.py
@@ -164,7 +164,7 @@ def pytest_runtest_call(item: pytest.Item):
 
     if "state_test" in item.fixturenames and "blockchain_test" in item.fixturenames:
         raise InvalidFillerError(
-            "A filler should only implement either a state test or " "a blockchain test; not both."
+            "A filler should only implement either a state test or a blockchain test; not both."
         )
 
     # Check that the test defines either test type as parameter.

--- a/tests/byzantium/eip198_modexp_precompile/test_modexp.py
+++ b/tests/byzantium/eip198_modexp_precompile/test_modexp.py
@@ -47,9 +47,9 @@ class ModExpInput(TestParameterGroup):
         """Generate input for the MODEXP precompile."""
         return (
             "0x"
-            + f"{int(len(self.base)/2):x}".zfill(64)
-            + f"{int(len(self.exponent)/2):x}".zfill(64)
-            + f"{int(len(self.modulus)/2):x}".zfill(64)
+            + f"{int(len(self.base) / 2):x}".zfill(64)
+            + f"{int(len(self.exponent) / 2):x}".zfill(64)
+            + f"{int(len(self.modulus) / 2):x}".zfill(64)
             + self.base
             + self.exponent
             + self.modulus

--- a/tests/cancun/eip1153_tstore/__init__.py
+++ b/tests/cancun/eip1153_tstore/__init__.py
@@ -90,9 +90,9 @@ class PytestParameterEnum(Enum):
                 if set(names) != set(test_case_names):
                     pprint(names)
                     pprint(test_case_names)
-                assert set(names) == set(
-                    test_case_names
-                ), "All test cases must have the same parameter names."
+                assert set(names) == set(test_case_names), (
+                    "All test cases must have the same parameter names."
+                )
         assert names is not None, "Enum must have at least one test case."
 
         return pytest.mark.parametrize(names, [test_case.param(names) for test_case in cls])

--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py
@@ -140,9 +140,9 @@ def test_valid_containers(
     Test creating various types of valid EOF V1 contracts using legacy
     initcode and a contract creating transaction.
     """
-    assert (
-        container.validity_error is None
-    ), f"Valid container with validity error: {container.validity_error}"
+    assert container.validity_error is None, (
+        f"Valid container with validity error: {container.validity_error}"
+    )
     eof_test(
         container=bytes(container),
     )

--- a/tests/osaka/eip7692_eof_v1/eip7480_data_section/test_code_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip7480_data_section/test_code_validation.py
@@ -151,9 +151,9 @@ def test_legacy_initcode_valid_eof_v1_contract(
     Test creating various types of valid EOF V1 contracts using legacy
     initcode and a contract creating transaction.
     """
-    assert (
-        container.validity_error is None
-    ), f"Valid container with validity error: {container.validity_error}"
+    assert container.validity_error is None, (
+        f"Valid container with validity error: {container.validity_error}"
+    )
     eof_test(
         container=container,
     )

--- a/tests/prague/eip2537_bls_12_381_precompiles/conftest.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/conftest.py
@@ -29,9 +29,9 @@ def precompile_gas(
     """Gas cost for the precompile."""
     calculated_gas = GAS_CALCULATION_FUNCTION_MAP[precompile_address](len(input_data))
     if vector_gas_value is not None:
-        assert (
-            calculated_gas == vector_gas_value
-        ), f"Calculated gas {calculated_gas} != Vector gas {vector_gas_value}"
+        assert calculated_gas == vector_gas_value, (
+            f"Calculated gas {calculated_gas} != Vector gas {vector_gas_value}"
+        )
     return calculated_gas
 
 

--- a/tests/prague/eip7623_increase_calldata_cost/helpers.py
+++ b/tests/prague/eip7623_increase_calldata_cost/helpers.py
@@ -42,8 +42,8 @@ def find_floor_cost_threshold(
     # Verify that increasing the tokens by one would always trigger the floor gas cost.
     assert (
         floor_data_gas_cost_calculator(tokens) <= intrinsic_gas_cost_calculator(tokens)
-    ) and floor_data_gas_cost_calculator(tokens + 1) > intrinsic_gas_cost_calculator(
-        tokens + 1
-    ), "invalid case"
+    ) and floor_data_gas_cost_calculator(tokens + 1) > intrinsic_gas_cost_calculator(tokens + 1), (
+        "invalid case"
+    )
 
     return tokens

--- a/tests/prague/eip7702_set_code_tx/test_gas.py
+++ b/tests/prague/eip7702_set_code_tx/test_gas.py
@@ -118,9 +118,9 @@ def authority_iterator(
         for i, current_authority_type in enumerate(authority_type_iterator):
             match current_authority_type:
                 case AddressType.EMPTY_ACCOUNT:
-                    assert (
-                        not self_sponsored
-                    ), "Self-sponsored empty-account authority is not supported"
+                    assert not self_sponsored, (
+                        "Self-sponsored empty-account authority is not supported"
+                    )
                     yield AuthorityWithProperties(
                         authority=pre.fund_eoa(0),
                         address_type=current_authority_type,
@@ -158,9 +158,9 @@ def authority_iterator(
                             empty=False,
                         )
                 case AddressType.CONTRACT:
-                    assert (
-                        not self_sponsored or i > 0
-                    ), "Self-sponsored contract authority is not supported"
+                    assert not self_sponsored or i > 0, (
+                        "Self-sponsored contract authority is not supported"
+                    )
                     authority = pre.fund_eoa()
                     authority_account = pre[authority]
                     assert authority_account is not None

--- a/uv.lock
+++ b/uv.lock
@@ -594,7 +594,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.31.0,<3" },
     { name = "requests-unixsocket2", specifier = ">=0.4.0" },
     { name = "rich", specifier = ">=13.7.0,<14" },
-    { name = "ruff", marker = "extra == 'lint'", specifier = "==0.8.2" },
+    { name = "ruff", marker = "extra == 'lint'", specifier = "==0.9.4" },
     { name = "semver", specifier = ">=3.0.1,<4" },
     { name = "setuptools" },
     { name = "solc-select", specifier = ">=1.0.4,<2" },
@@ -1728,27 +1728,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.8.2"
+version = "0.9.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5e/2b/01245f4f3a727d60bebeacd7ee6d22586c7f62380a2597ddb22c2f45d018/ruff-0.8.2.tar.gz", hash = "sha256:b84f4f414dda8ac7f75075c1fa0b905ac0ff25361f42e6d5da681a465e0f78e5", size = 3349020 }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/17/529e78f49fc6f8076f50d985edd9a2cf011d1dbadb1cdeacc1d12afc1d26/ruff-0.9.4.tar.gz", hash = "sha256:6907ee3529244bb0ed066683e075f09285b38dd5b4039370df6ff06041ca19e7", size = 3599458 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/29/366be70216dba1731a00a41f2f030822b0c96c7c4f3b2c0cdce15cbace74/ruff-0.8.2-py3-none-linux_armv6l.whl", hash = "sha256:c49ab4da37e7c457105aadfd2725e24305ff9bc908487a9bf8d548c6dad8bb3d", size = 10530649 },
-    { url = "https://files.pythonhosted.org/packages/63/82/a733956540bb388f00df5a3e6a02467b16c0e529132625fe44ce4c5fb9c7/ruff-0.8.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ec016beb69ac16be416c435828be702ee694c0d722505f9c1f35e1b9c0cc1bf5", size = 10274069 },
-    { url = "https://files.pythonhosted.org/packages/3d/12/0b3aa14d1d71546c988a28e1b412981c1b80c8a1072e977a2f30c595cc4a/ruff-0.8.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f05cdf8d050b30e2ba55c9b09330b51f9f97d36d4673213679b965d25a785f3c", size = 9909400 },
-    { url = "https://files.pythonhosted.org/packages/23/08/f9f08cefb7921784c891c4151cce6ed357ff49e84b84978440cffbc87408/ruff-0.8.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:60f578c11feb1d3d257b2fb043ddb47501ab4816e7e221fbb0077f0d5d4e7b6f", size = 10766782 },
-    { url = "https://files.pythonhosted.org/packages/e4/71/bf50c321ec179aa420c8ec40adac5ae9cc408d4d37283a485b19a2331ceb/ruff-0.8.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cbd5cf9b0ae8f30eebc7b360171bd50f59ab29d39f06a670b3e4501a36ba5897", size = 10286316 },
-    { url = "https://files.pythonhosted.org/packages/f2/83/c82688a2a6117539aea0ce63fdf6c08e60fe0202779361223bcd7f40bd74/ruff-0.8.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b402ddee3d777683de60ff76da801fa7e5e8a71038f57ee53e903afbcefdaa58", size = 11338270 },
-    { url = "https://files.pythonhosted.org/packages/7f/d7/bc6a45e5a22e627640388e703160afb1d77c572b1d0fda8b4349f334fc66/ruff-0.8.2-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:705832cd7d85605cb7858d8a13d75993c8f3ef1397b0831289109e953d833d29", size = 12058579 },
-    { url = "https://files.pythonhosted.org/packages/da/3b/64150c93946ec851e6f1707ff586bb460ca671581380c919698d6a9267dc/ruff-0.8.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:32096b41aaf7a5cc095fa45b4167b890e4c8d3fd217603f3634c92a541de7248", size = 11615172 },
-    { url = "https://files.pythonhosted.org/packages/e4/9e/cf12b697ea83cfe92ec4509ae414dc4c9b38179cc681a497031f0d0d9a8e/ruff-0.8.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e769083da9439508833cfc7c23e351e1809e67f47c50248250ce1ac52c21fb93", size = 12882398 },
-    { url = "https://files.pythonhosted.org/packages/a9/27/96d10863accf76a9c97baceac30b0a52d917eb985a8ac058bd4636aeede0/ruff-0.8.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5fe716592ae8a376c2673fdfc1f5c0c193a6d0411f90a496863c99cd9e2ae25d", size = 11176094 },
-    { url = "https://files.pythonhosted.org/packages/eb/10/cd2fd77d4a4e7f03c29351be0f53278a393186b540b99df68beb5304fddd/ruff-0.8.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:81c148825277e737493242b44c5388a300584d73d5774defa9245aaef55448b0", size = 10771884 },
-    { url = "https://files.pythonhosted.org/packages/71/5d/beabb2ff18870fc4add05fa3a69a4cb1b1d2d6f83f3cf3ae5ab0d52f455d/ruff-0.8.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:d261d7850c8367704874847d95febc698a950bf061c9475d4a8b7689adc4f7fa", size = 10382535 },
-    { url = "https://files.pythonhosted.org/packages/ae/29/6b3fdf3ad3e35b28d87c25a9ff4c8222ad72485ab783936b2b267250d7a7/ruff-0.8.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1ca4e3a87496dc07d2427b7dd7ffa88a1e597c28dad65ae6433ecb9f2e4f022f", size = 10886995 },
-    { url = "https://files.pythonhosted.org/packages/e9/dc/859d889b4d9356a1a2cdbc1e4a0dda94052bc5b5300098647e51a58c430b/ruff-0.8.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:729850feed82ef2440aa27946ab39c18cb4a8889c1128a6d589ffa028ddcfc22", size = 11220750 },
-    { url = "https://files.pythonhosted.org/packages/0b/08/e8f519f61f1d624264bfd6b8829e4c5f31c3c61193bc3cff1f19dbe7626a/ruff-0.8.2-py3-none-win32.whl", hash = "sha256:ac42caaa0411d6a7d9594363294416e0e48fc1279e1b0e948391695db2b3d5b1", size = 8729396 },
-    { url = "https://files.pythonhosted.org/packages/f8/d4/ba1c7ab72aba37a2b71fe48ab95b80546dbad7a7f35ea28cf66fc5cea5f6/ruff-0.8.2-py3-none-win_amd64.whl", hash = "sha256:2aae99ec70abf43372612a838d97bfe77d45146254568d94926e8ed5bbb409ea", size = 9594729 },
-    { url = "https://files.pythonhosted.org/packages/23/34/db20e12d3db11b8a2a8874258f0f6d96a9a4d631659d54575840557164c8/ruff-0.8.2-py3-none-win_arm64.whl", hash = "sha256:fb88e2a506b70cfbc2de6fae6681c4f944f7dd5f2fe87233a7233d888bad73e8", size = 9035131 },
+    { url = "https://files.pythonhosted.org/packages/b6/f8/3fafb7804d82e0699a122101b5bee5f0d6e17c3a806dcbc527bb7d3f5b7a/ruff-0.9.4-py3-none-linux_armv6l.whl", hash = "sha256:64e73d25b954f71ff100bb70f39f1ee09e880728efb4250c632ceed4e4cdf706", size = 11668400 },
+    { url = "https://files.pythonhosted.org/packages/2e/a6/2efa772d335da48a70ab2c6bb41a096c8517ca43c086ea672d51079e3d1f/ruff-0.9.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6ce6743ed64d9afab4fafeaea70d3631b4d4b28b592db21a5c2d1f0ef52934bf", size = 11628395 },
+    { url = "https://files.pythonhosted.org/packages/dc/d7/cd822437561082f1c9d7225cc0d0fbb4bad117ad7ac3c41cd5d7f0fa948c/ruff-0.9.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:54499fb08408e32b57360f6f9de7157a5fec24ad79cb3f42ef2c3f3f728dfe2b", size = 11090052 },
+    { url = "https://files.pythonhosted.org/packages/9e/67/3660d58e893d470abb9a13f679223368ff1684a4ef40f254a0157f51b448/ruff-0.9.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37c892540108314a6f01f105040b5106aeb829fa5fb0561d2dcaf71485021137", size = 11882221 },
+    { url = "https://files.pythonhosted.org/packages/79/d1/757559995c8ba5f14dfec4459ef2dd3fcea82ac43bc4e7c7bf47484180c0/ruff-0.9.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:de9edf2ce4b9ddf43fd93e20ef635a900e25f622f87ed6e3047a664d0e8f810e", size = 11424862 },
+    { url = "https://files.pythonhosted.org/packages/c0/96/7915a7c6877bb734caa6a2af424045baf6419f685632469643dbd8eb2958/ruff-0.9.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:87c90c32357c74f11deb7fbb065126d91771b207bf9bfaaee01277ca59b574ec", size = 12626735 },
+    { url = "https://files.pythonhosted.org/packages/0e/cc/dadb9b35473d7cb17c7ffe4737b4377aeec519a446ee8514123ff4a26091/ruff-0.9.4-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:56acd6c694da3695a7461cc55775f3a409c3815ac467279dfa126061d84b314b", size = 13255976 },
+    { url = "https://files.pythonhosted.org/packages/5f/c3/ad2dd59d3cabbc12df308cced780f9c14367f0321e7800ca0fe52849da4c/ruff-0.9.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e0c93e7d47ed951b9394cf352d6695b31498e68fd5782d6cbc282425655f687a", size = 12752262 },
+    { url = "https://files.pythonhosted.org/packages/c7/17/5f1971e54bd71604da6788efd84d66d789362b1105e17e5ccc53bba0289b/ruff-0.9.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1d4c8772670aecf037d1bf7a07c39106574d143b26cfe5ed1787d2f31e800214", size = 14401648 },
+    { url = "https://files.pythonhosted.org/packages/30/24/6200b13ea611b83260501b6955b764bb320e23b2b75884c60ee7d3f0b68e/ruff-0.9.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bfc5f1d7afeda8d5d37660eeca6d389b142d7f2b5a1ab659d9214ebd0e025231", size = 12414702 },
+    { url = "https://files.pythonhosted.org/packages/34/cb/f5d50d0c4ecdcc7670e348bd0b11878154bc4617f3fdd1e8ad5297c0d0ba/ruff-0.9.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:faa935fc00ae854d8b638c16a5f1ce881bc3f67446957dd6f2af440a5fc8526b", size = 11859608 },
+    { url = "https://files.pythonhosted.org/packages/d6/f4/9c8499ae8426da48363bbb78d081b817b0f64a9305f9b7f87eab2a8fb2c1/ruff-0.9.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a6c634fc6f5a0ceae1ab3e13c58183978185d131a29c425e4eaa9f40afe1e6d6", size = 11485702 },
+    { url = "https://files.pythonhosted.org/packages/18/59/30490e483e804ccaa8147dd78c52e44ff96e1c30b5a95d69a63163cdb15b/ruff-0.9.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:433dedf6ddfdec7f1ac7575ec1eb9844fa60c4c8c2f8887a070672b8d353d34c", size = 12067782 },
+    { url = "https://files.pythonhosted.org/packages/3d/8c/893fa9551760b2f8eb2a351b603e96f15af167ceaf27e27ad873570bc04c/ruff-0.9.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:d612dbd0f3a919a8cc1d12037168bfa536862066808960e0cc901404b77968f0", size = 12483087 },
+    { url = "https://files.pythonhosted.org/packages/23/15/f6751c07c21ca10e3f4a51ea495ca975ad936d780c347d9808bcedbd7182/ruff-0.9.4-py3-none-win32.whl", hash = "sha256:db1192ddda2200671f9ef61d9597fcef89d934f5d1705e571a93a67fb13a4402", size = 9852302 },
+    { url = "https://files.pythonhosted.org/packages/12/41/2d2d2c6a72e62566f730e49254f602dfed23019c33b5b21ea8f8917315a1/ruff-0.9.4-py3-none-win_amd64.whl", hash = "sha256:05bebf4cdbe3ef75430d26c375773978950bbf4ee3c95ccb5448940dc092408e", size = 10850051 },
+    { url = "https://files.pythonhosted.org/packages/c6/e6/3d6ec3bc3d254e7f005c543a661a41c3e788976d0e52a1ada195bd664344/ruff-0.9.4-py3-none-win_arm64.whl", hash = "sha256:585792f1e81509e38ac5123492f8875fbc36f3ede8185af0a26df348e5154f41", size = 10078251 },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🗒️ Description
Updates `ruff` from version 0.8.2 to 0.9.4 superceeding: #922 

The 0.9.x series brings improvements to the following areas:
- F-String formatting,
- Single line implicitly concatenated strings,
- Wrapping of assertion messages,
- Parenthesized function return annotations,
- Parenthesized if guards in match case statements.
For more information proceed here: https://astral.sh/blog/ruff-v0.9.0

For precise release changes: https://github.com/astral-sh/ruff/releases

## 🔗 Related Issues
Fixes the underlying "auto-saving" issue here: https://github.com/ethereum/execution-spec-tests/issues/1078

We may run into a similar issue in the future if our `ruff` version diverges from the default`charliermarsh.ruff` VSCode extension although unlikely.

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
