### PR TITLE
Fixed duplicate docstrings warnings when building documentation (Fixe…

### DIFF
--- a/tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py
+++ b/tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py
@@ -388,12 +388,7 @@ def test_fork_transition_excess_blob_gas_post_blob_genesis(
     post_fork_blocks: List[Block],
     post: Mapping[Address, Account],
 ):
-    """
-    Test `excessBlobGas` calculation in the header when the fork is activated.
-
-    Also produce enough blocks to test the blob gas price increase when the block is full with
-    `SpecHelpers.max_blobs_per_block()` blobs.
-    """
+    """Test `excessBlobGas` calculation in the header when the fork is activated."""
     blockchain_test(
         pre=pre,
         post=post,

--- a/tests/cancun/eip4844_blobs/test_point_evaluation_precompile.py
+++ b/tests/cancun/eip4844_blobs/test_point_evaluation_precompile.py
@@ -663,7 +663,7 @@ def test_precompile_during_fork(
     precompile_input: bytes,
     sender: EOA,
 ):
-    """Test calling the Point Evaluation Precompile before the appropriate fork."""
+    """Test calling the Point Evaluation Precompile during the appropriate fork."""
     # Blocks before fork
     blocks = [
         Block(

--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py
@@ -136,10 +136,7 @@ def test_valid_containers(
     eof_test: EOFTestFiller,
     container: Container,
 ):
-    """
-    Test creating various types of valid EOF V1 contracts using legacy
-    initcode and a contract creating transaction.
-    """
+    """Test various types of valid containers."""
     assert container.validity_error is None, (
         f"Valid container with validity error: {container.validity_error}"
     )
@@ -1114,10 +1111,7 @@ def test_invalid_containers(
     eof_test: EOFTestFiller,
     container: Container,
 ):
-    """
-    Test creating various types of valid EOF V1 contracts using legacy
-    initcode and a contract creating transaction.
-    """
+    """Test invalid containers."""
     assert container.validity_error is not None, "Invalid container without validity error"
     eof_test(
         container=bytes(container),
@@ -1167,7 +1161,7 @@ def test_single_code_section(
     plus_data: bool,
     plus_container: bool,
 ):
-    """Verify EOF container maximum number of code sections."""
+    """Verify EOF container single code section."""
     sections = [Section.Code(Op.RETURNCONTRACT[0](0, 0) if plus_container else Op.STOP)]
     if plus_container:
         sections.append(

--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_eof_example.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_eof_example.py
@@ -129,7 +129,7 @@ def test_eof_example_parameters(
     code_section_code: Bytecode,
     exception: EOFException,
 ):
-    """Example of python EOF classes."""
+    """Example of EOF example parameters."""
     eof_code = Container(
         name="parametrized_eof_example",
         sections=[

--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_opcodes_in_legacy.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_opcodes_in_legacy.py
@@ -94,7 +94,7 @@ def test_opcodes_in_legacy(state_test: StateTestFiller, pre: Alloc, code: Opcode
     eof_opcode_blocks,
 )
 def test_opcodes_in_create_tx(state_test: StateTestFiller, pre: Alloc, code: Opcodes):
-    """Test all EOF only opcodes in legacy contracts and expects failure."""
+    """Test all EOF only opcodes in create tx and expects failure."""
     env = Environment()
 
     sender = pre.fund_eoa()
@@ -138,7 +138,7 @@ def test_opcodes_in_create_operation(
     code: Opcodes,
     legacy_create_opcode: Opcodes,
 ):
-    """Test all EOF only opcodes in legacy contracts and expects failure."""
+    """Test opcodes in create operation."""
     env = Environment()
 
     init_code = Initcode(initcode_prefix=code, deploy_code=Op.RETURN(0, 0))
@@ -186,7 +186,7 @@ def test_opcodes_in_eof_calling_legacy(
     code: Opcodes,
     ext_call_opcode: Op,
 ):
-    """Test all EOF only opcodes in legacy contracts and expects failure."""
+    """Test all opcodes in eof calling legacy and expects failure."""
     env = Environment()
 
     address_test_contract = pre.deploy_contract(

--- a/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpi.py
+++ b/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpi.py
@@ -44,7 +44,7 @@ def test_rjumpi_condition_forwards(
     pre: Alloc,
     calldata: bytes,
 ):
-    """Test RJUMPI contract switching based on external input."""
+    """Test RJUMPI contract switching based on external input (forwards)."""
     env = Environment()
     sender = pre.fund_eoa(10**18)
     contract_address = pre.deploy_contract(
@@ -128,7 +128,7 @@ def test_rjumpi_condition_zero(
     pre: Alloc,
     calldata: bytes,
 ):
-    """Test RJUMPI contract switching based on external input."""
+    """Test RJUMPI contract switching based on external input (condition zero)."""
     env = Environment()
     sender = pre.fund_eoa(10**18)
     contract_address = pre.deploy_contract(
@@ -411,7 +411,10 @@ def test_rjumpi_into_self_data_portion(
     eof_test: EOFTestFiller,
     offset: int,
 ):
-    """EOF1I4200_0021 (Invalid) EOF code containing RJUMPI with target same RJUMPI immediate."""
+    """
+    EOF1I4200_0021 (Invalid) EOF code containing RJUMPI with target same RJUMPI immediate
+    (with offset).
+    """
     eof_test(
         container=Container(
             sections=[
@@ -674,7 +677,7 @@ def test_rjumpi_into_callf(
 def test_rjumpi_into_dupn(
     eof_test: EOFTestFiller,
 ):
-    """EOF code containing RJUMP with target DUPN immediate."""
+    """EOF code containing RJUMPI with target DUPN immediate."""
     eof_test(
         container=Container(
             sections=[
@@ -696,7 +699,7 @@ def test_rjumpi_into_dupn(
 def test_rjumpi_into_swapn(
     eof_test: EOFTestFiller,
 ):
-    """EOF code containing RJUMP with target SWAPN immediate."""
+    """EOF code containing RJUMPI with target SWAPN immediate."""
     eof_test(
         container=Container(
             sections=[
@@ -718,7 +721,7 @@ def test_rjumpi_into_swapn(
 def test_rjumpi_into_exchange(
     eof_test: EOFTestFiller,
 ):
-    """EOF code containing RJUMP with target EXCHANGE immediate."""
+    """EOF code containing RJUMPI with target EXCHANGE immediate."""
     eof_test(
         container=Container(
             sections=[
@@ -833,7 +836,7 @@ def test_rjumpi_at_the_end(
 ):
     """
     https://github.com/ipsilon/eof/blob/main/spec/eof.md#stack-validation 4.i:
-    This implies that the last instruction may be a terminating instruction or RJUMP.
+    This implies that the last instruction may be a terminating instruction or RJUMPI.
     """
     eof_test(
         container=Container(
@@ -909,7 +912,7 @@ def test_rjumpi_backwards_min_stack_wrong(
 def test_rjumpi_rjumpv_backwards_min_stack_wrong(
     eof_test: EOFTestFiller,
 ):
-    """Backwards rjumpv where min_stack does not match."""
+    """Backwards rjumpi rjumpv where min_stack does not match."""
     container = Container.Code(
         code=(
             Op.PUSH0  # (0, 0)

--- a/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py
+++ b/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py
@@ -123,7 +123,7 @@ def test_rjumpv_backwards(
 def test_rjumpv_backwards_onto_dup(
     eof_test: EOFTestFiller,
 ):
-    """Backwards jump vector onto a dup."""
+    """Backwards jumpv vector onto a dup."""
     container = Container.Code(
         code=(Op.PUSH0 + Op.DUP1 + Op.RJUMPV[-5] + Op.STOP),
         max_stack_height=2,
@@ -765,7 +765,7 @@ def test_rjumpv_into_push_n(
     invalid_index: int,
     data_portion_end: bool,
 ):
-    """EOF1I4200_0039 (Invalid) EOF code containing RJUMPV with target PUSH1 immediate."""
+    """EOF1I4200_0039 (Invalid) EOF code containing RJUMPV with target PUSHN immediate."""
     data_portion_length = int.from_bytes(opcode, byteorder="big") - 0x5F
     if jump == JumpDirection.FORWARD:
         invalid_destination = data_portion_length + 1 if data_portion_end else 2
@@ -892,7 +892,7 @@ def test_rjumpv_into_dupn(
     table_size: int,
     invalid_index: int,
 ):
-    """EOF code containing RJUMP with target DUPN immediate."""
+    """EOF code containing RJUMPV with target DUPN immediate."""
     invalid_destination = 1
     jump_table = [0 for _ in range(table_size)]
     jump_table[invalid_index] = invalid_destination
@@ -927,7 +927,7 @@ def test_rjumpv_into_swapn(
     table_size: int,
     invalid_index: int,
 ):
-    """EOF code containing RJUMP with target SWAPN immediate."""
+    """EOF code containing RJUMPV with target SWAPN immediate."""
     invalid_destination = 1
     jump_table = [0 for _ in range(table_size)]
     jump_table[invalid_index] = invalid_destination
@@ -962,7 +962,7 @@ def test_rjumpv_into_exchange(
     table_size: int,
     invalid_index: int,
 ):
-    """EOF code containing RJUMP with target EXCHANGE immediate."""
+    """EOF code containing RJUMPV with target EXCHANGE immediate."""
     invalid_destination = 1
     jump_table = [0 for _ in range(table_size)]
     jump_table[invalid_index] = invalid_destination
@@ -1092,7 +1092,7 @@ def test_rjumpv_at_the_end(
 ):
     """
     https://github.com/ipsilon/eof/blob/main/spec/eof.md#stack-validation 4.i:
-    This implies that the last instruction may be a terminating instruction or RJUMP.
+    This implies that the last instruction may be a terminating instruction or RJUMPV.
     """
     eof_test(
         container=Container(
@@ -1131,7 +1131,7 @@ def test_rjumpv_backwards_min_stack_wrong(
 def test_rjumpv_rjumpi_backwards_min_stack_wrong(
     eof_test: EOFTestFiller,
 ):
-    """Backwards rjumpv where min_stack does not match."""
+    """Backwards rjumpv rjumpi where min_stack does not match."""
     container = Container.Code(
         code=(
             Op.PUSH0  # (0, 0)

--- a/tests/osaka/eip7692_eof_v1/eip663_dupn_swapn_exchange/test_swapn.py
+++ b/tests/osaka/eip7692_eof_v1/eip663_dupn_swapn_exchange/test_swapn.py
@@ -55,7 +55,7 @@ def test_swapn_on_max_stack(
     swapn_operand: int,
     eof_test: EOFTestFiller,
 ):
-    """Test case out of bounds DUPN immediate."""
+    """Test case out of bounds SWAPN (max stack)."""
     eof_code = Container(
         sections=[
             Section.Code(
@@ -84,7 +84,7 @@ def test_swapn_stack_underflow(
     stack_height: int,
     eof_test: EOFTestFiller,
 ):
-    """Test case out of bounds DUPN immediate."""
+    """Test case out of bounds SWAPN (underflow)."""
     eof_code = Container(
         sections=[
             Section.Code(

--- a/tests/osaka/eip7692_eof_v1/eip7069_extcall/test_calldata.py
+++ b/tests/osaka/eip7692_eof_v1/eip7069_extcall/test_calldata.py
@@ -59,7 +59,7 @@ def test_extcalls_inputdata(
     length: int,
 ):
     """
-    Tests call data into EXT*CALL including multiple offset conditions.
+    Tests call data into EXTCALL including multiple offset conditions.
 
     Caller pushes data into memory, then calls the target.  Target writes 64 bytes of call data
     to storage and a success byte.
@@ -146,7 +146,7 @@ def test_extdelegatecall_inputdata(
     length: int,
 ):
     """
-    Tests call data into EXT*CALL including multiple offset conditions.
+    Tests call data into EXTDELEGATECALL including multiple offset conditions.
 
     Caller pushes data into memory, then calls the target.  Target writes 64 bytes of call data
     to storage and a success byte.
@@ -230,7 +230,7 @@ def test_extstaticcall_inputdata(
     length: int,
 ):
     """
-    Tests call data into EXT*CALL including multiple offset conditions.
+    Tests call data into EXTSTATICCALL including multiple offset conditions.
 
     Caller pushes data into memory, then calls the target.  Target writes 64 bytes of call data
     to storage and a success byte.

--- a/tests/osaka/eip7692_eof_v1/eip7480_data_section/test_code_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip7480_data_section/test_code_validation.py
@@ -224,7 +224,6 @@ def test_invalid_containers_with_data_section(
     eof_test: EOFTestFiller,
     container: Container,
 ):
-
     """Test EOF validation of invalid containers with data sections."""
     assert container.validity_error is not None, "Invalid container without validity error"
     eof_test(

--- a/tests/osaka/eip7692_eof_v1/eip7480_data_section/test_code_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip7480_data_section/test_code_validation.py
@@ -224,6 +224,7 @@ def test_invalid_containers_with_data_section(
     eof_test: EOFTestFiller,
     container: Container,
 ):
+
     """Test EOF validation of invalid containers with data sections."""
     assert container.validity_error is not None, "Invalid container without validity error"
     eof_test(

--- a/tests/osaka/eip7692_eof_v1/eip7480_data_section/test_data_opcodes.py
+++ b/tests/osaka/eip7692_eof_v1/eip7480_data_section/test_data_opcodes.py
@@ -112,7 +112,7 @@ def test_data_section_succeed(
     offset: int,
     datasize: int,
 ):
-    """Test simple contracts that are simply expected to succeed on call."""
+    """Test simple contracts that simply expect data section to succeed."""
     env = Environment()
 
     (container, expected_storage) = create_data_test(offset, datasize)

--- a/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_eofcreate.py
+++ b/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_eofcreate.py
@@ -494,7 +494,7 @@ def test_address_collision(
     state_test: StateTestFiller,
     pre: Alloc,
 ):
-    """Verifies a simple EOFCREATE case."""
+    """Tests address collision."""
     env = Environment()
 
     slot_create_address_2 = slot_last_slot * 2 + slot_create_address

--- a/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_eofcreate_failures.py
+++ b/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_eofcreate_failures.py
@@ -507,7 +507,7 @@ def test_insufficient_returncontract_auxdata_gas(
     state_test: StateTestFiller,
     pre: Alloc,
 ):
-    """Excercises an EOFCREATE when there is not enough gas for the initcode charge."""
+    """Exercises a RETURNCONTRACT when there is not enough gas for the initcode charge."""
     env = Environment()
 
     auxdata_size = 0x5000

--- a/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1msm.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1msm.py
@@ -44,7 +44,7 @@ def test_valid(
     post: dict,
     tx: Transaction,
 ):
-    """Test the BLS12_G1MSM precompile (valid)."""
+    """Test valid calls to the BLS12_G1MSM precompile."""
     state_test(
         env=Environment(),
         pre=pre,
@@ -106,7 +106,7 @@ def test_invalid(
     post: dict,
     tx: Transaction,
 ):
-    """Test the BLS12_G1MSM precompile (invalid)."""
+    """Test invalid calls to the BLS12_G1MSM precompile."""
     state_test(
         env=Environment(),
         pre=pre,

--- a/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1msm.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1msm.py
@@ -44,7 +44,7 @@ def test_valid(
     post: dict,
     tx: Transaction,
 ):
-    """Test the BLS12_G1MSM precompile."""
+    """Test the BLS12_G1MSM precompile (valid)."""
     state_test(
         env=Environment(),
         pre=pre,
@@ -106,7 +106,7 @@ def test_invalid(
     post: dict,
     tx: Transaction,
 ):
-    """Test the BLS12_G1MSM precompile."""
+    """Test the BLS12_G1MSM precompile (invalid)."""
     state_test(
         env=Environment(),
         pre=pre,

--- a/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g2mul.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g2mul.py
@@ -221,7 +221,7 @@ def test_gas(
     post: dict,
     tx: Transaction,
 ):
-    """Test the BLS12_G1MUL precompile gas requirements."""
+    """Test the BLS12_G2MUL precompile gas requirements."""
     state_test(
         env=Environment(),
         pre=pre,

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -2607,7 +2607,7 @@ def test_set_code_to_system_contract(
     system_contract: int,
     call_opcode: Op,
 ):
-    """Test setting the code of an account to a pre-compile address."""
+    """Test setting the code of an account to a system contract."""
     caller_code_storage = Storage()
     call_return_code_slot = caller_code_storage.store_next(
         call_return_code(


### PR DESCRIPTION
Fixes issue #1189

## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
