### PR TITLE
feat(unit-tests): verify transition tool support

### DIFF
--- a/.github/actions/build-evm-client/evmone/action.yaml
+++ b/.github/actions/build-evm-client/evmone/action.yaml
@@ -27,9 +27,15 @@ runs:
       uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be
       with:
         cmake-version: '3.x'
-    - name: "Install GMP"
+    - name: "Install GMP Linux"
+      if: runner.os == 'Linux'
       shell: bash
       run: sudo apt-get -q update && sudo apt-get -qy install libgmp-dev
+    - name: Install GMP macOS
+      if: runner.os == 'macOS'
+      shell: bash
+      run: |
+        brew update && brew install gmp
     - name: Build evmone binary
       shell: bash
       run: |

--- a/.github/configs/eels_resolutions.json
+++ b/.github/configs/eels_resolutions.json
@@ -28,5 +28,9 @@
     },
     "Cancun": {
         "path": "../../execution-specs/src/ethereum/cancun"
+    },
+    "Prague": {
+        "git_url": "https://github.com/ethereum/execution-specs.git",
+        "branch": "devnets/prague/6"
     }
 }

--- a/.github/workflows/tox_verify.yaml
+++ b/.github/workflows/tox_verify.yaml
@@ -113,6 +113,12 @@ jobs:
           cache-dependency-glob: "uv.lock"
           version: ${{ vars.UV_VERSION }}
           python-version: ${{ matrix.python }}
+      - name: Build EVMONE EVM
+        uses: ./.github/actions/build-evm-client/evmone
+        with:
+          targets: "evmone-t8n"
+      - name: Build GETH EVM
+        uses: ./.github/actions/build-evm-client/geth
       - name: Run tox - run framework unit tests with pytest
         env:
           EELS_RESOLUTIONS_FILE: ${{ github.workspace }}/.github/configs/eels_resolutions.json

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -1,11 +1,11 @@
-"""Local pytest configuration for framework tests."""
+"""Local pytest configuration used on multiple framework tests."""
 
 import os
-from typing import Generator
+from typing import Dict, Generator
 
 import pytest
 
-from ethereum_clis import ExecutionSpecsTransitionTool, TransitionTool
+from ethereum_clis import BesuTransitionTool, ExecutionSpecsTransitionTool, TransitionTool
 
 
 def pytest_runtest_setup(item):
@@ -16,21 +16,82 @@ def pytest_runtest_setup(item):
             pytest.skip("Skipping test because pytest-xdist is running with more than one worker.")
 
 
-DEFAULT_T8N_FOR_UNIT_TESTS = ExecutionSpecsTransitionTool
+DEFAULT_TRANSITION_TOOL_FOR_UNIT_TESTS = ExecutionSpecsTransitionTool
+
+INSTALLED_TRANSITION_TOOLS = [
+    transition_tool
+    for transition_tool in TransitionTool.registered_tools
+    if (
+        transition_tool.is_installed()
+        # Currently, Besu has the same `default_binary` as Geth, so we can't use `is_installed`.
+        and transition_tool != BesuTransitionTool
+    )
+]
 
 
 @pytest.fixture(scope="session")
-def default_t8n_instance() -> Generator[TransitionTool, None, None]:
-    """Fixture to provide a default t8n instance."""
-    instance = ExecutionSpecsTransitionTool()
-    instance.start_server()
-    yield instance
-    instance.shutdown()
+def installed_transition_tool_instances() -> Generator[
+    Dict[str, TransitionTool | Exception], None, None
+]:
+    """Return all instantiated transition tools."""
+    instances: Dict[str, TransitionTool | Exception] = {}
+    for transition_tool_class in INSTALLED_TRANSITION_TOOLS:
+        try:
+            instances[transition_tool_class.__name__] = transition_tool_class()
+        except Exception as e:
+            # Record the exception in order to provide context when failing the appropriate test
+            instances[transition_tool_class.__name__] = e
+    yield instances
+    for instance in instances.values():
+        if isinstance(instance, TransitionTool):
+            instance.shutdown()
+
+
+@pytest.fixture(
+    params=INSTALLED_TRANSITION_TOOLS,
+    ids=[transition_tool_class.__name__ for transition_tool_class in INSTALLED_TRANSITION_TOOLS],
+)
+def installed_t8n(
+    request: pytest.FixtureRequest,
+    installed_transition_tool_instances: Dict[str, TransitionTool | Exception],
+) -> TransitionTool:
+    """
+    Return an instantiated transition tool.
+
+    Tests using this fixture will be automatically parameterized with all
+    installed transition tools.
+    """
+    transition_tool_class = request.param
+    assert issubclass(transition_tool_class, TransitionTool)
+    assert transition_tool_class.__name__ in installed_transition_tool_instances, (
+        f"{transition_tool_class.__name__} not instantiated"
+    )
+    instance_or_error = installed_transition_tool_instances[transition_tool_class.__name__]
+    if isinstance(instance_or_error, Exception):
+        raise Exception(
+            f"Failed to instantiate {transition_tool_class.__name__}"
+        ) from instance_or_error
+    return instance_or_error
 
 
 @pytest.fixture
 def default_t8n(
-    default_t8n_instance: TransitionTool,
+    installed_transition_tool_instances: Dict[str, TransitionTool | Exception],
 ) -> TransitionTool:
     """Fixture to provide a default t8n instance."""
-    return default_t8n_instance
+    instance = installed_transition_tool_instances.get(
+        DEFAULT_TRANSITION_TOOL_FOR_UNIT_TESTS.__name__
+    )
+    if instance is None:
+        raise Exception(f"Failed to instantiate {DEFAULT_TRANSITION_TOOL_FOR_UNIT_TESTS.__name__}")
+    if isinstance(instance, Exception):
+        raise Exception(
+            f"Failed to instantiate {DEFAULT_TRANSITION_TOOL_FOR_UNIT_TESTS.__name__}"
+        ) from instance
+    return instance
+
+
+@pytest.fixture(scope="session")
+def running_in_ci() -> bool:
+    """Return whether the test is running in a CI environment."""
+    return "CI" in os.environ

--- a/src/ethereum_clis/clis/geth.py
+++ b/src/ethereum_clis/clis/geth.py
@@ -112,6 +112,7 @@ class GethEvm(EthereumCLI):
         self.binary = binary
         self.trace = trace
         self.exception_mapper = exception_mapper if exception_mapper else GethExceptionMapper()
+        self._info_metadata: Optional[Dict[str, Any]] = {}
 
     def _run_command(self, command: List[str]) -> subprocess.CompletedProcess:
         try:

--- a/src/ethereum_clis/clis/geth.py
+++ b/src/ethereum_clis/clis/geth.py
@@ -104,14 +104,12 @@ class GethEvm(EthereumCLI):
 
     def __init__(
         self,
-        binary: Path,
+        binary: Optional[Path] = None,
         trace: bool = False,
-        exception_mapper: ExceptionMapper | None = None,
     ):
         """Initialize the GethEvm class."""
-        self.binary = binary
+        self.binary = binary if binary else self.default_binary
         self.trace = trace
-        self.exception_mapper = exception_mapper if exception_mapper else GethExceptionMapper()
         self._info_metadata: Optional[Dict[str, Any]] = {}
 
     def _run_command(self, command: List[str]) -> subprocess.CompletedProcess:
@@ -168,12 +166,18 @@ class GethTransitionTool(GethEvm, TransitionTool):
     trace: bool
     t8n_use_stream = True
 
-    def __init__(self, *, binary: Path, trace: bool = False):
+    def __init__(
+        self,
+        *,
+        exception_mapper: Optional[ExceptionMapper] = None,
+        binary: Optional[Path] = None,
+        trace: bool = False,
+    ):
         """Initialize the GethTransitionTool class."""
+        if not exception_mapper:
+            exception_mapper = GethExceptionMapper()
         GethEvm.__init__(self, binary=binary, trace=trace)
-        TransitionTool.__init__(
-            self, exception_mapper=self.exception_mapper, binary=binary, trace=trace
-        )
+        TransitionTool.__init__(self, binary=binary, exception_mapper=exception_mapper)
         help_command = [str(self.binary), str(self.subcommand), "--help"]
         result = self._run_command(help_command)
         self.help_string = result.stdout

--- a/src/ethereum_clis/ethereum_cli.py
+++ b/src/ethereum_clis/ethereum_cli.py
@@ -126,6 +126,18 @@ class EthereumCLI:
 
         return cls.detect_binary_pattern.match(binary_output) is not None
 
+    @classmethod
+    def is_installed(cls, binary_path: Optional[Path] = None) -> bool:
+        """Return whether the tool is installed in the current system."""
+        if binary_path is None:
+            binary_path = cls.default_binary
+        else:
+            resolved_path = Path(os.path.expanduser(binary_path)).resolve()
+            if resolved_path.exists():
+                binary_path = resolved_path
+        binary = shutil.which(binary_path)
+        return binary is not None
+
     def version(self) -> str:
         """Return the name and version of the CLI as reported by the CLI's version flag."""
         if self.cached_version is None:

--- a/src/ethereum_clis/tests/test_transition_tools_support.py
+++ b/src/ethereum_clis/tests/test_transition_tools_support.py
@@ -1,0 +1,239 @@
+"""Check T8N filling support."""
+
+from pathlib import Path
+
+import pytest
+
+from ethereum_clis import (
+    EvmOneTransitionTool,
+    ExecutionSpecsTransitionTool,
+    GethTransitionTool,
+    TransitionTool,
+)
+from ethereum_test_base_types import Account, Address, TestAddress, TestPrivateKey
+from ethereum_test_forks import (
+    ArrowGlacier,
+    Berlin,
+    Byzantium,
+    Cancun,
+    Constantinople,
+    Fork,
+    GrayGlacier,
+    London,
+    MuirGlacier,
+    Paris,
+    Prague,
+    get_deployed_forks,
+)
+from ethereum_test_specs.blockchain import BlockchainFixture, BlockchainTest
+from ethereum_test_tools import (
+    AccessList,
+    AuthorizationTuple,
+    Block,
+    Environment,
+    Storage,
+    Transaction,
+    Withdrawal,
+    add_kzg_version,
+)
+from ethereum_test_tools.vm.opcode import Opcodes as Op
+from ethereum_test_types import Alloc
+
+BLOB_COMMITMENT_VERSION_KZG = 1
+
+
+@pytest.mark.parametrize("fork", get_deployed_forks() + [Prague])
+@pytest.mark.parametrize(
+    "t8n",
+    [
+        ExecutionSpecsTransitionTool(),
+        EvmOneTransitionTool(),
+        GethTransitionTool(binary=Path("evm")),
+    ],
+    ids=["eels-t8n", "evmone-t8n", "geth-t8n"],
+)
+def test_t8n_support(fork: Fork, t8n: TransitionTool):
+    """Stress test that sends all possible t8n interactions."""
+    if fork in [MuirGlacier, ArrowGlacier, GrayGlacier]:
+        return
+    if isinstance(t8n, ExecutionSpecsTransitionTool) and fork in [Constantinople]:
+        return
+    env = Environment()
+    sender = TestAddress
+    storage_1 = Storage()
+    storage_2 = Storage()
+
+    code_account_1 = Address(0x1001)
+    code_account_2 = Address(0x1002)
+    pre = Alloc(
+        {
+            TestAddress: Account(balance=10_000_000),
+            code_account_1: Account(
+                code=Op.SSTORE(
+                    storage_1.store_next(1, "blockhash_0_is_set"), Op.GT(Op.BLOCKHASH(0), 0)
+                )
+                + Op.SSTORE(storage_1.store_next(0, "blockhash_1"), Op.BLOCKHASH(1))
+                + Op.SSTORE(
+                    storage_1.store_next(1 if fork < Paris else 0, "difficulty_1_is_near_20000"),
+                    Op.AND(Op.GT(Op.PREVRANDAO(), 0x19990), Op.LT(Op.PREVRANDAO(), 0x20100)),
+                )
+            ),
+            code_account_2: Account(
+                code=Op.SSTORE(
+                    storage_2.store_next(1, "blockhash_1_is_set"), Op.GT(Op.BLOCKHASH(1), 0)
+                )
+                + Op.SSTORE(
+                    storage_2.store_next(1 if fork < Paris else 0, "difficulty_2_is_near_20000"),
+                    Op.AND(Op.GT(Op.PREVRANDAO(), 0x19990), Op.LT(Op.PREVRANDAO(), 0x20100)),
+                )
+            ),
+        }
+    )
+
+    tx_1 = Transaction(
+        gas_limit=100_000,
+        to=code_account_1,
+        data=b"",
+        nonce=0,
+        secret_key=TestPrivateKey,
+        protected=fork >= Byzantium,
+    )
+    if fork < Berlin:
+        # Feed legacy transaction, type 0
+        tx_2 = Transaction(
+            gas_limit=100_000,
+            to=code_account_2,
+            data=b"",
+            nonce=1,
+            secret_key=TestPrivateKey,
+            protected=fork >= Byzantium,
+        )
+    elif fork < London:
+        # Feed access list transaction, type 1
+        tx_2 = Transaction(
+            gas_limit=100_000,
+            to=code_account_2,
+            data=b"",
+            nonce=1,
+            secret_key=TestPrivateKey,
+            protected=fork >= Byzantium,
+            access_list=[
+                AccessList(
+                    address=0x1234,
+                    storage_keys=[0, 1],
+                )
+            ],
+        )
+    elif fork < Cancun:
+        # Feed base fee transaction, type 2
+        tx_2 = Transaction(
+            to=code_account_2,
+            data=b"",
+            nonce=1,
+            secret_key=TestPrivateKey,
+            protected=fork >= Byzantium,
+            gas_limit=100_000,
+            max_priority_fee_per_gas=5,
+            max_fee_per_gas=10,
+            access_list=[
+                AccessList(
+                    address=0x1234,
+                    storage_keys=[0, 1],
+                )
+            ],
+        )
+    elif fork < Prague:
+        # Feed blob transaction, type 3
+        tx_2 = Transaction(
+            to=code_account_2,
+            data=b"",
+            nonce=1,
+            secret_key=TestPrivateKey,
+            protected=fork >= Byzantium,
+            gas_limit=100_000,
+            max_priority_fee_per_gas=5,
+            max_fee_per_gas=10,
+            max_fee_per_blob_gas=30,
+            blob_versioned_hashes=add_kzg_version([1], BLOB_COMMITMENT_VERSION_KZG),
+            access_list=[
+                AccessList(
+                    address=0x1234,
+                    storage_keys=[0, 1],
+                )
+            ],
+        )
+    else:
+        # Feed set code transaction, type 4
+        tx_2 = Transaction(
+            to=sender,
+            data=b"",
+            sender=sender,
+            secret_key=TestPrivateKey,
+            protected=fork >= Byzantium,
+            gas_limit=100_000,
+            max_priority_fee_per_gas=5,
+            max_fee_per_gas=10,
+            nonce=1,
+            access_list=[
+                AccessList(
+                    address=0x1234,
+                    storage_keys=[0, 1],
+                )
+            ],
+            authorization_list=[
+                AuthorizationTuple(
+                    address=code_account_2, nonce=2, signer=sender, secret_key=TestPrivateKey
+                ),
+            ],
+        )
+
+    block_1 = Block(
+        txs=[tx_1],
+        expected_post_state={
+            code_account_1: Account(
+                storage=storage_1,
+            ),
+        },
+    )
+
+    block_2 = Block(
+        txs=[tx_2],
+        expected_post_state={
+            code_account_2: Account(
+                balance=1_000_000_000 if fork >= Cancun else 0,
+                storage=storage_2,
+            ),
+        }
+        if fork < Prague
+        else {
+            code_account_2: Account(
+                balance=1_000_000_000 if fork >= Cancun else 0,
+            ),
+            sender: Account(
+                storage=storage_2,
+            ),
+        },
+    )
+
+    if fork >= Cancun:
+        block_2.withdrawals = [
+            Withdrawal(
+                address=code_account_2,
+                amount=1,
+                index=1,
+                validator_index=0,
+            ),
+        ]
+
+    test = BlockchainTest(
+        genesis_environment=env,
+        pre=pre,
+        post=block_1.expected_post_state,
+        blocks=[block_1, block_2],
+    )
+    test.generate(
+        request=None,  # type: ignore
+        t8n=t8n,
+        fork=fork,
+        fixture_format=BlockchainFixture,
+    )

--- a/src/ethereum_clis/tests/test_transition_tools_support.py
+++ b/src/ethereum_clis/tests/test_transition_tools_support.py
@@ -85,7 +85,7 @@ def t8n(
     return t8n_instance_or_error
 
 
-@pytest.mark.parametrize("fork", fork_set)
+@pytest.mark.parametrize("fork", sorted(fork_set, key=lambda f: f.__name__))  # type: ignore
 @pytest.mark.parametrize(
     "t8n",
     test_transition_tools,

--- a/src/ethereum_clis/transition_tool.py
+++ b/src/ethereum_clis/transition_tool.py
@@ -49,6 +49,8 @@ class TransitionTool(EthereumCLI):
     registered_tools: List[Type["TransitionTool"]] = []
     default_tool: Optional[Type["TransitionTool"]] = None
 
+    exception_mapper: ExceptionMapper
+
     subcommand: Optional[str] = None
     cached_version: Optional[str] = None
     t8n_use_stream: bool = False
@@ -65,6 +67,7 @@ class TransitionTool(EthereumCLI):
         trace: bool = False,
     ):
         """Abstract initialization method that all subclasses must implement."""
+        assert exception_mapper is not None
         self.exception_mapper = exception_mapper
         super().__init__(binary=binary)
         self.trace = trace

--- a/src/ethereum_clis/transition_tool.py
+++ b/src/ethereum_clis/transition_tool.py
@@ -60,7 +60,7 @@ class TransitionTool(EthereumCLI):
     def __init__(
         self,
         *,
-        exception_mapper: ExceptionMapper,
+        exception_mapper: Optional[ExceptionMapper] = None,
         binary: Optional[Path] = None,
         trace: bool = False,
     ):

--- a/tox.ini
+++ b/tox.ini
@@ -53,6 +53,7 @@ description = Run library and framework unit tests (pytest)
 setenv =
     # Use custom EELS_RESOLUTIONS_FILE if it is set via the environment (eg, in CI)
     EELS_RESOLUTIONS_FILE = {env:EELS_RESOLUTIONS_FILE:}
+    CI = {env:CI:}
 extras = 
     test
     lint # Required `gentest` for formatting tests


### PR DESCRIPTION
## 🗒️ Description
Despite checks, and unit test pass, evmone t8n input is still inconsistent
geth t8n requires  0x20000  format for hex input and support decimals
evmone t8n requires 0x020000 format for hex input and does not support decimals
eest t8n supports all

first I introduce a unit test CI to verify that test filling works correctly on t8n's
TODO
design a simple test that triggers interesting t8n input on all forks. (with blockheader history and all fork fields in env) to run as a reference

## 🔗 Related Issues
Current coverage script is broken because of t8n format inconsistency with evmone after changing fields from int to hex in:
- https://github.com/ethereum/execution-spec-tests/pull/1027/files

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
