### PR TITLE
new(tests): Add EOF validation tests for stack underflow

### DIFF
--- a/converted-ethereum-tests.txt
+++ b/converted-ethereum-tests.txt
@@ -38,6 +38,8 @@ EOFTests/efStack/forwards_rjumpi_.json
 EOFTests/efStack/forwards_rjumpi_variable_stack_.json
 EOFTests/efStack/forwards_rjumpv_.json
 EOFTests/efStack/forwards_rjumpv_variable_stack_.json
+EOFTests/efStack/underflow_.json
+EOFTests/efStack/underflow_variable_stack_.json
 EOFTests/efStack/unreachable_instructions_.json
 EOFTests/efValidation/callf_into_nonreturning_.json
 EOFTests/efValidation/dataloadn_.json

--- a/tests/osaka/eip7692_eof_v1/eip4750_functions/test_code_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip4750_functions/test_code_validation.py
@@ -724,6 +724,113 @@ def test_callf_stack_overflow_by_height(eof_test, callee_stack_height):
     eof_test(container=container, expect_exception=EOFException.STACK_OVERFLOW)
 
 
+@pytest.mark.parametrize(
+    "container",
+    [
+        Container(
+            name="underflow_1",
+            sections=[
+                Section.Code(
+                    code=Op.CALLF[1] + Op.STOP,
+                    max_stack_height=1,
+                ),
+                Section.Code(
+                    code=Op.PUSH0 + Op.RETF,
+                    code_inputs=1,
+                    code_outputs=2,
+                    max_stack_height=2,
+                ),
+            ],
+        ),
+        Container(
+            name="underflow_2",
+            sections=[
+                Section.Code(
+                    code=Op.CALLF[1] + Op.STOP,
+                    max_stack_height=2,
+                ),
+                Section.Code(
+                    code=Op.PUSH0 + Op.RETF,
+                    code_inputs=1,
+                    code_outputs=2,
+                    max_stack_height=2,
+                ),
+            ],
+        ),
+        Container(
+            name="underflow_variable_stack_2",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0 + Op.RJUMPI[2](0) + Op.PUSH0 + Op.PUSH0 + Op.CALLF[1] + Op.STOP,
+                    max_stack_height=4,
+                ),
+                Section.Code(
+                    code=Op.PUSH0 + Op.RETF,
+                    code_inputs=4,
+                    code_outputs=5,
+                    max_stack_height=5,
+                ),
+            ],
+        ),
+        Container(
+            name="underflow_variable_stack_2a",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0
+                    + Op.PUSH0
+                    + Op.RJUMPI[2](0)
+                    + Op.PUSH0
+                    + Op.PUSH0
+                    + Op.CALLF[1]
+                    + Op.STOP,
+                    max_stack_height=5,
+                ),
+                Section.Code(
+                    code=Op.PUSH0 + Op.RETF,
+                    code_inputs=4,
+                    code_outputs=5,
+                    max_stack_height=5,
+                ),
+            ],
+        ),
+        Container(
+            name="underflow_variable_stack_3",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0 + Op.RJUMPI[2](0) + Op.PUSH0 + Op.PUSH0 + Op.CALLF[1] + Op.STOP,
+                    max_stack_height=4,
+                ),
+                Section.Code(
+                    code=Op.PUSH0 + Op.RETF,
+                    code_inputs=3,
+                    code_outputs=4,
+                    max_stack_height=4,
+                ),
+            ],
+        ),
+        Container(
+            name="underflow_variable_stack_4",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0 * 3 + Op.RJUMPI[1](0) + Op.POP + Op.CALLF[1] + Op.STOP,
+                    max_stack_height=4,
+                ),
+                Section.Code(
+                    code=Op.PUSH0 + Op.RETF,
+                    code_inputs=3,
+                    code_outputs=4,
+                    max_stack_height=4,
+                ),
+            ],
+        ),
+    ],
+    ids=lambda x: x.name,
+)
+def test_callf_stack_underflow_examples(eof_test, container):
+    """Test CALLF instruction causing validation time stack underflow."""
+    eof_test(container=container, expect_exception=EOFException.STACK_UNDERFLOW)
+
+
 def test_returning_section_aborts(
     eof_test: EOFTestFiller,
 ):

--- a/tests/osaka/eip7692_eof_v1/eip5450_stack/test_code_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip5450_stack/test_code_validation.py
@@ -520,3 +520,50 @@ def test_all_opcodes_stack_underflow(
             validity_error=EOFException.STACK_UNDERFLOW,
         )
     )
+
+
+@pytest.mark.parametrize(
+    "container",
+    [
+        Container(
+            name="underflow_0",
+            sections=[
+                Section.Code(
+                    code=Op.ADD + Op.STOP,
+                    max_stack_height=1,
+                ),
+            ],
+        ),
+        Container(
+            name="underflow_variable_stack_0",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0 + Op.RJUMPI[2](0) + Op.PUSH0 + Op.PUSH0 + Op.LOG2 + Op.STOP,
+                    max_stack_height=3,
+                ),
+            ],
+        ),
+        Container(
+            name="underflow_variable_stack_1",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0 + Op.RJUMPI[2](0) + Op.PUSH0 + Op.PUSH0 + Op.ADD + Op.STOP,
+                    max_stack_height=3,
+                ),
+            ],
+        ),
+        Container(
+            name="underflow_variable_stack_2",
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0 * 2 + Op.RJUMPI[1](0) + Op.POP + Op.ADD + Op.STOP,
+                    max_stack_height=3,
+                ),
+            ],
+        ),
+    ],
+    ids=lambda x: x.name,
+)
+def test_stack_underflow_examples(eof_test, container):
+    """Test EOF validation failing due to stack underflow at basic instructions."""
+    eof_test(container=container, expect_exception=EOFException.STACK_UNDERFLOW)

--- a/tests/osaka/eip7692_eof_v1/eof_tracker.md
+++ b/tests/osaka/eip7692_eof_v1/eof_tracker.md
@@ -246,8 +246,8 @@
 
 - [ ] Valid CALLFs to functions with inputs (ethereum/tests: src/EOFTestsFiller/efStack/callf_stack_validation_Copier.json)
 - [ ] CALLF stack underflows (ethereum/tests: ./src/EOFTestsFiller/efExample/validInvalidFiller.yml src/EOFTestsFiller/EIP5450/validInvalidFiller.yml src/EOFTestsFiller/efStack/callf_stack_validation_Copier.json)
-- [ ] CALLF stack underflow in variable stack segment, only min underflow (ethereum/tests: src/EOFTestsFiller/efStack/underflow_variable_stack_Copier.json)
-- [ ] CALLF stack underflow in variable stack segment, both min and max underflow (ethereum/tests: src/EOFTestsFiller/efStack/underflow_variable_stack_Copier.json)
+- [x] CALLF stack underflow in variable stack segment, only min underflow ([`tests/osaka/eip7692_eof_v1/eip4750_functions/test_code_validation.py::test_callf_stack_underflow_examples`](./eip4750_functions/test_code_validation/test_callf_stack_underflow_examples.md))
+- [x] CALLF stack underflow in variable stack segment, both min and max underflow ([`tests/osaka/eip7692_eof_v1/eip4750_functions/test_code_validation.py::test_callf_stack_underflow_examples`](./eip4750_functions/test_code_validation/test_callf_stack_underflow_examples.md))
 - [ ] Branching to CALLFs with the same number of outputs (ethereum/tests: src/EOFTestsFiller/EIP5450/validInvalidFiller.yml)
 - [ ] Check that CALLF stack inputs/outputs equal to target section type definition
 


### PR DESCRIPTION
## 🗒️ Description

Port ethereum/tests EOF validation tests for stack underflow.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened. https://github.com/ethereum/tests/pull/1476
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
