### PR TITLE
new(tests): gas cost of delegation access in CALL

### DIFF
--- a/src/ethereum_clis/clis/evmone.py
+++ b/src/ethereum_clis/clis/evmone.py
@@ -105,6 +105,14 @@ class EvmoneExceptionMapper(ExceptionMapper):
                 TransactionException.TYPE_3_TX_ZERO_BLOBS,
                 "empty blob hashes list",
             ),
+            ExceptionMessage(
+                TransactionException.NONCE_MISMATCH_TOO_LOW,
+                "nonce too low",
+            ),
+            ExceptionMessage(
+                TransactionException.NONCE_MISMATCH_TOO_HIGH,
+                "nonce too high",
+            ),
             # TODO EVMONE needs to differentiate when the section is missing in the header or body
             ExceptionMessage(EOFException.MISSING_STOP_OPCODE, "err: no_terminating_instruction"),
             ExceptionMessage(EOFException.MISSING_CODE_HEADER, "err: code_section_missing"),


### PR DESCRIPTION
## 🗒️ Description
Test additional cost of delegation contract access in call instructions.

This test can be extended to other call instructions and parametrized by the delegation contract being warm or cold.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
