### PR TITLE
new(tests): a test for empty EOF type section

### DIFF
--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py
@@ -935,9 +935,21 @@ def test_valid_containers(
             validity_error=[EOFException.MISSING_CODE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
         ),
         Container(
-            name="empty_type_section",
+            name="empty_type_section_empty_code",
             sections=[
-                Section(kind=SectionKind.TYPE, data="0x"),
+                Section(kind=SectionKind.TYPE),
+                Section.Code(),
+            ],
+            expected_bytecode="ef00 01 01 0000 02 0001 0000 04 0000 00",
+            validity_error=[
+                EOFException.ZERO_SECTION_SIZE,
+                EOFException.INVALID_SECTION_BODIES_SIZE,
+            ],
+        ),
+        Container(
+            name="empty_type_section_with_code",
+            sections=[
+                Section(kind=SectionKind.TYPE),
                 Section.Code(Op.STOP),
             ],
             expected_bytecode="ef00 01 01 0000 02 0001 0001 04 0000 00 00",


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
