### PR TITLE
fix(execution,fixtures): Labeled formats comparison

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,7 +14,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Blockchain and Blockchain-Engine tests now have a marker to specify that they were generated from a state test, which can be used with `-m blockchain_test_from_state_test` and `-m blockchain_test_engine_from_state_test` respectively ([#1220](https://github.com/ethereum/execution-spec-tests/pull/1220)).
 - ✨ Blockchain and Blockchain-Engine tests that were generated from a state test now have `blockchain_test_from_state_test` or `blockchain_test_engine_from_state_test` as part of their test IDs ([#1220](https://github.com/ethereum/execution-spec-tests/pull/1220)).
 - 🔀 Refactor `ethereum_test_fixtures` and `ethereum_clis` to create `FixtureConsumer` and `FixtureConsumerTool` classes which abstract away the consumption process used by `consume direct` ([#935](https://github.com/ethereum/execution-spec-tests/pull/935)).
-- ✨ EOF Container validation tests (`eof_test`) now generate container deployment state tests, by wrapping the EOF container in an init-container and sending a deploy transaction ([#783](https://github.com/ethereum/execution-spec-tests/pull/783)).
+- ✨ EOF Container validation tests (`eof_test`) now generate container deployment state tests, by wrapping the EOF container in an init-container and sending a deploy transaction ([#783](https://github.com/ethereum/execution-spec-tests/pull/783), [#1233](https://github.com/ethereum/execution-spec-tests/pull/1233)).
 
 ### 📋 Misc
 

--- a/src/ethereum_test_execution/base.py
+++ b/src/ethereum_test_execution/base.py
@@ -64,7 +64,7 @@ class LabeledExecuteFormat:
         """
         Check if two labeled execute formats are equal.
 
-        If the other object is a FixtureFormat type, the format of the labeled execute
+        If the other object is a ExecuteFormat type, the format of the labeled execute
         format will be compared with the format of the other object.
         """
         if isinstance(other, LabeledExecuteFormat):

--- a/src/ethereum_test_execution/base.py
+++ b/src/ethereum_test_execution/base.py
@@ -22,11 +22,11 @@ class BaseExecute(CamelModel):
     @classmethod
     def __pydantic_init_subclass__(cls, **kwargs):
         """
-        Register all subclasses of BaseFixture with a fixture format name set
-        as possible fixture formats.
+        Register all subclasses of BaseExecute with a execute format name set
+        as possible execute formats.
         """
         if cls.format_name:
-            # Register the new fixture format
+            # Register the new execute format
             BaseExecute.formats[cls.format_name] = cls
 
     @abstractmethod
@@ -62,9 +62,9 @@ class LabeledExecuteFormat:
 
     def __eq__(self, other: Any) -> bool:
         """
-        Check if two labeled fixture formats are equal.
+        Check if two labeled execute formats are equal.
 
-        If the other object is a FixtureFormat type, the format of the labeled fixture
+        If the other object is a FixtureFormat type, the format of the labeled execute
         format will be compared with the format of the other object.
         """
         if isinstance(other, LabeledExecuteFormat):

--- a/src/ethereum_test_execution/base.py
+++ b/src/ethereum_test_execution/base.py
@@ -1,7 +1,7 @@
 """Ethereum test execution base types."""
 
 from abc import abstractmethod
-from typing import Annotated, ClassVar, Dict, Type
+from typing import Annotated, Any, ClassVar, Dict, Type
 
 from pydantic import PlainSerializer, PlainValidator
 
@@ -59,6 +59,19 @@ class LabeledExecuteFormat:
     def format_name(self) -> str:
         """Get the execute format name."""
         return self.format.format_name
+
+    def __eq__(self, other: Any) -> bool:
+        """
+        Check if two labeled fixture formats are equal.
+
+        If the other object is a FixtureFormat type, the format of the labeled fixture
+        format will be compared with the format of the other object.
+        """
+        if isinstance(other, LabeledExecuteFormat):
+            return self.format == other.format
+        if isinstance(other, type) and issubclass(other, BaseExecute):
+            return self.format == other
+        return False
 
 
 # Type alias for a base execute class

--- a/src/ethereum_test_fixtures/base.py
+++ b/src/ethereum_test_fixtures/base.py
@@ -169,6 +169,19 @@ class LabeledFixtureFormat:
         """Get the execute format name."""
         return self.format.format_name
 
+    def __eq__(self, other: Any) -> bool:
+        """
+        Check if two labeled fixture formats are equal.
+
+        If the other object is a FixtureFormat type, the format of the labeled fixture
+        format will be compared with the format of the other object.
+        """
+        if isinstance(other, LabeledFixtureFormat):
+            return self.format == other.format
+        if isinstance(other, type) and issubclass(other, BaseFixture):
+            return self.format == other
+        return False
+
 
 # Annotated type alias for a base fixture class
 FixtureFormat = Annotated[


### PR DESCRIPTION
## 🗒️ Description
Fixes the following error:
```
================================================================ FAILURES ================================================================
__________________________ test_all_opcodes_in_container[fork_Osaka-blockchain_test_from_eof_test-opcode_STOP] ___________________________
tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_all_opcodes_in_container.py:115: in test_all_opcodes_in_container
    eof_test(
src/pytest_plugins/filler/filler.py:695: in __init__
    fixture = self.generate(
src/ethereum_test_specs/eof.py:464: in generate
    raise Exception(f"Unknown fixture format: {fixture_format}")
E   Exception: Unknown fixture format: <class 'ethereum_test_fixtures.blockchain.BlockchainFixture'>
============================================================ warnings summary ============================================================
```

Caused due to the comparison between the labeled fixture format and non-labeled ones during the fill process.

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.