### PR TITLE
chore(fill): fix `--fork/from/until` for transition forks

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,10 +15,11 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Add support for Nethermind's `nethtest` command to `consume direct` ([#1250](https://github.com/ethereum/execution-spec-tests/pull/1250)).
 - ✨ Allow filtering of test cases by fork via pytest marks (via, e.g., `-m "Cancun or Prague"`) ([#1304](https://github.com/ethereum/execution-spec-tests/pull/1304)).
 - 🐞 Improve index generation of ethereum/tests fixtures: Allow generation at any directory level and include `generatedTestHash` in the index file for the `fixture_hash` ([#1303](https://github.com/ethereum/execution-spec-tests/pull/1303)).
+- 🐞 Fix `--fork/from/until` for transition forks when using `fill` [#1311](https://github.com/ethereum/execution-spec-tests/pull/1311).
 
 ### 📋 Misc
 
-- Bump the version of `execution-specs` used by the framework to the package [`ethereum-execution==1.17.0rc6.dev1`](https://pypi.org/project/ethereum-execution/1.17.0rc6.dev1/); bump the version used for test fixture generation for forks < Prague to current `execution-specs` master, [fa847a0](https://github.com/ethereum/execution-specs/commit/fa847a0e48309debee8edc510ceddb2fd5db2f2e) ([#1310](https://github.com/ethereum/execution-spec-tests/pull/1310)).
+- 🔀 Bump the version of `execution-specs` used by the framework to the package [`ethereum-execution==1.17.0rc6.dev1`](https://pypi.org/project/ethereum-execution/1.17.0rc6.dev1/); bump the version used for test fixture generation for forks < Prague to current `execution-specs` master, [fa847a0](https://github.com/ethereum/execution-specs/commit/fa847a0e48309debee8edc510ceddb2fd5db2f2e) ([#1310](https://github.com/ethereum/execution-spec-tests/pull/1310)).
 
 ### 🧪 Test Cases
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,9 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Add support for Nethermind's `nethtest` command to `consume direct` ([#1250](https://github.com/ethereum/execution-spec-tests/pull/1250)).
 - ✨ Allow filtering of test cases by fork via pytest marks (via, e.g., `-m "Cancun or Prague"`) ([#1304](https://github.com/ethereum/execution-spec-tests/pull/1304)).
 - 🐞 Improve index generation of ethereum/tests fixtures: Allow generation at any directory level and include `generatedTestHash` in the index file for the `fixture_hash` ([#1303](https://github.com/ethereum/execution-spec-tests/pull/1303)).
+
+#### `fill`
+
 - 🐞 Fix `--fork/from/until` for transition forks when using `fill` [#1311](https://github.com/ethereum/execution-spec-tests/pull/1311).
 
 ### 📋 Misc

--- a/src/pytest_plugins/forks/tests/test_markers.py
+++ b/src/pytest_plugins/forks/tests/test_markers.py
@@ -112,6 +112,14 @@ def test_case(state_test):
             {"passed": 2, "failed": 0, "skipped": 0, "errors": 0},
             id="valid_at_transition_to,subsequent_forks=True,until",
         ),
+        pytest.param(
+            generate_test(
+                valid_at_transition_to='"Cancun"',
+            ),
+            ["--fork=ShanghaiToCancunAtTime15k"],
+            {"passed": 1, "failed": 0, "skipped": 0, "errors": 0},
+            id="valid_at_transition_to,--fork=transition_fork_only",
+        ),
     ],
 )
 def test_fork_markers(pytester, test_function: str, outcomes: dict, pytest_args: List[str]):


### PR DESCRIPTION
## 🗒️ Description
Transition forks do not work within `--fork/from/until` when using `fill`. This PR fixes the latter.

```sh
>> uv run fill --fork ShanghaiToCancunAtTime15k 
Error: Unsupported fork provided to --fork: ShanghaiToCancunAtTime15k 

Available forks:
Byzantium, Prague, Homestead, Istanbul, Cancun, Frontier, London, Osaka, Paris, CancunEIP7692, Shanghai, ConstantinopleFix, Berlin, Constantinople
Available transition forks:
BerlinToLondonAt5, CancunToPragueAtTime15k, ShanghaiToCancunAtTime15k, ParisToShanghaiAtTime15k

Exit: Invalid command-line options.
```

## 🔗 Related Issues
More context: https://github.com/ethereum/execution-spec-tests/issues/1307

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.