### PR TITLE
feat(tooling): run `tox -e typecheck` in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     hooks:
       - id: tox
         name: tox
-        entry: uvx --with=tox-uv tox --parallel -e lint
+        entry: uvx --with=tox-uv tox --parallel -e lint,typecheck
         language: system
         types: [python]
         pass_filenames: false


### PR DESCRIPTION
## 🗒️ Description
Adds the tox `typecheck` env to the default pre-commit config, cf https://ethereum.github.io/execution-spec-tests/main/dev/precommit/

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] ~~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~ skipped

