### PR TITLE
feat(tests): improve tests for EOF prefix

### DIFF
--- a/converted-ethereum-tests.txt
+++ b/converted-ethereum-tests.txt
@@ -12,6 +12,7 @@ GeneralStateTests/stCreate2/call_then_create2_successful_then_returndatasize.jso
 ([#598](https://github.com/ethereum/execution-spec-tests/pull/598))
 EOFTests/EIP3540/validInvalid.json
 
+EOFTests/efExample/ymlExample.json
 EOFTests/EIP3670/validInvalid.json
 EOFTests/EIP4200/validInvalid.json
 EOFTests/EIP4750/validInvalid.json
@@ -40,6 +41,8 @@ EOFTests/efValidation/jumpf_equal_outputs_.json
 EOFTests/efValidation/jumpf_incompatible_outputs_.json
 EOFTests/efValidation/non_returning_status_.json
 EOFTests/efValidation/unreachable_code_sections_.json
+EOFTests/efValidation/validate_EOF_prefix_.json
+EOFTests/efValidation/validate_EOF_version_.json
 
 ([#647](https://github.com/ethereum/execution-spec-tests/pull/647))
 EOFTests/efValidation/EOF1_returncontract_invalid_.json

--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py
@@ -1,5 +1,7 @@
 """EOF validation tests for EIP-3540 container format."""
 
+import itertools
+
 import pytest
 
 from ethereum_test_tools import EOFException, EOFTestFiller
@@ -1125,38 +1127,35 @@ def test_invalid_containers(
     )
 
 
-@pytest.mark.parametrize("magic_0", [0, 1, 0xEE, 0xEF, 0xF0, 0xFF])
-@pytest.mark.parametrize("magic_1", [0, 1, 2, 0xFE, 0xFF])
+@pytest.mark.parametrize(
+    "magic",
+    set(itertools.product([0, 1, 0x60, 0xEE, 0xEF, 0xF0, 0xFF], [0, 1, 2, 0xFE, 0xFF]))
+    - {(0xEF, 0)},
+)
 def test_magic_validation(
     eof_test: EOFTestFiller,
-    magic_0: int,
-    magic_1: int,
+    magic: tuple[int, int],
 ):
     """Verify EOF container 2-byte magic."""
-    if magic_0 == 0xEF and magic_1 == 0:
-        pytest.skip("Valid magic")
     code = bytearray(bytes(VALID_CONTAINER))
-    code[0] = magic_0
-    code[1] = magic_1
+    code[0:2] = magic
     eof_test(
         container=bytes(code),
-        expect_exception=None if magic_0 == 0xEF and magic_1 == 0 else EOFException.INVALID_MAGIC,
+        expect_exception=EOFException.INVALID_MAGIC,
     )
 
 
-@pytest.mark.parametrize("version", [0, 1, 2, 0xFE, 0xFF])
+@pytest.mark.parametrize("version", [0, 2, 0xEF, 0xFE, 0xFF])
 def test_version_validation(
     eof_test: EOFTestFiller,
     version: int,
 ):
     """Verify EOF container version."""
-    if version == 1:
-        pytest.skip("Valid version")
     code = bytearray(bytes(VALID_CONTAINER))
     code[2] = version
     eof_test(
         container=bytes(code),
-        expect_exception=None if version == 1 else EOFException.INVALID_VERSION,
+        expect_exception=EOFException.INVALID_VERSION,
     )
 
 


### PR DESCRIPTION
## 🗒️ Description
Improve tests for EOF magic and version bytes in the EOF prefix by omitting parameters of valid values. Also add some new parameter values suggested by ethereum/tests.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt). https://github.com/ethereum/tests/pull/1450
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
