### PR TITLE
create fixtures folder when it does not exist when fill is run (#1200)

### DIFF
--- a/src/cli/pytest_commands/fill.py
+++ b/src/cli/pytest_commands/fill.py
@@ -1,6 +1,8 @@
 """CLI entry point for the `fill` pytest-based command."""
 
 import sys
+from os import getcwd, makedirs
+from os.path import join
 from typing import List
 
 import click
@@ -43,6 +45,10 @@ def handle_fill_command_flags(fill_args: List[str]) -> List[str]:
 @common_click_options
 def fill(pytest_args: List[str], **kwargs) -> None:
     """Entry point for the fill command."""
+    # create fixtures folder in repo rootdir if it doesn't exist already
+    fixtures_folder_path = join(getcwd(), "fixtures")
+    makedirs(fixtures_folder_path, exist_ok=True)
+
     result = pytest.main(
         handle_fill_command_flags(list(pytest_args)),
     )


### PR DESCRIPTION
## 🗒️ Description
create fixtures folder when it does not exist when fill is run

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
