### PR TITLE
chore(fill,spec): write `fixture-format` not `fixture_format` to fixtures

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 The following changes may be potentially breaking (all clients were tested with these changes with the state test format, but not the blockchain test format):
 
 - 💥 Add a `yParity` field (that duplicates `v`) to transaction authorization tuples in fixture formats to have fields that conform to EIP-7702 spec, resolves [erigontech/erigon#14073](https://github.com/erigontech/erigon/issues/14073) ([#1286](https://github.com/ethereum/execution-spec-tests/pull/1286)).
+- 💥 Rename the recently introduced `_info` field `fixture_format` to `fixture-format` for consistency [#1295](https://github.com/ethereum/execution-spec-tests/pull/1295).
 
 ### 🛠️ Framework
 

--- a/src/cli/eofwrap.py
+++ b/src/cli/eofwrap.py
@@ -313,7 +313,7 @@ class EofWrapper:
             fork=Osaka,
             fixture_format=BlockchainFixture,
         )
-        result.info["fixture_format"] = "blockchain_test"
+        result.info["fixture-format"] = "blockchain_test"
         if traces:
             print_traces(t8n.get_traces())
         return result

--- a/src/ethereum_test_fixtures/base.py
+++ b/src/ethereum_test_fixtures/base.py
@@ -31,7 +31,9 @@ def fixture_format_discriminator(v: Any) -> str | None:
     assert info_dict is not None, (
         f"Fixture does not have an info field, cannot determine fixture format: {v}"
     )
-    fixture_format = info_dict.get("fixture_format")
+    fixture_format = info_dict.get("fixture-format")
+    if not fixture_format:
+        fixture_format = info_dict.get("fixture_format")
     assert fixture_format is not None, f"Fixture format not found in info field: {info_dict}"
     return fixture_format
 
@@ -124,7 +126,7 @@ class BaseFixture(CamelModel):
         self.info["filling-transition-tool"] = t8n_version
         self.info["description"] = test_case_description
         self.info["url"] = fixture_source_url
-        self.info["fixture_format"] = self.format_name
+        self.info["fixture-format"] = self.format_name
         if ref_spec is not None:
             ref_spec.write_info(self.info)
         if _info_metadata:


### PR DESCRIPTION
## 🗒️ Description

Renames the `info["fixture_format"]` field to `info["fixture-format"]`.

Both `fixture-format` and `fixture_format` can be used when loading fixtures from now on -> old fixtures can be used with this new change. But this will break loading (new) fixtures using this format from older versions of EEST.

@winsvega noticed that this was inconsistent with the existing field names in `_info`, so we decided to fix this now, as it's only been recently introduced.

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
.
