### PR TITLE
Fillci

### DIFF
--- a/src/ethereum_clis/clis/geth.py
+++ b/src/ethereum_clis/clis/geth.py
@@ -164,14 +164,12 @@ class GethEvm(EthereumCLI):
 
     def __init__(
         self,
-        binary: Path,
+        binary: Optional[Path] = None,
         trace: bool = False,
-        exception_mapper: ExceptionMapper | None = None,
     ):
         """Initialize the GethEvm class."""
-        self.binary = binary
+        self.binary = binary if binary else self.default_binary
         self.trace = trace
-        self.exception_mapper = exception_mapper if exception_mapper else GethExceptionMapper()
         self._info_metadata: Optional[Dict[str, Any]] = {}
 
     def _run_command(self, command: List[str]) -> subprocess.CompletedProcess:
@@ -228,9 +226,18 @@ class GethTransitionTool(GethEvm, TransitionTool):
     trace: bool
     t8n_use_stream = True
 
-    def __init__(self, *, binary: Path, trace: bool = False):
+    def __init__(
+        self,
+        *,
+        exception_mapper: Optional[ExceptionMapper] = None,
+        binary: Optional[Path] = None,
+        trace: bool = False,
+    ):
         """Initialize the GethTransitionTool class."""
-        super().__init__(binary=binary, trace=trace)
+        if not exception_mapper:
+            exception_mapper = GethExceptionMapper()
+        GethEvm.__init__(self, binary=binary, trace=trace)
+        TransitionTool.__init__(self, binary=binary, exception_mapper=exception_mapper)
         help_command = [str(self.binary), str(self.subcommand), "--help"]
         result = self._run_command(help_command)
         self.help_string = result.stdout

--- a/src/ethereum_clis/ethereum_cli.py
+++ b/src/ethereum_clis/ethereum_cli.py
@@ -126,6 +126,18 @@ class EthereumCLI:
 
         return cls.detect_binary_pattern.match(binary_output) is not None
 
+    @classmethod
+    def is_installed(cls, binary_path: Optional[Path] = None) -> bool:
+        """Return whether the tool is installed in the current system."""
+        if binary_path is None:
+            binary_path = cls.default_binary
+        else:
+            resolved_path = Path(os.path.expanduser(binary_path)).resolve()
+            if resolved_path.exists():
+                binary_path = resolved_path
+        binary = shutil.which(binary_path)
+        return binary is not None
+
     def version(self) -> str:
         """Return the name and version of the CLI as reported by the CLI's version flag."""
         if self.cached_version is None:

--- a/src/ethereum_clis/tests/test_transition_tools_support.py
+++ b/src/ethereum_clis/tests/test_transition_tools_support.py
@@ -85,7 +85,7 @@ def t8n(
     return t8n_instance_or_error
 
 
-@pytest.mark.parametrize("fork", fork_set)
+@pytest.mark.parametrize("fork", sorted(fork_set, key=lambda f: f.__name__))  # type: ignore
 @pytest.mark.parametrize(
     "t8n",
     test_transition_tools,

--- a/src/ethereum_clis/transition_tool.py
+++ b/src/ethereum_clis/transition_tool.py
@@ -49,6 +49,8 @@ class TransitionTool(EthereumCLI):
     registered_tools: List[Type["TransitionTool"]] = []
     default_tool: Optional[Type["TransitionTool"]] = None
 
+    exception_mapper: ExceptionMapper
+
     subcommand: Optional[str] = None
     cached_version: Optional[str] = None
     t8n_use_stream: bool = False
@@ -65,6 +67,7 @@ class TransitionTool(EthereumCLI):
         trace: bool = False,
     ):
         """Abstract initialization method that all subclasses must implement."""
+        assert exception_mapper is not None
         self.exception_mapper = exception_mapper
         super().__init__(binary=binary)
         self.trace = trace

--- a/src/ethereum_clis/transition_tool.py
+++ b/src/ethereum_clis/transition_tool.py
@@ -60,7 +60,7 @@ class TransitionTool(EthereumCLI):
     def __init__(
         self,
         *,
-        exception_mapper: ExceptionMapper,
+        exception_mapper: Optional[ExceptionMapper] = None,
         binary: Optional[Path] = None,
         trace: bool = False,
     ):

--- a/tox.ini
+++ b/tox.ini
@@ -53,6 +53,7 @@ description = Run library and framework unit tests (pytest)
 setenv =
     # Use custom EELS_RESOLUTIONS_FILE if it is set via the environment (eg, in CI)
     EELS_RESOLUTIONS_FILE = {env:EELS_RESOLUTIONS_FILE:}
+    CI = {env:CI:}
 extras = 
     test
     lint # Required `gentest` for formatting tests


### PR DESCRIPTION
Changes #1263 to dynamically detect installed t8n tools instead of forcing the unit tests to fail for all users if they don't install Geth and Evm-one.

Even with this change, CI still requires an update to install Evm-one and Geth in `pytest_framework` in https://github.com/ethereum/execution-spec-tests/blob/main/.github/workflows/tox_verify.yaml.