### PR TITLE
bug(fill,types): duplicate `FixtureAuthorizationTuple`'s `v` field as `yParity`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,11 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 ## 🔜 [Unreleased](https://github.com/ethereum/execution-spec-tests/releases/tag/UNRELEASED) - 2025-XX-XX
 
-### 💥 Breaking Change
+### 💥 Breaking Changes
+
+The following changes may be potentially breaking (all clients were tested with these changes with the state test format, but not the blockchain test format):
+
+- 💥 Add a `yParity` field (that duplicates `v`) to transaction authorization tuples in fixture formats to have fields that conform to EIP-7702 spec, resolves [erigontech/erigon#14073](https://github.com/erigontech/erigon/issues/14073) ([#1286](https://github.com/ethereum/execution-spec-tests/pull/1286)).
 
 ### 🛠️ Framework
 

--- a/src/ethereum_test_fixtures/blockchain.py
+++ b/src/ethereum_test_fixtures/blockchain.py
@@ -34,7 +34,6 @@ from ethereum_test_base_types import (
 from ethereum_test_exceptions import EngineAPIError, ExceptionInstanceOrList
 from ethereum_test_forks import Fork, Paris
 from ethereum_test_types.types import (
-    AuthorizationTupleGeneric,
     Transaction,
     TransactionFixtureConverter,
     TransactionGeneric,
@@ -43,7 +42,7 @@ from ethereum_test_types.types import (
 )
 
 from .base import BaseFixture
-from .common import FixtureBlobSchedule
+from .common import FixtureAuthorizationTuple, FixtureBlobSchedule
 
 
 class HeaderForkRequirement(str):
@@ -316,19 +315,6 @@ class FixtureEngineNewPayload(CamelModel):
         )
 
         return new_payload
-
-
-class FixtureAuthorizationTuple(AuthorizationTupleGeneric[ZeroPaddedHexNumber]):
-    """Authorization tuple for fixture transactions."""
-
-    signer: Address | None = None
-
-    @classmethod
-    def from_authorization_tuple(
-        cls, auth_tuple: AuthorizationTupleGeneric
-    ) -> "FixtureAuthorizationTuple":
-        """Return FixtureAuthorizationTuple from an AuthorizationTuple."""
-        return cls(**auth_tuple.model_dump())
 
 
 class FixtureTransaction(TransactionFixtureConverter, TransactionGeneric[ZeroPaddedHexNumber]):

--- a/src/ethereum_test_fixtures/state.py
+++ b/src/ethereum_test_fixtures/state.py
@@ -14,7 +14,6 @@ from ethereum_test_base_types import (
 )
 from ethereum_test_exceptions import TransactionExceptionInstanceOrList
 from ethereum_test_types.types import (
-    AuthorizationTupleGeneric,
     CamelModel,
     EnvironmentGeneric,
     Transaction,
@@ -22,26 +21,13 @@ from ethereum_test_types.types import (
 )
 
 from .base import BaseFixture
-from .common import FixtureBlobSchedule
+from .common import FixtureAuthorizationTuple, FixtureBlobSchedule
 
 
 class FixtureEnvironment(EnvironmentGeneric[ZeroPaddedHexNumber]):
     """Type used to describe the environment of a state test."""
 
     prev_randao: Hash | None = Field(None, alias="currentRandom")  # type: ignore
-
-
-class FixtureAuthorizationTuple(AuthorizationTupleGeneric[ZeroPaddedHexNumber]):
-    """Authorization tuple for fixture transactions."""
-
-    signer: Address | None = None
-
-    @classmethod
-    def from_authorization_tuple(
-        cls, auth_tuple: AuthorizationTupleGeneric
-    ) -> "FixtureAuthorizationTuple":
-        """Return FixtureAuthorizationTuple from an AuthorizationTuple."""
-        return cls(**auth_tuple.model_dump())
 
 
 class FixtureTransaction(TransactionFixtureConverter):

--- a/src/ethereum_test_fixtures/tests/test_blockchain.py
+++ b/src/ethereum_test_fixtures/tests/test_blockchain.py
@@ -215,6 +215,7 @@ fixture_header_ones = FixtureHeader(
                         "r": "0xda29c3bd0304ae475b06d1a11344e0b6d75590f2c23138c9507f4b5bedde3c79",
                         "s": "0x3e1fb143ae0460373d567cf901645757b321e42c423a53b2d46ed13c9ef0a9ab",
                         "signer": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+                        "yParity": "0x00",
                     }
                 ],
                 "v": "0x01",


### PR DESCRIPTION
## 🗒️ Description
Unfortunately, the `yParity` field in authorization lists was named `v` in our state test fixture format, which differs from from EIP-7702:
https://github.com/ethereum/EIPs/blob/aa391ae306408fcd049a1442a5deab47675c0c87/EIPS/eip-7702.md?plain=1#L45

This change will enable erigon to correctly run the 7702 tests (with non-zero `yParity` in authorization lists, this default to `0` as it wasn't found).

Thanks to @holiman for detecting this issue.

## 🔗 Related Issues
- https://github.com/erigontech/erigon/issues/14073
- https://github.com/bluealloy/revm/pull/2150

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
