### PR TITLE
fix: disabled ruff e501 (line too long) checks due to it not being able to autofix this issue

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -53,6 +53,5 @@
         // "-c", "pytest-consume.ini", "--input=fixtures/", "src/pytest_plugins/consume/direct/test_via_direct.py", "--evm-bin=~/bin/evm"
     ],
     "ruff.enable": true,
-    "ruff.lint.args": ["--line-length", "99", "--fix"],
     "extensions.ignoreRecommendations": false,
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ Changelog = "https://ethereum.github.io/execution-spec-tests/main/CHANGELOG/"
 [project.optional-dependencies]
 test = ["pytest-cov>=4.1.0,<5"]
 lint = [
-    "ruff==0.9.4",
+    "ruff>=0.9.4",
     "mypy==0.991; implementation_name == 'cpython'",
     "types-requests"
 ]
@@ -109,13 +109,10 @@ exclude = ["*tests*"]
 [tool.setuptools.package-data]
 ethereum_test_forks = ["forks/contracts/*.bin"]
 
-[tool.ruff]
-line-length = 99
-
 [tool.ruff.lint]
 select = ["E", "F", "B", "W", "I", "A", "N", "D", "C"]
 fixable = ["I", "B", "E", "F", "W", "D", "C"]
-ignore = ["D205", "D203", "D212", "D415", "C901", "A005"] 
+ignore = ["D205", "D203", "D212", "D415", "C901", "A005", "E501"] 
 
 
 [tool.mypy]
@@ -124,3 +121,8 @@ plugins = ["pydantic.mypy"]
 
 [tool.uv.sources]
 ethereum = { git = "https://github.com/ethereum/execution-specs", rev = "9923823367b5586228e590537d47aa9cc4c6a206" }
+
+[dependency-groups]
+dev = [
+    "ruff>=0.9.4",
+]


### PR DESCRIPTION
## 🗒️ Description
disabled ruff e501 (line too long) checks due to it not being able to autofix this issue. leads to failing PRs due to e501 which is unnecessarily frustrating

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
