### PR TITLE
refactor(plugins/execute): Refactor account refunds logic

### DIFF
--- a/src/cli/gentest/request_manager.py
+++ b/src/cli/gentest/request_manager.py
@@ -36,6 +36,7 @@ class RPCRequest:
     def eth_get_transaction_by_hash(self, transaction_hash: Hash) -> TransactionByHashResponse:
         """Get transaction data."""
         res = self.rpc.get_transaction_by_hash(transaction_hash)
+        assert res is not None, "Transaction not found"
         block_number = res.block_number
         assert block_number is not None, "Transaction does not seem to be included in any block"
 

--- a/src/pytest_plugins/execute/execute.py
+++ b/src/pytest_plugins/execute/execute.py
@@ -7,11 +7,10 @@ from typing import Any, Dict, Generator, List, Type
 import pytest
 from pytest_metadata.plugin import metadata_key  # type: ignore
 
-from ethereum_test_base_types import Number
 from ethereum_test_execution import BaseExecute
 from ethereum_test_forks import Fork
 from ethereum_test_rpc import EthRPC
-from ethereum_test_tools import SPEC_TYPES, BaseTest, TestInfo, Transaction
+from ethereum_test_tools import SPEC_TYPES, BaseTest, TestInfo
 from ethereum_test_types import TransactionDefaults
 from pytest_plugins.spec_version_checker.spec_version_checker import EIPSpecTestItem
 
@@ -252,7 +251,6 @@ def base_test_parametrizer(cls: Type[BaseTest]):
         eips: List[int],
         eth_rpc: EthRPC,
         collector: Collector,
-        default_gas_price: int,
     ):
         """
         Fixture used to instantiate an auto-fillable BaseTest object from within
@@ -297,33 +295,7 @@ def base_test_parametrizer(cls: Type[BaseTest]):
                 execute.execute(eth_rpc)
                 collector.collect(request.node.nodeid, execute)
 
-        sender_start_balance = eth_rpc.get_balance(pre._sender)
-
-        yield BaseTestWrapper
-
-        # Refund all EOAs (regardless of whether the test passed or failed)
-        refund_txs = []
-        for eoa in pre._funded_eoa:
-            remaining_balance = eth_rpc.get_balance(eoa)
-            eoa.nonce = Number(eth_rpc.get_transaction_count(eoa))
-            refund_gas_limit = 21_000
-            tx_cost = refund_gas_limit * default_gas_price
-            if remaining_balance < tx_cost:
-                continue
-            refund_txs.append(
-                Transaction(
-                    sender=eoa,
-                    to=pre._sender,
-                    gas_limit=21_000,
-                    gas_price=default_gas_price,
-                    value=remaining_balance - tx_cost,
-                ).with_signature_and_sender()
-            )
-        eth_rpc.send_wait_transactions(refund_txs)
-
-        sender_end_balance = eth_rpc.get_balance(pre._sender)
-        used_balance = sender_start_balance - sender_end_balance
-        print(f"Used balance={used_balance / 10**18:.18f}")
+        return BaseTestWrapper
 
     return base_test_parametrizer_func
 

--- a/src/pytest_plugins/execute/pre_alloc.py
+++ b/src/pytest_plugins/execute/pre_alloc.py
@@ -2,7 +2,7 @@
 
 from itertools import count
 from random import randint
-from typing import Iterator, List, Literal, Tuple
+from typing import Generator, Iterator, List, Literal, Tuple
 
 import pytest
 from pydantic import PrivateAttr
@@ -373,9 +373,14 @@ def pre(
     evm_code_type: EVMCodeType,
     chain_id: int,
     eoa_fund_amount_default: int,
-) -> Alloc:
+    default_gas_price: int,
+) -> Generator[Alloc, None, None]:
     """Return default pre allocation for all tests (Empty alloc)."""
-    return Alloc(
+    # Record the starting balance of the sender
+    sender_test_starting_balance = eth_rpc.get_balance(sender_key)
+
+    # Prepare the pre-alloc
+    pre = Alloc(
         fork=fork,
         sender=sender_key,
         eth_rpc=eth_rpc,
@@ -384,3 +389,31 @@ def pre(
         chain_id=chain_id,
         eoa_fund_amount_default=eoa_fund_amount_default,
     )
+
+    # Yield the pre-alloc for usage during the test
+    yield pre
+
+    # Refund all EOAs (regardless of whether the test passed or failed)
+    refund_txs = []
+    for eoa in pre._funded_eoa:
+        remaining_balance = eth_rpc.get_balance(eoa)
+        eoa.nonce = Number(eth_rpc.get_transaction_count(eoa))
+        refund_gas_limit = 21_000
+        tx_cost = refund_gas_limit * default_gas_price
+        if remaining_balance < tx_cost:
+            continue
+        refund_txs.append(
+            Transaction(
+                sender=eoa,
+                to=sender_key,
+                gas_limit=21_000,
+                gas_price=default_gas_price,
+                value=remaining_balance - tx_cost,
+            ).with_signature_and_sender()
+        )
+    eth_rpc.send_wait_transactions(refund_txs)
+
+    # Record the ending balance of the sender
+    sender_test_ending_balance = eth_rpc.get_balance(sender_key)
+    used_balance = sender_test_starting_balance - sender_test_ending_balance
+    print(f"Used balance={used_balance / 10**18:.18f}")

--- a/src/pytest_plugins/execute/pre_alloc.py
+++ b/src/pytest_plugins/execute/pre_alloc.py
@@ -7,7 +7,7 @@ from typing import Generator, Iterator, List, Literal, Tuple
 import pytest
 from pydantic import PrivateAttr
 
-from ethereum_test_base_types import Number, StorageRootType, ZeroPaddedHexNumber
+from ethereum_test_base_types import Bytes, Number, StorageRootType, ZeroPaddedHexNumber
 from ethereum_test_base_types.conversions import (
     BytesConvertible,
     FixedSizeBytesConvertible,
@@ -94,7 +94,7 @@ class Alloc(BaseAlloc):
     _sender: EOA = PrivateAttr()
     _eth_rpc: EthRPC = PrivateAttr()
     _txs: List[Transaction] = PrivateAttr(default_factory=list)
-    _deployed_contracts: List[Tuple[Address, bytes]] = PrivateAttr(default_factory=list)
+    _deployed_contracts: List[Tuple[Address, Bytes]] = PrivateAttr(default_factory=list)
     _funded_eoa: List[EOA] = PrivateAttr(default_factory=list)
     _evm_code_type: EVMCodeType | None = PrivateAttr(None)
     _chain_id: int = PrivateAttr()
@@ -206,7 +206,7 @@ class Alloc(BaseAlloc):
         self._txs.append(deploy_tx)
 
         contract_address = deploy_tx.created_contract
-        self._deployed_contracts.append((contract_address, bytes(code)))
+        self._deployed_contracts.append((contract_address, Bytes(code)))
 
         assert Number(nonce) >= 1, "impossible to deploy contract with nonce lower than one"
 

--- a/src/pytest_plugins/execute/rpc/hive.py
+++ b/src/pytest_plugins/execute/rpc/hive.py
@@ -721,6 +721,7 @@ class EthRPC(BaseEthRPC):
             while tx_id < len(tx_hashes):
                 tx_hash = tx_hashes[tx_id]
                 tx = self.get_transaction_by_hash(tx_hash)
+                assert tx is not None, f"Transaction {tx_hash} not found"
                 if tx.block_number is not None:
                     responses.append(tx)
                     tx_hashes.pop(tx_id)


### PR DESCRIPTION
## 🗒️ Description

Makes the following changes to help the refund logic complete in case of a failure during fixture setup:

### Move Refund Logic to `pre` fixture

Previously the sender refund logic was placed in the `base_test_parametrizer` function, which is responsible for setting up the `state_test`, `blockchain_test`, etc, fixtures that are used in tests to actually generate the test.

The problem was that this fixture is not guaranteed to be the first fixture prepared during the pytest routine, so it could be that we had a fixture order preparation of:

`pre` -> `sender` -> `blockchain_test`

If an error occurred during the `sender` fixture setup, which potentially used `pre` fixture to fund a sender account, the refund logic would not be reached because the setup failed before reaching `blockchain_test`

The fix in this case is to put all the refund logic right in the `pre` fixture, and that way we can make sure that there is no potential fixture setup between the `pre` and the `blockchain_test` that could make the refund logic not take place.

### Use A Replacement Transaction For Refunds

In the case of refunds, we now use a replacement transaction because it was difficult to estimate the real remaining balance of the sender account if there was a pending transaction in the mempool, so now we simply reuse the nonce to replace any transaction still present in the mempool.

### Handle `eth_getTransactionByHash` Returning `null`

Handles the case where the transaction could not be found by the client and a `null` (`None`) response is returned.

## 🔗 Related Issues
None

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
