### PR TITLE
docs(getting_started,fill): added solc building instructions for arm64 users with fill issues

### DIFF
--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -22,16 +22,27 @@ The latest version of `uv` can be installed via `curl` (recommended; can self-up
 
 If installed via `curl`, `uv` will download Python for your target platform if one of the required versions (Python 3.10, 3.11 or 3.12) is not available natively.
 
-## Installation
+## Installation Commands
 
-Clone [execution-spec-tests](https://github.com/ethereum/execution-spec-tests) and install its dependencies:
+Clone [execution-spec-tests](https://github.com/ethereum/execution-spec-tests) and install its dependencies. If you are using an ARM64 OS ensure that you select the ARM64 tab below.
 
-```console
-git clone https://github.com/ethereum/execution-spec-tests
-cd execution-spec-tests
-uv sync --all-extras
-uv run solc-select use 0.8.24 --always-install
-```
+=== "x86-64"
+
+    ```console
+    git clone https://github.com/ethereum/execution-spec-tests
+    cd execution-spec-tests
+    uv sync --all-extras
+    uv run solc-select use 0.8.24 --always-install
+    ```
+
+=== "ARM64"
+
+    ```console
+    git clone https://github.com/ethereum/execution-spec-tests
+    cd execution-spec-tests
+    uv sync --all-extras
+    ```
+    Follow [this guide](./installation_troubleshooting.md#problem-exception-failed-to-compile-yul-source) to build solidity 0.8.24 from source.
 
 ## Installation Troubleshooting
 

--- a/docs/getting_started/installation_troubleshooting.md
+++ b/docs/getting_started/installation_troubleshooting.md
@@ -36,6 +36,8 @@ This page provides guidance on how to troubleshoot common issues that may arise 
 
 ## Problem: `solc` Installation issues
 
+### Problem: `CERTIFICATE_VERIFY_FAILED`
+
 !!! danger "Problem: `Failed to install solc ... CERTIFICATE_VERIFY_FAILED`"
     When running either `uv run solc-select use 0.8.24 --always-install` or `fill` you encounter the following error:
 
@@ -61,6 +63,26 @@ This page provides guidance on how to troubleshoot common issues that may arise 
         ```bash
         /Applications/Python\ 3.11/Install\ Certificates.command
         ```
+
+### Problem: `Exception: failed to compile yul source`
+
+!!! danger "Problem: `Running fill fails with tests that contain yul source code`"
+    This is happening when you are using an ARM64 OS but used the x86-64 installation guide.
+    To resolve the issue you must build solidity from source (avoid 0.8.24 as it might require building z3 from source as well).
+
+!!! success "Solution: Build solc from source"
+    The following steps have been tested on Ubuntu 24.04.2 LTS ARM64:
+    ```bash
+    git clone --branch v0.8.28 --depth 1 https://github.com/ethereum/solidity.git
+    cd solidity && mkdir build && cd build
+    sudo apt install build-essential libboost-all-dev z3
+    cmake ..
+    make
+    mv $HOME/Documents/execution-spec-tests/.venv/bin/solc $HOME/Documents/execution-spec-tests/.venv/bin/solc-x86-64
+    cp ./solc/solc $HOME/Documents/execution-spec-tests/.venv/bin/
+    chmod +x $HOME/Documents/execution-spec-tests/.venv/bin/solc
+    ```
+    Running `uv run solc --version` should now be functional. Verify that fill is now working by running `uv run fill -m yul_test` in the execution-spec-tests folder.
 
 ## Problem: `ValueError: unsupported hash type ripemd160`
 


### PR DESCRIPTION
## 🗒️ Description
When using ARM64 you can't use the solc x86-64 that you end up with when following the old instructions in the docs. Updated the docs with a guide to install solc on ARM and a description of the fill issue that would have resulted if an ARM user would not have followed these instructions.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
