### PR TITLE
chore(ci): fix github pages docs push

### DIFF
--- a/.github/workflows/docs_deploy.yaml
+++ b/.github/workflows/docs_deploy.yaml
@@ -1,5 +1,8 @@
 name: Deploy Docs
 
+permissions:
+  pages: write # Required for deploying to GitHub Pages with `secrets.GITHUB_TOKEN`
+
 on:
   push:
     tags:


### PR DESCRIPTION
## 🗒️ Description
Gives the ephemeral github token write access to github pages.  

## 🔗 Related Issues
Fixes the CI failure here: https://github.com/ethereum/execution-spec-tests/actions/runs/13910619884/job/38923833604
(hopefully :P)
- This didn't work #1319
- The original solution that did work #179
 
## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] ~~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~
- [x] ~~All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.~~
