### PR TITLE
feat(consume): add support for ethereum/{tests,legacytests} tarball urls

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,9 +2,23 @@
 
 Test fixtures for use by clients are available for each release on the [Github releases page](https://github.com/ethereum/execution-spec-tests/releases).
 
-**Key:** ✨ = New, 🐞 = Fixed, 🔀 = Changed.
+**Key:** ✨ = New, 🐞 = Fixed, 🔀 = Changed. 💥 = Breaking
 
 ## 🔜 [Unreleased]
+
+**Note**: Although not a breaking change, `consume` users should delete the cache directory (typically located at `~/.cache/ethereum-execution-spec-tests`) used to store downloaded fixture release tarballs. This release adds support for [ethereum/tests](https://github.com/ethereum/tests) and [ethereum/legacytests](https://github.com/ethereum/legacytests) fixture release downloads and the structure of the cache directory has been updated to accommodate this change.
+
+To try this feature:
+
+```shell
+consume direct --input=https://github.com/ethereum/tests/releases/download/v17.0/fixtures_blockchain_tests.tgz
+```
+
+To determine the cache directory location, see the `--cache-folder` entry from the command:
+
+```shell
+consume cache --help
+```
 
 ### 💥 Breaking Change
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 #### `consume`
 
+- ✨ Add support for [ethereum/tests](https://github.com/ethereum/tests) and [ethereum/legacytests](https://github.com/ethereum/legacytests) release tarball download via URL to the `--input` flag of `consume` commands ([#1306](https://github.com/ethereum/execution-spec-tests/pull/1306)).
 - ✨ Add support for Nethermind's `nethtest` command to `consume direct` ([#1250](https://github.com/ethereum/execution-spec-tests/pull/1250)).
 - ✨ Allow filtering of test cases by fork via pytest marks (e.g., `-m "Cancun or Prague"`) ([#1304](https://github.com/ethereum/execution-spec-tests/pull/1304), [#1318](https://github.com/ethereum/execution-spec-tests/pull/1318)).
 - ✨ Allow filtering of test cases by fixture format via pytest marks (e.g., `-m blockchain_test`) ([#1314](https://github.com/ethereum/execution-spec-tests/pull/1314)).

--- a/src/pytest_plugins/consume/releases.py
+++ b/src/pytest_plugins/consume/releases.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import re
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -11,12 +12,11 @@ import platformdirs
 import requests
 from pydantic import BaseModel, Field, RootModel
 
-RELEASE_INFORMATION_URL = "https://api.github.com/repos/ethereum/execution-spec-tests/releases"
-
-
 CACHED_RELEASE_INFORMATION_FILE = (
     Path(platformdirs.user_cache_dir("ethereum-execution-spec-tests")) / "release_information.json"
 )
+
+SUPPORTED_REPOS = ["ethereum/execution-spec-tests", "ethereum/tests", "ethereum/legacytests"]
 
 
 class NoSuchReleaseError(Exception):
@@ -154,19 +154,20 @@ def download_release_information(destination_file: Path | None) -> List[ReleaseI
     crucial for finding older version or latest releases.
     """
     all_releases = []
-    current_url: str | None = RELEASE_INFORMATION_URL
-    max_pages = 2
-    while current_url and max_pages > 0:
-        max_pages -= 1
-        response = requests.get(current_url)
-        response.raise_for_status()
-        all_releases.extend(response.json())
-        current_url = None
-        if "link" in response.headers:
-            for link in requests.utils.parse_header_links(response.headers["link"]):
-                if link["rel"] == "next":
-                    current_url = link["url"]
-                    break
+    for repo in SUPPORTED_REPOS:
+        current_url: str | None = f"https://api.github.com/repos/{repo}/releases"
+        max_pages = 2
+        while current_url and max_pages > 0:
+            max_pages -= 1
+            response = requests.get(current_url)
+            response.raise_for_status()
+            all_releases.extend(response.json())
+            current_url = None
+            if "link" in response.headers:
+                for link in requests.utils.parse_header_links(response.headers["link"]):
+                    if link["rel"] == "next":
+                        current_url = link["url"]
+                        break
 
     if destination_file:
         destination_file.parent.mkdir(parents=True, exist_ok=True)
@@ -200,7 +201,7 @@ def get_release_page_url(release_string: str) -> str:
     Return the GitHub Release page URL for a specific release descriptor.
 
     This function can handle:
-    - A standard release string (e.g., "eip7692@latest").
+    - A standard release string (e.g., "eip7692@latest") - from execution-spec-tests only.
     - A direct asset download link (e.g.,
         "https://github.com/ethereum/execution-spec-tests/releases/download/v4.0.0/fixtures_eip7692.tar.gz").
     """
@@ -208,9 +209,9 @@ def get_release_page_url(release_string: str) -> str:
 
     # Case 1: If it's a direct GitHub Releases download link,
     #         find which release in `release_information` has an asset with this exact URL.
-    if release_string.startswith(
-        "https://github.com/ethereum/execution-spec-tests/releases/download/"
-    ):
+    repo_pattern = "|".join(re.escape(repo) for repo in SUPPORTED_REPOS)
+    regex_pattern = rf"https://github\.com/({repo_pattern})/releases/download/"
+    if re.match(regex_pattern, release_string):
         for release in release_information:
             for asset in release.assets.root:
                 if asset.url == release_string:

--- a/src/pytest_plugins/consume/releases.py
+++ b/src/pytest_plugins/consume/releases.py
@@ -115,7 +115,7 @@ class ReleaseInformation(BaseModel):
     def __contains__(self, release_descriptor: ReleaseTag) -> bool:
         """Check if the release information contains the release descriptor."""
         if release_descriptor.version is not None:
-            return release_descriptor.version == self.tag_name
+            return release_descriptor == self.tag_name
         for asset in self.assets.root:
             if asset.name == release_descriptor.asset_name:
                 return True

--- a/src/pytest_plugins/consume/releases.py
+++ b/src/pytest_plugins/consume/releases.py
@@ -115,7 +115,7 @@ class ReleaseInformation(BaseModel):
     def __contains__(self, release_descriptor: ReleaseTag) -> bool:
         """Check if the release information contains the release descriptor."""
         if release_descriptor.version is not None:
-            return release_descriptor == self.tag_name
+            return release_descriptor.version == self.tag_name
         for asset in self.assets.root:
             if asset.name == release_descriptor.asset_name:
                 return True

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -856,3 +856,4 @@ ize
 nectos
 fibonacci
 CPython
+legacytests


### PR DESCRIPTION
## 🗒️ Description

Adds tarball release URL download support for ethereum/tests and ethereum/legacytests to `consume`, for example:
```
consume cache --input=https://github.com/ethereum/tests/releases/download/v17.0/fixtures_blockchain_tests.tgz
```

An additional fix that was required to enable this feature with the above tarball: Don't assume that the directory contained within the tarball is hard-coded as "fixtures", now the top-level directory name is automatically detected, this was the offending code:
https://github.com/ethereum/execution-spec-tests/blob/ab62c8d674ad0de3b83718d837f231617153ce52/src/pytest_plugins/consume/consume.py#L122
and
https://github.com/ethereum/execution-spec-tests/blob/ab62c8d674ad0de3b83718d837f231617153ce52/src/pytest_plugins/consume/consume.py#L130


## 🔗 Related Issues
- Fixes #1302 

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).

