### PR TITLE
feat,test(consume): use regex for `--sim.limit`; don't use xdist if `--sim.parallelism=1`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Allow `consume direct --collect-only` without specifying a fixture consumer binary on the command-line ([#1237](https://github.com/ethereum/execution-spec-tests/pull/1237)).
 - ✨ Report the (resolved) fixture tarball URL and local fixture cache directory when `consume`'s `--input` flag is a release spec or URL  [#1239](https://github.com/ethereum/execution-spec-tests/pull/1239).
 - ✨ EOF Container validation tests (`eof_test`) now generate container deployment state tests, by wrapping the EOF container in an init-container and sending a deploy transaction ([#783](https://github.com/ethereum/execution-spec-tests/pull/783), [#1233](https://github.com/ethereum/execution-spec-tests/pull/1233)).
+- ✨ Use regexes for Hive's `--sim.limit` argument and don't use xdist if `--sim.parallelism==1` in the `eest/consume-rlp` and `eest/consume-rlp` simulators ([#1220](https://github.com/ethereum/execution-spec-tests/pull/1220)).
 
 ### 📋 Misc
 
@@ -294,7 +295,6 @@ Test fixtures for use by clients are available for each release on the [Github r
 - 🔀 `ethereum_test_tools` library has been split into multiple libraries ([#645](https://github.com/ethereum/execution-spec-tests/pull/645)).
 - ✨ Add the consume engine simulator and refactor the consume simulator suite ([#691](https://github.com/ethereum/execution-spec-tests/pull/691)).
 - 🐞 Prevents forcing consume to use stdin as an input when running from hive ([#701](https://github.com/ethereum/execution-spec-tests/pull/701)).
-- ✨ Use regexes for Hive's `--sim.limit` argument and don't use xdist if `--sim.parallelism==1` in the `eest/consume-rlp` and `eest/consume-rlp` simulators ([#1220](https://github.com/ethereum/execution-spec-tests/pull/1220)).
 
 ### 📋 Misc
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -292,8 +292,9 @@ Test fixtures for use by clients are available for each release on the [Github r
 - 🔀 Refactor `gentest` to use `ethereum_test_tools.rpc.rpc` by adding to `get_transaction_by_hash`, `debug_trace_call` to `EthRPC` ([#568](https://github.com/ethereum/execution-spec-tests/pull/568)).
 - ✨ Write a properties file to the output directory and enable direct generation of a fixture tarball from `fill` via `--output=fixtures.tgz`([#627](https://github.com/ethereum/execution-spec-tests/pull/627)).
 - 🔀 `ethereum_test_tools` library has been split into multiple libraries ([#645](https://github.com/ethereum/execution-spec-tests/pull/645)).
-- ✨ Add the consume engine simulator and refactor the consume simulator suite. ([#691](https://github.com/ethereum/execution-spec-tests/pull/691)).
-- 🐞 Prevents forcing consume to use stdin as an input when running from hive. ([#701](https://github.com/ethereum/execution-spec-tests/pull/701)).
+- ✨ Add the consume engine simulator and refactor the consume simulator suite ([#691](https://github.com/ethereum/execution-spec-tests/pull/691)).
+- 🐞 Prevents forcing consume to use stdin as an input when running from hive ([#701](https://github.com/ethereum/execution-spec-tests/pull/701)).
+- ✨ Use regexes for Hive's `--sim.limit` argument and don't use xdist if `--sim.parallelism==1` in the `eest/consume-rlp` and `eest/consume-rlp` simulators ([#1220](https://github.com/ethereum/execution-spec-tests/pull/1220)).
 
 ### 📋 Misc
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
     "questionary @ git+https://github.com/tmbo/questionary@ff22aeae1cd9c1c734f14329934e349bec7873bc",
     "prompt_toolkit>=3.0.48,<4", # ensure we have a new enough version for ipython
     "ethereum-rlp>=0.1.3,<0.2",
+    "pytest-regex>=0.2.0,<0.3",
 ]
 
 [project.urls]

--- a/src/cli/gentest/tests/test_cli.py
+++ b/src/cli/gentest/tests/test_cli.py
@@ -98,4 +98,4 @@ def test_generate_success(tmp_path, monkeypatch):
 
     ## Fill ##
     fill_result = runner.invoke(fill, ["-c", "pytest.ini", "--skip-evm-dump", output_file])
-    assert fill_result.exit_code == 0
+    assert fill_result.exit_code == 0, f"Fill command failed:\n{fill_result.output}"

--- a/src/cli/pytest_commands/consume.py
+++ b/src/cli/pytest_commands/consume.py
@@ -1,6 +1,7 @@
 """CLI entry point for the `consume` pytest-based command."""
 
 import os
+import re
 import sys
 import warnings
 from pathlib import Path
@@ -12,14 +13,38 @@ import pytest
 from .common import common_click_options, handle_help_flags
 
 
+def process_sim_limit(pattern: str) -> str:
+    """
+    Process hive's `--sim.limit` argument.
+
+    If the user passes a test id (either by explicit prefix 'id:' or by heuristically
+    detecting a pytest node id, i.e. containing '::'), then escape any special regex
+    characters in the expression.
+    """
+    prefix = "id:"
+    if pattern.startswith(prefix):
+        literal_id = pattern[len(prefix) :]
+        return re.escape(literal_id)
+    elif "::" in pattern:
+        return re.sub(r"([\[\]])", r"\\\1", pattern)
+    else:
+        return pattern  # user-provided regex
+
+
 def handle_hive_env_flags(args: List[str]) -> List[str]:
     """Convert hive environment variables into pytest flags."""
     env_var_mappings = {
-        "HIVE_TEST_PATTERN": ["-k"],
-        "HIVE_PARALLELISM": ["-n"],
+        "HIVE_TEST_PATTERN": ["--regex"],  # --sim.limit
+        "HIVE_PARALLELISM": ["-n"],  # --sim.parallelism
     }
     for env_var, pytest_flag in env_var_mappings.items():
         value = os.getenv(env_var)
+        if env_var == "HIVE_TEST_PATTERN" and value is not None:
+            value = process_sim_limit(value)
+        if env_var == "HIVE_PARALLELISM" and value not in ["1", None]:
+            value = str(value)
+        else:
+            value = None
         if value is not None:
             args.extend(pytest_flag + [value])
     if os.getenv("HIVE_RANDOM_SEED") is not None:

--- a/src/pytest_plugins/consume/consume.py
+++ b/src/pytest_plugins/consume/consume.py
@@ -230,7 +230,7 @@ def pytest_addoption(parser):  # noqa: D103
             "will be automatically escaped so that all special regex characters are treated as "
             "literals. Without the `id:` prefix, the argument is interpreted as a Python regex "
             "pattern. To see which test cases are matched, without executing them, prefix with "
-            "`collectonly:`, e.g. `--sim.limit collectonly:.*eip4788.*fork_Prague.*`. "
+            '`collectonly:`, e.g. `--sim.limit "collectonly:.*eip4788.*fork_Prague.*"`. '
             "To list all available test case IDs, set the value to `collectonly`."
         ),
     )

--- a/src/pytest_plugins/consume/consume.py
+++ b/src/pytest_plugins/consume/consume.py
@@ -3,6 +3,7 @@
 import re
 import sys
 import tarfile
+from dataclasses import dataclass
 from io import BytesIO
 from pathlib import Path
 from typing import List, Tuple

--- a/src/pytest_plugins/consume/direct/conftest.py
+++ b/src/pytest_plugins/consume/direct/conftest.py
@@ -19,8 +19,7 @@ from ethereum_test_base_types import to_json
 from ethereum_test_fixtures import BaseFixture
 from ethereum_test_fixtures.consume import TestCaseIndexFile, TestCaseStream
 from ethereum_test_fixtures.file import Fixtures
-
-from ..consume import FixturesSource
+from pytest_plugins.consume.consume import FixturesSource
 
 
 class CollectOnlyCLI(EthereumCLI):

--- a/src/pytest_plugins/consume/direct/test_via_direct.py
+++ b/src/pytest_plugins/consume/direct/test_via_direct.py
@@ -7,8 +7,7 @@ from pathlib import Path
 
 from ethereum_test_fixtures import BaseFixture, FixtureConsumer, FixtureFormat
 from ethereum_test_fixtures.consume import TestCaseIndexFile, TestCaseStream
-
-from ..decorator import fixture_format
+from pytest_plugins.consume.decorator import fixture_format
 
 
 @fixture_format(*BaseFixture.formats.values())

--- a/src/pytest_plugins/consume/tests/test_consume_args.py
+++ b/src/pytest_plugins/consume/tests/test_consume_args.py
@@ -71,7 +71,7 @@ def fill_tests(
             # if we fill many tests, it might help to add -n 8/auto
         ],
     )
-    assert fill_result.exit_code == 0
+    assert fill_result.exit_code == 0, f"Fill command failed:\n{fill_result.output}"
 
 
 @pytest.fixture(autouse=True, scope="function")

--- a/src/pytest_plugins/consume/tests/test_consume_args.py
+++ b/src/pytest_plugins/consume/tests/test_consume_args.py
@@ -24,12 +24,12 @@ def test_paths() -> list[Path]:
 def consume_test_case_ids() -> list[str]:
     """Hard-coded expected output of `consume direct --collectonly -q`."""
     return [
-        "src/pytest_plugins/consume/direct/test_via_direct.py::test_blocktest[tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Cancun-blockchain_test]-blockchain_test]",
-        "src/pytest_plugins/consume/direct/test_via_direct.py::test_blocktest[tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Paris-blockchain_test]-blockchain_test]",
-        "src/pytest_plugins/consume/direct/test_via_direct.py::test_blocktest[tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Shanghai-blockchain_test]-blockchain_test]",
-        "src/pytest_plugins/consume/direct/test_via_direct.py::test_statetest[tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Cancun-state_test]-state_test]",
-        "src/pytest_plugins/consume/direct/test_via_direct.py::test_statetest[tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Paris-state_test]-state_test]",
-        "src/pytest_plugins/consume/direct/test_via_direct.py::test_statetest[tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Shanghai-state_test]-state_test]",
+        "src/pytest_plugins/consume/direct/test_via_direct.py::test_fixture[CollectOnlyFixtureConsumer-tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Cancun-blockchain_test_from_state_test]]",
+        "src/pytest_plugins/consume/direct/test_via_direct.py::test_fixture[CollectOnlyFixtureConsumer-tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Paris-blockchain_test_from_state_test]]",
+        "src/pytest_plugins/consume/direct/test_via_direct.py::test_fixture[CollectOnlyFixtureConsumer-tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Shanghai-blockchain_test_from_state_test]]",
+        "src/pytest_plugins/consume/direct/test_via_direct.py::test_fixture[CollectOnlyFixtureConsumer-tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Cancun-state_test]]",
+        "src/pytest_plugins/consume/direct/test_via_direct.py::test_fixture[CollectOnlyFixtureConsumer-tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Paris-state_test]]",
+        "src/pytest_plugins/consume/direct/test_via_direct.py::test_fixture[CollectOnlyFixtureConsumer-tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Shanghai-state_test]]",
     ]
 
 
@@ -61,6 +61,8 @@ def fill_tests(
         [
             "-c=pytest.ini",
             "--skip-evm-dump",
+            "-m",
+            "not blockchain_test_engine_from_state_test",
             f"--from={fill_fork_from}",
             f"--until={fill_fork_until}",
             f"--output={str(fixtures_dir)}",
@@ -103,6 +105,9 @@ def copy_consume_test_paths(pytester: Pytester):
         shutil.move("conftest.py", target_dir / "conftest.py")
 
 
+single_test_id = "src/pytest_plugins/consume/direct/test_via_direct.py::test_fixture[CollectOnlyFixtureConsumer-tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Shanghai-state_test]]"  # noqa: E501
+
+
 @pytest.mark.parametrize(
     "extra_args, expected_filter_pattern",
     [
@@ -126,24 +131,18 @@ def copy_consume_test_paths(pytester: Pytester):
                 "--collect-only",
                 "-q",
                 "--sim.limit",
-                "id:src/pytest_plugins/consume/direct/test_via_direct.py::test_blocktest[tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Cancun-blockchain_test]-blockchain_test]",
+                f"id:{single_test_id}",
             ],
-            re.compile(
-                re.escape(
-                    "src/pytest_plugins/consume/direct/test_via_direct.py::test_blocktest[tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Cancun-blockchain_test]-blockchain_test]"
-                )
-            ),
+            re.compile(re.escape(f"{single_test_id}")),
             id="sim_limit_id",
         ),
         pytest.param(
             [
                 "--sim.limit",
-                "collectonly:id:src/pytest_plugins/consume/direct/test_via_direct.py::test_blocktest[tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Cancun-blockchain_test]-blockchain_test]",
+                f"collectonly:id:{single_test_id}",
             ],
             re.compile(
-                re.escape(
-                    "src/pytest_plugins/consume/direct/test_via_direct.py::test_blocktest[tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Cancun-blockchain_test]-blockchain_test]"
-                )
+                re.compile(re.escape(f"{single_test_id}")),
             ),
             id="sim_limit_collect_only_id",
         ),

--- a/src/pytest_plugins/consume/tests/test_consume_args.py
+++ b/src/pytest_plugins/consume/tests/test_consume_args.py
@@ -1,0 +1,184 @@
+"""Test the consume plugins with various cli arguments."""
+
+import re
+import shutil
+from pathlib import Path
+from typing import List
+
+import pytest
+from click.testing import CliRunner
+from pytest import Pytester, TempPathFactory
+
+from cli.pytest_commands.fill import fill
+
+
+@pytest.fixture(scope="module")
+def test_paths() -> list[Path]:
+    """Specify the test paths to be filled."""
+    return [
+        Path("tests/istanbul/eip1344_chainid/test_chainid.py"),
+    ]
+
+
+@pytest.fixture(scope="module")
+def consume_test_case_ids() -> list[str]:
+    """Hard-coded expected output of `consume direct --collectonly -q`."""
+    return [
+        "src/pytest_plugins/consume/direct/test_via_direct.py::test_blocktest[tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Cancun-blockchain_test]-blockchain_test]",
+        "src/pytest_plugins/consume/direct/test_via_direct.py::test_blocktest[tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Paris-blockchain_test]-blockchain_test]",
+        "src/pytest_plugins/consume/direct/test_via_direct.py::test_blocktest[tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Shanghai-blockchain_test]-blockchain_test]",
+        "src/pytest_plugins/consume/direct/test_via_direct.py::test_statetest[tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Cancun-state_test]-state_test]",
+        "src/pytest_plugins/consume/direct/test_via_direct.py::test_statetest[tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Paris-state_test]-state_test]",
+        "src/pytest_plugins/consume/direct/test_via_direct.py::test_statetest[tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Shanghai-state_test]-state_test]",
+    ]
+
+
+@pytest.fixture(scope="module")
+def fill_fork_from() -> str:
+    """Specify the value for `fill`'s `--from` argument."""
+    return "Paris"
+
+
+@pytest.fixture(scope="module")
+def fill_fork_until() -> str:
+    """Specify the value for `fill`'s `--until` argument."""
+    return "Cancun"
+
+
+@pytest.fixture(scope="module")
+def fixtures_dir(tmp_path_factory: TempPathFactory) -> Path:
+    """Define the temporary test fixture directory for fill output."""
+    return tmp_path_factory.mktemp("fixtures")
+
+
+@pytest.fixture(autouse=True, scope="module")
+def fill_tests(
+    fixtures_dir: Path, fill_fork_from: str, fill_fork_until: str, test_paths: List[Path]
+) -> None:
+    """Run fill to generate test fixtures for use with testing consume."""
+    fill_result = CliRunner().invoke(
+        fill,
+        [
+            "-c=pytest.ini",
+            "--skip-evm-dump",
+            f"--from={fill_fork_from}",
+            f"--until={fill_fork_until}",
+            f"--output={str(fixtures_dir)}",
+            *[str(p) for p in test_paths],
+            # if we fill many tests, it might help to add -n 8/auto
+        ],
+    )
+    assert fill_result.exit_code == 0
+
+
+@pytest.fixture(autouse=True, scope="function")
+def test_fixtures(pytester: Pytester, fixtures_dir: Path, fill_tests: None) -> List[Path]:
+    """
+    Copy test fixtures from the regular temp path to the pytester temporary dir.
+
+    We intentionally copy the `.meta/index.json` file to test its compatibility with consume.
+    """
+    test_fixtures = []
+    for json_file in fixtures_dir.rglob("*.json"):
+        target_dir = Path(pytester.path) / json_file.parent
+        if not target_dir.exists():
+            target_dir.mkdir(parents=True)
+        pytester.copy_example(name=json_file.as_posix())
+        shutil.move(json_file.name, target_dir / json_file.name)
+        if ".meta" not in str(json_file):
+            test_fixtures.append(json_file)
+    return test_fixtures
+
+
+@pytest.fixture(autouse=True)
+def copy_consume_test_paths(pytester: Pytester):
+    """Specify and copy the consume test paths to the testdir."""
+    local_test_paths = [Path("src/pytest_plugins/consume/direct/test_via_direct.py")]
+    for test_path in local_test_paths:
+        target_dir = Path(pytester.path) / test_path.parent
+        target_dir.mkdir(parents=True, exist_ok=True)
+        pytester.copy_example(name=str(test_path))
+        pytester.copy_example(name=str(test_path.parent / "conftest.py"))
+        shutil.move(test_path.name, target_dir / test_path.name)
+        shutil.move("conftest.py", target_dir / "conftest.py")
+
+
+@pytest.mark.parametrize(
+    "extra_args, expected_filter_pattern",
+    [
+        pytest.param(
+            ["--collect-only", "-q"],
+            re.compile(r".*"),
+            id="no_extra_args",
+        ),
+        pytest.param(
+            ["--collect-only", "-q", "--sim.limit", ".*fork_Cancun.*"],
+            re.compile(".*Cancun.*"),
+            id="sim_limit_regex",
+        ),
+        pytest.param(
+            ["--sim.limit", "collectonly:.*fork_Cancun.*"],
+            re.compile(".*Cancun.*"),
+            id="sim_limit_collect_only_regex",
+        ),
+        pytest.param(
+            [
+                "--collect-only",
+                "-q",
+                "--sim.limit",
+                "id:src/pytest_plugins/consume/direct/test_via_direct.py::test_blocktest[tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Cancun-blockchain_test]-blockchain_test]",
+            ],
+            re.compile(
+                re.escape(
+                    "src/pytest_plugins/consume/direct/test_via_direct.py::test_blocktest[tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Cancun-blockchain_test]-blockchain_test]"
+                )
+            ),
+            id="sim_limit_id",
+        ),
+        pytest.param(
+            [
+                "--sim.limit",
+                "collectonly:id:src/pytest_plugins/consume/direct/test_via_direct.py::test_blocktest[tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Cancun-blockchain_test]-blockchain_test]",
+            ],
+            re.compile(
+                re.escape(
+                    "src/pytest_plugins/consume/direct/test_via_direct.py::test_blocktest[tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Cancun-blockchain_test]-blockchain_test]"
+                )
+            ),
+            id="sim_limit_collect_only_id",
+        ),
+    ],
+)
+def test_consume_simlimit_collectonly(
+    pytester: Pytester,
+    fixtures_dir: Path,
+    consume_test_case_ids: List[str],
+    extra_args: List[str],
+    expected_filter_pattern: re.Pattern,
+) -> None:
+    """Test consume's --sim.limit argument in collect-only mode."""
+    ini_file = "pytest-consume.ini"
+    pytester.copy_example(name=ini_file)
+    consume_test_path = "src/pytest_plugins/consume/direct/test_via_direct.py"
+    args = [
+        "-c",
+        ini_file,
+        "--input",
+        str(fixtures_dir),
+        consume_test_path,
+        *extra_args,
+    ]
+    result = pytester.runpytest(*args)
+    assert result.ret == 0
+    stdout_lines = str(result.stdout).splitlines()
+    collected_test_ids = [
+        line
+        for line in stdout_lines
+        if line.strip()
+        and "tests collected in" not in line
+        and "pytest-regex selected" not in line
+    ]
+    expected_collected_test_ids = [
+        line for line in consume_test_case_ids if expected_filter_pattern.search(line)
+    ]
+    assert set(collected_test_ids) == set(expected_collected_test_ids)

--- a/src/pytest_plugins/consume/tests/test_consume_args.py
+++ b/src/pytest_plugins/consume/tests/test_consume_args.py
@@ -59,7 +59,8 @@ def fill_tests(
     fill_result = CliRunner().invoke(
         fill,
         [
-            "-c=pytest.ini",
+            "-c",
+            "pytest.ini",
             "--skip-evm-dump",
             "-m",
             "not blockchain_test_engine_from_state_test",

--- a/src/pytest_plugins/consume/tests/test_consume_args.py
+++ b/src/pytest_plugins/consume/tests/test_consume_args.py
@@ -63,7 +63,7 @@ def fill_tests(
             "pytest.ini",
             "--skip-evm-dump",
             "-m",
-            "not blockchain_test_engine_from_state_test",
+            "(not blockchain_test_engine) and (not eip_version_check)",
             f"--from={fill_fork_from}",
             f"--until={fill_fork_until}",
             f"--output={str(fixtures_dir)}",

--- a/src/pytest_plugins/filler/tests/test_filler.py
+++ b/src/pytest_plugins/filler/tests/test_filler.py
@@ -1,5 +1,5 @@
 """
-Test the forks plugin.
+Test the filler plugin.
 """
 
 import configparser

--- a/uv.lock
+++ b/uv.lock
@@ -511,6 +511,7 @@ dependencies = [
     { name = "pytest-html" },
     { name = "pytest-json-report" },
     { name = "pytest-metadata" },
+    { name = "pytest-regex" },
     { name = "pytest-xdist" },
     { name = "pyyaml" },
     { name = "questionary" },
@@ -589,6 +590,7 @@ requires-dist = [
     { name = "pytest-html", specifier = ">=4.1.0,<5" },
     { name = "pytest-json-report", specifier = ">=1.5.0,<2" },
     { name = "pytest-metadata", specifier = ">=3,<4" },
+    { name = "pytest-regex", specifier = ">=0.2.0,<0.3" },
     { name = "pytest-xdist", specifier = ">=3.3.1,<4" },
     { name = "pyyaml", specifier = ">=6.0.2,<7" },
     { name = "questionary", git = "https://github.com/tmbo/questionary?rev=ff22aeae1cd9c1c734f14329934e349bec7873bc" },
@@ -1537,6 +1539,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a6/85/8c969f8bec4e559f8f2b958a15229a35495f5b4ce499f6b865eac54b878d/pytest_metadata-3.1.1.tar.gz", hash = "sha256:d2a29b0355fbc03f168aa96d41ff88b1a3b44a3b02acbe491801c98a048017c8", size = 9952 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3e/43/7e7b2ec865caa92f67b8f0e9231a798d102724ca4c0e1f414316be1c1ef2/pytest_metadata-3.1.1-py3-none-any.whl", hash = "sha256:c8e0844db684ee1c798cfa38908d20d67d0463ecb6137c72e91f418558dd5f4b", size = 11428 },
+]
+
+[[package]]
+name = "pytest-regex"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/67/e3f3700e8f95fc9e80ab83d589346c117de4e6d01e6b922f7300282e7fc9/pytest-regex-0.2.0.tar.gz", hash = "sha256:f4076c49abece2503815c8b2e282a8fd22d330f06f9bf91d620b3ef02de7a353", size = 4097 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/72/d4143c66c1806599358c119c0af530bab92ef0c48129f17522dfd5a7ff6a/pytest_regex-0.2.0-py3-none-any.whl", hash = "sha256:c97e9c49e8c7e7482bd1fa701e3a5cccd18eb78d263752e32dba4937d8cee6d9", size = 3824 },
 ]
 
 [[package]]

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -396,6 +396,7 @@ sha
 SHA
 sharding
 SignerType
+simlimit
 solc
 soliditylang
 Spec4844


### PR DESCRIPTION
## 🗒️ Description
This PR improves how the `consume` hive simulators handle the `--sim.parallelism` (^= `HIVE_PARALLELISM`) and `--sim.limit` (`HIVE_TEST_PATTERN`) args.

### `HIVE_PARALLELISM`

Don't activate `pytest-xdist` if `--sim.parallelism` is 1 (the default). This sets `-n=1` in the pytest simulator which superflously activates the pytest-xdist plugin. This has no benefits and obfuscates pytest output; xdist is now only used if `HIVE_PARALLELISM > 1`.

### `HIVE_TEST_PATTERN`

The previous behavior was to pass `HIVE_TEST_PATTERN` to pytest's `-k` argument, which is very pytest specific. This PR adds a dependency on `pytest-regex` and allows users to provide a regex to `--sim.limit` which is more consistent with other simulators.

To ensure transparent behavior between running between the two modes: 

1. Directly `./hive --sim eest/consume-engine,eest/consume-rlp`, and,
2. Sending tests from a `consume` session to `./hive --dev`

a `--sim.limit` cli option has been added to all the consume commands (including `consume direct`). This flag has does have some special non-breaking extra behavior:
 
1. If the value is exactly `collectonly`, enable collection mode without
    filtering.
2. If the value starts with `collectonly:`, enable collection mode and use the
    rest as a regex pattern.
3. If the (now possibly transformed) value starts with `id:`, treat the rest as a
    literal test ID and escape special regex characters for the user.

### Test Cases

Adds the first `pytester` based framework tests for `consume` for the new `--sim.limit` arg in `--collect-only` mode (no dependences required). These tests serve as a start and could be improved. They currently do an end-to-end test from `fill` to `consume` (in collect-only mode). Instead of running `fill`, this could be simplified to load an `index.json` file instead, but as-is, serves as a starting point to generate fixtures to actually be executed by `consume` in framework tests (if an `evm` bin is available).

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).

