### PR TITLE
new(tests) EIP-7698 - legacy cannot create EOF

### DIFF
--- a/tests/osaka/eip7692_eof_v1/eip7698_eof_creation_tx/test_eof_creation_tx.py
+++ b/tests/osaka/eip7692_eof_v1/eip7698_eof_creation_tx/test_eof_creation_tx.py
@@ -3,7 +3,7 @@
 import pytest
 
 from ethereum_test_base_types.base_types import Address
-from ethereum_test_tools import Account, Alloc, Environment, StateTestFiller, Transaction
+from ethereum_test_tools import Account, Alloc, Environment, Initcode, StateTestFiller, Transaction
 from ethereum_test_tools.eof.v1 import Container, Section
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 from ethereum_test_types.helpers import compute_create_address
@@ -67,6 +67,32 @@ def test_eof_creation_tx_context(
 
     post = {
         destination_contract_address: Account(storage=destination_contract_storage),
+    }
+
+    state_test(
+        env=env,
+        pre=pre,
+        post=post,
+        tx=tx,
+    )
+
+
+def test_lecacy_cannot_create_eof(
+        state_test: StateTestFiller,
+        pre: Alloc,
+):
+    """Test that a legacy contract creation initcode cannot deploy an EOF contract"""
+    env = Environment()
+    sender = pre.fund_eoa()
+
+    initcode = Initcode(deploy_code=smallest_runtime_subcontainer)
+
+    destination_contract_address = compute_create_address(address=sender, nonce=sender.nonce)
+
+    tx = Transaction(sender=sender, to=None, gas_limit=100000, data=initcode)
+
+    post = {
+        destination_contract_address: Account.NONEXISTENT,
     }
 
     state_test(


### PR DESCRIPTION

## 🗒️ Description
Verify that a legacy contract creation cannot deploy an EOF contract.


## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
