### PR TITLE
fix(tests): EOF - Rename RETURNCONTRACT to RETURNCODE

### DIFF
--- a/src/ethereum_test_specs/eof.py
+++ b/src/ethereum_test_specs/eof.py
@@ -415,7 +415,7 @@ class EOFTest(BaseTest):
             )
             initcode = Container(
                 sections=[
-                    Section.Code(Op.RETURNCONTRACT[0](0, 0)),
+                    Section.Code(Op.RETURNCODE[0](0, 0)),
                     Section.Container(self.container),
                 ]
             )

--- a/src/ethereum_test_types/eof/v1/__init__.py
+++ b/src/ethereum_test_types/eof/v1/__init__.py
@@ -454,7 +454,7 @@ class Container(CopyValidateModel):
         return cls(
             sections=[
                 Section.Code(
-                    code=initcode_prefix + Op.RETURNCONTRACT[0](0, 0),
+                    code=initcode_prefix + Op.RETURNCODE[0](0, 0),
                 ),
                 Section.Container(
                     container=deploy_container,
@@ -502,7 +502,7 @@ class Initcode(Bytecode):
         return Container(
             sections=[
                 Section.Code(
-                    code=Op.RETURNCONTRACT[0](0, 0),
+                    code=Op.RETURNCODE[0](0, 0),
                     max_stack_height=2,
                 ),
                 Section.Container(

--- a/src/ethereum_test_types/tests/test_eof_v1.py
+++ b/src/ethereum_test_types/tests/test_eof_v1.py
@@ -790,7 +790,7 @@ test_cases: List[Tuple[str, Container, str]] = [
               # Code segment 0 code
          6000 #  1 PUSH1 0
          6000 #  2 PUSH1 0
-         ee00 #  3 RETURNCONTRACT[0]
+         ee00 #  3 RETURNCODE[0]
               # Subcontainer 0
       ef0001  # Magic followed by version
       010004  # Types section
@@ -823,7 +823,7 @@ test_cases: List[Tuple[str, Container, str]] = [
            55 #  3 SSTORE
          6000 #  4 PUSH1 0
          6000 #  5 PUSH1 0
-         ee00 #  6 RETURNCONTRACT[0]
+         ee00 #  6 RETURNCODE[0]
               # Subcontainer 0
       ef0001  # Magic followed by version
       010004  # Types section

--- a/src/ethereum_test_vm/opcode.py
+++ b/src/ethereum_test_vm/opcode.py
@@ -5117,7 +5117,7 @@ class Opcodes(Opcode, Enum):
 
     """
 
-    RETURNCONTRACT = Opcode(
+    RETURNCODE = Opcode(
         0xEE,
         popped_stack_items=2,
         data_portion_length=1,
@@ -5127,7 +5127,7 @@ class Opcodes(Opcode, Enum):
     """
     !!! Note: This opcode is under development
 
-    RETURNCONTRACT()
+    RETURNCODE()
     ----
 
     Description

--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/opcodes.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/opcodes.py
@@ -31,7 +31,7 @@ V1_EOF_OPCODES: List[Op] = [
     Op.DATACOPY,
     # EIP-7620 EOF Create and Return Contract operation
     Op.EOFCREATE,
-    Op.RETURNCONTRACT,
+    Op.RETURNCODE,
     # Non-deprecated Legacy Opcodes
     Op.STOP,
     Op.ADD,
@@ -216,7 +216,7 @@ V1_EOF_ONLY_OPCODES = [
     Op.DATACOPY,
     # EIP-7620 EOF Create and Return Contract operation
     Op.EOFCREATE,
-    Op.RETURNCONTRACT,
+    Op.RETURNCODE,
 ]
 """
 List of valid EOF V1 opcodes that are disabled in legacy bytecode.

--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_all_opcodes_in_container.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_all_opcodes_in_container.py
@@ -46,7 +46,7 @@ valid_eof_opcodes = all_opcodes - invalid_eof_opcodes
 # Halting the execution opcodes can be placed without STOP instruction at the end
 halting_opcodes = {
     Op.STOP,
-    Op.RETURNCONTRACT,
+    Op.RETURNCODE,
     Op.RETURN,
     Op.REVERT,
     Op.INVALID,
@@ -88,7 +88,7 @@ def test_all_opcodes_in_container(
     sections = [Section.Code(code=bytecode)]
 
     match opcode:
-        case Op.EOFCREATE | Op.RETURNCONTRACT:
+        case Op.EOFCREATE | Op.RETURNCODE:
             sections.append(
                 Section.Container(
                     container=Container(
@@ -107,7 +107,7 @@ def test_all_opcodes_in_container(
             )
     sections.append(Section.Data("1122334455667788" * 4))
 
-    if opcode == Op.RETURNCONTRACT:
+    if opcode == Op.RETURNCODE:
         eof_code = Container(sections=sections, kind=ContainerKind.INITCODE)
     else:
         eof_code = Container(sections=sections)
@@ -136,8 +136,8 @@ def test_invalid_opcodes_after_stop(
     """Test that an invalid opcode placed after STOP (terminating instruction) invalidates EOF."""
     terminating_code = Bytecode(terminating_opcode)
     match terminating_opcode:  # Enhance the code for complex opcodes.
-        case Op.RETURNCONTRACT:
-            terminating_code = Op.RETURNCONTRACT[0]
+        case Op.RETURNCODE:
+            terminating_code = Op.RETURNCODE[0]
         case Op.RETURN | Op.REVERT:
             terminating_code = Op.PUSH0 + Op.PUSH0 + terminating_opcode
         case Op.RJUMP:
@@ -145,7 +145,7 @@ def test_invalid_opcodes_after_stop(
 
     eof_code = Container(
         kind=ContainerKind.INITCODE
-        if terminating_opcode == Op.RETURNCONTRACT
+        if terminating_opcode == Op.RETURNCODE
         else ContainerKind.RUNTIME,
         sections=[
             Section.Code(code=terminating_code + opcode),
@@ -153,7 +153,7 @@ def test_invalid_opcodes_after_stop(
         ]
         + (
             [Section.Container(container=Container.Code(Op.INVALID))]
-            if terminating_opcode == Op.RETURNCONTRACT
+            if terminating_opcode == Op.RETURNCODE
             else []
         ),
     )
@@ -194,7 +194,7 @@ def test_all_invalid_terminating_opcodes(
             Section.Container(
                 container=Container(
                     sections=[
-                        Section.Code(code=Op.RETURNCONTRACT[0](0, 0)),
+                        Section.Code(code=Op.RETURNCODE[0](0, 0)),
                         Section.Container(Container.Code(code=Op.STOP)),
                     ]
                 )
@@ -233,13 +233,13 @@ def test_all_unreachable_terminating_opcodes_after_stop(
                 Section.Code(code=Op.STOP + Op.JUMPF[1]),
                 Section.Code(code=Op.STOP),
             ]
-        case Op.RETURNCONTRACT:
+        case Op.RETURNCODE:
             sections = [
                 Section.Code(code=Op.EOFCREATE[0](0, 0, 0, 0) + Op.STOP),
                 Section.Container(
                     container=Container(
                         sections=[
-                            Section.Code(code=Op.STOP + Op.RETURNCONTRACT[0](0, 0)),
+                            Section.Code(code=Op.STOP + Op.RETURNCODE[0](0, 0)),
                             Section.Container(Container.Code(code=Op.STOP)),
                         ]
                     )
@@ -257,7 +257,7 @@ def test_all_unreachable_terminating_opcodes_after_stop(
             sections=sections,
         ),
         expect_exception=EOFException.UNREACHABLE_INSTRUCTIONS
-        if opcode != Op.RETURNCONTRACT
+        if opcode != Op.RETURNCODE
         else EOFException.INCOMPATIBLE_CONTAINER_KIND,
     )
 
@@ -282,13 +282,13 @@ def test_all_unreachable_terminating_opcodes_before_stop(
                 Section.Code(code=Op.JUMPF[1] + Op.STOP),
                 Section.Code(code=Op.STOP),
             ]
-        case Op.RETURNCONTRACT:
+        case Op.RETURNCODE:
             sections = [
                 Section.Code(code=Op.EOFCREATE[0](0, 0, 0, 0) + Op.STOP),
                 Section.Container(
                     container=Container(
                         sections=[
-                            Section.Code(code=Op.RETURNCONTRACT[0](0, 0) + Op.STOP),
+                            Section.Code(code=Op.RETURNCODE[0](0, 0) + Op.STOP),
                             Section.Container(Container.Code(code=Op.STOP)),
                         ]
                     )
@@ -306,7 +306,7 @@ def test_all_unreachable_terminating_opcodes_before_stop(
             sections=sections,
         ),
         expect_exception=EOFException.UNREACHABLE_INSTRUCTIONS
-        if opcode != Op.RETURNCONTRACT
+        if opcode != Op.RETURNCODE
         else EOFException.INCOMPATIBLE_CONTAINER_KIND,
     )
 
@@ -336,13 +336,13 @@ def test_all_opcodes_stack_underflow(
             Section.Container(
                 container=Container(
                     sections=[
-                        Section.Code(code=Op.RETURNCONTRACT[0](0, 0)),
+                        Section.Code(code=Op.RETURNCODE[0](0, 0)),
                         Section.Container(Container.Code(code=Op.STOP)),
                     ]
                 )
             ),
         ]
-    elif opcode == Op.RETURNCONTRACT:
+    elif opcode == Op.RETURNCODE:
         sections = [
             Section.Code(code=Op.EOFCREATE[0](0, 0, 0, 0) + Op.STOP),
             Section.Container(

--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py
@@ -926,7 +926,7 @@ def test_valid_containers(
                 Section.Container(
                     Container(
                         sections=[
-                            Section.Code(code=Op.RETURNCONTRACT[0](0, 0)),
+                            Section.Code(code=Op.RETURNCODE[0](0, 0)),
                             Section.Container(container=Container.Code(code=Op.STOP)),
                         ],
                     )
@@ -1237,7 +1237,7 @@ def test_single_code_section(
     plus_container: bool,
 ):
     """Verify EOF container single code section."""
-    sections = [Section.Code(Op.RETURNCONTRACT[0](0, 0) if plus_container else Op.STOP)]
+    sections = [Section.Code(Op.RETURNCODE[0](0, 0) if plus_container else Op.STOP)]
     if plus_container:
         sections.append(
             Section.Container(
@@ -1271,7 +1271,7 @@ def test_max_code_sections(
     if plus_container:
         sections = [
             Section.Code(
-                Op.JUMPF[i + 1] if i < (MAX_CODE_SECTIONS - 1) else Op.RETURNCONTRACT[0](0, 0)
+                Op.JUMPF[i + 1] if i < (MAX_CODE_SECTIONS - 1) else Op.RETURNCODE[0](0, 0)
             )
             for i in range(MAX_CODE_SECTIONS)
         ]

--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_opcodes_in_legacy.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_opcodes_in_legacy.py
@@ -48,7 +48,7 @@ eof_opcode_blocks = [
     pytest.param(Op.DATASIZE, id="DATASIZE"),
     pytest.param(Op.DATACOPY(0, 0, 32), id="DATACOPY"),
     pytest.param(Op.EOFCREATE[0](0, 0, 0, 0), id="EOFCREATE"),
-    pytest.param(Op.RETURNCONTRACT[0], id="RETURNCONTRACT"),
+    pytest.param(Op.RETURNCODE[0], id="RETURNCODE"),
 ]
 
 

--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_section_size.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_section_size.py
@@ -139,7 +139,7 @@ def test_section_size(
             Section.Container(
                 container=Container(
                     sections=[
-                        Section.Code(Op.RETURNCONTRACT[0](0, 0)),
+                        Section.Code(Op.RETURNCODE[0](0, 0)),
                         Section.Container(container=Container(sections=[Section.Code(Op.STOP)])),
                     ]
                 ),
@@ -151,7 +151,7 @@ def test_section_size(
             Section.Container(
                 container=Container(
                     sections=[
-                        Section.Code(Op.RETURNCONTRACT[0](0, 0)),
+                        Section.Code(Op.RETURNCODE[0](0, 0)),
                         Section.Container(container=Container(sections=[Section.Code(Op.STOP)])),
                     ]
                 ),

--- a/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjump.py
+++ b/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjump.py
@@ -975,7 +975,7 @@ def test_rjump_into_eofcreate(
                     container=Container(
                         sections=[
                             Section.Code(
-                                code=Op.RETURNCONTRACT[0](0, 0),
+                                code=Op.RETURNCODE[0](0, 0),
                             ),
                             Section.Container(
                                 container=Container.Code(code=Op.STOP),
@@ -989,10 +989,10 @@ def test_rjump_into_eofcreate(
     )
 
 
-def test_rjump_into_returncontract(
+def test_rjump_into_returncode(
     eof_test: EOFTestFiller,
 ):
-    """EOF code containing RJUMP with target RETURNCONTRACT immediate."""
+    """EOF code containing RJUMP with target RETURNCODE immediate."""
     eof_test(
         container=Container(
             sections=[
@@ -1003,7 +1003,7 @@ def test_rjump_into_returncontract(
                     container=Container(
                         sections=[
                             Section.Code(
-                                code=Op.PUSH0 * 2 + Op.RJUMP[1] + Op.RETURNCONTRACT[0],
+                                code=Op.PUSH0 * 2 + Op.RJUMP[1] + Op.RETURNCODE[0],
                             ),
                             Section.Container(
                                 container=Container.Code(code=Op.STOP),

--- a/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpi.py
+++ b/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpi.py
@@ -1397,7 +1397,7 @@ def test_rjumpi_into_eofcreate(
                     container=Container(
                         sections=[
                             Section.Code(
-                                code=Op.RETURNCONTRACT[0](0, 0),
+                                code=Op.RETURNCODE[0](0, 0),
                             ),
                             Section.Container(
                                 container=Container.Code(code=Op.STOP),
@@ -1411,10 +1411,10 @@ def test_rjumpi_into_eofcreate(
     )
 
 
-def test_rjumpi_into_returncontract(
+def test_rjumpi_into_returncode(
     eof_test: EOFTestFiller,
 ):
-    """EOF code containing RJUMPI with target RETURNCONTRACT immediate."""
+    """EOF code containing RJUMPI with target RETURNCODE immediate."""
     eof_test(
         container=Container(
             sections=[
@@ -1425,7 +1425,7 @@ def test_rjumpi_into_returncontract(
                     container=Container(
                         sections=[
                             Section.Code(
-                                code=Op.PUSH0 * 3 + Op.RJUMPI[1] + Op.RETURNCONTRACT[0],
+                                code=Op.PUSH0 * 3 + Op.RJUMPI[1] + Op.RETURNCODE[0],
                             ),
                             Section.Container(
                                 container=Container.Code(code=Op.STOP),

--- a/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py
+++ b/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py
@@ -1012,7 +1012,7 @@ def test_rjumpv_into_eofcreate(
                     container=Container(
                         sections=[
                             Section.Code(
-                                code=Op.RETURNCONTRACT[0](0, 0),
+                                code=Op.RETURNCODE[0](0, 0),
                             ),
                             Section.Container(
                                 container=Container.Code(Op.STOP),
@@ -1034,12 +1034,12 @@ def test_rjumpv_into_eofcreate(
         pytest.param(256, 255, id="t256i255"),
     ],
 )
-def test_rjumpv_into_returncontract(
+def test_rjumpv_into_returncode(
     eof_test: EOFTestFiller,
     table_size: int,
     invalid_index: int,
 ):
-    """EOF code containing RJUMPV with target RETURNCONTRACT immediate."""
+    """EOF code containing RJUMPV with target RETURNCODE immediate."""
     invalid_destination = 1
     jump_table = [0 for _ in range(table_size)]
     jump_table[invalid_index] = invalid_destination
@@ -1053,7 +1053,7 @@ def test_rjumpv_into_returncontract(
                     container=Container(
                         sections=[
                             Section.Code(
-                                code=Op.PUSH0 * 3 + Op.RJUMPV[jump_table] + Op.RETURNCONTRACT[0],
+                                code=Op.PUSH0 * 3 + Op.RJUMPV[jump_table] + Op.RETURNCODE[0],
                             ),
                             Section.Container(
                                 container=Container.Code(Op.STOP),

--- a/tests/osaka/eip7692_eof_v1/eip6206_jumpf/test_nonreturning_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip6206_jumpf/test_nonreturning_validation.py
@@ -69,19 +69,17 @@ def test_returning_section_not_returning(eof_test: EOFTestFiller, code_section: 
 @pytest.mark.parametrize(
     "code_section",
     [
+        pytest.param(Section.Code(Op.RETURNCODE[0](0, 0), code_outputs=0), id="returncode0"),
         pytest.param(
-            Section.Code(Op.RETURNCONTRACT[0](0, 0), code_outputs=0), id="returncontract0"
-        ),
-        pytest.param(
-            Section.Code(Op.PUSH0 + Op.RETURNCONTRACT[0](0, 0), code_outputs=1),
-            id="returncontract1",
+            Section.Code(Op.PUSH0 + Op.RETURNCODE[0](0, 0), code_outputs=1),
+            id="returncode1",
         ),
     ],
 )
-def test_returning_section_returncontract(eof_test: EOFTestFiller, code_section: Section):
+def test_returning_section_returncode(eof_test: EOFTestFiller, code_section: Section):
     """
     Test EOF validation failing because a returning section has no RETF or JUMPF-to-returning -
-    RETURNCONTRACT version.
+    RETURNCODE version.
     """
     eof_test(
         container=Container(

--- a/tests/osaka/eip7692_eof_v1/eip7620_eof_create/__init__.py
+++ b/tests/osaka/eip7692_eof_v1/eip7620_eof_create/__init__.py
@@ -1,15 +1,15 @@
 """
 abstract: Test cases for [EIP-7620: EOF Contract Creation](https://eips.ethereum.org/EIPS/eip-7620)
     EIP-7620 replaces `CREATE` and `CREATE2` with `EOFCREATE` for deploying contracts in the EOF format.
-    Opcodes introduced: `EOFCREATE` (`0xEC`), `RETURNCONTRACT` (`0xEE`).
+    Opcodes introduced: `EOFCREATE` (`0xEC`), `RETURNCODE` (`0xEE`).
 
 
-EOFCREATE, RETURNCONTRACT, and container tests
+EOFCREATE, RETURNCODE, and container tests
 
 evmone tests not ported
 
 - create_tx_with_eof_initcode - This calls it invalid, it is now the way to add EOF contacts to state
-- eofcreate_extcall_returncontract - per the new initcode mode tests you cannot have RETURNCONTRACT
+- eofcreate_extcall_returncode - per the new initcode mode tests you cannot have RETURNCODE
     in a deployed contract
 - eofcreate_dataloadn_referring_to_auxdata - covered by
     tests.osaka.eip7480_data_section.test_data_opcodes.test_data_section_succeed

--- a/tests/osaka/eip7692_eof_v1/eip7620_eof_create/helpers.py
+++ b/tests/osaka/eip7692_eof_v1/eip7620_eof_create/helpers.py
@@ -32,7 +32,7 @@ smallest_runtime_subcontainer = Container.Code(code=Op.STOP, name="Runtime Subco
 smallest_initcode_subcontainer = Container(
     name="Initcode Subcontainer",
     sections=[
-        Section.Code(code=Op.RETURNCONTRACT[0](0, 0)),
+        Section.Code(code=Op.RETURNCODE[0](0, 0)),
         Section.Container(container=smallest_runtime_subcontainer),
     ],
 )
@@ -51,9 +51,9 @@ bigger_initcode_subcontainer = Container(
     name="Bigger Initcode Subcontainer",
     sections=[
         Section.Code(
-            code=Op.RJUMPI[len(Op.RETURNCONTRACT[0](0, 0))](1)
-            + Op.RETURNCONTRACT[0](0, 0)
-            + Op.RETURNCONTRACT[1](0, 0)
+            code=Op.RJUMPI[len(Op.RETURNCODE[0](0, 0))](1)
+            + Op.RETURNCODE[0](0, 0)
+            + Op.RETURNCODE[1](0, 0)
         ),
         Section.Container(container=smallest_runtime_subcontainer),
         Section.Container(container=smallest_runtime_subcontainer),
@@ -66,7 +66,7 @@ data_runtime_container.sections.append(Section.Data("0x00"))
 data_initcode_subcontainer = Container(
     name="Data Initcode Subcontainer",
     sections=[
-        Section.Code(code=Op.RETURNCONTRACT[0](0, 0)),
+        Section.Code(code=Op.RETURNCODE[0](0, 0)),
         Section.Container(container=data_runtime_container),
     ],
 )
@@ -74,7 +74,7 @@ data_initcode_subcontainer = Container(
 data_appending_initcode_subcontainer = Container(
     name="Data Appending Initcode Subcontainer",
     sections=[
-        Section.Code(code=Op.RETURNCONTRACT[0](0, 1)),
+        Section.Code(code=Op.RETURNCODE[0](0, 1)),
         Section.Container(container=smallest_runtime_subcontainer),
     ],
 )

--- a/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_eofcreate.py
+++ b/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_eofcreate.py
@@ -87,7 +87,7 @@ def test_eofcreate_then_dataload(
     sender = pre.fund_eoa()
     small_auxdata_container = Container(
         sections=[
-            Section.Code(code=Op.RETURNCONTRACT[0](0, 32)),
+            Section.Code(code=Op.RETURNCODE[0](0, 32)),
             Section.Container(container=smallest_runtime_subcontainer),
         ],
     )
@@ -142,7 +142,7 @@ def test_eofcreate_then_call(
     callable_contract_initcode = Container(
         sections=[
             Section.Code(
-                code=Op.RETURNCONTRACT[0](0, 0),
+                code=Op.RETURNCODE[0](0, 0),
             ),
             Section.Container(container=callable_contract),
         ]
@@ -196,7 +196,7 @@ def test_eofcreate_then_call(
     ],
 )
 def test_auxdata_variations(state_test: StateTestFiller, pre: Alloc, auxdata_bytes: bytes):
-    """Verifies that auxdata bytes are correctly handled in RETURNCONTRACT."""
+    """Verifies that auxdata bytes are correctly handled in RETURNCODE."""
     env = Environment()
     auxdata_size = len(auxdata_bytes)
     pre_deploy_header_data_size = 18
@@ -216,7 +216,7 @@ def test_auxdata_variations(state_test: StateTestFiller, pre: Alloc, auxdata_byt
         sections=[
             Section.Code(
                 code=Op.MSTORE(0, Op.PUSH32(auxdata_bytes.ljust(32, b"\0")))
-                + Op.RETURNCONTRACT[0](0, auxdata_size),
+                + Op.RETURNCODE[0](0, auxdata_size),
             ),
             Section.Container(container=runtime_subcontainer),
         ],
@@ -269,7 +269,7 @@ def test_calldata(state_test: StateTestFiller, pre: Alloc):
             Section.Code(
                 code=Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE)
                 + Op.SSTORE(slot_calldata, Op.MLOAD(0))
-                + Op.RETURNCONTRACT[0](0, Op.CALLDATASIZE),
+                + Op.RETURNCODE[0](0, Op.CALLDATASIZE),
             ),
             Section.Container(container=smallest_runtime_subcontainer),
         ],
@@ -328,7 +328,7 @@ def test_eofcreate_in_initcode(
             Section.Code(
                 code=Op.SSTORE(slot_create_address, Op.EOFCREATE[0](0, 0, 0, 0))
                 + Op.SSTORE(slot_code_worked, value_code_worked)
-                + Op.RETURNCONTRACT[1](0, 0),
+                + Op.RETURNCODE[1](0, 0),
             ),
             Section.Container(container=smallest_initcode_subcontainer),
             Section.Container(container=smallest_runtime_subcontainer),
@@ -695,9 +695,7 @@ def test_eofcreate_context(
 
     initcode = Container(
         sections=[
-            Section.Code(
-                Op.SSTORE(slot_call_result, destination_code) + Op.RETURNCONTRACT[0](0, 0)
-            ),
+            Section.Code(Op.SSTORE(slot_call_result, destination_code) + Op.RETURNCODE[0](0, 0)),
             Section.Container(smallest_runtime_subcontainer),
         ]
     )
@@ -773,7 +771,7 @@ def test_eofcreate_memory_context(
                 + Op.SSTORE(destination_storage.store_next(0), Op.MLOAD(0))
                 + Op.MSTORE(0, 2)
                 + Op.MSTORE(32, 2)
-                + Op.RETURNCONTRACT[0](0, 0)
+                + Op.RETURNCODE[0](0, 0)
             ),
             Section.Container(smallest_runtime_subcontainer),
         ]

--- a/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_eofcreate_failures.py
+++ b/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_eofcreate_failures.py
@@ -185,7 +185,7 @@ def test_eofcreate_deploy_sizes(
         name="Initcode Subcontainer",
         sections=[
             Section.Code(
-                code=Op.RETURNCONTRACT[0](0, 0),
+                code=Op.RETURNCODE[0](0, 0),
             ),
             Section.Container(container=runtime_container),
         ],
@@ -281,8 +281,7 @@ def test_auxdata_size_failures(state_test: StateTestFiller, pre: Alloc, auxdata_
         name="Initcode Subcontainer",
         sections=[
             Section.Code(
-                code=Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE)
-                + Op.RETURNCONTRACT[0](0, Op.CALLDATASIZE),
+                code=Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE) + Op.RETURNCODE[0](0, Op.CALLDATASIZE),
             ),
             Section.Container(container=smallest_runtime_subcontainer),
         ],
@@ -397,7 +396,7 @@ def test_insufficient_initcode_gas(
         name="Large Initcode Subcontainer",
         sections=[
             Section.Code(
-                code=Op.RETURNCONTRACT[0](0, 0),
+                code=Op.RETURNCODE[0](0, 0),
             ),
             Section.Container(container=smallest_runtime_subcontainer),
             Section.Data(data=initcode_data),
@@ -503,11 +502,11 @@ def test_insufficient_gas_memory_expansion(
     state_test(env=env, pre=pre, post=post, tx=tx)
 
 
-def test_insufficient_returncontract_auxdata_gas(
+def test_insufficient_returncode_auxdata_gas(
     state_test: StateTestFiller,
     pre: Alloc,
 ):
-    """Exercises a RETURNCONTRACT when there is not enough gas for the initcode charge."""
+    """Exercises a RETURNCODE when there is not enough gas for the initcode charge."""
     env = Environment()
 
     auxdata_size = 0x5000
@@ -515,7 +514,7 @@ def test_insufficient_returncontract_auxdata_gas(
         name="Large Initcode Subcontainer",
         sections=[
             Section.Code(
-                code=Op.RETURNCONTRACT[0](0, auxdata_size),
+                code=Op.RETURNCODE[0](0, auxdata_size),
             ),
             Section.Container(container=smallest_runtime_subcontainer),
         ],
@@ -773,7 +772,7 @@ def test_reentrant_eofcreate(
                 Op.CALLDATALOAD(0)
                 + Op.RJUMPI[len(reenter_code)]
                 + reenter_code
-                + Op.RETURNCONTRACT[0](0, 0)
+                + Op.RETURNCODE[0](0, 0)
             ),
             Section.Container(smallest_runtime_subcontainer),
         ]

--- a/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_returncode.py
+++ b/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_returncode.py
@@ -1,4 +1,4 @@
-"""Tests for RETURNCONTRACT instruction validation."""
+"""Tests for RETURNCODE instruction validation."""
 
 import pytest
 
@@ -23,7 +23,7 @@ REFERENCE_SPEC_VERSION = "f20b164b00ae5553f7536a6d7a83a0f254455e09"
 pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
 
 
-def test_returncontract_valid_index_0(
+def test_returncode_valid_index_0(
     eof_test: EOFTestFiller,
 ):
     """Deploy container index 0."""
@@ -32,7 +32,7 @@ def test_returncontract_valid_index_0(
         container=Container(
             sections=[
                 Section.Code(
-                    code=Op.RETURNCONTRACT[0](0, 0),
+                    code=Op.RETURNCODE[0](0, 0),
                 ),
                 Section.Container(container=Container(sections=[Section.Code(code=Op.INVALID)])),
             ],
@@ -40,7 +40,7 @@ def test_returncontract_valid_index_0(
     )
 
 
-def test_returncontract_valid_index_1(
+def test_returncode_valid_index_1(
     eof_test: EOFTestFiller,
 ):
     """Deploy container index 1."""
@@ -49,7 +49,7 @@ def test_returncontract_valid_index_1(
         container=Container(
             sections=[
                 Section.Code(
-                    code=Op.RJUMPI[6](0) + Op.RETURNCONTRACT[0](0, 0) + Op.RETURNCONTRACT[1](0, 0),
+                    code=Op.RJUMPI[6](0) + Op.RETURNCODE[0](0, 0) + Op.RETURNCODE[1](0, 0),
                     max_stack_height=2,
                 ),
                 Section.Container(container=Container(sections=[Section.Code(code=Op.INVALID)])),
@@ -59,7 +59,7 @@ def test_returncontract_valid_index_1(
     )
 
 
-def test_returncontract_valid_index_255(
+def test_returncode_valid_index_255(
     eof_test: EOFTestFiller,
 ):
     """Deploy container index 255."""
@@ -68,7 +68,7 @@ def test_returncontract_valid_index_255(
         container=Container(
             sections=[
                 Section.Code(
-                    sum((Op.RJUMPI[6](0) + Op.RETURNCONTRACT[i](0, 0)) for i in range(256))
+                    sum((Op.RJUMPI[6](0) + Op.RETURNCODE[i](0, 0)) for i in range(256))
                     + Op.REVERT(0, 0),
                     max_stack_height=2,
                 )
@@ -79,7 +79,7 @@ def test_returncontract_valid_index_255(
     )
 
 
-def test_returncontract_invalid_truncated_immediate(
+def test_returncode_invalid_truncated_immediate(
     eof_test: EOFTestFiller,
 ):
     """Truncated immediate."""
@@ -88,7 +88,7 @@ def test_returncontract_invalid_truncated_immediate(
         container=Container(
             sections=[
                 Section.Code(
-                    code=Op.PUSH0 + Op.PUSH0 + Op.RETURNCONTRACT,
+                    code=Op.PUSH0 + Op.PUSH0 + Op.RETURNCODE,
                 ),
             ],
         ),
@@ -96,7 +96,7 @@ def test_returncontract_invalid_truncated_immediate(
     )
 
 
-def test_returncontract_invalid_index_0(
+def test_returncode_invalid_index_0(
     eof_test: EOFTestFiller,
 ):
     """Referring to non-existent container section index 0."""
@@ -105,7 +105,7 @@ def test_returncontract_invalid_index_0(
         container=Container(
             sections=[
                 Section.Code(
-                    code=Op.RETURNCONTRACT[0](0, 0),
+                    code=Op.RETURNCODE[0](0, 0),
                 ),
             ],
         ),
@@ -113,7 +113,7 @@ def test_returncontract_invalid_index_0(
     )
 
 
-def test_returncontract_invalid_index_1(
+def test_returncode_invalid_index_1(
     eof_test: EOFTestFiller,
 ):
     """Referring to non-existent container section index 1."""
@@ -122,7 +122,7 @@ def test_returncontract_invalid_index_1(
         container=Container(
             sections=[
                 Section.Code(
-                    code=Op.RETURNCONTRACT[1](0, 0),
+                    code=Op.RETURNCODE[1](0, 0),
                 ),
                 Section.Container(container=Container(sections=[Section.Code(code=Op.INVALID)])),
             ],
@@ -131,7 +131,7 @@ def test_returncontract_invalid_index_1(
     )
 
 
-def test_returncontract_invalid_index_255(
+def test_returncode_invalid_index_255(
     eof_test: EOFTestFiller,
 ):
     """Referring to non-existent container section index 255."""
@@ -140,7 +140,7 @@ def test_returncontract_invalid_index_255(
         container=Container(
             sections=[
                 Section.Code(
-                    code=Op.RETURNCONTRACT[255](0, 0),
+                    code=Op.RETURNCODE[255](0, 0),
                 ),
                 Section.Container(container=Container(sections=[Section.Code(code=Op.INVALID)])),
             ],
@@ -149,16 +149,16 @@ def test_returncontract_invalid_index_255(
     )
 
 
-def test_returncontract_terminating(
+def test_returncode_terminating(
     eof_test: EOFTestFiller,
 ):
-    """Unreachable code after RETURNCONTRACT."""
+    """Unreachable code after RETURNCODE."""
     eof_test(
         container_kind=ContainerKind.INITCODE,
         container=Container(
             sections=[
                 Section.Code(
-                    code=Op.RETURNCONTRACT[0](0, 0) + Op.REVERT(0, 0),
+                    code=Op.RETURNCODE[0](0, 0) + Op.REVERT(0, 0),
                 ),
                 Section.Container(container=Container(sections=[Section.Code(code=Op.INVALID)])),
             ],
@@ -195,7 +195,7 @@ def test_returncontract_terminating(
         pytest.param(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF, False, id="256-bit"),
     ],
 )
-def test_returncontract_memory_expansion(
+def test_returncode_memory_expansion(
     state_test: StateTestFiller,
     pre: Alloc,
     offset_field: str,
@@ -224,7 +224,7 @@ def test_returncontract_memory_expansion(
     mem_size_initcode_container = Container(
         sections=[
             Section.Code(
-                code=Op.RETURNCONTRACT[0](
+                code=Op.RETURNCODE[0](
                     auxdata_offset=test_arg if offset_field else 32,
                     auxdata_size=32 if offset_field else test_arg,
                 )

--- a/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
@@ -23,8 +23,8 @@ eofcreate_code_section = Section.Code(
 eofcreate_revert_code_section = Section.Code(
     code=Op.EOFCREATE[0](0, 0, 0, 0) + Op.REVERT(0, 0),
 )
-returncontract_code_section = Section.Code(
-    code=Op.SSTORE(slot_code_worked, value_code_worked) + Op.RETURNCONTRACT[0](0, 0),
+returncode_code_section = Section.Code(
+    code=Op.SSTORE(slot_code_worked, value_code_worked) + Op.RETURNCODE[0](0, 0),
     max_stack_height=2,
 )
 stop_container = Container.Code(Op.STOP)
@@ -32,10 +32,10 @@ stop_sub_container = Section.Container(stop_container)
 return_sub_container = Section.Container(Container.Code(Op.RETURN(0, 0)))
 revert_sub_container = Section.Container(Container.Code(Op.REVERT(0, 0)))
 abort_sub_container = Section.Container(Container.Code(Op.INVALID))
-returncontract_sub_container = Section.Container(
+returncode_sub_container = Section.Container(
     Container(
         sections=[
-            Section.Code(Op.RETURNCONTRACT[0](0, 0)),
+            Section.Code(Op.RETURNCODE[0](0, 0)),
             stop_sub_container,
         ],
     )
@@ -50,7 +50,7 @@ def test_simple_create_from_deployed(
         container=Container(
             sections=[
                 eofcreate_code_section,
-                returncontract_sub_container,
+                returncode_sub_container,
             ],
         ),
         container_post=Account(storage={slot_code_worked: value_code_worked}),
@@ -64,7 +64,7 @@ def test_simple_create_from_creation(
     eof_state_test(
         container=Container(
             sections=[
-                returncontract_code_section,
+                returncode_code_section,
                 stop_sub_container,
             ],
             kind=ContainerKind.INITCODE,
@@ -75,8 +75,8 @@ def test_simple_create_from_creation(
 
 @pytest.mark.parametrize(
     "zero_section",
-    [eofcreate_code_section, returncontract_code_section],
-    ids=["eofcreate", "returncontract"],
+    [eofcreate_code_section, returncode_code_section],
+    ids=["eofcreate", "returncode"],
 )
 def test_reverting_container(
     eof_state_test: EOFStateTestFiller,
@@ -91,7 +91,7 @@ def test_reverting_container(
             ],
             kind=(
                 ContainerKind.INITCODE
-                if zero_section == returncontract_code_section
+                if zero_section == returncode_code_section
                 else ContainerKind.RUNTIME
             ),
         ),
@@ -102,15 +102,15 @@ def test_reverting_container(
 @pytest.mark.parametrize(
     "code_section,first_sub_container,container_kind",
     [
-        (eofcreate_code_section, returncontract_sub_container, ContainerKind.RUNTIME),
-        (returncontract_code_section, stop_sub_container, ContainerKind.INITCODE),
+        (eofcreate_code_section, returncode_sub_container, ContainerKind.RUNTIME),
+        (returncode_code_section, stop_sub_container, ContainerKind.INITCODE),
     ],
-    ids=["eofcreate", "returncontract"],
+    ids=["eofcreate", "returncode"],
 )
 @pytest.mark.parametrize(
     "extra_sub_container",
-    [stop_sub_container, revert_sub_container, returncontract_sub_container],
-    ids=["stop", "revert", "returncontract"],
+    [stop_sub_container, revert_sub_container, returncode_sub_container],
+    ids=["stop", "revert", "returncode"],
 )
 def test_orphan_container(
     eof_test: EOFTestFiller,
@@ -138,21 +138,21 @@ def test_orphan_container(
     [
         pytest.param(
             eofcreate_code_section,
-            returncontract_sub_container,
+            returncode_sub_container,
             ContainerKind.RUNTIME,
-            id="EOFCREATE_RETURNCONTRACT",
+            id="EOFCREATE_RETURNCODE",
         ),
         pytest.param(
-            returncontract_code_section,
+            returncode_code_section,
             stop_sub_container,
             ContainerKind.INITCODE,
-            id="RETURNCONTRACT_STOP",
+            id="RETURNCODE_STOP",
         ),
         pytest.param(
-            returncontract_code_section,
+            returncode_code_section,
             return_sub_container,
             ContainerKind.INITCODE,
-            id="RETURNCONTRACT_RETURN",
+            id="RETURNCODE_RETURN",
         ),
         pytest.param(
             eofcreate_code_section,
@@ -161,10 +161,10 @@ def test_orphan_container(
             id="EOFCREATE_REVERT",
         ),
         pytest.param(
-            returncontract_code_section,
+            returncode_code_section,
             revert_sub_container,
             ContainerKind.INITCODE,
-            id="RETURNCONTRACT_REVERT",
+            id="RETURNCODE_REVERT",
         ),
     ],
 )
@@ -203,10 +203,10 @@ def test_container_combos_valid(
             id="EOFCREATE_RETURN",
         ),
         pytest.param(
-            returncontract_code_section,
-            returncontract_sub_container,
+            returncode_code_section,
+            returncode_sub_container,
             ContainerKind.INITCODE,
-            id="RETURNCONTRACT_RETURNCONTRACT",
+            id="RETURNCODE_RETURNCODE",
         ),
     ],
 )
@@ -234,18 +234,18 @@ def test_container_combos_invalid(
     [
         pytest.param(
             eofcreate_revert_code_section,
-            returncontract_sub_container,
-            id="EOFCREATE_RETURNCONTRACT",
+            returncode_sub_container,
+            id="EOFCREATE_RETURNCODE",
         ),
         pytest.param(
-            returncontract_code_section,
+            returncode_code_section,
             stop_sub_container,
-            id="RETURNCONTRACT_STOP",
+            id="RETURNCODE_STOP",
         ),
         pytest.param(
-            returncontract_code_section,
+            returncode_code_section,
             return_sub_container,
-            id="RETURNCONTRACT_RETURN",
+            id="RETURNCODE_RETURN",
         ),
         pytest.param(
             eofcreate_revert_code_section,
@@ -253,9 +253,9 @@ def test_container_combos_invalid(
             id="EOFCREATE_REVERT",
         ),
         pytest.param(
-            returncontract_code_section,
+            returncode_code_section,
             revert_sub_container,
-            id="RETURNCONTRACT_REVERT",
+            id="RETURNCODE_REVERT",
         ),
     ],
 )
@@ -303,9 +303,9 @@ def test_container_combos_deeply_nested_valid(
             id="EOFCREATE_RETURN",
         ),
         pytest.param(
-            returncontract_code_section,
-            returncontract_sub_container,
-            id="RETURNCONTRACT_RETURNCONTRACT",
+            returncode_code_section,
+            returncode_sub_container,
+            id="RETURNCODE_RETURNCODE",
         ),
     ],
 )
@@ -344,21 +344,21 @@ def test_container_combos_deeply_nested_invalid(
     [
         pytest.param(
             eofcreate_code_section,
-            returncontract_sub_container,
+            returncode_sub_container,
             ContainerKind.RUNTIME,
-            id="EOFCREATE_RETURNCONTRACT",
+            id="EOFCREATE_RETURNCODE",
         ),
         pytest.param(
-            returncontract_code_section,
+            returncode_code_section,
             stop_sub_container,
             ContainerKind.INITCODE,
-            id="RETURNCONTRACT_STOP",
+            id="RETURNCODE_STOP",
         ),
         pytest.param(
-            returncontract_code_section,
+            returncode_code_section,
             return_sub_container,
             ContainerKind.INITCODE,
-            id="RETURNCONTRACT_RETURN",
+            id="RETURNCODE_RETURN",
         ),
         pytest.param(
             eofcreate_code_section,
@@ -367,10 +367,10 @@ def test_container_combos_deeply_nested_invalid(
             id="EOFCREATE_REVERT",
         ),
         pytest.param(
-            returncontract_code_section,
+            returncode_code_section,
             revert_sub_container,
             ContainerKind.INITCODE,
-            id="RETURNCONTRACT_REVERT",
+            id="RETURNCODE_REVERT",
         ),
     ],
 )
@@ -406,10 +406,10 @@ def test_container_combos_non_first_code_sections_valid(
             id="EOFCREATE_RETURN",
         ),
         pytest.param(
-            returncontract_code_section,
-            returncontract_sub_container,
+            returncode_code_section,
+            returncode_sub_container,
             ContainerKind.INITCODE,
-            id="RETURNCONTRACT_RETURNCONTRACT",
+            id="RETURNCODE_RETURNCODE",
         ),
     ],
 )
@@ -431,7 +431,7 @@ def test_container_combos_non_first_code_sections_invalid(
 
 
 def test_container_both_kinds_same_sub(eof_test: EOFTestFiller):
-    """Test subcontainer conflicts (both EOFCREATE and RETURNCONTRACT Reference)."""
+    """Test subcontainer conflicts (both EOFCREATE and RETURNCODE Reference)."""
     eof_test(
         container=Container(
             sections=[
@@ -439,7 +439,7 @@ def test_container_both_kinds_same_sub(eof_test: EOFTestFiller):
                     code=Op.EOFCREATE[0](0, 0, 0, 0) + Op.JUMPF[1],
                 ),
                 Section.Code(
-                    code=Op.RETURNCONTRACT[0](0, 0),
+                    code=Op.RETURNCODE[0](0, 0),
                 ),
                 revert_sub_container,
             ],
@@ -461,14 +461,14 @@ def test_container_ambiguous_kind(
 ):
     """
     Test ambiguous container kind:
-    a single subcontainer reference by both EOFCREATE and RETURNCONTRACT.
+    a single subcontainer reference by both EOFCREATE and RETURNCODE.
     """
     sections = [
         Section.Code(
             code=(
                 sum(Op.EOFCREATE[i](0, 0, 0, 0) for i in range(container_idx))
                 + Op.EOFCREATE[container_idx](0, 0, 0, 0)
-                + Op.RETURNCONTRACT[container_idx](0, 0)
+                + Op.RETURNCODE[container_idx](0, 0)
             ),
         ),
     ]
@@ -492,9 +492,9 @@ def test_container_both_kinds_different_sub(eof_test: EOFTestFiller):
                     code=Op.EOFCREATE[0](0, 0, 0, 0) + Op.JUMPF[1],
                 ),
                 Section.Code(
-                    code=Op.RETURNCONTRACT[1](0, 0),
+                    code=Op.RETURNCODE[1](0, 0),
                 ),
-                returncontract_sub_container,
+                returncode_sub_container,
                 stop_sub_container,
             ],
             kind=ContainerKind.INITCODE,
@@ -511,13 +511,13 @@ def test_container_multiple_eofcreate_references(eof_test: EOFTestFiller):
                 Section.Code(
                     code=Op.EOFCREATE[0](0, 0, 0, 0) + Op.EOFCREATE[0](0, 0, 0, 0) + Op.STOP,
                 ),
-                returncontract_sub_container,
+                returncode_sub_container,
             ],
         ),
     )
 
 
-def test_container_multiple_returncontract_references(eof_test: EOFTestFiller):
+def test_container_multiple_returncode_references(eof_test: EOFTestFiller):
     """Test multiple references to the same subcontainer from a RETURNCONTACT operation."""
     eof_test(
         container=Container(
@@ -526,8 +526,8 @@ def test_container_multiple_returncontract_references(eof_test: EOFTestFiller):
                     code=Op.PUSH0
                     + Op.CALLDATALOAD
                     + Op.RJUMPI[6]
-                    + Op.RETURNCONTRACT[0](0, 0)
-                    + Op.RETURNCONTRACT[0](0, 0)
+                    + Op.RETURNCODE[0](0, 0)
+                    + Op.RETURNCODE[0](0, 0)
                 ),
                 stop_sub_container,
             ],
@@ -572,7 +572,7 @@ def test_subcontainer_wrong_size(
                 Section.Code(
                     code=(Op.EOFCREATE[0](0, 0, 0, 0) + Op.STOP)
                     if kind == ContainerKind.RUNTIME
-                    else (Op.RETURNCONTRACT[0](0, 0)),
+                    else (Op.RETURNCODE[0](0, 0)),
                 ),
                 Section.Container(
                     container=Container(sections=[Section.Code(code=Op.STOP)]),
@@ -626,7 +626,7 @@ def test_deep_container(
                     container=Container(
                         sections=[
                             Section.Code(
-                                code=Op.PUSH0 + Op.PUSH0 + Op.RETURNCONTRACT[0],
+                                code=Op.PUSH0 + Op.PUSH0 + Op.RETURNCODE[0],
                             ),
                             Section.Container(container=last_container),
                         ]
@@ -646,7 +646,7 @@ def test_deep_container_initcode(
     container = Container(
         sections=[
             Section.Code(
-                code=Op.PUSH0 + Op.PUSH0 + Op.RETURNCONTRACT[0],
+                code=Op.PUSH0 + Op.PUSH0 + Op.RETURNCODE[0],
             ),
             Section.Container(container=deepest_container),
         ],
@@ -658,7 +658,7 @@ def test_deep_container_initcode(
         container = Container(
             sections=[
                 Section.Code(
-                    code=Op.PUSH0 + Op.PUSH0 + Op.RETURNCONTRACT[0],
+                    code=Op.PUSH0 + Op.PUSH0 + Op.RETURNCODE[0],
                 ),
                 Section.Container(
                     container=Container(
@@ -721,7 +721,7 @@ def test_wide_container(eof_test: EOFTestFiller, width: int, exception: EOFExcep
                             container=Container(
                                 sections=[
                                     Section.Code(
-                                        code=Op.PUSH0 + Op.PUSH0 + Op.RETURNCONTRACT[0],
+                                        code=Op.PUSH0 + Op.PUSH0 + Op.RETURNCODE[0],
                                     ),
                                     stop_sub_container,
                                 ]
@@ -900,7 +900,7 @@ def test_dangling_initcode_subcontainer_bytes(
     eof_test(
         container=Container(
             sections=[
-                returncontract_code_section,
+                returncode_code_section,
                 Section.Container(
                     container=Container(
                         raw_bytes=stop_sub_container.data + b"\x99",
@@ -923,7 +923,7 @@ def test_dangling_runtime_subcontainer_bytes(
                 eofcreate_code_section,
                 Section.Container(
                     container=Container(
-                        raw_bytes=returncontract_sub_container.data + b"\x99",
+                        raw_bytes=returncode_sub_container.data + b"\x99",
                     ),
                 ),
             ],

--- a/tests/osaka/eip7692_eof_v1/eip7698_eof_creation_tx/test_eof_creation_tx.py
+++ b/tests/osaka/eip7692_eof_v1/eip7698_eof_creation_tx/test_eof_creation_tx.py
@@ -52,9 +52,7 @@ def test_eof_creation_tx_context(
 
     initcode = Container(
         sections=[
-            Section.Code(
-                Op.SSTORE(slot_call_result, destination_code) + Op.RETURNCONTRACT[0](0, 0)
-            ),
+            Section.Code(Op.SSTORE(slot_call_result, destination_code) + Op.RETURNCODE[0](0, 0)),
             Section.Container(smallest_runtime_subcontainer),
         ]
     )
@@ -159,7 +157,7 @@ def test_invalid_container_deployment(
     )
     init_container: Container = Container(
         sections=[
-            Section.Code(code=Op.RETURNCONTRACT[0](0, 0)),
+            Section.Code(code=Op.RETURNCODE[0](0, 0)),
             Section.Container(deployed_container),
         ],
         kind=ContainerKind.INITCODE,
@@ -178,14 +176,14 @@ def test_invalid_container_deployment(
         )
         init_container = Container(
             sections=[
-                Section.Code(code=Op.RETURNCONTRACT[0](0, 0)),
+                Section.Code(code=Op.RETURNCODE[0](0, 0)),
                 Section.Container(deployed_container),
             ],
         )
     elif reason == "invalid_initcode":
         init_container = Container(
             sections=[
-                Section.Code(code=Op.RETURNCONTRACT[1](0, 0)),
+                Section.Code(code=Op.RETURNCODE[1](0, 0)),
                 Section.Container(deployed_container),
             ],
         )
@@ -209,7 +207,7 @@ def test_invalid_container_deployment(
                 Section.Code(
                     code=Op.RJUMPI[len(invalid_code_path)](Op.PUSH0)
                     + invalid_code_path
-                    + Op.RETURNCONTRACT[0](0, 0)
+                    + Op.RETURNCODE[0](0, 0)
                 ),
                 Section.Container(deployed_container),
             ],
@@ -236,7 +234,7 @@ def test_invalid_container_deployment(
         tx_gas_limit = gas_cost
         init_container = Container(
             sections=[
-                Section.Code(code=Op.RETURNCONTRACT[0](0, 1)),
+                Section.Code(code=Op.RETURNCODE[0](0, 1)),
                 Section.Container(deployed_container),
             ],
         )
@@ -286,7 +284,7 @@ def test_short_data_subcontainer(
         data=Container(
             name="Runtime Subcontainer with truncated data",
             sections=[
-                Section.Code(code=Op.RETURNCONTRACT[0](0, 1)),
+                Section.Code(code=Op.RETURNCODE[0](0, 1)),
                 Section.Container(
                     Container(
                         sections=[

--- a/tests/osaka/eip7692_eof_v1/eof_tracker.md
+++ b/tests/osaka/eip7692_eof_v1/eof_tracker.md
@@ -431,10 +431,10 @@
 - [ ] EOFCREATE is not a valid terminating instruction
 - [x] EOFCREATE immediate referring to non-existing container ([`tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_eofcreate.py`](./eip7620_eof_create/test_eofcreate/index.md)`-k test_eofcreate_invalid_index`)
 - [x] EOFCREATE immediate referring to container with truncated data ([`tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_eofcreate.py`](./eip7620_eof_create/test_eofcreate/index.md)`-k test_eofcreate_truncated_container`)
-- [x] Valid RETURNCONTRACTs referring to various container numbers ([`tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_returncontract.py`](./eip7620_eof_create/test_returncontract/index.md)`-k test_returncontract_valid_index`)
-- [x] Truncated before RETURNCONTRACT immediate ([`tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_returncontract.py::test_returncontract_invalid_truncated_immediate`](./eip7620_eof_create/test_returncontract/test_returncontract_invalid_truncated_immediate.md))
-- [x] RETURNCONTRACT immediate referring to non-existing container ([`tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_returncontract.py`](./eip7620_eof_create/test_returncontract/index.md)`-k test_returncontract_invalid_index`)
-- [x] Unreachable code after RETURNCONTRACT, check that RETURNCONTRACT is terminating ([`tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_returncontract.py::test_returncontract_terminating`](./eip7620_eof_create/test_returncontract/test_returncontract_terminating.md))
+- [x] Valid RETURNCODEs referring to various container numbers ([`tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_returncode.py`](./eip7620_eof_create/test_returncode/index.md)`-k test_returncode_valid_index`)
+- [x] Truncated before RETURNCODE immediate ([`tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_returncode.py::test_returncode_invalid_truncated_immediate`](./eip7620_eof_create/test_returncode/test_returncode_invalid_truncated_immediate.md))
+- [x] RETURNCODE immediate referring to non-existing container ([`tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_returncode.py`](./eip7620_eof_create/test_returncode/index.md)`-k test_returncode_invalid_index`)
+- [x] Unreachable code after RETURNCODE, check that RETURNCODE is terminating ([`tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_returncode.py::test_returncode_terminating`](./eip7620_eof_create/test_returncode/test_returncode_terminating.md))
 
 ### Execution
 
@@ -463,7 +463,7 @@
 - [ ] EOFCREATE with value - not enough caller balance (evmone-tests: state_tests/state_transition/eof_create/eofcreate_caller_balance_too_low.json)
 - [ ] EOFCREATE not enough gas for initcode (EIP-3860) charge (evmone-tests: state_tests/state_transition/eof_create/eofcreate_not_enough_gas_for_initcode_charge.json)
 - [ ] EOFCREATE not enough gas for input memory expansion (evmone-tests: state_tests/state_transition/eof_create/eofcreate_not_enough_gas_for_mem_expansion.json)
-- [ ] RETURNCONTRACT not enough gas for aux data memory expansion (evmone-tests: state_tests/state_transition/eof_create/returncontract_not_enough_gas_for_mem_expansion.json)
+- [ ] RETURNCODE not enough gas for aux data memory expansion (evmone-tests: state_tests/state_transition/eof_create/returncode_not_enough_gas_for_mem_expansion.json)
 - [ ] Successful EOFCREATE clears returndata  (evmone-tests: state_tests/state_transition/eof_create/eofcreate_clears_returndata.json)
 - [ ] Second EOFCREATE with the same container and salt fails (evmone-tests: state_tests/state_transition/eof_create/eofcreate_failure_after_eofcreate_success.json)
 - [ ] Call created contract after EOFCREATE (evmone-tests: state_tests/state_transition/eof_create/eofcreate_call_created_contract.json)

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -374,6 +374,7 @@ reentrant
 repo
 repo's
 repos
+returncode
 returncontract
 returndata
 returndatacopy


### PR DESCRIPTION
## 🗒️ Description

As title, aligns with https://github.com/ipsilon/eof/pull/182

## 🔗 Related Issues

NA

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
