### PR TITLE
feat(consume): enable test case filtering by fixture format

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,7 +14,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 - ✨ Add support for Nethermind's `nethtest` command to `consume direct` ([#1250](https://github.com/ethereum/execution-spec-tests/pull/1250)).
 - ✨ Allow filtering of test cases by fork via pytest marks (e.g., `-m "Cancun or Prague"`) ([#1304](https://github.com/ethereum/execution-spec-tests/pull/1304)).
-- ✨ Allow filtering of test cases by fixture format via pytest marks (e.g., `-m blockchain_test`) ([](https://github.com/ethereum/execution-spec-tests/pull/)).
+- ✨ Allow filtering of test cases by fixture format via pytest marks (e.g., `-m blockchain_test`) ([#1314](https://github.com/ethereum/execution-spec-tests/pull/1314)).
 - 🐞 Improve index generation of ethereum/tests fixtures: Allow generation at any directory level and include `generatedTestHash` in the index file for the `fixture_hash` ([#1303](https://github.com/ethereum/execution-spec-tests/pull/1303)).
 
 ### 📋 Misc

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,8 @@ Test fixtures for use by clients are available for each release on the [Github r
 #### `consume`
 
 - ✨ Add support for Nethermind's `nethtest` command to `consume direct` ([#1250](https://github.com/ethereum/execution-spec-tests/pull/1250)).
-- ✨ Allow filtering of test cases by fork via pytest marks (via, e.g., `-m "Cancun or Prague"`) ([#1304](https://github.com/ethereum/execution-spec-tests/pull/1304)).
+- ✨ Allow filtering of test cases by fork via pytest marks (e.g., `-m "Cancun or Prague"`) ([#1304](https://github.com/ethereum/execution-spec-tests/pull/1304)).
+- ✨ Allow filtering of test cases by fixture format via pytest marks (e.g., `-m blockchain_test`) ([](https://github.com/ethereum/execution-spec-tests/pull/)).
 - 🐞 Improve index generation of ethereum/tests fixtures: Allow generation at any directory level and include `generatedTestHash` in the index file for the `fixture_hash` ([#1303](https://github.com/ethereum/execution-spec-tests/pull/1303)).
 
 ### 📋 Misc

--- a/src/pytest_plugins/consume/direct/conftest.py
+++ b/src/pytest_plugins/consume/direct/conftest.py
@@ -81,7 +81,9 @@ def pytest_configure(config):  # noqa: D103
                 trace=config.getoption("consumer_collect_traces"),
             )
         )
-    if not fixture_consumers and (config.option.collectonly or config.option.markers):
+    if config.option.markers:
+        return
+    elif not fixture_consumers and config.option.collectonly:
         warnings.warn(
             (
                 "No fixture consumer binaries provided; using a dummy consumer for collect-only; "

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -856,4 +856,3 @@ ize
 nectos
 fibonacci
 CPython
-pytest_report_collectionfinish

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -856,3 +856,4 @@ ize
 nectos
 fibonacci
 CPython
+pytest_report_collectionfinish


### PR DESCRIPTION
## 🗒️ Description

1. Enables filtering of test cases by their fixture format via pytest markers (relevant for `consume direct` which supports multiple fixture formats.
2. Fixes a spurious and unnecessary warning when running `uv run consume direct --markers`.

### Examples
```
$ consume direct --markers

@pytest.mark.blockchain_test_engine: Tests in `blockchain_test_engine` format 

@pytest.mark.eof_test: Tests in `eof_test` format 

@pytest.mark.state_test: Tests in `state_test` format 

@pytest.mark.transaction_test: Tests in `transaction_test` format 

@pytest.mark.Shanghai: Tests for the Shanghai fork
...
```
```
$ consume direct --input=develop@latest --bin=~/bin/nethtest -m blockchain_test -k chainid --collect-only -q
 pytest-regex selected 14823 tests to run for regex: .*
src/pytest_plugins/consume/direct/test_via_direct.py::test_fixture[NethtestFixtureConsumer-tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Berlin-blockchain_test_from_state_test]]
src/pytest_plugins/consume/direct/test_via_direct.py::test_fixture[NethtestFixtureConsumer-tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Cancun-blockchain_test_from_state_test]]
src/pytest_plugins/consume/direct/test_via_direct.py::test_fixture[NethtestFixtureConsumer-tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Istanbul-blockchain_test_from_state_test]]
src/pytest_plugins/consume/direct/test_via_direct.py::test_fixture[NethtestFixtureConsumer-tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_London-blockchain_test_from_state_test]]
src/pytest_plugins/consume/direct/test_via_direct.py::test_fixture[NethtestFixtureConsumer-tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Paris-blockchain_test_from_state_test]]
src/pytest_plugins/consume/direct/test_via_direct.py::test_fixture[NethtestFixtureConsumer-tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Prague-blockchain_test_from_state_test]]
src/pytest_plugins/consume/direct/test_via_direct.py::test_fixture[NethtestFixtureConsumer-tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Shanghai-blockchain_test_from_state_test]]

7564/22380 tests collected (14816 deselected) in 3.46s
```

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).

