### PR TITLE
new(tests): EIP-7702: Sender not EOA test

### DIFF
--- a/src/ethereum_clis/clis/execution_specs.py
+++ b/src/ethereum_clis/clis/execution_specs.py
@@ -137,6 +137,10 @@ class ExecutionSpecsExceptionMapper(ExceptionMapper):
                 "Failed transaction: InvalidBlock()",
             ),
             ExceptionMessage(
+                TransactionException.SENDER_NOT_EOA,
+                "Failed transaction: InvalidSenderError('not EOA')",
+            ),
+            ExceptionMessage(
                 TransactionException.TYPE_4_TX_CONTRACT_CREATION,
                 "Failed transaction: ",
             ),

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -3482,3 +3482,76 @@ def test_authorization_reusing_nonce(
             sender: Account(nonce=1),
         },
     )
+
+
+@pytest.mark.parametrize(
+    "set_code_type",
+    list(AddressType),
+    ids=lambda address_type: address_type.name,
+)
+@pytest.mark.execute(pytest.mark.skip(reason="Requires contract-eoa address collision"))
+def test_set_code_from_account_with_non_delegating_code(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    set_code_type: AddressType,
+):
+    """
+    Test that a transaction is correctly rejected if the sender account has a non-delegating code
+    set.
+    """
+    sender = pre.fund_eoa()
+    auth_signer = pre.fund_eoa(0)
+
+    set_code_to_address: Address
+    set_code: Bytecode | Bytes
+    match set_code_type:
+        case AddressType.EMPTY_ACCOUNT:
+            set_code = Bytecode()
+            set_code_to_address = pre.fund_eoa(0)
+        case AddressType.EOA:
+            set_code = Bytecode()
+            set_code_to_address = pre.fund_eoa(1)
+        case AddressType.EOA_WITH_SET_CODE:
+            set_code_account = pre.fund_eoa(0)
+            set_code = Spec.delegation_designation(set_code_account)
+            set_code_to_address = pre.fund_eoa(1, delegation=set_code_account)
+        case AddressType.CONTRACT:
+            set_code = Op.STOP
+            set_code_to_address = pre.deploy_contract(set_code)
+        case _:
+            raise ValueError(f"Unsupported set code type: {set_code_type}")
+    callee_address = pre.deploy_contract(Op.SSTORE(0, 1) + Op.STOP)
+
+    # Set the sender account to have some code, that is specifically not
+    # a delegation.
+    sender_account = pre[sender]
+    assert sender_account is not None
+    sender_account.code = Bytes(Op.STOP)
+    tx = Transaction(
+        gas_limit=100_000,
+        to=callee_address,
+        authorization_list=[
+            AuthorizationTuple(
+                address=set_code_to_address,
+                nonce=0,
+                signer=auth_signer,
+            ),
+        ],
+        sender=sender,
+        error=TransactionException.SENDER_NOT_EOA,
+    )
+
+    state_test(
+        env=Environment(),
+        pre=pre,
+        tx=tx,
+        post={
+            set_code_to_address: (
+                Account.NONEXISTENT
+                if set_code_type == AddressType.EMPTY_ACCOUNT
+                else Account(storage={})
+            ),
+            auth_signer: Account.NONEXISTENT,
+            callee_address: Account(storage={0: 0}),
+        },
+    )


### PR DESCRIPTION
## 🗒️ Description
Adds a test where the sender of a type-4 transaction (not an auth signer) contains code that is not a delegation (would require a contract-eoa address collision to be produced).

cc @gurukamath 

## 🔗 Related Issues
None

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
