### PR TITLE
fix(clis): Update Besu's binary pattern

### DIFF
--- a/src/ethereum_clis/clis/besu.py
+++ b/src/ethereum_clis/clis/besu.py
@@ -29,7 +29,7 @@ class BesuTransitionTool(TransitionTool):
     """Besu EvmTool Transition tool frontend wrapper class."""
 
     default_binary = Path("evm")
-    detect_binary_pattern = re.compile(r"^Hyperledger Besu evm .*$")
+    detect_binary_pattern = re.compile(r"^Besu evm .*$")
     binary: Path
     cached_version: Optional[str] = None
     trace: bool


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
We have recently removed the string `Hyperledger` from the version string of Besu's EVM tool.

The PR with this change can be found here: https://github.com/hyperledger/besu/commit/5215c953e0fbe0259479c0b272dfea343d101c92#diff-cff5ab4373e323fb0a6d885fcfda67b52b514d7109c194892d4874465b452d0eL43-L44

This PR updates the binary pattern to take this into consideration

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
