### PR TITLE
feat(consume): allow `consume direct --collect-only` without `--bin`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Blockchain and Blockchain-Engine tests now have a marker to specify that they were generated from a state test, which can be used with `-m blockchain_test_from_state_test` and `-m blockchain_test_engine_from_state_test` respectively ([#1220](https://github.com/ethereum/execution-spec-tests/pull/1220)).
 - ✨ Blockchain and Blockchain-Engine tests that were generated from a state test now have `blockchain_test_from_state_test` or `blockchain_test_engine_from_state_test` as part of their test IDs ([#1220](https://github.com/ethereum/execution-spec-tests/pull/1220)).
 - 🔀 Refactor `ethereum_test_fixtures` and `ethereum_clis` to create `FixtureConsumer` and `FixtureConsumerTool` classes which abstract away the consumption process used by `consume direct` ([#935](https://github.com/ethereum/execution-spec-tests/pull/935)).
+- ✨ Allow `consume direct --collect-only` without specifying a fixture consumer binary on the command-line ([#1237](https://github.com/ethereum/execution-spec-tests/pull/1237)).
 - ✨ EOF Container validation tests (`eof_test`) now generate container deployment state tests, by wrapping the EOF container in an init-container and sending a deploy transaction ([#783](https://github.com/ethereum/execution-spec-tests/pull/783), [#1233](https://github.com/ethereum/execution-spec-tests/pull/1233)).
 
 ### 📋 Misc

--- a/src/pytest_plugins/consume/direct/conftest.py
+++ b/src/pytest_plugins/consume/direct/conftest.py
@@ -7,17 +7,36 @@ For example, via go-ethereum's `evm blocktest` or `evm statetest` commands.
 
 import json
 import tempfile
+import warnings
 from pathlib import Path
 from typing import List
 
 import pytest
 
+from ethereum_clis.ethereum_cli import EthereumCLI
 from ethereum_clis.fixture_consumer_tool import FixtureConsumerTool
 from ethereum_test_base_types import to_json
+from ethereum_test_fixtures import BaseFixture
 from ethereum_test_fixtures.consume import TestCaseIndexFile, TestCaseStream
 from ethereum_test_fixtures.file import Fixtures
 
 from ..consume import FixturesSource
+
+
+class CollectOnlyCLI(EthereumCLI):
+    """A dummy CLi for use with `--collect-only`."""
+
+    def __init__(self):  # noqa: D107
+        pass
+
+
+class CollectOnlyFixtureConsumer(
+    FixtureConsumerTool, CollectOnlyCLI, fixture_formats=list(BaseFixture.formats.values())
+):
+    """A dummy fixture consumer for use with `--collect-only`."""
+
+    def consume_fixture(self):  # noqa: D102
+        pass
 
 
 def pytest_addoption(parser):  # noqa: D103
@@ -26,15 +45,14 @@ def pytest_addoption(parser):  # noqa: D103
     )
 
     consume_group.addoption(
-        "--fixture-consumer-bin",
+        "--bin",
         action="append",
         dest="fixture_consumer_bin",
         type=list,
-        default=[Path("evm")],
+        default=[],
         help=(
             "Path to a geth evm executable that provides `blocktest` or `statetest`. "
             "Flag can be used multiple times to specify multiple fixture consumer binaries."
-            "Default: First 'evm' entry in PATH."
         ),
     )
     consume_group.addoption(
@@ -63,6 +81,20 @@ def pytest_configure(config):  # noqa: D103
                 binary_path=Path(fixture_consumer_bin_path),
                 trace=config.getoption("consumer_collect_traces"),
             )
+        )
+    if not fixture_consumers and config.option.collectonly:
+        warnings.warn(
+            (
+                "No fixture consumer binaries provided; using a dummy consumer for collect-only; "
+                "all possible fixture formats will be collected. "
+                "Specify fixture consumer(s) via `--bin` to see actual collection results."
+            ),
+            stacklevel=1,
+        )
+        fixture_consumers = [CollectOnlyFixtureConsumer()]
+    elif not fixture_consumers:
+        pytest.exit(
+            "No fixture consumer binaries provided; please specify a binary path via `--bin`."
         )
     config.fixture_consumers = fixture_consumers
 

--- a/src/pytest_plugins/consume/direct/conftest.py
+++ b/src/pytest_plugins/consume/direct/conftest.py
@@ -48,7 +48,7 @@ def pytest_addoption(parser):  # noqa: D103
         "--bin",
         action="append",
         dest="fixture_consumer_bin",
-        type=str,
+        type=Path,
         default=[],
         help=(
             "Path to a geth evm executable that provides `blocktest` or `statetest`. "

--- a/src/pytest_plugins/consume/direct/conftest.py
+++ b/src/pytest_plugins/consume/direct/conftest.py
@@ -48,7 +48,7 @@ def pytest_addoption(parser):  # noqa: D103
         "--bin",
         action="append",
         dest="fixture_consumer_bin",
-        type=list,
+        type=str,
         default=[],
         help=(
             "Path to a geth evm executable that provides `blocktest` or `statetest`. "

--- a/src/pytest_plugins/consume/direct/conftest.py
+++ b/src/pytest_plugins/consume/direct/conftest.py
@@ -24,7 +24,7 @@ from ..consume import FixturesSource
 
 
 class CollectOnlyCLI(EthereumCLI):
-    """A dummy CLi for use with `--collect-only`."""
+    """A dummy CLI for use with `--collect-only`."""
 
     def __init__(self):  # noqa: D107
         pass


### PR DESCRIPTION
## 🗒️ Description
Changes to `consume direct` behavior:
1. Rename the `--fixture-consume-bin` option to `--bin`.
2. Removes the default value for `--fixture-consume-bin`, previously this was `["evm"]` geth. Now this value must be explicitly specified (some preparation for #1232), unless ran with `--collect-only`.
3. Enables `--collect-only` without `--bin`.
4. Fixes `--bin`'s type: `list` -> `Path`.
 
The main motivation of this PR was 3. in order to enable consume unit testing without requiring a fixture consumer binary (required for #1221).

## 🔗 Related Issues
- #1232
- #935
- #1221 

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).

