### PR TITLE
feat(docs): added fast build mechanic with usage examples

### DIFF
--- a/docs/gen_test_case_reference.py
+++ b/docs/gen_test_case_reference.py
@@ -30,7 +30,7 @@ logger = logging.getLogger("mkdocs")
 # USAGE 1 (use fast mode):
 #       export FAST_DOCS=true && uv run mkdocs serve
 # USAGE 2 (use fast mode + hide side-effect warnings):
-#       export FAST_DOCS=true && uv run mkdocs serve 2>&1 | sed '/is not found among documentation files/d'
+#       export FAST_DOCS=true && uv run mkdocs serve 2>&1 | sed '/is not found among documentation files/d' # noqa: E501
 test_arg = "tests"
 fast_mode = getenv("FAST_DOCS")
 if fast_mode is not None:

--- a/docs/gen_test_case_reference.py
+++ b/docs/gen_test_case_reference.py
@@ -51,9 +51,6 @@ args = [
     "(not blockchain_test_engine) and (not eip_version_check)",
     "-s",
     test_arg,
-    # "tests/shanghai",
-    # "tests/osaka/eip7692_eof_v1",  # noqa: SC100
-    # "tests/prague/eip2537_bls_12_381_precompiles",  # noqa: SC100
 ]
 
 runner = CliRunner()

--- a/docs/gen_test_case_reference.py
+++ b/docs/gen_test_case_reference.py
@@ -9,6 +9,7 @@ src/pytest_plugins/filler/gen_test_doc.py.
 import importlib
 import logging
 import sys
+from os import getenv
 
 import pytest
 from click.testing import CliRunner
@@ -24,6 +25,19 @@ GENERATE_UNTIL_FORK = DocsConfig().GENERATE_UNTIL_FORK
 
 logger = logging.getLogger("mkdocs")
 
+
+# if docs are generated while FAST_DOCS is true, then use "tests/frontier" otherwise use "tests"
+# USAGE 1 (use fast mode):
+#       export FAST_DOCS=true && uv run mkdocs serve
+# USAGE 2 (use fast mode + hide side-effect warnings):
+#       export FAST_DOCS=true && uv run mkdocs serve 2>&1 | sed '/is not found among documentation files/d'
+test_arg = "tests"
+fast_mode = getenv("FAST_DOCS")
+if fast_mode is not None:
+    if fast_mode.lower() == "true":
+        print("-" * 40, "\nWill generate docs using FAST_DOCS mode.\n" + "-" * 40)
+        test_arg = "tests/frontier"
+
 args = [
     "--override-ini",
     "filterwarnings=ignore::pytest.PytestAssertRewriteWarning",  # suppress warnings due to reload
@@ -36,7 +50,7 @@ args = [
     "-m",
     "(not blockchain_test_engine) and (not eip_version_check)",
     "-s",
-    "tests",
+    test_arg,
     # "tests/shanghai",
     # "tests/osaka/eip7692_eof_v1",  # noqa: SC100
     # "tests/prague/eip2537_bls_12_381_precompiles",  # noqa: SC100

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,6 @@ commands = python -c "import src.cli.tox_helpers; src.cli.tox_helpers.markdownli
 description = Build documentation in strict mode (mkdocs)
 extras = docs
 setenv =
-    SPEC_TESTS_AUTO_GENERATE_FILES = true
     GEN_TEST_DOC_VERSION = "tox"
     # Required for `cairosvg` so tox can find `libcairo-2`.
     # https://squidfunk.github.io/mkdocs-material/plugins/requirements/image-processing/?h=cairo#cairo-library-was-not-found


### PR DESCRIPTION
## 🗒️ Description
When using `tests` as arg the build time can be more than 40 sec, when using `tests/frontier` it is around 7 sec on my machine. While working on the docs it is nice to have the options to have access to a faster build mode that doesn't spend most of its time rebuilding docs you are not modifying anyways. It is advised to create a bashrc alias for the usage example commands. Before creating a PR for any docs changes it is advised to run `uvx --with=tox-uv tox -e docs` once to ensure that there are no issues when building using the `--strict` flag.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
