### PR TITLE
chore(fill): fix for geth transition tool

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 ### 📋 Misc
 
 - 🔀 Bump the version of `execution-specs` used by the framework to the package [`ethereum-execution==1.17.0rc6.dev1`](https://pypi.org/project/ethereum-execution/1.17.0rc6.dev1/); bump the version used for test fixture generation for forks < Prague to current `execution-specs` master, [fa847a0](https://github.com/ethereum/execution-specs/commit/fa847a0e48309debee8edc510ceddb2fd5db2f2e) ([#1310](https://github.com/ethereum/execution-spec-tests/pull/1310)).
+- 🐞 Init `TransitionTool` in `GethTransitionTool` ([#1276](https://github.com/ethereum/execution-spec-tests/pull/1276)).
 
 ### 🧪 Test Cases
 

--- a/src/ethereum_clis/clis/geth.py
+++ b/src/ethereum_clis/clis/geth.py
@@ -229,7 +229,10 @@ class GethTransitionTool(GethEvm, TransitionTool):
 
     def __init__(self, *, binary: Path, trace: bool = False):
         """Initialize the GethTransitionTool class."""
-        super().__init__(binary=binary, trace=trace)
+        GethEvm.__init__(self, binary=binary, trace=trace)
+        TransitionTool.__init__(
+            self, exception_mapper=self.exception_mapper, binary=binary, trace=trace
+        )
         help_command = [str(self.binary), str(self.subcommand), "--help"]
         result = self._run_command(help_command)
         self.help_string = result.stdout


### PR DESCRIPTION
## 🗒️ Description

When running fill with the geth transition tool we get the following error:
```
tests/shanghai/eip3855_push0/test_push0.py:145: in test_push0_contract_during_call_contexts
    state_test(env=env, pre=pre, post=post, tx=tx)
src/pytest_plugins/filler/filler.py:707: in __init__
    _info_metadata=t8n._info_metadata,
E   AttributeError: 'GethTransitionTool' object has no attribute '_info_metadata'
```

This is because `GethTransitionTool` does not init the parent class `TransitionTool`.

## 🔗 Related Issues
N/A

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
