### PR TITLE
fix(tox): Change `package` to editable in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ env_list =
 
 [testenv]
 runner = uv-venv-lock-runner
-package = wheel
+package = editable
 wheel_build_env = .pkg
 solc_version = 0.8.24
 python_source_dirs = src tests docs .github/scripts


### PR DESCRIPTION
## 🗒️ Description
Fixes CI failures by changing the `package` type to `editable` instead of `wheel`.

Issue showed up because of the use of `uvx --with=tox-uv tox` throughout the CI, and the `tox-uv` plugin being updated to version [1.23.0](https://github.com/tox-dev/tox-uv/releases/tag/1.23.0).

We could try to pin the `tox-uv` version to prevent this from happening, but for the time being this patch will do.

## 🔗 Related Issues
CI failure example: https://github.com/ethereum/execution-spec-tests/actions/runs/13207079743/job/36872669510

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.