### PR TITLE
new(tests): add more RJUMPV validation tests

### DIFF
--- a/converted-ethereum-tests.txt
+++ b/converted-ethereum-tests.txt
@@ -20,11 +20,15 @@ EOFTests/efStack/backwards_rjump_.json
 EOFTests/efStack/backwards_rjump_variable_stack_.json
 EOFTests/efStack/backwards_rjumpi_.json
 EOFTests/efStack/backwards_rjumpi_variable_stack_.json
+EOFTests/efStack/backwards_rjumpv_.json
+EOFTests/efStack/backwards_rjumpv_variable_stack_.json
 EOFTests/efStack/jumpf_stack_overflow_.json
 EOFTests/efStack/forwards_rjump_.json
 EOFTests/efStack/forwards_rjump_variable_stack_.json
 EOFTests/efStack/forwards_rjumpi_.json
 EOFTests/efStack/forwards_rjumpi_variable_stack_.json
+EOFTests/efStack/forwards_rjumpv_.json
+EOFTests/efStack/forwards_rjumpv_variable_stack_.json
 EOFTests/efStack/unreachable_instructions_.json
 EOFTests/efValidation/callf_into_nonreturning_.json
 EOFTests/efValidation/dataloadn_.json

--- a/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpi.py
+++ b/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpi.py
@@ -898,7 +898,7 @@ def test_rjumpi_valid_backward(
     container: Container,
 ):
     """
-    Validate a valid code section containing at least one backward RJUMP.
+    Validate a valid code section containing at least one backward RJUMPI.
     These tests exercise the stack height validation.
     """
     eof_test(container=container)
@@ -1837,7 +1837,7 @@ def test_rjumpi_backward_invalid_max_stack_height(
     container: Container,
 ):
     """
-    Validate a code section containing at least one backward RJUMP
+    Validate a code section containing at least one backward RJUMPI
     invalid because of the incorrect max stack height.
     """
     eof_test(container=container, expect_exception=EOFException.STACK_HEIGHT_MISMATCH)

--- a/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py
+++ b/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py
@@ -1162,3 +1162,682 @@ def test_double_rjumpv(
         container=container,
         expect_exception=EOFException.STACK_UNDERFLOW,
     )
+
+
+@pytest.mark.parametrize(
+    "container",
+    [
+        Container(
+            name="forwards_rjumpv_0",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH1(1) + Op.RJUMPV[0] + Op.STOP,
+                    max_stack_height=1,
+                ),
+            ],
+            expected_bytecode="ef0001010004020001000704000000008000016001e200000000",
+        ),
+        Container(
+            name="forwards_rjumpv_1",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0 + Op.PUSH1(0) + Op.RJUMPV[1] + Op.NOT + Op.STOP,
+                    max_stack_height=2,
+                ),
+            ],
+            expected_bytecode="ef0001010004020001000904000000008000025f6000e20000011900",
+        ),
+        Container(
+            name="forwards_rjumpv_2",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPV[[2, 3]]
+                    + Op.PUSH0
+                    + Op.POP
+                    + Op.NOT
+                    + Op.STOP,
+                    max_stack_height=2,
+                ),
+            ],
+            expected_bytecode="ef0001010004020001000d04000000008000025f6000e201000200035f501900",
+        ),
+        Container(
+            name="forwards_rjumpv_3",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0 + Op.PUSH1[0] + Op.RJUMPV[1] + Op.PUSH0 + Op.STOP,
+                    max_stack_height=2,
+                ),
+            ],
+            expected_bytecode="ef0001010004020001000904000000008000025f6000e20000015f00",
+        ),
+        Container(
+            name="forwards_rjumpv_4",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPV[[1, 2]]
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.NOT
+                    + Op.STOP,
+                    max_stack_height=3,
+                ),
+            ],
+            expected_bytecode="ef0001010004020001000d04000000008000035f6000e201000100025f5f1900",
+        ),
+        Container(
+            name="forwards_rjumpv_5",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPV[[5, 10]]
+                    + Op.PUSH1(1)
+                    + Op.RJUMP[7]
+                    + Op.PUSH1(2)
+                    + Op.RJUMP[2]
+                    + Op.PUSH1(3)
+                    + Op.STOP,
+                    max_stack_height=2,
+                ),
+            ],
+            expected_bytecode="ef0001010004020001001604000000008000025f6000e2010005000a6001e000076002e00002600300",
+        ),
+        Container(
+            name="forwards_rjumpv_6",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPV[[4, 9]]
+                    + Op.PUSH0
+                    + Op.RJUMP[8]
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.RJUMP[3]
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.STOP,
+                    max_stack_height=4,
+                ),
+            ],
+            expected_bytecode="ef0001010004020001001604000000008000045f6000e201000400095fe000085f5fe000035f5f5f00",
+        ),
+        Container(
+            name="forwards_rjumpv_7",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPV[[4, 9]]
+                    + Op.POP
+                    + Op.RJUMP[8]
+                    + Op.POP
+                    + Op.POP
+                    + Op.RJUMP[3]
+                    + Op.POP
+                    + Op.POP
+                    + Op.POP
+                    + Op.STOP,
+                    max_stack_height=5,
+                ),
+            ],
+            expected_bytecode="ef0001010004020001001904000000008000055f5f5f5f6000e2010004000950e000085050e0000350505000",
+        ),
+        Container(
+            name="forwards_rjumpv_8",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0 + Op.PUSH1[0] + Op.RJUMPV[3] + Op.RJUMP[0] + Op.STOP,
+                    max_stack_height=2,
+                ),
+            ],
+            expected_bytecode="ef0001010004020001000b04000000008000025f6000e2000003e0000000",
+        ),
+        Container(
+            name="forwards_rjumpv_9",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0 + Op.PUSH1[0] + Op.RJUMPV[4] + Op.PUSH0 + Op.RJUMP[0] + Op.STOP,
+                    max_stack_height=2,
+                ),
+            ],
+            expected_bytecode="ef0001010004020001000c04000000008000025f6000e20000045fe0000000",
+        ),
+        Container(
+            name="forwards_rjumpv_variable_stack_0",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPI[2]
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.PUSH1(1)
+                    + Op.RJUMPV[0]
+                    + Op.STOP,
+                    max_stack_height=4,
+                ),
+            ],
+            expected_bytecode="ef0001010004020001000f04000000008000045f6000e100025f5f6001e200000000",
+        ),
+        Container(
+            name="forwards_rjumpv_variable_stack_1",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPI[2]
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPV[1]
+                    + Op.NOT
+                    + Op.STOP,
+                    max_stack_height=5,
+                ),
+            ],
+            expected_bytecode="ef0001010004020001001104000000008000055f6000e100025f5f5f6000e20000011900",
+        ),
+        Container(
+            name="forwards_rjumpv_variable_stack_2",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPI[2]
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPV[[2, 3]]
+                    + Op.PUSH0
+                    + Op.POP
+                    + Op.NOT
+                    + Op.STOP,
+                    max_stack_height=5,
+                ),
+            ],
+            expected_bytecode="ef0001010004020001001504000000008000055f6000e100025f5f5f6000e201000200035f501900",
+        ),
+        Container(
+            name="forwards_rjumpv_variable_stack_3",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPI[2]
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPV[1]
+                    + Op.PUSH0
+                    + Op.STOP,
+                    max_stack_height=5,
+                ),
+            ],
+            expected_bytecode="ef0001010004020001001104000000008000055f6000e100025f5f5f6000e20000015f00",
+        ),
+        Container(
+            name="forwards_rjumpv_variable_stack_4",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPI[2]
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPV[[1, 2]]
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.NOT
+                    + Op.STOP,
+                    max_stack_height=6,
+                ),
+            ],
+            expected_bytecode="ef0001010004020001001504000000008000065f6000e100025f5f5f6000e201000100025f5f1900",
+        ),
+        Container(
+            name="forwards_rjumpv_variable_stack_5",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPI[2]
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPV[[5, 10]]
+                    + Op.PUSH1(1)
+                    + Op.RJUMP[7]
+                    + Op.PUSH1(2)
+                    + Op.RJUMP[2]
+                    + Op.PUSH1(3)
+                    + Op.STOP,
+                    max_stack_height=5,
+                ),
+            ],
+            expected_bytecode="ef0001010004020001001e04000000008000055f6000e100025f5f5f6000e2010005000a6001e000076002e00002600300",
+        ),
+        Container(
+            name="forwards_rjumpv_variable_stack_6",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPI[2]
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPV[[4, 9]]
+                    + Op.PUSH0
+                    + Op.RJUMP[8]
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.RJUMP[3]
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.STOP,
+                    max_stack_height=7,
+                ),
+            ],
+            expected_bytecode="ef0001010004020001001e04000000008000075f6000e100025f5f5f6000e201000400095fe000085f5fe000035f5f5f00",
+        ),
+        Container(
+            name="forwards_rjumpv_variable_stack_7",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPI[2]
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPV[[4, 9]]
+                    + Op.POP
+                    + Op.RJUMP[8]
+                    + Op.POP
+                    + Op.POP
+                    + Op.RJUMP[3]
+                    + Op.POP
+                    + Op.POP
+                    + Op.POP
+                    + Op.STOP,
+                    max_stack_height=8,
+                ),
+            ],
+            expected_bytecode="ef0001010004020001002104000000008000085f6000e100025f5f5f5f5f5f6000e2010004000950e000085050e0000350505000",
+        ),
+        Container(
+            name="forwards_rjumpv_variable_stack_8",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPI[2]
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPV[3]
+                    + Op.RJUMP[0]
+                    + Op.STOP,
+                    max_stack_height=5,
+                ),
+            ],
+            expected_bytecode="ef0001010004020001001304000000008000055f6000e100025f5f5f6000e2000003e0000000",
+        ),
+        Container(
+            name="forwards_rjumpv_variable_stack_9",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPI[2]
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPV[4]
+                    + Op.PUSH0
+                    + Op.RJUMP[0]
+                    + Op.STOP,
+                    max_stack_height=5,
+                ),
+            ],
+            expected_bytecode="ef0001010004020001001404000000008000055f6000e100025f5f5f6000e20000045fe0000000",
+        ),
+    ],
+    ids=lambda x: x.name,
+)
+def test_rjumpv_valid_forward(
+    eof_test: EOFTestFiller,
+    container: Container,
+):
+    """
+    Validate a valid code section containing at least one forward RJUMPV.
+    These tests exercise the stack height validation.
+    """
+    eof_test(container=container)
+
+
+@pytest.mark.parametrize(
+    "container",
+    [
+        Container(
+            name="backwards_rjumpv_0",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH1[0] + Op.RJUMPV[-6] + Op.STOP,
+                    max_stack_height=1,
+                ),
+            ],
+            expected_bytecode="ef0001010004020001000704000000008000016000e200fffa00",
+        ),
+        Container(
+            name="backwards_rjumpv_1",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0 + Op.POP + Op.PUSH1[0] + Op.RJUMPV[-8] + Op.STOP,
+                    max_stack_height=1,
+                ),
+            ],
+            expected_bytecode="ef0001010004020001000904000000008000015f506000e200fff800",
+        ),
+        Container(
+            name="backwards_rjumpv_2",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0
+                    + Op.POP
+                    + Op.PUSH1[0]
+                    + Op.RJUMPV[-8]
+                    + Op.PUSH1[0]
+                    + Op.RJUMPV[-14]
+                    + Op.STOP,
+                    max_stack_height=1,
+                ),
+            ],
+            expected_bytecode="ef0001010004020001000f04000000008000015f506000e200fff86000e200fff200",
+        ),
+        Container(
+            name="backwards_rjumpv_4",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0 + Op.POP + Op.PUSH1[0] + Op.RJUMPV[-8] + Op.RJUMP[-11],
+                    max_stack_height=1,
+                ),
+            ],
+            expected_bytecode="ef0001010004020001000b04000000008000015f506000e200fff8e0fff5",
+        ),
+        Container(
+            name="backwards_rjumpv_variable_stack_0",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPI[2]
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPV[-6]
+                    + Op.STOP,
+                    max_stack_height=4,
+                ),
+            ],
+            expected_bytecode="ef0001010004020001000f04000000008000045f6000e100025f5f6000e200fffa00",
+        ),
+        Container(
+            name="backwards_rjumpv_variable_stack_1",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPI[2]
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.POP
+                    + Op.PUSH1[0]
+                    + Op.RJUMPV[-8]
+                    + Op.STOP,
+                    max_stack_height=4,
+                ),
+            ],
+            expected_bytecode="ef0001010004020001001104000000008000045f6000e100025f5f5f506000e200fff800",
+        ),
+        Container(
+            name="backwards_rjumpv_variable_stack_2",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPI[2]
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.POP
+                    + Op.PUSH1[0]
+                    + Op.RJUMPV[-8]
+                    + Op.PUSH1[0]
+                    + Op.RJUMPV[-14]
+                    + Op.STOP,
+                    max_stack_height=4,
+                ),
+            ],
+            expected_bytecode="ef0001010004020001001704000000008000045f6000e100025f5f5f506000e200fff86000e200fff200",
+        ),
+        Container(
+            name="backwards_rjumpv_variable_stack_4",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPI[2]
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.POP
+                    + Op.PUSH1[0]
+                    + Op.RJUMPV[-8]
+                    + Op.RJUMP[-11],
+                    max_stack_height=4,
+                ),
+            ],
+            expected_bytecode="ef0001010004020001001304000000008000045f6000e100025f5f5f506000e200fff8e0fff5",
+        ),
+    ],
+    ids=lambda x: x.name,
+)
+def test_rjumpv_valid_backward(
+    eof_test: EOFTestFiller,
+    container: Container,
+):
+    """
+    Validate a valid code section containing at least one backward RJUMPV.
+    These tests exercise the stack height validation.
+    """
+    eof_test(container=container)
+
+
+@pytest.mark.parametrize(
+    "container",
+    [
+        Container(
+            name="backwards_rjumpv_3",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0
+                    + Op.POP
+                    + Op.PUSH1[0]
+                    + Op.RJUMPV[-8]
+                    + Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPV[-15]
+                    + Op.STOP,
+                    max_stack_height=2,
+                ),
+            ],
+            expected_bytecode="ef0001010004020001001004000000008000025f506000e200fff85f6000e200fff100",
+        ),
+        Container(
+            name="backwards_rjumpv_5",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0
+                    + Op.POP
+                    + Op.PUSH1[0]
+                    + Op.RJUMPV[-7]
+                    + Op.PUSH0
+                    + Op.RJUMP[-11],
+                    max_stack_height=1,
+                ),
+            ],
+        ),
+        Container(
+            name="backwards_rjumpv_6",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPI[1]
+                    + Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPV[-12]
+                    + Op.STOP,
+                    max_stack_height=3,
+                ),
+            ],
+            expected_bytecode="ef0001010004020001000e04000000008000035f6000e100015f6000e200fff400",
+        ),
+        Container(
+            name="backwards_rjumpv_7",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH1[190]
+                    + Op.PUSH1[0]
+                    + Op.RJUMPI[1]
+                    + Op.POP
+                    + Op.PUSH1[0]
+                    + Op.RJUMPV[-12]
+                    + Op.STOP,
+                    max_stack_height=3,
+                ),
+            ],
+            expected_bytecode="ef0001010004020001000f040000000080000360be6000e10001506000e200fff400",
+        ),
+        Container(
+            name="backwards_rjumpv_variable_stack_3",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPI[2]
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.POP
+                    + Op.PUSH1[0]
+                    + Op.RJUMPV[-8]
+                    + Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPV[-15]
+                    + Op.STOP,
+                    max_stack_height=5,
+                ),
+            ],
+            expected_bytecode="ef0001010004020001001804000000008000055f6000e100025f5f5f506000e200fff85f6000e200fff100",
+        ),
+        Container(
+            name="backwards_rjumpv_variable_stack_5",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPI[2]
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.POP
+                    + Op.PUSH1[0]
+                    + Op.RJUMPV[-7]
+                    + Op.PUSH0
+                    + Op.RJUMP[-11],
+                    max_stack_height=4,
+                ),
+            ],
+        ),
+        Container(
+            name="backwards_rjumpv_variable_stack_6",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPI[2]
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPI[1]
+                    + Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPV[-12]
+                    + Op.STOP,
+                    max_stack_height=5,
+                ),
+            ],
+            expected_bytecode="ef0001010004020001001604000000008000055f6000e100025f5f5f6000e100015f6000e200fff400",
+        ),
+        Container(
+            name="backwards_rjumpv_variable_stack_7",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPI[2]
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.PUSH1[0]
+                    + Op.RJUMPI[1]
+                    + Op.POP
+                    + Op.PUSH1[0]
+                    + Op.RJUMPV[-12]
+                    + Op.STOP,
+                    max_stack_height=5,
+                ),
+            ],
+            expected_bytecode="ef0001010004020001001704000000008000055f6000e100025f5f5f5f6000e10001506000e200fff400",
+        ),
+    ],
+    ids=lambda x: x.name,
+)
+def test_rjumpv_backward_invalid_max_stack_height(
+    eof_test: EOFTestFiller,
+    container: Container,
+):
+    """
+    Validate a code section containing at least one backward RJUMPV
+    invalid because of the incorrect max stack height.
+    """
+    eof_test(container=container, expect_exception=EOFException.STACK_HEIGHT_MISMATCH)

--- a/tests/osaka/eip7692_eof_v1/eof_tracker.md
+++ b/tests/osaka/eip7692_eof_v1/eof_tracker.md
@@ -212,19 +212,19 @@
 
 ##### RJUMPV
 
-- [ ] Valid RJUMPV backwards in a constant stack segment (ethereum/tests: src/EOFTestsFiller/efStack/backwards_rjumpv_Copier.json)
-- [ ] Invalid RJUMPV backwards with mismatching stack in a constant stack segment(ethereum/tests: src/EOFTestsFiller/efStack/backwards_rjumpv_Copier.json)
-- [ ] Valid RJUMPV backwards in a variable stack segment (ethereum/tests: src/EOFTestsFiller/efStack/backwards_rjumpv_variable_stack_Copier.json)
-- [ ] Invalid RJUMPV backwards with mismatching stack in a variable stack segment (ethereum/tests: src/EOFTestsFiller/efStack/backwards_rjumpv_variable_stack_Copier.json)
-- [ ] RJUMPV forward with branches of equal stack height (ethereum/tests: src/EOFTestsFiller/efStack/forwards_rjumpv_Copier.json src/EOFTestsFiller/EIP5450/validInvalidFiller.yml)
-- [ ] RJUMPV forward with branches of equal stack height in a variable stack segment (ethereum/tests: src/EOFTestsFiller/efStack/forwards_rjumpv_variable_stack_Copier.json)
-- [ ] RJUMPV forward with branches of different stack height (ethereum/tests: src/EOFTestsFiller/efStack/forwards_rjumpv_Copier.json src/EOFTestsFiller/EIP5450/validInvalidFiller.yml)
-- [ ] RJUMPV forward with branches of different stack height  in a variable stack segment (ethereum/tests: src/EOFTestsFiller/efStack/forwards_rjumpv_variable_stack_Copier.json)
+- [x] Valid RJUMPV backwards in a constant stack segment ([`tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py::test_rjumpv_valid_backward`](./eip4200_relative_jumps/test_rjumpv/test_rjumpv_valid_backward.md)
+- [x] Invalid RJUMPV backwards with mismatching stack in a constant stack segment ([`tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py::test_rjumpv_backward_invalid_max_stack_height`](./eip4200_relative_jumps/test_rjumpv/test_rjumpv_backward_invalid_max_stack_height.md)
+- [x] Valid RJUMPV backwards in a variable stack segment ([`tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py::test_rjumpv_valid_backward`](./eip4200_relative_jumps/test_rjumpv/test_rjumpv_valid_backward.md)
+- [x] Invalid RJUMPV backwards with mismatching stack in a variable stack segment ([`tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py::test_rjumpv_backward_invalid_max_stack_height`](./eip4200_relative_jumps/test_rjumpv/test_rjumpv_backward_invalid_max_stack_height.md)
+- [x] RJUMPV forward with branches of equal stack height ([`tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py::test_rjumpv_valid_forward`](./eip4200_relative_jumps/test_rjumpv/test_rjumpv_valid_forward.md)
+- [x] RJUMPV forward with branches of equal stack height in a variable stack segment ([`tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py::test_rjumpv_valid_forward`](./eip4200_relative_jumps/test_rjumpv/test_rjumpv_valid_forward.md)
+- [x] RJUMPV forward with branches of different stack height ([`tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py::test_rjumpv_valid_forward`](./eip4200_relative_jumps/test_rjumpv/test_rjumpv_valid_forward.md)
+- [x] RJUMPV forward with branches of different stack height  in a variable stack segment ([`tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py::test_rjumpv_valid_forward`](./eip4200_relative_jumps/test_rjumpv/test_rjumpv_valid_forward.md)
 - [ ] Valid infinite loop using RJUMPV (ethereum/tests: src/EOFTestsFiller/EIP5450/validInvalidFiller.yml)
-- [ ] Switch with equal stack height in branches (ethereum/tests: src/EOFTestsFiller/efStack/forwards_rjumpv_Copier.json)
-- [ ] Switch with equal stack height in branches, variable stack segment (ethereum/tests: src/EOFTestsFiller/efStack/forwards_rjumpv_variable_stack_Copier.json)
-- [ ] Switch with different stack height in branches (ethereum/tests: src/EOFTestsFiller/efStack/forwards_rjumpv_Copier.json)
-- [ ] Switch with different stack height in branches, variable stack segment (ethereum/tests: src/EOFTestsFiller/efStack/forwards_rjumpv_variable_stack_Copier.json)
+- [x] Switch with equal stack height in branches ([`tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py::test_rjumpv_valid_forward`](./eip4200_relative_jumps/test_rjumpv/test_rjumpv_valid_forward.md)
+- [x] Switch with equal stack height in branches, variable stack segment ([`tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py::test_rjumpv_valid_forward`](./eip4200_relative_jumps/test_rjumpv/test_rjumpv_valid_forward.md)
+- [x] Switch with different stack height in branches ([`tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py::test_rjumpv_valid_forward`](./eip4200_relative_jumps/test_rjumpv/test_rjumpv_valid_forward.md)
+- [x] Switch with different stack height in branches, variable stack segment ([`tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py::test_rjumpv_valid_forward`](./eip4200_relative_jumps/test_rjumpv/test_rjumpv_valid_forward.md)
 
 ##### Combinations
 


### PR DESCRIPTION
## 🗒️ Description
Add test cases for max stack height validation for code sections having at least one RJUMPV instruction. These cases are converted from ethereum/tests.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened. https://github.com/ethereum/tests/pull/1458
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
