### PR TITLE
fix(test): remove test violating EIP-7523

### DIFF
--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -212,11 +212,6 @@ def test_set_code_to_sstore(
 @pytest.mark.parametrize(
     "auth_signer_nonce",
     [
-        pytest.param(
-            0,
-            id="zero_nonce",
-            marks=pytest.mark.execute(pytest.mark.skip("unrealistic scenario")),
-        ),
         pytest.param(None, id="non_zero_nonce"),
     ],
 )


### PR DESCRIPTION
This case has an account with empty code, balance, nonce=0 and non-empty stor.age in prestate, which is forbidden since The Merge according to [EIP-7523](https://eips.ethereum.org/EIPS/eip-7523).

Background: not having to satisfy this test simplifies the implementation of refund logic in EIP-7702, where we can assume that if account is empty, then it does not exist in the state (no need to additionally check if it has non-empty storage), and then no refund is assigned when processing authorizations.