### PR TITLE
fix(ci,docs): use deploy key docs deployment

### DIFF
--- a/.github/workflows/docs_deploy.yaml
+++ b/.github/workflows/docs_deploy.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh-key: ${{secrets.GH_ACTIONS_DEPLOY_KEY}}
       - name: Build transition tool
         uses: ./.github/actions/build-evm-base
         with:


### PR DESCRIPTION
## 🗒️ Description
Fixes deploying the docs to gh-pages using a deploy key as originally configured.

## 🔗 Related Issues
- The original solution that did work #179
- This didn't work #1319
- This didn't work either #1323 

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
