### PR TITLE
fix(docs,ci): don't include function pages in site search index

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,7 @@ The following changes may be potentially breaking (all clients were tested with 
 - ✨ Improve the `uv run eest make test` interactive CLI to enable creation of new test modules within existing test sub-folders ([#1241](https://github.com/ethereum/execution-spec-tests/pull/1241)).
 - ✨ Update `mypy` to latest release `>=1.15.0,<1.16` ([#1209](https://github.com/ethereum/execution-spec-tests/pull/1209)).
 - 🐞 Bug fix for filling with EELS for certain Python versions due to an issue with CPython ([#1231](https://github.com/ethereum/execution-spec-tests/pull/1231)).
+- 🐞 Fix HTML site deployment due to the site's index file exceeding Github's max file size limit ([#1292](https://github.com/ethereum/execution-spec-tests/pull/1292)).
 
 ### 🧪 Test Cases
 

--- a/docs/templates/function.md.j2
+++ b/docs/templates/function.md.j2
@@ -1,5 +1,14 @@
 {% extends "base.md.j2" %}
 {% block title %}
+---
+search:
+  exclude: true
+---
+{#
+    don't include function pages in the mkdocs-material site search index
+    see https://github.com/ethereum/execution-spec-tests/issues/1291
+#}
+
 # `{{ title }}()`
 {% endblock %}
 {% block additional_content %}

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -211,6 +211,7 @@ GHSA
 git's
 github
 Github
+Github's
 glightbox
 globals
 go-ethereum's


### PR DESCRIPTION
## 🗒️ Description
Fixes #1291 by removing the automatically generated test function pages from the mkdocs-material search index.

This change reduces the size of `site/search/search_index.json` from ~123 Mb to ~2 Mb.

## 🔗 Related Issues
Fixes:
- #1291

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
