### PR TITLE
new(tests): add state test with empty 7702 authorization list

### DIFF
--- a/src/ethereum_clis/clis/execution_specs.py
+++ b/src/ethereum_clis/clis/execution_specs.py
@@ -133,6 +133,10 @@ class ExecutionSpecsExceptionMapper(ExceptionMapper):
     def _mapping_data(self):
         return [
             ExceptionMessage(
+                TransactionException.TYPE_4_EMPTY_AUTHORIZATION_LIST,
+                "Failed transaction: InvalidBlock()",
+            ),
+            ExceptionMessage(
                 TransactionException.TYPE_4_TX_CONTRACT_CREATION,
                 "Failed transaction: ",
             ),

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -2930,6 +2930,28 @@ def test_contract_create(
     )
 
 
+def test_empty_authorization_list(
+    state_test: StateTestFiller,
+    pre: Alloc,
+):
+    """Test sending an invalid transaction with empty authorization list."""
+    tx = Transaction(
+        gas_limit=100_000,
+        to=pre.deploy_contract(code=b""),
+        value=0,
+        authorization_list=[],
+        error=TransactionException.TYPE_4_EMPTY_AUTHORIZATION_LIST,
+        sender=pre.fund_eoa(),
+    )
+
+    state_test(
+        env=Environment(),
+        pre=pre,
+        tx=tx,
+        post={},
+    )
+
+
 @pytest.mark.parametrize(
     "self_sponsored",
     [


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
