### PR TITLE
fix(execute,fill): Fix warnings due to labels being unknown markers

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,7 +11,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 ### 🛠️ Framework
 
 - 🔀 Make `BaseFixture` able to parse any fixture format such as `BlockchainFixture` ([#1210](https://github.com/ethereum/execution-spec-tests/pull/1210)).
-- ✨ Blockchain and Blockchain-Engine tests now have a marker to specify that they were generated from a state test, which can be used with `-m blockchain_test_from_state_test` and `-m blockchain_test_engine_from_state_test` respectively ([#1220](https://github.com/ethereum/execution-spec-tests/pull/1220)).
+- ✨ Blockchain and Blockchain-Engine tests now have a marker to specify that they were generated from a state test, which can be used with `-m blockchain_test_from_state_test` and `-m blockchain_test_engine_from_state_test` respectively ([#1220](https://github.com/ethereum/execution-spec-tests/pull/1220), [#1238](https://github.com/ethereum/execution-spec-tests/pull/1238)).
 - ✨ Blockchain and Blockchain-Engine tests that were generated from a state test now have `blockchain_test_from_state_test` or `blockchain_test_engine_from_state_test` as part of their test IDs ([#1220](https://github.com/ethereum/execution-spec-tests/pull/1220)).
 - 🔀 Refactor `ethereum_test_fixtures` and `ethereum_clis` to create `FixtureConsumer` and `FixtureConsumerTool` classes which abstract away the consumption process used by `consume direct` ([#935](https://github.com/ethereum/execution-spec-tests/pull/935)).
 - ✨ Allow `consume direct --collect-only` without specifying a fixture consumer binary on the command-line ([#1237](https://github.com/ethereum/execution-spec-tests/pull/1237)).

--- a/src/ethereum_test_execution/base.py
+++ b/src/ethereum_test_execution/base.py
@@ -46,6 +46,8 @@ class LabeledExecuteFormat:
     format: Type[BaseExecute]
     label: str
 
+    registered_labels: ClassVar[Dict[str, "LabeledExecuteFormat"]] = {}
+
     def __init__(self, execute_format: "Type[BaseExecute] | LabeledExecuteFormat", label: str):
         """Initialize the execute format with a custom label."""
         self.format = (
@@ -54,6 +56,8 @@ class LabeledExecuteFormat:
             else execute_format
         )
         self.label = label
+        if label not in LabeledExecuteFormat.registered_labels:
+            LabeledExecuteFormat.registered_labels[label] = self
 
     @property
     def format_name(self) -> str:

--- a/src/ethereum_test_fixtures/base.py
+++ b/src/ethereum_test_fixtures/base.py
@@ -155,6 +155,8 @@ class LabeledFixtureFormat:
     format: Type[BaseFixture]
     label: str
 
+    registered_labels: ClassVar[Dict[str, "LabeledFixtureFormat"]] = {}
+
     def __init__(self, fixture_format: "Type[BaseFixture] | LabeledFixtureFormat", label: str):
         """Initialize the fixture format with a custom label."""
         self.format = (
@@ -163,6 +165,8 @@ class LabeledFixtureFormat:
             else fixture_format
         )
         self.label = label
+        if label not in LabeledFixtureFormat.registered_labels:
+            LabeledFixtureFormat.registered_labels[label] = self
 
     @property
     def format_name(self) -> str:

--- a/src/pytest_plugins/shared/execute_fill.py
+++ b/src/pytest_plugins/shared/execute_fill.py
@@ -5,8 +5,8 @@ from typing import List, cast
 
 import pytest
 
-from ethereum_test_execution import BaseExecute
-from ethereum_test_fixtures import BaseFixture
+from ethereum_test_execution import BaseExecute, LabeledExecuteFormat
+from ethereum_test_fixtures import BaseFixture, LabeledFixtureFormat
 from ethereum_test_forks import (
     Fork,
     get_closest_fork_with_solc_support,
@@ -39,11 +39,21 @@ def pytest_configure(config: pytest.Config):
                 "markers",
                 (f"{fixture_format.format_name.lower()}: {fixture_format.description}"),
             )
+        for label, labeled_fixture_format in LabeledFixtureFormat.registered_labels.items():
+            config.addinivalue_line(
+                "markers",
+                (f"{label}: Custom label for {labeled_fixture_format.format.format_name}."),
+            )
     elif config.pluginmanager.has_plugin("pytest_plugins.execute.execute"):
         for execute_format in BaseExecute.formats.values():
             config.addinivalue_line(
                 "markers",
                 (f"{execute_format.format_name.lower()}: {execute_format.description}"),
+            )
+        for label, labeled_execute_format in LabeledExecuteFormat.registered_labels.items():
+            config.addinivalue_line(
+                "markers",
+                (f"{label}: Custom label for {labeled_execute_format.format.format_name}."),
             )
     else:
         raise Exception("Neither the filler nor the execute plugin is loaded.")


### PR DESCRIPTION
## 🗒️ Description
#1220 added labeled fixture and execute formats, which were added as markers to each generated test.

This caused a warning due to appear because the label markers were not registered during the config phase of the pytest plugins.

This PR adds all known fixture or execute formats markers to the config at the start.

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.