### PR TITLE
chore(tooling): update `execution-specs` version to `99238233`

### DIFF
--- a/.github/workflows/tox_verify.yaml
+++ b/.github/workflows/tox_verify.yaml
@@ -102,7 +102,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ethereum/execution-specs
-          ref: 9b95554a88d2a8485f8180254d0f6a493a593fda
+          ref: 9923823367b5586228e590537d47aa9cc4c6a206
           path: execution-specs
           sparse-checkout: |
             src/ethereum
@@ -139,7 +139,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ethereum/execution-specs
-          ref: 9b95554a88d2a8485f8180254d0f6a493a593fda
+          ref: 9923823367b5586228e590537d47aa9cc4c6a206
           path: execution-specs
           sparse-checkout: |
             src/ethereum

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -87,6 +87,7 @@ Release tarball changes:
 - ✨ `state_test`, `blockchain_test` and `blockchain_test_engine` fixtures now contain the `blobSchedule` from [EIP-7840](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7840.md), only for tests filled for Cancun and Prague forks ([#1040](https://github.com/ethereum/execution-spec-tests/pull/1040)).
 - 🔀 Change `--dist` flag to the default value, `load`, for better parallelism handling during test filling ([#1118](https://github.com/ethereum/execution-spec-tests/pull/1118)).
 - 🔀 Refactor framework code to use the [`ethereum-rlp`](https://pypi.org/project/ethereum-rlp/) package instead of `ethereum.rlp`, previously available in ethereum/execution-specs ([#1180](https://github.com/ethereum/execution-spec-tests/pull/1180)).
+- 🔀 Update EELS / execution-specs EEST dependency to [99238233](https://github.com/ethereum/execution-specs/commit/9923823367b5586228e590537d47aa9cc4c6a206) for EEST framework libraries and test case generation ([#1181](https://github.com/ethereum/execution-spec-tests/pull/1181)).
 
 ### 🔧 EVM Tools
 

--- a/eels_resolutions.json
+++ b/eels_resolutions.json
@@ -2,7 +2,7 @@
     "EELSMaster": {
         "git_url": "https://github.com/ethereum/execution-specs.git",
         "branch": "master",
-        "commit": "9b95554a88d2a8485f8180254d0f6a493a593fda"
+        "commit": "9923823367b5586228e590537d47aa9cc4c6a206"
     },
     "Frontier": {
         "same_as": "EELSMaster"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 dependencies = [
     "click>=8.1.0,<9",
-    "ethereum @ git+https://github.com/ethereum/execution-specs",
+    "ethereum @ git+https://github.com/ethereum/execution-specs@9923823367b5586228e590537d47aa9cc4c6a206",
     "hive.py @ git+https://github.com/marioevz/hive.py",
     "ethereum-spec-evm-resolver @ git+https://github.com/petertdavies/ethereum-spec-evm-resolver",
     "setuptools",
@@ -121,3 +121,6 @@ ignore = ["D205", "D203", "D212", "D415", "C901", "A005"]
 [tool.mypy]
 mypy_path = ["src", "$MYPY_CONFIG_FILE_DIR/stubs"]
 plugins = ["pydantic.mypy"]
+
+[tool.uv.sources]
+ethereum = { git = "https://github.com/ethereum/execution-specs", rev = "9923823367b5586228e590537d47aa9cc4c6a206" }

--- a/src/ethereum_test_types/types.py
+++ b/src/ethereum_test_types/types.py
@@ -11,7 +11,7 @@ from coincurve.keys import PrivateKey, PublicKey
 from ethereum.frontier.fork_types import Account as FrontierAccount
 from ethereum.frontier.fork_types import Address as FrontierAddress
 from ethereum.frontier.state import State, set_account, set_storage, state_root
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.numeric import U256, Bytes32, Uint
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -231,7 +231,7 @@ class Alloc(BaseAlloc):
                     set_storage(
                         state=state,
                         address=FrontierAddress(address),
-                        key=Hash(key),
+                        key=Bytes32(Hash(key)),
                         value=U256(value),
                     )
         return state_root(state)

--- a/uv.lock
+++ b/uv.lock
@@ -477,9 +477,10 @@ wheels = [
 [[package]]
 name = "ethereum"
 version = "0.1.0"
-source = { git = "https://github.com/ethereum/execution-specs#9b95554a88d2a8485f8180254d0f6a493a593fda" }
+source = { git = "https://github.com/ethereum/execution-specs?rev=9923823367b5586228e590537d47aa9cc4c6a206#9923823367b5586228e590537d47aa9cc4c6a206" }
 dependencies = [
     { name = "coincurve" },
+    { name = "ethereum-rlp" },
     { name = "ethereum-types" },
     { name = "py-ecc" },
     { name = "pycryptodome" },
@@ -558,7 +559,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.1.0,<9" },
     { name = "coincurve", specifier = ">=20.0.0,<21" },
     { name = "colorlog", specifier = ">=6.7.0,<7" },
-    { name = "ethereum", git = "https://github.com/ethereum/execution-specs" },
+    { name = "ethereum", git = "https://github.com/ethereum/execution-specs?rev=9923823367b5586228e590537d47aa9cc4c6a206" },
     { name = "ethereum-rlp", specifier = ">=0.1.3,<0.2" },
     { name = "ethereum-spec-evm-resolver", git = "https://github.com/petertdavies/ethereum-spec-evm-resolver" },
     { name = "ethereum-types", specifier = ">=0.2.1,<0.3" },


### PR DESCRIPTION
~~Requires #1180~~

## 🗒️ Description

Bumps the version of execution-spec used by:

1. EEST libraries (`uv.lock`, `pyproject.toml`), and,
2. EEST test fixture generation (`eels_resolutions.json`, `tox_verify.yaml`)

to https://github.com/ethereum/execution-specs/commit/9923823367b5586228e590537d47aa9cc4c6a206.

Note, the version is intentionally added to `pyproject.toml` to pin `ethereum` when used with ediable, interactive use (`uvx --with-editable . ipython`).

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).

