### PR TITLE
chore(ci): enable all precompiles in `evmone` build

### DIFF
--- a/.github/actions/build-evm-client/evmone/action.yaml
+++ b/.github/actions/build-evm-client/evmone/action.yaml
@@ -25,11 +25,14 @@ runs:
         submodules: true
     - name: Setup cmake
       uses: jwlawson/actions-setup-cmake@v2
+    - name: "Install GMP"
+      shell: bash
+      run: sudo apt-get -q update && sudo apt-get -qy install libgmp-dev
     - name: Build evmone binary
       shell: bash
       run: |
         mkdir -p $GITHUB_WORKSPACE/bin
         cd $GITHUB_WORKSPACE/evmone
-        cmake -S . -B build -DEVMONE_TESTING=ON
+        cmake -S . -B build -DEVMONE_TESTING=ON -DEVMONE_PRECOMPILES_SILKPRE=1
         cmake --build build --parallel --target ${{ inputs.targets }}
         echo $GITHUB_WORKSPACE/evmone/build/bin/ >> $GITHUB_PATH


### PR DESCRIPTION
## 🗒️ Description
See https://github.com/ethereum/evmone/blob/0be7b1624b993fa7f3710ec61016c74163fe40f1/README.md?plain=1#L100

CC @winsvega, @reedsa

## 🔗 Related Issues
Should fix the fails when filling with `emvone` in the "Evmone Coverage Report" CI flow the coverage script in 
- #1244

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] ~~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~ skipped

