### PR TITLE
feat(tests): port ethereum/tests `CALLDATALOAD` tests

### DIFF
--- a/converted-ethereum-tests.txt
+++ b/converted-ethereum-tests.txt
@@ -1,6 +1,9 @@
 ([#1056](https://github.com/ethereum/execution-spec-tests/pull/1056))
 GeneralStateTests/VMTests/vmTests/calldatacopy.json
 
+([#1248](https://github.com/ethereum/execution-spec-tests/pull/1248))
+GeneralStateTests/VMTests/vmTests/calldataload.json
+
 ([#748](https://github.com/ethereum/execution-spec-tests/pull/748))
 GeneralStateTests/stBadOpcode/badOpcodes.json
 GeneralStateTests/stBugs/evmBytecode.json

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 - ✨ Add gas cost of delegation access in CALL opcode ([#1208](https://github.com/ethereum/execution-spec-tests/pull/1208)).
 - ✨ Add EIP-7698 failed nonce and short data tests ([#1211](https://github.com/ethereum/execution-spec-tests/pull/1211)).
+- ✨ Port [calldataload test](https://github.com/ethereum/tests/blob/2cd297403439b6eea6e0eb5c2fab2111cb210c6f/src/GeneralStateTestsFiller/VMTests/vmTests/calldataloadFiller.yml#L4) ([#1056](https://github.com/ethereum/execution-spec-tests/pull/1248)).
 
 ## [v4.0.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v3.0.0) - 2025-02-14 - 💕
 

--- a/tests/frontier/opcodes/test_calldataload.py
+++ b/tests/frontier/opcodes/test_calldataload.py
@@ -69,6 +69,21 @@ def test_calldataload(
     This test verifies that `CALLDATALOAD` correctly retrieves a 32-byte word
     from calldata at different offsets, handling various edge cases.
 
+    Parameter:
+
+    calldataload_offset: int
+        The offset that determines the memory reading position, controlling whether the test case
+        retrieves a partial or full 32-byte word from calldata.
+    memory_preset_code: Bytecode
+        Simulates different memory layouts to test how `CALLDATALOAD` behaves when calldata
+        is smaller or larger than 32 bytes.
+    call_args_size: int
+        Specifies the number of bytes from `memory_preset_code` that are actually forwarded
+        as calldata during execution.
+    expected_calldataload_memory: int
+        Validates whether `CALLDATALOAD` correctly retrieves and zero-pads data by comparing
+        the stored result in contract storage with this expected reference value.
+
     Test Cases:
 
     calldata_short_start_0:
@@ -92,7 +107,7 @@ def test_calldataload(
     sender = pre.fund_eoa()
     post = {}
 
-    # Deploy the contract that will store the calldate
+    # Deploy the contract that will store the calldata
     sstore_contract = pre.deploy_contract(
         code=(Op.SSTORE(key=0x0, value=Op.CALLDATALOAD(offset=calldataload_offset)))
     )

--- a/tests/frontier/opcodes/test_calldataload.py
+++ b/tests/frontier/opcodes/test_calldataload.py
@@ -1,0 +1,140 @@
+"""
+abstract: Test `CALLDATALOAD`
+    Test the `CALLDATALOAD` opcodes.
+
+"""
+
+import pytest
+
+from ethereum_test_forks import Frontier, Homestead
+from ethereum_test_tools import (
+    Account,
+    Alloc,
+    Bytecode,
+    Environment,
+    StateTestFiller,
+    Transaction,
+)
+from ethereum_test_tools import Opcodes as Op
+
+
+@pytest.mark.parametrize(
+    "sstore_test_opcode,calldata_opcode,validate_length,expected_storage",
+    [
+        (
+            Bytecode(Op.SSTORE(key=0x0, value=Op.CALLDATALOAD(offset=0x0))),
+            Bytecode(Op.MSTORE8(offset=0x0, value=0x25) + Op.MSTORE8(offset=0x1, value=0x60)),
+            0x02,
+            (
+                Account(
+                    storage={
+                        0x00: 0x2560000000000000000000000000000000000000000000000000000000000000
+                    }
+                )
+            ),
+        ),
+        (
+            Bytecode(Op.SSTORE(key=0x0, value=Op.CALLDATALOAD(offset=0x01))),
+            Bytecode(
+                Op.MSTORE(
+                    offset=0x0,
+                    value=0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF,
+                )
+                + Op.MSTORE8(offset=0x20, value=0x23),
+            ),
+            0x21,
+            (
+                Account(
+                    storage={
+                        0x00: 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF23
+                    }
+                )
+            ),
+        ),
+        (
+            Bytecode(Op.SSTORE(key=0x0, value=Op.CALLDATALOAD(offset=0x05))),
+            Bytecode(
+                Op.MSTORE(
+                    offset=0x0,
+                    value=0x123456789ABCDEF0000000000000000000000000000000000000000000000000,
+                )
+                + Op.MSTORE8(offset=0x20, value=0x0)
+                + Op.MSTORE8(offset=0x21, value=0x24),
+            ),
+            0x22,
+            (
+                Account(
+                    storage={
+                        0x00: 0xBCDEF00000000000000000000000000000000000000000000000000024000000
+                    }
+                )
+            ),
+        ),
+    ],
+    ids=["two_bytes", "word_n_byte", "34_bytes"],
+)
+@pytest.mark.valid_from("Frontier")
+def test_calldataload(
+    state_test: StateTestFiller,
+    fork: str,
+    sstore_test_opcode: Bytecode,
+    calldata_opcode: Bytecode,
+    validate_length: int,
+    expected_storage: Account,
+    pre: Alloc,
+):
+    """
+    Test `CALLDATACOPY` opcode.
+
+    Based on https://github.com/ethereum/tests/blob/develop/src/GeneralStateTestsFiller/VMTests/vmTests/calldataloadFiller.yml
+    """
+    env = Environment()
+    sender = pre.fund_eoa()
+    post = {}
+
+    # Deploy the contract that will store the calldate
+    sstore_contract = pre.deploy_contract(sstore_test_opcode)
+
+    # Deploy the contract that will forward the calldata to the first contract
+    calldata_contract = pre.deploy_contract(
+        code=(
+            calldata_opcode
+            + Op.CALL(
+                gas=0xFFFFFF,
+                address=sstore_contract,
+                value=0x0,
+                args_offset=0x0,
+                args_size=validate_length,
+                ret_offset=0x0,
+                ret_size=0x0,
+            )
+        )
+    )
+
+    validation_contract = pre.deploy_contract(
+        code=(
+            Op.CALL(
+                gas=0xFFFFFF,
+                address=calldata_contract,
+                value=0x0,
+                args_offset=0x0,
+                args_size=0x0,
+                ret_offset=0x0,
+                ret_size=0x0,
+            )
+        )
+    )
+
+    tx = Transaction(
+        data=b"\x01",
+        gas_limit=100_000,
+        gas_price=0x0A,
+        protected=False if fork in [Frontier, Homestead] else True,
+        to=validation_contract,
+        value=0x01,
+        sender=sender,
+    )
+
+    post[sstore_contract] = expected_storage
+
+    state_test(env=env, pre=pre, post=post, tx=tx)


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

Migrate `calldataload` test from [ethereum/tests](https://github.com/ethereum/tests/blob/develop/src/GeneralStateTestsFiller/VMTests/vmTests/calldataloadFiller.yml)

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

[https://github.com/ethereum/execution-spec-tests/issues/972](https://t.lever-analytics.com/email-link?dest=https%3A%2F%2Fgithub.com%2Fethereum%2Fexecution-spec-tests%2Fissues%2F972&eid=b2754d1c-26f3-497b-a30c-64969bcc2825&idx=0&token=UbPKThYOl-abrWJ0Xph65E56huc)

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
