### PR TITLE
new(tests): EOF - ensure EOFCREATE bumps nonce as EIP-161

### DIFF
--- a/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_eofcreate_failures.py
+++ b/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_eofcreate_failures.py
@@ -765,8 +765,8 @@ def test_reentrant_eofcreate(
     env = Environment()
     # Calls into the factory contract with 1 as input.
     reenter_code = Op.MSTORE(0, 1) + Op.EXTCALL(address=Op.CALLDATALOAD(32), args_size=32)
-    # Initcode: if given 0 as 2nd word of input will call into the factory again.
-    #           1ts word of input is the address of the factory.
+    # Initcode: if given 0 as 1st word of input will call into the factory again.
+    #           2nd word of input is the address of the factory.
     initcontainer = Container(
         sections=[
             Section.Code(
@@ -797,7 +797,7 @@ def test_reentrant_eofcreate(
     )
     # Flow is: reenter flag 0 -> factory -> reenter flag 0 -> initcode -> reenter ->
     #          reenter flag 1 -> factory -> reenter flag 1 -> (!) initcode -> stop,
-    # If the EIP-161 nonce bump is not implemented. If it is, it fails before second
+    # if the EIP-161 nonce bump is not implemented. If it is, it fails before second
     # inicode marked (!).
     # Storage in 0 should have the address from the outer EOFCREATE.
     # Storage in 1 should have 0 from the inner EOFCREATE.

--- a/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_eofcreate_failures.py
+++ b/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_eofcreate_failures.py
@@ -755,3 +755,63 @@ def test_eof_eofcreate_msg_depth(
         post=post,
         tx=tx,
     )
+
+
+def test_reentrant_eofcreate(
+    state_test: StateTestFiller,
+    pre: Alloc,
+):
+    """Verifies a reentrant EOFCREATE case, where EIP-161 prevents conflict via nonce bump."""
+    env = Environment()
+    # Calls into the factory contract with 1 as input.
+    reenter_code = Op.MSTORE(0, 1) + Op.EXTCALL(address=Op.CALLDATALOAD(32), args_size=32)
+    # Initcode: if given 0 as 2nd word of input will call into the factory again.
+    #           1ts word of input is the address of the factory.
+    initcontainer = Container(
+        sections=[
+            Section.Code(
+                Op.CALLDATALOAD(0)
+                + Op.RJUMPI[len(reenter_code)]
+                + reenter_code
+                + Op.RETURNCONTRACT[0](0, 0)
+            ),
+            Section.Container(smallest_runtime_subcontainer),
+        ]
+    )
+    # Factory: Passes on its input into the initcode. It's 0 first time, 1 the second time.
+    #          Saves the result of deployment in slot 0 first time, 1 the second time.
+    contract_address = pre.deploy_contract(
+        code=Container(
+            sections=[
+                Section.Code(
+                    Op.CALLDATACOPY(0, 0, 32)
+                    + Op.MSTORE(32, Op.ADDRESS)
+                    # 1st word - copied from input (reenter flag), 2nd word - `this.address`.
+                    + Op.SSTORE(Op.CALLDATALOAD(0), Op.EOFCREATE[0](input_size=64))
+                    + Op.STOP,
+                ),
+                Section.Container(initcontainer),
+            ],
+        ),
+        storage={0: 0xB17D, 1: 0xB17D},  # a canary to be overwritten
+    )
+    # Flow is: reenter flag 0 -> factory -> reenter flag 0 -> initcode -> reenter ->
+    #          reenter flag 1 -> factory -> reenter flag 1 -> (!) initcode -> stop,
+    # If the EIP-161 nonce bump is not implemented. If it is, it fails before second
+    # inicode marked (!).
+    # Storage in 0 should have the address from the outer EOFCREATE.
+    # Storage in 1 should have 0 from the inner EOFCREATE.
+    post = {
+        contract_address: Account(
+            storage={
+                0: compute_eofcreate_address(contract_address, 0, initcontainer),
+                1: 0,
+            }
+        )
+    }
+    tx = Transaction(
+        to=contract_address,
+        gas_limit=500_000,
+        sender=pre.fund_eoa(),
+    )
+    state_test(env=env, pre=pre, post=post, tx=tx)


### PR DESCRIPTION
## 🗒️ Description

EIP-161 requires the creating instructions to bump the nonce of the account where the contract is created. This test uses a reentrant EOFCREATE factory, which without this rule would happily create the contract twice.

## 🔗 Related Issues

NA

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
