### PR TITLE
chore(cli): temp eofwrap pydantic fix

### DIFF
--- a/src/cli/eofwrap.py
+++ b/src/cli/eofwrap.py
@@ -38,7 +38,7 @@ from ethereum_test_vm.bytecode import Bytecode
 
 
 @click.command()
-@click.argument("input", type=click.Path(exists=True, dir_okay=True, file_okay=True))
+@click.argument("input_path", type=click.Path(exists=True, dir_okay=True, file_okay=True))
 @click.argument("output_dir", type=click.Path(dir_okay=True, file_okay=False))
 @click.option("--traces", is_flag=True, type=bool)
 def eof_wrap(input_path: str, output_dir: str, traces: bool):
@@ -169,7 +169,16 @@ class EofWrapper:
                 return
 
         with open(in_path, "r") as input_file:
-            fixtures = BlockchainFixtures.from_json_data(json.load(input_file))
+            data = json.load(input_file)
+            # TODO: temp solution until `ethereum/tests` are updated with the FixtureConfig
+            for _, f in data.items():
+                if isinstance(f, dict) and "config" not in f:
+                    network = f.get("network")
+                    f["config"] = {
+                        "chainid": "0x1",
+                        "network": network,
+                    }
+            fixtures = BlockchainFixtures.from_json_data(data)
 
         out_fixtures = BaseFixturesRootModel({})
         fixture: BlockchainFixture


### PR DESCRIPTION
## 🗒️ Description
Fixes a small bug introduced by the ruff refactor and adds a temp solution to load in blockchain fixtures from `ethereum/tests` due to the introduction of `FixtureConfig` in this [PR](https://github.com/ethereum/execution-spec-tests/pull/1040).

Note that in the most recent `ethereum/tests` release only the Pyspecs/ tests contain this field.

## 🔗 Related Issues
N/A

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
