### PR TITLE
bug: fix EELS t8n for CPython versions on macOS

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 - ✨ Add a guide to the docs for porting tests from `ethereum/tests` to EEST ([#1165](https://github.com/ethereum/execution-spec-tests/pull/1165)).
 - ✨ Update `mypy` to latest release `>=1.15.0,<1.16` ([#1209](https://github.com/ethereum/execution-spec-tests/pull/1209)).
+- 🐞 Bug fix for filling with EELS for certain Python versions due to an issue with CPython ([#1231](https://github.com/ethereum/execution-spec-tests/pull/1231)).
 
 ### 🧪 Test Cases
 

--- a/src/ethereum_clis/clis/execution_specs.py
+++ b/src/ethereum_clis/clis/execution_specs.py
@@ -4,6 +4,7 @@ Ethereum Specs EVM Resolver Transition Tool Interface.
 https://github.com/petertdavies/ethereum-spec-evm-resolver
 """
 
+import os
 import re
 import subprocess
 import time
@@ -53,6 +54,7 @@ class ExecutionSpecsTransitionTool(TransitionTool):
         trace: bool = False,
     ):
         """Initialize the Ethereum Specs EVM Resolver Transition Tool interface."""
+        os.environ.setdefault("NO_PROXY", "*")  # Disable proxy for local connections
         super().__init__(
             exception_mapper=ExecutionSpecsExceptionMapper(), binary=binary, trace=trace
         )

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -848,3 +848,4 @@ subcontainers
 ize
 nectos
 fibonacci
+CPython


### PR DESCRIPTION
## 🗒️ Description
A `fill`-ing error found by @gurukamath on macOS appeared for python version `3.11.2`. The key issue is specifically due to a platform limitation in `cpython` as commented here: https://github.com/python/cpython/issues/105912#issuecomment-1858769943

The error occurs as the requests library (via urllib.request) attempts to perform a proxy bypass check on a URL that uses the `http+unix://` scheme. A crash occurs when running the function `proxy_bypass_macosx_sysconf` causing an empty label to be passed to the IDNA encoder. Key error logs are below:
```console
.venv/lib/python3.11/site-packages/requests/utils.py:816: in should_bypass_proxies
    bypass = proxy_bypass(parsed.hostname)
/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/urllib/request.py:2654: in proxy_bypass
    return proxy_bypass_macosx_sysconf(host)
/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/urllib/request.py:2631: in proxy_bypass_macosx_sysconf
    return _proxy_bypass_macosx_sysconf(host, proxy_settings)
/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/urllib/request.py:2599: in _proxy_bypass_macosx_sysconf
    hostIP = socket.gethostbyname(hostonly)
E   UnicodeError: encoding with 'idna' codec failed (UnicodeError: label empty or too long)
```

To work around this issue, this PR sets the `NO_PROXY` environment variable to `"*"`.  This ensures that all proxy lookups are bypassed for our local Unix socket connections, thereby preventing the IDNA encoding error. This is the suggestion as denoted from the issue linked.


## 🔗 Related Issues
https://github.com/python/cpython/issues/105912

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
