### PR TITLE
chore(consume): fix `--sim.limit` in hive commands shown in test reports

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,7 @@ consume cache --help
 - ✨ Add top-level entries `forks` and `fixture_formats` to the index file that list all the forks and fixture formats used in the indexed fixtures ([#1318](https://github.com/ethereum/execution-spec-tests/pull/1318)).
 - 🐞 Don't parametrize tests for unsupported fixture formats; improve `consume` test collection ([#1315](https://github.com/ethereum/execution-spec-tests/pull/1314)).
 - 🐞 Improve index generation of ethereum/tests fixtures: Allow generation at any directory level and include `generatedTestHash` in the index file for the `fixture_hash` ([#1303](https://github.com/ethereum/execution-spec-tests/pull/1303)).
+- 🐞 Fix the the hive command printed in test reports to reproduce tests in isolation by prefixing the `--sim.limit` flag value with `id:` ([#1333](https://github.com/ethereum/execution-spec-tests/pull/1333)).
 
 #### `fill`
 

--- a/src/pytest_plugins/consume/hive_simulators/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/conftest.py
@@ -67,7 +67,7 @@ def hive_consume_command(
     command = ["./hive", "--sim", f"ethereum/{test_suite_name}"]
     if hive_client_config_file_parameter:
         command += hive_client_config_file_parameter
-    command += ["--client", client_type.name, "--sim.limit", f'"{test_case.id}"']
+    command += ["--client", client_type.name, "--sim.limit", f'"id:{test_case.id}"']
     return command
 
 


### PR DESCRIPTION
## 🗒️ Description
Fixes the `--sim.limit` flag value written to the test case description sent back to hive in order to help developers reproduce tests.

Thanks @macfarla for reporting!

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
