### PR TITLE
fix(tests): EOF - Align EOFCREATE args with EXT*CALL

### DIFF
--- a/src/ethereum_test_vm/opcode.py
+++ b/src/ethereum_test_vm/opcode.py
@@ -5092,12 +5092,12 @@ class Opcodes(Opcode, Enum):
         popped_stack_items=4,
         pushed_stack_items=1,
         data_portion_length=1,
-        kwargs=["value", "salt", "input_offset", "input_size"],
+        kwargs=["salt", "input_offset", "input_size", "value"],
     )
     """
     !!! Note: This opcode is under development
 
-    EOFCREATE[initcontainer_index] (value, salt, input_offset, input_size)
+    EOFCREATE[initcontainer_index] (salt, input_offset, input_size, value)
     ----
 
     Description

--- a/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_eofcreate.py
+++ b/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_eofcreate.py
@@ -275,7 +275,7 @@ def test_calldata(state_test: StateTestFiller, pre: Alloc):
             sections=[
                 Section.Code(
                     code=Op.MSTORE(0, Op.PUSH32(calldata))
-                    + Op.SSTORE(slot_create_address, Op.EOFCREATE[0](0, 0, 0, calldata_size))
+                    + Op.SSTORE(slot_create_address, Op.EOFCREATE[0](input_size=calldata_size))
                     + Op.STOP,
                 ),
                 Section.Container(container=initcode_subcontainer),
@@ -497,7 +497,7 @@ def test_address_collision(
                 Section.Code(
                     code=Op.SSTORE(slot_create_address, Op.EOFCREATE[0](0, 0, 0, 0))
                     + Op.SSTORE(slot_create_address_2, Op.EOFCREATE[0](0, 0, 0, 0))
-                    + Op.SSTORE(slot_create_address_3, Op.EOFCREATE[0](0, 1, 0, 0))
+                    + Op.SSTORE(slot_create_address_3, Op.EOFCREATE[0](salt=1))
                     + Op.SSTORE(slot_code_worked, value_code_worked)
                     + Op.STOP,
                 ),
@@ -556,7 +556,9 @@ def test_eofcreate_revert_eof_returndata(
             sections=[
                 Section.Code(
                     code=Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE)
-                    + Op.SSTORE(slot_create_address, Op.EOFCREATE[0](0, salt, 0, Op.CALLDATASIZE))
+                    + Op.SSTORE(
+                        slot_create_address, Op.EOFCREATE[0](salt=salt, input_size=Op.CALLDATASIZE)
+                    )
                     + Op.SSTORE(slot_returndata_size, Op.RETURNDATASIZE)
                     + Op.STOP,
                 ),
@@ -688,7 +690,7 @@ def test_eofcreate_context(
         sections=[
             Section.Code(
                 Op.SSTORE(slot_code_worked, value_code_worked)
-                + Op.EOFCREATE[0](eofcreate_value, 0, 0, 0)
+                + Op.EOFCREATE[0](value=eofcreate_value)
                 + Op.STOP
             ),
             Section.Container(initcode),

--- a/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_eofcreate_failures.py
+++ b/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_eofcreate_failures.py
@@ -291,7 +291,7 @@ def test_auxdata_size_failures(state_test: StateTestFiller, pre: Alloc, auxdata_
             sections=[
                 Section.Code(
                     code=Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE)
-                    + Op.SSTORE(slot_create_address, Op.EOFCREATE[0](0, 0, 0, Op.CALLDATASIZE))
+                    + Op.SSTORE(slot_create_address, Op.EOFCREATE[0](input_size=Op.CALLDATASIZE))
                     + Op.SSTORE(slot_code_worked, value_code_worked)
                     + Op.STOP,
                 ),
@@ -347,7 +347,7 @@ def test_eofcreate_insufficient_stipend(
     initcode_container = Container(
         sections=[
             Section.Code(
-                code=Op.SSTORE(slot_create_address, Op.EOFCREATE[0](value, 0, 0, 0))
+                code=Op.SSTORE(slot_create_address, Op.EOFCREATE[0](value=value))
                 + Op.SSTORE(slot_code_worked, value_code_worked)
                 + Op.STOP,
             ),
@@ -451,7 +451,7 @@ def test_insufficient_gas_memory_expansion(
     initcode_container = Container(
         sections=[
             Section.Code(
-                code=Op.SSTORE(slot_create_address, Op.EOFCREATE[0](0, 0, 0, auxdata_size))
+                code=Op.SSTORE(slot_create_address, Op.EOFCREATE[0](input_size=auxdata_size))
                 + Op.SSTORE(slot_code_should_fail, slot_code_worked)
                 + Op.STOP,
             ),

--- a/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_gas.py
+++ b/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_gas.py
@@ -140,10 +140,10 @@ def test_eofcreate_gas(
         state_test,
         Environment(),
         pre,
-        setup_code=Op.PUSH1(mem_expansion_bytes)
+        setup_code=Op.PUSH32(value)
+        + Op.PUSH1(mem_expansion_bytes)
         + Op.PUSH0
-        + code_increment_counter
-        + Op.PUSH32(value),
+        + code_increment_counter,
         subject_code=Op.EOFCREATE[0],
         tear_down_code=Op.STOP,
         cold_gas=EOFCREATE_GAS


### PR DESCRIPTION
## 🗒️ Description

Update with https://github.com/ipsilon/eof/pull/156, planned for EOF Osaka-devnet-1. EOFCREATE stack args order to match that of EXT*CALL.

Filling requires `evmone` with an update which will be flagged below :point_down: 

## 🔗 Related Issues



## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
