### PR TITLE
fix(consume): fixes for index generation with ethereum/tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,20 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 **Key:** ✨ = New, 🐞 = Fixed, 🔀 = Changed.
 
+## 🔜 [Unreleased]
+
+### 💥 Breaking Change
+
+### 🛠️ Framework
+
+#### `consume`
+
+- 🐞 Improve index generation of ethereum/tests fixtures: Allow generation at any directory level and include `generatedTestHash` in the index file for the `fixture_hash` [#1303](https://github.com/ethereum/execution-spec-tests/pull/1303).
+
+### 📋 Misc
+
+### 🧪 Test Cases
+
 ## [v4.1.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v4.1.0) - 2025-03-11
 
 ### 💥 Breaking Changes

--- a/src/cli/gen_index.py
+++ b/src/cli/gen_index.py
@@ -23,18 +23,6 @@ from ethereum_test_fixtures.file import Fixtures
 
 from .hasher import HashableItem
 
-# TODO: remove when these tests are ported from ethereum/tests to execution-spec-tests.
-fixtures_to_skip = {
-    # ethereum/tests fixtures with fields (bigint) that aren't supported by EEST's pydantic models.
-    # Specifying only the file name without path allows index file generation at any level of the
-    # fixtures directory tree; the file names are unique.
-    "ValueOverflowParis.json",
-    "withdrawalsAmountBounds.json",
-    "withdrawalsIndexBounds.json",
-    "withdrawalsValidatorIndexBounds.json",
-    "withdrawalsAddressBounds.json",
-}
-
 
 def count_json_files_exclude_index(start_path: Path) -> int:
     """
@@ -156,9 +144,6 @@ def generate_fixtures_index(
         test_cases: List[TestCaseIndexFile] = []
         for file in input_path.rglob("*.json"):
             if file.name == "index.json" or ".meta" in file.parts:
-                continue
-            if any(fixture in str(file) for fixture in fixtures_to_skip):
-                rich.print(f"Skipping '{file}'")
                 continue
 
             try:

--- a/src/cli/gen_index.py
+++ b/src/cli/gen_index.py
@@ -173,7 +173,9 @@ def generate_fixtures_index(
                     TestCaseIndexFile(
                         id=fixture_name,
                         json_path=relative_file_path,
-                        fixture_hash=fixture.info.get("hash", None),
+                        # eest uses hash; ethereum/tests uses generatedTestHash
+                        fixture_hash=fixture.info.get("hash")
+                        or f"0x{fixture.info.get('generatedTestHash')}",
                         fork=fixture.get_fork(),
                         format=fixture.__class__,
                     )

--- a/src/cli/gen_index.py
+++ b/src/cli/gen_index.py
@@ -23,14 +23,16 @@ from ethereum_test_fixtures.file import Fixtures
 
 from .hasher import HashableItem
 
-# TODO: remove when these tests are ported or fixed within ethereum/tests.
+# TODO: remove when these tests are ported from ethereum/tests to execution-spec-tests.
 fixtures_to_skip = {
-    # These fixtures have invalid fields that we can't load into our pydantic models (bigint).
-    "BlockchainTests/GeneralStateTests/stTransactionTest/ValueOverflowParis.json",
-    "BlockchainTests/InvalidBlocks/bc4895-withdrawals/withdrawalsAmountBounds.json",
-    "BlockchainTests/InvalidBlocks/bc4895-withdrawals/withdrawalsIndexBounds.json",
-    "BlockchainTests/InvalidBlocks/bc4895-withdrawals/withdrawalsValidatorIndexBounds.json",
-    "BlockchainTests/InvalidBlocks/bc4895-withdrawals/withdrawalsAddressBounds.json",
+    # ethereum/tests fixtures with fields (bigint) that aren't supported by EEST's pydantic models.
+    # Specifying only the file name without path allows index file generation at any level of the
+    # fixtures directory tree; the file names are unique.
+    "ValueOverflowParis.json",
+    "withdrawalsAmountBounds.json",
+    "withdrawalsIndexBounds.json",
+    "withdrawalsValidatorIndexBounds.json",
+    "withdrawalsAddressBounds.json",
 }
 
 


### PR DESCRIPTION
## 🗒️ Description
Two small fixes for index generation with ethereum/tests:
1. Allow index generation at any level of the directory structure by removing the relative path prefixes to fixtures that aren't supported. Only check their names (they have unique names). This allows `uv run genindex -i ethereum/tests/BlockchainTests/some/path`. Note, we can't load ethereum/tests state tests yet, only blockchain tests.
2. Include the ethereum/tests `info_[`generatedTestHash` as `fixture_hash`. This is not ideal, due to the info field name mismatch and as EEST fixture hashes are "0x" prefixed and ethereum/tests hashes aren't. But, it will at least allow verification that individual fixture files are up-to-date (this will not affect index.json regeneration, as this depends entirely on `hasher`).


## 🔗 Related Issues
- https://github.com/ethereum/execution-spec-tests/issues/1302

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).

