### PR TITLE
fix(fill,execute): register new label type markers to prevent warnings

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,13 +11,14 @@ Test fixtures for use by clients are available for each release on the [Github r
 ### 🛠️ Framework
 
 - 🔀 Make `BaseFixture` able to parse any fixture format such as `BlockchainFixture` ([#1210](https://github.com/ethereum/execution-spec-tests/pull/1210)).
-- ✨ Blockchain and Blockchain-Engine tests now have a marker to specify that they were generated from a state test, which can be used with `-m blockchain_test_from_state_test` and `-m blockchain_test_engine_from_state_test` respectively ([#1220](https://github.com/ethereum/execution-spec-tests/pull/1220), [#1238](https://github.com/ethereum/execution-spec-tests/pull/1238)).
+- ✨ Blockchain and Blockchain-Engine tests now have a marker to specify that they were generated from a state test, which can be used with `-m blockchain_test_from_state_test` and `-m blockchain_test_engine_from_state_test` respectively ([#1220](https://github.com/ethereum/execution-spec-tests/pull/1220)).
 - ✨ Blockchain and Blockchain-Engine tests that were generated from a state test now have `blockchain_test_from_state_test` or `blockchain_test_engine_from_state_test` as part of their test IDs ([#1220](https://github.com/ethereum/execution-spec-tests/pull/1220)).
 - 🔀 Refactor `ethereum_test_fixtures` and `ethereum_clis` to create `FixtureConsumer` and `FixtureConsumerTool` classes which abstract away the consumption process used by `consume direct` ([#935](https://github.com/ethereum/execution-spec-tests/pull/935)).
 - ✨ Allow `consume direct --collect-only` without specifying a fixture consumer binary on the command-line ([#1237](https://github.com/ethereum/execution-spec-tests/pull/1237)).
 - ✨ Report the (resolved) fixture tarball URL and local fixture cache directory when `consume`'s `--input` flag is a release spec or URL  [#1239](https://github.com/ethereum/execution-spec-tests/pull/1239).
 - ✨ EOF Container validation tests (`eof_test`) now generate container deployment state tests, by wrapping the EOF container in an init-container and sending a deploy transaction ([#783](https://github.com/ethereum/execution-spec-tests/pull/783), [#1233](https://github.com/ethereum/execution-spec-tests/pull/1233)).
 - ✨ Use regexes for Hive's `--sim.limit` argument and don't use xdist if `--sim.parallelism==1` in the `eest/consume-rlp` and `eest/consume-rlp` simulators ([#1220](https://github.com/ethereum/execution-spec-tests/pull/1220)).
+- 🐞 Register generated test markers, e.g., `blockchain_test_from_state_test`, to prevent test session warnings ([#1238](https://github.com/ethereum/execution-spec-tests/pull/1238), [#1245](https://github.com/ethereum/execution-spec-tests/pull/1245)).
 
 ### 📋 Misc
 

--- a/src/ethereum_test_execution/base.py
+++ b/src/ethereum_test_execution/base.py
@@ -45,10 +45,16 @@ class LabeledExecuteFormat:
 
     format: Type[BaseExecute]
     label: str
+    description: str
 
     registered_labels: ClassVar[Dict[str, "LabeledExecuteFormat"]] = {}
 
-    def __init__(self, execute_format: "Type[BaseExecute] | LabeledExecuteFormat", label: str):
+    def __init__(
+        self,
+        execute_format: "Type[BaseExecute] | LabeledExecuteFormat",
+        label: str,
+        description: str,
+    ):
         """Initialize the execute format with a custom label."""
         self.format = (
             execute_format.format
@@ -56,6 +62,7 @@ class LabeledExecuteFormat:
             else execute_format
         )
         self.label = label
+        self.description = description
         if label not in LabeledExecuteFormat.registered_labels:
             LabeledExecuteFormat.registered_labels[label] = self
 

--- a/src/ethereum_test_fixtures/base.py
+++ b/src/ethereum_test_fixtures/base.py
@@ -154,10 +154,16 @@ class LabeledFixtureFormat:
 
     format: Type[BaseFixture]
     label: str
+    description: str
 
     registered_labels: ClassVar[Dict[str, "LabeledFixtureFormat"]] = {}
 
-    def __init__(self, fixture_format: "Type[BaseFixture] | LabeledFixtureFormat", label: str):
+    def __init__(
+        self,
+        fixture_format: "Type[BaseFixture] | LabeledFixtureFormat",
+        label: str,
+        description: str,
+    ):
         """Initialize the fixture format with a custom label."""
         self.format = (
             fixture_format.format
@@ -165,6 +171,7 @@ class LabeledFixtureFormat:
             else fixture_format
         )
         self.label = label
+        self.description = description
         if label not in LabeledFixtureFormat.registered_labels:
             LabeledFixtureFormat.registered_labels[label] = self
 

--- a/src/ethereum_test_specs/eof.py
+++ b/src/ethereum_test_specs/eof.py
@@ -236,6 +236,7 @@ class EOFTest(BaseTest):
         LabeledFixtureFormat(
             fixture_format,
             f"{fixture_format.format_name}_from_eof_test",
+            f"A {fixture_format.format_name} generated from an eof_test.",
         )
         for fixture_format in StateTest.supported_fixture_formats
     ]
@@ -244,6 +245,7 @@ class EOFTest(BaseTest):
         LabeledExecuteFormat(
             execute_format,
             f"{execute_format.format_name}_from_eof_test",
+            f"A {execute_format.format_name} generated from an eof_test.",
         )
         for execute_format in StateTest.supported_execute_formats
     ]
@@ -519,6 +521,7 @@ class EOFStateTest(EOFTest, Transaction):
         LabeledFixtureFormat(
             fixture_format,
             f"eof_{fixture_format.format_name}",
+            f"Tests that generate an EOF {fixture_format.format_name}.",
         )
         for fixture_format in StateTest.supported_fixture_formats
     ]
@@ -527,6 +530,7 @@ class EOFStateTest(EOFTest, Transaction):
         LabeledExecuteFormat(
             execute_format,
             f"eof_{execute_format.format_name}",
+            f"Tests that generate an EOF {execute_format.format_name}.",
         )
         for execute_format in StateTest.supported_execute_formats
     ]

--- a/src/ethereum_test_specs/state.py
+++ b/src/ethereum_test_specs/state.py
@@ -54,6 +54,7 @@ class StateTest(BaseTest):
         LabeledFixtureFormat(
             fixture_format,
             f"{fixture_format.format_name}_from_state_test",
+            f"A {fixture_format.format_name} generated from a state_test",
         )
         for fixture_format in BlockchainTest.supported_fixture_formats
     ]

--- a/src/pytest_plugins/shared/execute_fill.py
+++ b/src/pytest_plugins/shared/execute_fill.py
@@ -42,7 +42,7 @@ def pytest_configure(config: pytest.Config):
         for label, labeled_fixture_format in LabeledFixtureFormat.registered_labels.items():
             config.addinivalue_line(
                 "markers",
-                (f"{label}: Custom label for {labeled_fixture_format.format.format_name}."),
+                (f"{label}: {labeled_fixture_format.description}"),
             )
     elif config.pluginmanager.has_plugin("pytest_plugins.execute.execute"):
         for execute_format in BaseExecute.formats.values():
@@ -53,7 +53,7 @@ def pytest_configure(config: pytest.Config):
         for label, labeled_execute_format in LabeledExecuteFormat.registered_labels.items():
             config.addinivalue_line(
                 "markers",
-                (f"{label}: Custom label for {labeled_execute_format.format.format_name}."),
+                (f"{label}: {labeled_execute_format.description}"),
             )
     else:
         raise Exception("Neither the filler nor the execute plugin is loaded.")


### PR DESCRIPTION
## 🗒️ Description

Follow-up to #1220.

1. Register the new label type markers that get applied to tests to avoid pytest test session warnings, e.g.:
    ```
    ================================================== warnings summary ===================================================
    
    src/pytest_plugins/shared/helpers.py:37
      /home/dtopz/code/github/danceratopz/eest/src/pytest_plugins/shared/helpers.py:37: PytestUnknownMarkWarning: Unknown pytest.mark.state_test_from_eof_test - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
        getattr(
    ...
    ```
    (can be reproduced via `fill tests/osaka --fork=osaka`).
2. Additionally adds a `description` field to `LabeledExecuteFormat` and `LabeledFixtureFormat` that can be used in the marker doc.

### Fill
Command to view markers:
```
fill --markers
```
Relevant output:
```
@pytest.mark.blockchain_test: Tests that generate a blockchain test fixture.
@pytest.mark.blockchain_test_engine: Tests that generate a blockchain test fixture in Engine API format.
@pytest.mark.eof_test: Tests that generate an EOF test fixture.
@pytest.mark.state_test: Tests that generate a state test fixture.
@pytest.mark.transaction_test: Tests that generate a transaction test fixture.
@pytest.mark.eof_state_test: Tests that generate an EOF state_test.
@pytest.mark.eof_blockchain_test: Tests that generate an EOF blockchain_test.
@pytest.mark.eof_blockchain_test_engine: Tests that generate an EOF blockchain_test_engine.
@pytest.mark.state_test_from_eof_test: A state_test generated from an eof_test.
@pytest.mark.blockchain_test_from_eof_test: A blockchain_test generated from an eof_test.
@pytest.mark.blockchain_test_engine_from_eof_test: A blockchain_test_engine generated from an eof_test.
@pytest.mark.blockchain_test_from_state_test: A blockchain_test generated from a state_test
@pytest.mark.blockchain_test_engine_from_state_test: A blockchain_test_engine generated from a state_test
@pytest.mark.blockchain_test_engine_only: Only generate a blockchain test engine fixture
@pytest.mark.blockchain_test_only: Only generate a blockchain test fixture
@pytest.mark.eof_test_only: Only generate an EOF test fixture
@pytest.mark.eof_test_only: Only generate an EOF test fixture
@pytest.mark.state_test_only: Only generate a state test fixture
```

### Execute
Command to view markers:
```
uv run execute remote --markers --rpc-seed-key=0xa --rpc-endpoint=foo --rpc-chain-id=1 --fork=cancun
```
Relevant output:
```
@pytest.mark.transaction_post: Simple transaction sending, then post-check after all transactions are included
@pytest.mark.eof_transaction_post: Tests that generate an EOF transaction_post.
@pytest.mark.transaction_post_from_eof_test: A transaction_post generated from an eof_test.
@pytest.mark.blockchain_test_engine_only: Only generate a blockchain test engine fixture
@pytest.mark.blockchain_test_only: Only generate a blockchain test fixture
@pytest.mark.eof_test_only: Only generate an EOF test fixture
@pytest.mark.eof_test_only: Only generate an EOF test fixture
@pytest.mark.state_test_only: Only generate a state test fixture

```

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).

