### PR TITLE
refactor(fw): use `ethereum-rlp` instead of `ethereum.rlp`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     # https://ethereum.github.io/execution-spec-tests/main/dev/interactive_usage/
     "questionary @ git+https://github.com/tmbo/questionary@ff22aeae1cd9c1c734f14329934e349bec7873bc",
     "prompt_toolkit>=3.0.48,<4", # ensure we have a new enough version for ipython
-    "ethereum-rlp==0.1.3",
+    "ethereum-rlp>=0.1.3,<0.2",
 ]
 
 [project.urls]

--- a/src/ethereum_test_fixtures/blockchain.py
+++ b/src/ethereum_test_fixtures/blockchain.py
@@ -14,7 +14,7 @@ from typing import (
     get_type_hints,
 )
 
-from ethereum import rlp as eth_rlp
+import ethereum_rlp as eth_rlp
 from ethereum_types.numeric import Uint
 from pydantic import AliasChoices, Field, PlainSerializer, computed_field
 

--- a/src/ethereum_test_types/helpers.py
+++ b/src/ethereum_test_types/helpers.py
@@ -3,7 +3,7 @@
 from dataclasses import MISSING, dataclass, fields
 from typing import List, SupportsBytes
 
-from ethereum.rlp import encode
+import ethereum_rlp as eth_rlp
 
 from ethereum_test_base_types.base_types import Address, Bytes, Hash
 from ethereum_test_base_types.conversions import BytesConvertible, FixedSizeBytesConvertible
@@ -44,7 +44,7 @@ def compute_create_address(
             address = Address(address)
         if nonce is None:
             nonce = 0
-        hash_bytes = Bytes(encode([address, int_to_bytes(nonce)])).keccak256()
+        hash_bytes = Bytes(eth_rlp.encode([address, int_to_bytes(nonce)])).keccak256()
         return Address(hash_bytes[-20:])
     if opcode == Op.CREATE2:
         return compute_create2_address(address, salt, initcode)

--- a/src/ethereum_test_types/types.py
+++ b/src/ethereum_test_types/types.py
@@ -6,8 +6,8 @@ from dataclasses import dataclass
 from functools import cached_property
 from typing import Any, ClassVar, Dict, Generic, List, Literal, Sequence, SupportsBytes, Tuple
 
+import ethereum_rlp as eth_rlp
 from coincurve.keys import PrivateKey, PublicKey
-from ethereum import rlp as eth_rlp
 from ethereum.frontier.fork_types import Account as FrontierAccount
 from ethereum.frontier.fork_types import Address as FrontierAddress
 from ethereum.frontier.state import State, set_account, set_storage, state_root

--- a/uv.lock
+++ b/uv.lock
@@ -559,7 +559,7 @@ requires-dist = [
     { name = "coincurve", specifier = ">=20.0.0,<21" },
     { name = "colorlog", specifier = ">=6.7.0,<7" },
     { name = "ethereum", git = "https://github.com/ethereum/execution-specs" },
-    { name = "ethereum-rlp", specifier = "==0.1.3" },
+    { name = "ethereum-rlp", specifier = ">=0.1.3,<0.2" },
     { name = "ethereum-spec-evm-resolver", git = "https://github.com/petertdavies/ethereum-spec-evm-resolver" },
     { name = "ethereum-types", specifier = ">=0.2.1,<0.3" },
     { name = "filelock", specifier = ">=3.15.1,<4" },


### PR DESCRIPTION
## 🗒️ Description
Updates EEST framework libraries to use Sam's new [ethereum-rlp](https://pypi.org/project/ethereum-rlp/) library, which was moved out of the `ethereum` package in:
- https://github.com/ethereum/execution-specs/pull/1034

## 🔗 Related Issues
`ethereum-rlp` was already added as a dependency as a hot-fix to CI issues in:
- #1080

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).

