### PR TITLE
new(tests): EOF - mix RETF with INVALID, RETF underflow

### DIFF
--- a/tests/osaka/eip7692_eof_v1/eip4750_functions/test_code_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip4750_functions/test_code_validation.py
@@ -570,3 +570,23 @@ def test_callf_stack_overflow_by_height(eof_test, callee_stack_height):
         ],
     )
     eof_test(container=container, expect_exception=EOFException.STACK_OVERFLOW)
+
+
+def test_returning_section_aborts(
+    eof_test: EOFTestFiller,
+):
+    """
+    Test EOF container validation where in the same code section we have returning
+    and nonreturning terminating instructions.
+    """
+    container = Container(
+        name="returning_section_aborts",
+        sections=[
+            Section.Code(code=Op.PUSH0 + Op.CALLF[1] + Op.POP + Op.POP + Op.STOP),
+            Section.Code(
+                code=Op.PUSH0 * 2 + Op.RJUMPI[1] + Op.RETF + Op.INVALID,
+                code_outputs=1,
+            ),
+        ],
+    )
+    eof_test(container=container)

--- a/tests/osaka/eip7692_eof_v1/eip4750_functions/test_code_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip4750_functions/test_code_validation.py
@@ -156,6 +156,38 @@ INVALID: List[Container] = [
         validity_error=EOFException.INVALID_MAX_STACK_HEIGHT,
     ),
     Container(
+        name="stack_shorter_than_code_outputs_1",
+        sections=[
+            Section.Code(
+                code=(Op.CALLF[1] + Op.STOP),
+                # max_stack_heights of sections aligned with actual stack
+                max_stack_height=1,
+            ),
+            Section.Code(
+                code=(Op.PUSH0 + Op.RETF),
+                code_outputs=2,
+                max_stack_height=1,
+            ),
+        ],
+        validity_error=EOFException.INVALID_MAX_STACK_HEIGHT,
+    ),
+    Container(
+        name="stack_shorter_than_code_outputs_2",
+        sections=[
+            Section.Code(
+                code=(Op.CALLF[1] + Op.STOP),
+                # max_stack_heights of sections aligned with declared outputs
+                max_stack_height=2,
+            ),
+            Section.Code(
+                code=(Op.PUSH0 + Op.RETF),
+                code_outputs=2,
+                max_stack_height=2,
+            ),
+        ],
+        validity_error=EOFException.STACK_UNDERFLOW,
+    ),
+    Container(
         name="overflow_code_sections_1",
         sections=[
             Section.Code(

--- a/tests/osaka/eip7692_eof_v1/eip6206_jumpf/test_jumpf_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip6206_jumpf/test_jumpf_validation.py
@@ -112,3 +112,27 @@ def test_invalid_code_section_index(
 ):
     """Test cases for JUMPF instructions with invalid target code section index."""
     eof_test(container=container, expect_exception=EOFException.INVALID_CODE_SECTION_INDEX)
+
+
+def test_returning_section_aborts_jumpf(
+    eof_test: EOFTestFiller,
+):
+    """
+    Test EOF container validation where in the same code section we have returning
+    and nonreturning terminating instructions.
+    """
+    container = Container(
+        sections=[
+            Section.Code(code=Op.CALLF[1] + Op.STOP, max_stack_height=1),
+            Section.Code(
+                code=Op.PUSH0 * 2 + Op.RJUMPI[4] + Op.POP + Op.JUMPF[2] + Op.RETF,
+                code_outputs=1,
+            ),
+            Section.Code(
+                code=Op.PUSH0 * 2 + Op.RJUMPI[1] + Op.RETF + Op.INVALID,
+                code_inputs=0,
+                code_outputs=1,
+            ),
+        ],
+    )
+    eof_test(container=container)


### PR DESCRIPTION
## 🗒️ Description

I've noticed we don't have a test where RETF and INVALID share the same code section. JUMPF tests seem not to be migrated yet, so the addition looks a bit silly, but I'm anticipating the migration will happen.

## 🔗 Related Issues

NA

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
