### PR TITLE
new(tests): add a test for multiple EOF type sections

### DIFF
--- a/converted-ethereum-tests.txt
+++ b/converted-ethereum-tests.txt
@@ -22,6 +22,7 @@ EOFTests/efValidation/EOF1_embedded_container_.json
 EOFTests/efValidation/EOF1_eofcreate_valid_.json
 EOFTests/efValidation/EOF1_callf_truncated_.json
 EOFTests/efValidation/EOF1_dataloadn_truncated_.json
+EOFTests/efValidation/EOF1_multiple_type_sections_.py
 EOFTests/efValidation/EOF1_no_type_section_.json
 EOFTests/efValidation/EOF1_valid_rjump_.json
 EOFTests/efValidation/EOF1_valid_rjumpi_.json

--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py
@@ -373,6 +373,17 @@ def test_valid_containers(
             validity_error=EOFException.MISSING_CODE_HEADER,
         ),
         Container(
+            # EOF code containing multiple type headers followed by 2 code sections
+            name="multiple_type_headers_3",
+            sections=[
+                Section(kind=SectionKind.TYPE, data="00800000"),
+                Section(kind=SectionKind.TYPE, data="00800000"),
+                Section.Code(Op.JUMPF[1]),
+                Section.Code(Op.INVALID),
+            ],
+            validity_error=EOFException.MISSING_CODE_HEADER,
+        ),
+        Container(
             # EOF code containing type section size (Size 1)
             name="EOF1I4750_0003",
             raw_bytes="ef000101000102000100010400000000800000fe",


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt). https://github.com/ethereum/tests/pull/1452
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
