### PR TITLE
new(tests): add EOF tests for type section missing

### DIFF
--- a/converted-ethereum-tests.txt
+++ b/converted-ethereum-tests.txt
@@ -22,6 +22,7 @@ EOFTests/efValidation/EOF1_embedded_container_.json
 EOFTests/efValidation/EOF1_eofcreate_valid_.json
 EOFTests/efValidation/EOF1_callf_truncated_.json
 EOFTests/efValidation/EOF1_dataloadn_truncated_.json
+EOFTests/efValidation/EOF1_no_type_section_.json
 EOFTests/efValidation/EOF1_valid_rjump_.json
 EOFTests/efValidation/EOF1_valid_rjumpi_.json
 EOFTests/efValidation/EOF1_valid_rjumpv_.json
@@ -33,6 +34,7 @@ EOFTests/efValidation/EOF1_rjumpi_invalid_destination_.json
 EOFTests/efValidation/EOF1_rjumpv_invalid_destination_.json
 EOFTests/efValidation/EOF1_section_order_.json
 EOFTests/efValidation/EOF1_truncated_section_.json
+EOFTests/efValidation/EOF1_types_section_missing_.json
 EOFTests/efValidation/EOF1_undefined_opcodes_.json
 EOFTests/efValidation/EOF1_truncated_push_.json
 EOFTests/efValidation/deprecated_instructions_.json

--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py
@@ -875,6 +875,27 @@ def test_valid_containers(
             validity_error=[EOFException.MISSING_TYPE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
         ),
         Container(
+            name="no_type_section_2_codes",
+            sections=[
+                Section.Code(Op.INVALID),
+                Section.Code(Op.INVALID),
+            ],
+            auto_type_section=AutoSection.NONE,
+            auto_data_section=False,
+            expected_bytecode="ef0001 020002 0001 0001 00 fefe",
+            validity_error=[EOFException.MISSING_TYPE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
+        ),
+        Container(
+            name="no_type_section_data_section",
+            sections=[
+                Section.Code(Op.INVALID),
+                Section.Data("0xda"),
+            ],
+            auto_type_section=AutoSection.NONE,
+            expected_bytecode="ef0001 020001 0001 040001 00 feda",
+            validity_error=[EOFException.MISSING_TYPE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
+        ),
+        Container(
             name="too_many_type_sections",
             sections=[
                 Section(kind=SectionKind.TYPE, data="0x00000000"),

--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py
@@ -896,6 +896,25 @@ def test_valid_containers(
             validity_error=[EOFException.MISSING_TYPE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
         ),
         Container(
+            name="no_type_section_container_section",
+            sections=[
+                Section.Code(Op.INVALID),
+                Section.Container(
+                    Container(
+                        sections=[
+                            Section.Code(code=Op.RETURNCONTRACT[0](0, 0)),
+                            Section.Container(container=Container.Code(code=Op.STOP)),
+                        ],
+                    )
+                ),
+            ],
+            auto_type_section=AutoSection.NONE,
+            expected_bytecode="ef0001 020001 0001 030001 0032 040000 00 fe"
+            "ef0001 010004 020001 0006 030001 0014 040000 00 00800002 60006000ee00"
+            "ef0001 010004 020001 0001 040000 00 0080000000",
+            validity_error=[EOFException.MISSING_TYPE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
+        ),
+        Container(
             name="too_many_type_sections",
             sections=[
                 Section(kind=SectionKind.TYPE, data="0x00000000"),


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt). https://github.com/ethereum/tests/pull/1445
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
