### PR TITLE
fix(test): improve EIP-7702 test for type 4 transaction with empty to

### DIFF
--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -2913,11 +2913,16 @@ def test_contract_create(
     pre: Alloc,
 ):
     """Test sending type-4 tx as a create transaction."""
+    authorization_tuple = AuthorizationTuple(
+        address=Address(0x01),
+        nonce=0,
+        signer=pre.fund_eoa(),
+    )
     tx = Transaction(
         gas_limit=100_000,
         to=None,
         value=0,
-        authorization_list=[],
+        authorization_list=[authorization_tuple],
         error=TransactionException.TYPE_4_TX_CONTRACT_CREATION,
         sender=pre.fund_eoa(),
     )


### PR DESCRIPTION
The transaction in this test is invalid for 2 reasons: empty `to` and also empty `authorization_list`. Some test runners that don't check for exact error can pass it for the wrong reason.
