### PR TITLE
chore(ci): pin github actions at hashed versions

### DIFF
--- a/.github/actions/build-evm-client/besu/action.yaml
+++ b/.github/actions/build-evm-client/besu/action.yaml
@@ -21,13 +21,13 @@ runs:
   using: "composite"
   steps:
     - name: Checkout Besu
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         repository: ${{ inputs.repo }}
         ref: ${{ inputs.ref }}
         path: besu
     - name: Setup Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12
       with:
         java-version: ${{ inputs.java }}
         distribution: ${{ inputs.java-distro }}

--- a/.github/actions/build-evm-client/ethjs/action.yml
+++ b/.github/actions/build-evm-client/ethjs/action.yml
@@ -13,14 +13,14 @@ runs:
   using: "composite"
   steps:
     - name: Checkout EthereumJS monorepo
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         repository: ${{ inputs.repo }}
         ref: ${{ inputs.ref }}
         path: ethereumjs
 
     - name: Setup node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
       with:
         node-version: 18
 

--- a/.github/actions/build-evm-client/evmone/action.yaml
+++ b/.github/actions/build-evm-client/evmone/action.yaml
@@ -17,14 +17,14 @@ runs:
   using: "composite"
   steps:
     - name: Checkout evmone
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         repository: ${{ inputs.repo }}
         ref: ${{ inputs.ref }}
         path: evmone
         submodules: true
     - name: Setup cmake
-      uses: jwlawson/actions-setup-cmake@v2
+      uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be
     - name: "Install GMP"
       shell: bash
       run: sudo apt-get -q update && sudo apt-get -qy install libgmp-dev

--- a/.github/actions/build-evm-client/geth/action.yaml
+++ b/.github/actions/build-evm-client/geth/action.yaml
@@ -17,13 +17,13 @@ runs:
   using: "composite"
   steps:
     - name: Checkout go-ethereum
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         repository: ${{ inputs.repo }}
         ref: ${{ inputs.ref }}
         path: go-ethereum
     - name: Setup golang
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
       with:
         go-version: ${{ inputs.golang }}
         cache-dependency-path: go-ethereum/go.sum

--- a/.github/actions/build-fixtures/action.yaml
+++ b/.github/actions/build-fixtures/action.yaml
@@ -41,7 +41,7 @@ runs:
       shell: bash
       run: |
         uv run fill -n ${{ steps.evm-builder.outputs.x-dist }} --evm-bin=${{ steps.evm-builder.outputs.evm-bin }} --solc-version=${{ steps.properties.outputs.solc }} --skip-evm-dump ${{ steps.properties.outputs.fill-params }} --output=fixtures_${{ inputs.release_name }}.tar.gz --build-name ${{ inputs.release_name }}
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       with:
         name: fixtures_${{ inputs.release_name }}
         path: fixtures_${{ inputs.release_name }}.tar.gz

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Debug GitHub context
         run: |
@@ -26,7 +26,7 @@ jobs:
 
       - name: Get all changed python files in tests/ and changes to coverted-ethereum-tests.txt
         id: changed-tests
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@48d8f15b2aaa3d255ca5af3eba4870f807ce6b3c
         with:
           # TODO: non-test modules such as __init__.py or spec.py could effect coverage - in this case we should
           # fill all applicable tests (i.e., all the test_*.py files in or under the changed module's directory)
@@ -60,7 +60,7 @@ jobs:
 
       - name: Log in to Docker Hub
         if: ${{  steps.changed-tests.outputs.tests_any_changed == 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
         with:
           username: winsvega
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -94,7 +94,7 @@ jobs:
           targets: "evmone-t8n"
 
       - name: Checkout ethereum/tests
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         if: steps.changed-tests.outputs.tests_any_changed == 'true'
         with:
           repository: ethereum/tests
@@ -104,7 +104,7 @@ jobs:
             EOFTests
 
       - name: Checkout ethereum/legacytests
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         if: steps.changed-tests.outputs.tests_any_changed == 'true'      
         with:
           repository: ethereum/legacytests
@@ -277,7 +277,7 @@ jobs:
           ls ${{ github.workspace }}/evmtest_coverage/coverage/PATCH_TESTS
 
       - name: Run coverage of the BASE tests
-        uses: addnab/docker-run-action@v3
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185
         if: ${{ steps.changed-tests.outputs.tests_any_changed == 'true' }}
         with:
           image: winsvega/evmone-coverage-script:latest
@@ -285,7 +285,7 @@ jobs:
           run: /entrypoint.sh --mode=cover --driver=native --testpath=/tests/BASE_TESTS --outputname=BASE
 
       - name: Run coverage of the PATCH tests
-        uses: addnab/docker-run-action@v3
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185
         if: ${{ steps.changed-tests.outputs.tests_any_changed == 'true' }}
         with:
           image: winsvega/evmone-coverage-script:latest
@@ -293,7 +293,7 @@ jobs:
           run: /entrypoint.sh --mode=cover --driver=native --testpath=/tests/PATCH_TESTS --outputname=PATCH
 
       - name: Run coverage DIFF of the PATCH tests compared to BASE tests
-        uses: addnab/docker-run-action@v3
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185
         if: ${{  steps.changed-tests.outputs.tests_any_changed == 'true' }}
         with:
           image: winsvega/evmone-coverage-script:latest
@@ -307,7 +307,7 @@ jobs:
           sudo chown -R $user:$user ${{ github.workspace }}/evmtest_coverage/coverage
 
       - name: Upload coverage results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         if: ${{ steps.changed-tests.outputs.tests_any_changed == 'true' }}
         with:
           name: coverage-diff-native-${{ github.run_id }}-${{ github.run_attempt }}
@@ -315,7 +315,7 @@ jobs:
           compression-level: 6  # Default compression level for optimal balance
 
       - name: Verify coverage results
-        uses: addnab/docker-run-action@v3
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185
         if: ${{ steps.changed-tests.outputs.tests_any_changed == 'true' }}
         with:
           image: winsvega/evmone-coverage-script:latest

--- a/.github/workflows/docs_deploy.yaml
+++ b/.github/workflows/docs_deploy.yaml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
           ssh-key: ${{secrets.GH_ACTIONS_DEPLOY_KEY}}

--- a/.github/workflows/fixtures.yaml
+++ b/.github/workflows/fixtures.yaml
@@ -12,7 +12,7 @@ jobs:
     outputs:
       features: ${{ steps.parse.outputs.features }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Get names from .github/configs/feature.yaml
         id: parse
         shell: bash
@@ -25,7 +25,7 @@ jobs:
       matrix:
         name: ${{ fromJson(needs.features.outputs.features) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           submodules: true
       - uses: ./.github/actions/build-fixtures
@@ -37,11 +37,11 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e
         with:
           path: .
       - name: Draft Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda
         with:
           files: "./**"
           draft: true

--- a/.github/workflows/fixtures_feature.yaml
+++ b/.github/workflows/fixtures_feature.yaml
@@ -12,7 +12,7 @@ jobs:
     outputs:
       names: ${{ steps.feature-name.outputs.names }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           submodules: false
       - name: Get feature names
@@ -29,7 +29,7 @@ jobs:
       matrix:
         feature: ${{ fromJSON(needs.feature-names.outputs.names) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           submodules: true
       - uses: ./.github/actions/build-fixtures
@@ -41,11 +41,11 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e
         with:
           path: .
       - name: Draft Pre-release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda
         with:
           files: "./**"
           draft: true

--- a/.github/workflows/tox_verify.yaml
+++ b/.github/workflows/tox_verify.yaml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout ethereum/execution-spec-tests
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Install uv ${{ vars.UV_VERSION }} and python ${{ vars.DEFAULT_PYTHON_VERSION }}
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@f94ec6bedd8674c4426838e6b50417d36b6ab231
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -25,9 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout ethereum/execution-spec-tests
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Install uv ${{ vars.UV_VERSION }} and python ${{ vars.DEFAULT_PYTHON_VERSION }}
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@f94ec6bedd8674c4426838e6b50417d36b6ab231
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -41,9 +41,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout ethereum/execution-spec-tests
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Install uv ${{ vars.UV_VERSION }} and python ${{ vars.DEFAULT_PYTHON_VERSION }}
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@f94ec6bedd8674c4426838e6b50417d36b6ab231
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -60,8 +60,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout ethereum/execution-spec-tests
-        uses: actions/checkout@v4
-      - uses: DavidAnson/markdownlint-cli2-action@v16
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: DavidAnson/markdownlint-cli2-action@b4c9feab76d8025d1e83c653fa3990936df0e6c8
         with:
           globs: |
             README.md
@@ -72,9 +72,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout ethereum/execution-spec-tests
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Install uv ${{ vars.UV_VERSION }} and python ${{ vars.DEFAULT_PYTHON_VERSION }}
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@f94ec6bedd8674c4426838e6b50417d36b6ab231
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -97,9 +97,9 @@ jobs:
             python: "3.12"
     steps:
       - name: Checkout ethereum/execution-spec-tests
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Checkout ethereum/execution-specs for local EELS implementation
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           repository: ethereum/execution-specs
           ref: fa847a0e48309debee8edc510ceddb2fd5db2f2e
@@ -108,7 +108,7 @@ jobs:
             src/ethereum
           fetch-depth: 1
       - name: Install uv ${{ vars.UV_VERSION }} and python ${{ matrix.python }}
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@f94ec6bedd8674c4426838e6b50417d36b6ab231
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -134,9 +134,9 @@ jobs:
             python: "3.12"
     steps:
       - name: Checkout ethereum/execution-spec-tests
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Checkout ethereum/execution-specs for local EELS implementation
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           repository: ethereum/execution-specs
           ref: fa847a0e48309debee8edc510ceddb2fd5db2f2e
@@ -145,7 +145,7 @@ jobs:
             src/ethereum
           fetch-depth: 1
       - name: Install uv ${{ vars.UV_VERSION }} and python ${{ matrix.python }}
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@f94ec6bedd8674c4426838e6b50417d36b6ab231
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"


### PR DESCRIPTION
## 🗒️ Description
execution-spec-tests was affected by a compromised action, see #1316. Pinning github actions to specific hashes avoids future vulnerabilities by automatically using an updated, compromised version.

Done with the help of the amazing https://github.com/ethpandaops/github-actions-checker

## 🔗 Related Issues
- Fixes #1316
Here's an example of an ethpandops pr that recently pinned its actions:
- https://github.com/ethpandaops/ethereum-package/pull/921

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] ~~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~ skipped
