### PR TITLE
fix(cli/gen_index): Fix index generation for EOF files

### DIFF
--- a/src/cli/gen_index.py
+++ b/src/cli/gen_index.py
@@ -155,6 +155,7 @@ def generate_fixtures_index(
 
             relative_file_path = Path(file).absolute().relative_to(Path(input_path).absolute())
             for fixture_name, fixture in fixtures.items():
+                fixture_fork = fixture.get_fork()
                 test_cases.append(
                     TestCaseIndexFile(
                         id=fixture_name,
@@ -162,11 +163,12 @@ def generate_fixtures_index(
                         # eest uses hash; ethereum/tests uses generatedTestHash
                         fixture_hash=fixture.info.get("hash")
                         or f"0x{fixture.info.get('generatedTestHash')}",
-                        fork=fixture.get_fork(),
+                        fork=fixture_fork,
                         format=fixture.__class__,
                     )
                 )
-                forks.add(fixture.get_fork())
+                if fixture_fork:
+                    forks.add(fixture_fork)
                 fixture_formats.add(fixture.format_name)
 
             display_filename = file.name


### PR DESCRIPTION
## 🗒️ Description
Fixes a small issues that prevents index generation for EOF tests because they return `None` on `get_fork` call, so we would end up with a list that cotained `None` as the single element.

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] Skipped - All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
