### PR TITLE
feat(consume): improve test case ids for ethereum/tests fixtures

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Add top-level entries `forks` and `fixture_formats` to the index file that list all the forks and fixture formats used in the indexed fixtures ([#1318](https://github.com/ethereum/execution-spec-tests/pull/1318)).
 - 🐞 Don't parametrize tests for unsupported fixture formats; improve `consume` test collection ([#1315](https://github.com/ethereum/execution-spec-tests/pull/1314)).
 - 🐞 Improve index generation of ethereum/tests fixtures: Allow generation at any directory level and include `generatedTestHash` in the index file for the `fixture_hash` ([#1303](https://github.com/ethereum/execution-spec-tests/pull/1303)).
+- ✨ Improve index generation of ethereum/tests fixtures: Create better test case IDs by prepending the relative JSON file path to the ID ([#1321](https://github.com/ethereum/execution-spec-tests/pull/1321)).
 
 #### `fill`
 

--- a/src/cli/gen_index.py
+++ b/src/cli/gen_index.py
@@ -86,6 +86,14 @@ def generate_fixtures_index_cli(
     )
 
 
+def get_test_case_id(fixture_name, relative_file_path) -> str:
+    """Create an appropriate test case id based on its source."""
+    # TODO: Update this function for multi-fork/multi-tx-index state test fixtures
+    if ".py" in fixture_name:  # EEST fixture
+        return fixture_name
+    return f"{relative_file_path}::{fixture_name}"  # ethereum/tests fixture
+
+
 def generate_fixtures_index(
     input_path: Path,
     quiet_mode: bool = False,
@@ -155,9 +163,10 @@ def generate_fixtures_index(
 
             relative_file_path = Path(file).absolute().relative_to(Path(input_path).absolute())
             for fixture_name, fixture in fixtures.items():
+                test_case_id = get_test_case_id(fixture_name, relative_file_path)
                 test_cases.append(
                     TestCaseIndexFile(
-                        id=fixture_name,
+                        id=test_case_id,
                         json_path=relative_file_path,
                         # eest uses hash; ethereum/tests uses generatedTestHash
                         fixture_hash=fixture.info.get("hash")

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -856,3 +856,4 @@ ize
 nectos
 fibonacci
 CPython
+prepending


### PR DESCRIPTION
## 🗒️ Description
Improve index generation of `ethereum/tests` fixtures: Create better test case IDs by prepending the relative JSON file path to the ID.

EEST fixture IDs remain the same for `consume`; they stay the same as generated by `fill`.

**Before**
```
chainId_d0g0v0_Cancun
chainIdGasCost_d0g0v0_Cancun
```
**After**
```
GeneralStateTests/stChainId/chainId.json::chainId_d0g0v0_Cancun
GeneralStateTests/stChainId/chainIdGasCost.json::chainIdGasCost_d0g0v0_Cancun
```


## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
