### PR TITLE
fix warning in vscode about ruff legacy server

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -53,6 +53,6 @@
         // "-c", "pytest-consume.ini", "--input=fixtures/", "src/pytest_plugins/consume/direct/test_via_direct.py", "--evm-bin=~/bin/evm"
     ],
     "ruff.enable": true,
-    "ruff.lint.args": ["--line-length", "99", "--fix"],
+    "ruff.lineLength": 99,
     "extensions.ignoreRecommendations": false,
 }


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

Update `ruff` settings in vscode to get rid of the "legacy server" warning that's been popping up recently.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
