### PR TITLE
chore(deps): Bump EELS dependency

### DIFF
--- a/.github/workflows/tox_verify.yaml
+++ b/.github/workflows/tox_verify.yaml
@@ -102,7 +102,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ethereum/execution-specs
-          ref: 78fb726158c69d8fa164e28f195fabf6ab59b915
+          ref: fa847a0e48309debee8edc510ceddb2fd5db2f2e
           path: execution-specs
           sparse-checkout: |
             src/ethereum
@@ -139,7 +139,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ethereum/execution-specs
-          ref: 78fb726158c69d8fa164e28f195fabf6ab59b915
+          ref: fa847a0e48309debee8edc510ceddb2fd5db2f2e
           path: execution-specs
           sparse-checkout: |
             src/ethereum

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,10 +13,12 @@ Test fixtures for use by clients are available for each release on the [Github r
 #### `consume`
 
 - ✨ Add support for Nethermind's `nethtest` command to `consume direct` ([#1250](https://github.com/ethereum/execution-spec-tests/pull/1250)).
-- ✨ Allow filtering of test cases by fork via pytest marks (via, e.g., `-m "Cancun or Prague"`) [#1304](https://github.com/ethereum/execution-spec-tests/pull/1304).
-- 🐞 Improve index generation of ethereum/tests fixtures: Allow generation at any directory level and include `generatedTestHash` in the index file for the `fixture_hash` [#1303](https://github.com/ethereum/execution-spec-tests/pull/1303).
+- ✨ Allow filtering of test cases by fork via pytest marks (via, e.g., `-m "Cancun or Prague"`) ([#1304](https://github.com/ethereum/execution-spec-tests/pull/1304)).
+- 🐞 Improve index generation of ethereum/tests fixtures: Allow generation at any directory level and include `generatedTestHash` in the index file for the `fixture_hash` ([#1303](https://github.com/ethereum/execution-spec-tests/pull/1303)).
 
 ### 📋 Misc
+
+- Bump the version of `execution-specs` used by the framework to the package [`ethereum-execution==1.17.0rc6.dev1`](https://pypi.org/project/ethereum-execution/1.17.0rc6.dev1/); bump the version used for test fixture generation for forks < Prague to current `execution-specs` master, [fa847a0](https://github.com/ethereum/execution-specs/commit/fa847a0e48309debee8edc510ceddb2fd5db2f2e) ([#1310](https://github.com/ethereum/execution-spec-tests/pull/1310)).
 
 ### 🧪 Test Cases
 

--- a/eels_resolutions.json
+++ b/eels_resolutions.json
@@ -2,7 +2,7 @@
     "EELSMaster": {
         "git_url": "https://github.com/ethereum/execution-specs.git",
         "branch": "master",
-        "commit": "78fb726158c69d8fa164e28f195fabf6ab59b915"
+        "commit": "fa847a0e48309debee8edc510ceddb2fd5db2f2e"
     },
     "Frontier": {
         "same_as": "EELSMaster"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 dependencies = [
     "click>=8.1.0,<9",
-    "ethereum @ git+https://github.com/ethereum/execution-specs@78fb726158c69d8fa164e28f195fabf6ab59b915",
+    "ethereum @ git+https://github.com/ethereum/execution-specs@fa847a0e48309debee8edc510ceddb2fd5db2f2e",
     "hive.py @ git+https://github.com/marioevz/hive.py",
     "ethereum-spec-evm-resolver @ git+https://github.com/petertdavies/ethereum-spec-evm-resolver",
     "setuptools",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,9 @@ classifiers = [
 ]
 dependencies = [
     "click>=8.1.0,<9",
-    "ethereum @ git+https://github.com/ethereum/execution-specs@fa847a0e48309debee8edc510ceddb2fd5db2f2e",
+    "ethereum-execution==1.17.0rc6.dev1",
     "hive.py @ git+https://github.com/marioevz/hive.py",
-    "ethereum-spec-evm-resolver @ git+https://github.com/petertdavies/ethereum-spec-evm-resolver",
+    "ethereum-spec-evm-resolver",
     "setuptools",
     "types-setuptools",
     "gitpython>=3.1.31,<4",
@@ -125,4 +125,4 @@ mypy_path = ["src", "$MYPY_CONFIG_FILE_DIR/stubs"]
 plugins = ["pydantic.mypy"]
 
 [tool.uv.sources]
-ethereum = { git = "https://github.com/ethereum/execution-specs", rev = "fa847a0e48309debee8edc510ceddb2fd5db2f2e" }
+ethereum-spec-evm-resolver = { git = "https://github.com/petertdavies/ethereum-spec-evm-resolver", rev = "623ac4565025e72b65f45b926da2a3552041b469" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,4 +125,4 @@ mypy_path = ["src", "$MYPY_CONFIG_FILE_DIR/stubs"]
 plugins = ["pydantic.mypy"]
 
 [tool.uv.sources]
-ethereum = { git = "https://github.com/ethereum/execution-specs", rev = "78fb726158c69d8fa164e28f195fabf6ab59b915" }
+ethereum = { git = "https://github.com/ethereum/execution-specs", rev = "fa847a0e48309debee8edc510ceddb2fd5db2f2e" }

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version < '3.13'",
@@ -60,15 +61,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ac/f1/ac657fd234f4ee61da9d90f2bae7d6078074de2f97cb911743faa8d10a91/bracex-2.5.tar.gz", hash = "sha256:0725da5045e8d37ea9592ab3614d8b561e22c3c5fde3964699be672e072ab611", size = 26622 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/05/4f/54d324c35221c027ca77e9aae418f525003bd0cc2613eea162a1246b5a92/bracex-2.5-py3-none-any.whl", hash = "sha256:d2fcf4b606a82ac325471affe1706dd9bbaa3536c91ef86a31f6b766f3dad1d0", size = 11509 },
-]
-
-[[package]]
-name = "cached-property"
-version = "1.5.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/61/2c/d21c1c23c2895c091fa7a91a54b6872098fea913526932d21902088a7c41/cached-property-1.5.2.tar.gz", hash = "sha256:9fa5755838eecbb2d234c3aa390bd80fbd3ac6b6869109bfc1b499f7bd89a130", size = 12244 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/19/f2090f7dad41e225c7f2326e4cfe6fff49e57dedb5b53636c9551f86b069/cached_property-1.5.2-py2.py3-none-any.whl", hash = "sha256:df4f613cf7ad9a588cc381aaf4a512d26265ecebd5eb9e1ba12f1319eb85a6a0", size = 7573 },
 ]
 
 [[package]]
@@ -475,9 +467,9 @@ wheels = [
 ]
 
 [[package]]
-name = "ethereum"
-version = "0.1.0"
-source = { git = "https://github.com/ethereum/execution-specs?rev=78fb726158c69d8fa164e28f195fabf6ab59b915#78fb726158c69d8fa164e28f195fabf6ab59b915" }
+name = "ethereum-execution"
+version = "1.17.0rc6.dev1"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "coincurve" },
     { name = "ethereum-rlp" },
@@ -485,6 +477,10 @@ dependencies = [
     { name = "py-ecc" },
     { name = "pycryptodome" },
     { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/a1/f20e2b489a4d84afe97dfe10180fdd06d191ff448d1cbfd8c144c0f6c453/ethereum_execution-1.17.0rc6.dev1.tar.gz", hash = "sha256:70e9585ccaaa3e1fd6f8648f392ef25c0fb619aaadb58fb6a54f13f3b3f7bccc", size = 1120570 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/6f/722677ffcfc0eebe925d20eeb8715f8c9d0dc3de4b9f04ab98601b5ab185/ethereum_execution-1.17.0rc6.dev1-py3-none-any.whl", hash = "sha256:1dd379e88be14fac040219ed59a7660f491d1ac336b56ae5cdc2a3b230b7f93e", size = 1452337 },
 ]
 
 [[package]]
@@ -496,7 +492,7 @@ dependencies = [
     { name = "click" },
     { name = "coincurve" },
     { name = "colorlog" },
-    { name = "ethereum" },
+    { name = "ethereum-execution" },
     { name = "ethereum-rlp" },
     { name = "ethereum-spec-evm-resolver" },
     { name = "ethereum-types" },
@@ -561,9 +557,9 @@ requires-dist = [
     { name = "click", specifier = ">=8.1.0,<9" },
     { name = "coincurve", specifier = ">=20.0.0,<21" },
     { name = "colorlog", specifier = ">=6.7.0,<7" },
-    { name = "ethereum", git = "https://github.com/ethereum/execution-specs?rev=78fb726158c69d8fa164e28f195fabf6ab59b915" },
+    { name = "ethereum-execution", specifier = "==1.17.0rc6.dev1" },
     { name = "ethereum-rlp", specifier = ">=0.1.3,<0.2" },
-    { name = "ethereum-spec-evm-resolver", git = "https://github.com/petertdavies/ethereum-spec-evm-resolver" },
+    { name = "ethereum-spec-evm-resolver", git = "https://github.com/petertdavies/ethereum-spec-evm-resolver?rev=623ac4565025e72b65f45b926da2a3552041b469" },
     { name = "ethereum-types", specifier = ">=0.2.1,<0.3" },
     { name = "filelock", specifier = ">=3.15.1,<4" },
     { name = "gitpython", specifier = ">=3.1.31,<4" },
@@ -609,6 +605,7 @@ requires-dist = [
     { name = "types-setuptools" },
     { name = "typing-extensions", specifier = ">=4.12.2,<5" },
 ]
+provides-extras = ["test", "lint", "docs"]
 
 [[package]]
 name = "ethereum-rlp"
@@ -626,7 +623,7 @@ wheels = [
 [[package]]
 name = "ethereum-spec-evm-resolver"
 version = "0.0.5"
-source = { git = "https://github.com/petertdavies/ethereum-spec-evm-resolver#c35d96f80cb7bcf82890dd8dacbbb73c7d7a4671" }
+source = { git = "https://github.com/petertdavies/ethereum-spec-evm-resolver?rev=623ac4565025e72b65f45b926da2a3552041b469#623ac4565025e72b65f45b926da2a3552041b469" }
 dependencies = [
     { name = "coincurve" },
     { name = "filelock" },
@@ -1299,12 +1296,15 @@ wheels = [
 
 [[package]]
 name = "py-ecc"
-version = "7.0.1"
-source = { git = "https://github.com/petertdavies/py_ecc.git?rev=127184f4c57b1812da959586d0fe8f43bb1a2389#127184f4c57b1812da959586d0fe8f43bb1a2389" }
+version = "8.0.0b2"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cached-property" },
     { name = "eth-typing" },
     { name = "eth-utils" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/0c/0a464c42af3645fbd04cef544f750f30c76181c273f14a9169e9ea15810b/py_ecc-8.0.0b2.tar.gz", hash = "sha256:1fc0c134b7f47cd49f46e4a175b58ea75efdf999a3598fba9312bfa127f4e1c7", size = 51076 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/f5/4300faff27929595642869351ea9c1467fcb52372498a11d80a5b0d3b685/py_ecc-8.0.0b2-py3-none-any.whl", hash = "sha256:d20ff031519b39d6413ded43c803a9af5e0d0857132d63de240da62ab496dfa1", size = 47808 },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🗒️ Description

The `py_ecc` dependency has been changed from a git dependency to a standard PyPI dependency. Since EEST indirectly depends on `py_ecc` through EELS it needs its EELS dependency bumped.

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] Add CHANGELOG entry.