### PR TITLE
fix(eofwrap): fixture_format and auxiliary logging

### DIFF
--- a/src/cli/eofwrap.py
+++ b/src/cli/eofwrap.py
@@ -313,6 +313,7 @@ class EofWrapper:
             fork=Osaka,
             fixture_format=BlockchainFixture,
         )
+        result.info["fixture_format"] = "blockchain_test"
         if traces:
             print_traces(t8n.get_traces())
         return result

--- a/src/cli/eofwrap.py
+++ b/src/cli/eofwrap.py
@@ -228,6 +228,8 @@ class EofWrapper:
                 self.metrics[self.FIXTURES_CANT_GENERATE] += 1
                 self.metrics[self.ACCOUNTS_CANT_GENERATE] += len(fixture_eof_codes)
 
+                print(f"Exception {e} occurred during generation of {in_path}: {fixture_id}")
+
         if len(out_fixtures) == 0:
             self.metrics[self.FILES_SKIPPED] += 1
             return


### PR DESCRIPTION
## 🗒️ Description

Two minor fixes to `eofwrap.py` to enable including the eofwrap tests in EOF release

## 🔗 Related Issues

N/A

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
