### PR TITLE
fix(tests): EOF - Change kind_data from 0x04 to 0xff

### DIFF
--- a/src/ethereum_test_tools/eof/v1/__init__.py
+++ b/src/ethereum_test_tools/eof/v1/__init__.py
@@ -1,7 +1,6 @@
 """Mirror module to import `ethereum_test_types.eof.v1`."""
 
 from ethereum_test_types.eof.v1 import (
-    VERSION_MAX_SECTION_KIND,
     AutoSection,
     Container,
     ContainerKind,
@@ -11,7 +10,6 @@ from ethereum_test_types.eof.v1 import (
 )
 
 __all__ = (
-    "VERSION_MAX_SECTION_KIND",
     "AutoSection",
     "Container",
     "ContainerKind",

--- a/src/ethereum_test_types/eof/v1/__init__.py
+++ b/src/ethereum_test_types/eof/v1/__init__.py
@@ -31,8 +31,6 @@ from .constants import (
     VERSION_NUMBER_BYTES,
 )
 
-VERSION_MAX_SECTION_KIND = 3
-
 
 class SectionKind(IntEnum):
     """Enum class of V1 valid section kind values."""
@@ -40,7 +38,7 @@ class SectionKind(IntEnum):
     TYPE = 1
     CODE = 2
     CONTAINER = 3
-    DATA = 4
+    DATA = 0xFF
 
     def __str__(self) -> str:
         """Return string representation of the section kind."""

--- a/src/ethereum_test_types/tests/test_eof_v1.py
+++ b/src/ethereum_test_types/tests/test_eof_v1.py
@@ -451,7 +451,7 @@ test_cases: List[Tuple[str, Container, str]] = [
         010004  # One code segment
         020001  # One code segment
             0003  #   code seg 0: 3 bytes
-        040001  # One byte data segment
+        ff0001  # One byte data segment
         00      # End of header
                 # Code segment 0 header
             00  # Zero inputs
@@ -485,7 +485,7 @@ test_cases: List[Tuple[str, Container, str]] = [
       010004  # One code segment
       020001  # One code segment
         0003  #   code seg 0: 3 bytes
-      040004  # Four byte data segment
+      ff0004  # Four byte data segment
       00      # End of header
               # Code segment 0 header
           00  # Zero inputs
@@ -547,7 +547,7 @@ test_cases: List[Tuple[str, Container, str]] = [
        0003 # Code section  2 , 3  bytes
        0001 # Code section  3 , 1  bytes
        0001 # Code section  4 , 1  bytes
-     040004 # Data section length ( 4 )
+     ff0004 # Data section length ( 4 )
          00 # Terminator (end of header)
             # Code 0 types
          00 # 0 inputs
@@ -615,7 +615,7 @@ test_cases: List[Tuple[str, Container, str]] = [
       010008  # Two code segments
       020001  # One code segment
         0003  #   code seg 0: 3 bytes
-      040004  # Four byte data segment
+      ff0004  # Four byte data segment
       00      # End of header
               # Code segment 0 header
           00  # Zero inputs
@@ -654,7 +654,7 @@ test_cases: List[Tuple[str, Container, str]] = [
       020001  # One code segment
         0003  #   code seg 0: 3 bytes
       010004  # One code segment
-      040001  # One byte data segment
+      ff0001  # One byte data segment
       00      # End of header
               # Code segment 0 header
           00  # Zero inputs
@@ -693,7 +693,7 @@ test_cases: List[Tuple[str, Container, str]] = [
       010004  # One code segment
       020001  # One code segment
         0003  #   code seg 0: 3 bytes
-      040001  # One byte data segment
+      ff0001  # One byte data segment
       00      # End of header
               # Code segment 0 code
            30 #  1 ADDRESS
@@ -727,7 +727,7 @@ test_cases: List[Tuple[str, Container, str]] = [
       ef0001  # Magic followed by version
       020001  # One code segment
         0003  #   code seg 0: 3 bytes
-      040001  # One byte data segment
+      ff0001  # One byte data segment
       00      # End of header
               # Code segment 0 header
           00  # Zero inputs
@@ -762,7 +762,7 @@ test_cases: List[Tuple[str, Container, str]] = [
       010004  # Types section
       020001  # One code segment
         0003  #   code seg 0: 3 bytes
-      040001  # One byte data segment
+      ff0001  # One byte data segment
       00      # End of header
               # Code segment 0 header
               # Code segment 0 code
@@ -784,7 +784,7 @@ test_cases: List[Tuple[str, Container, str]] = [
         0006  #   code seg 0: 6 bytes
       030001  # One container segment
         0014  #   container seg 0: 20 bytes
-      040000  # Zero byte data segment
+      ff0000  # Zero byte data segment
       00      # End of header
    0080 0002  # Types section
               # Code segment 0 code
@@ -796,7 +796,7 @@ test_cases: List[Tuple[str, Container, str]] = [
       010004  # Types section
       020001  # One code segment
         0001  #   code seg 0: 1 byte
-      040000  # Zero byte data segment
+      ff0000  # Zero byte data segment
       00      # End of header
    0080 0000  # Types section
               # Code segment 0 code
@@ -814,7 +814,7 @@ test_cases: List[Tuple[str, Container, str]] = [
         000b  #   code seg 0: 11 bytes
       030001  # One container segment
         0014  #   container seg 0: 20 bytes
-      040000  # Zero byte data segment
+      ff0000  # Zero byte data segment
       00      # End of header
    0080 0002  # Types section
               # Code segment 0 code
@@ -829,7 +829,7 @@ test_cases: List[Tuple[str, Container, str]] = [
       010004  # Types section
       020001  # One code segment
         0001  #   code seg 0: 1 byte
-      040000  # Zero byte data segment
+      ff0000  # Zero byte data segment
       00      # End of header
    0080 0000  # Types section
               # Code segment 0 code

--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py
@@ -6,7 +6,6 @@ import pytest
 
 from ethereum_test_tools import EOFException, EOFTestFiller
 from ethereum_test_tools.eof.v1 import (
-    VERSION_MAX_SECTION_KIND,
     AutoSection,
     Container,
     ContainerKind,
@@ -221,7 +220,7 @@ def test_valid_containers(
                 Section(kind=SectionKind.TYPE, data="00800000"),
                 Section.Data("da"),
             ],
-            expected_bytecode="ef0001 010004 040001 00 00800000 da",
+            expected_bytecode="ef0001 010004 ff0001 00 00800000 da",
             validity_error=[EOFException.MISSING_CODE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
         ),
         Container(
@@ -294,7 +293,7 @@ def test_valid_containers(
                 Section(kind=SectionKind.TYPE, data=b"", custom_size=4),
                 Section.Code(code=b"", custom_size=0x01),
             ],
-            expected_bytecode="ef00 01 01 0004 02 0001 0001 04 0000",
+            expected_bytecode="ef00 01 01 0004 02 0001 0001 ff 0000",
             validity_error=EOFException.MISSING_HEADERS_TERMINATOR,
         ),
         Container(
@@ -304,12 +303,12 @@ def test_valid_containers(
         ),
         Container(
             name="no_data_section_size",
-            raw_bytes="ef00 01 01 0004 02 0001 0001 04",
+            raw_bytes="ef00 01 01 0004 02 0001 0001 ff",
             validity_error=EOFException.MISSING_HEADERS_TERMINATOR,
         ),
         Container(
             name="data_section_size_incomplete",
-            raw_bytes="ef00 01 01 0004 02 0001 0001 04 00",
+            raw_bytes="ef00 01 01 0004 02 0001 0001 ff 00",
             validity_error=EOFException.INCOMPLETE_SECTION_SIZE,
         ),
         Container(
@@ -324,7 +323,7 @@ def test_valid_containers(
         ),
         Container(
             name="zero_container_section_count",
-            raw_bytes="ef00 01 01 0004 02 0001 0001 03 0000 04 0000 00 00800000 00",
+            raw_bytes="ef00 01 01 0004 02 0001 0001 03 0000 ff 0000 00 00800000 00",
             validity_error=EOFException.ZERO_SECTION_SIZE,
         ),
         Container(
@@ -349,7 +348,7 @@ def test_valid_containers(
         ),
         Container(
             name="zero_size_container_section",
-            raw_bytes="ef00 01 01 0004 02 0001 0001 03 0001 0000 04 0000 00 00800000 00",
+            raw_bytes="ef00 01 01 0004 02 0001 0001 03 0001 0000 ff 0000 00 00800000 00",
             validity_error=EOFException.ZERO_SECTION_SIZE,
         ),
         Container(
@@ -359,30 +358,30 @@ def test_valid_containers(
         ),
         Container(
             name="no_data_section_size_with_container_section",
-            raw_bytes="ef00 01 01 0004 02 0001 0001 03 0001 0001 04",
+            raw_bytes="ef00 01 01 0004 02 0001 0001 03 0001 0001 ff",
             validity_error=EOFException.MISSING_HEADERS_TERMINATOR,
         ),
         Container(
             name="data_section_size_incomplete_with_container_section",
-            raw_bytes="ef00 01 01 0004 02 0001 0001 03 0001 0001 04 00",
+            raw_bytes="ef00 01 01 0004 02 0001 0001 03 0001 0001 ff 00",
             validity_error=EOFException.INCOMPLETE_SECTION_SIZE,
         ),
         Container(
             # EOF code missing mandatory type section
             name="EOF1I4750_0001",
-            raw_bytes="ef000102000100010400000000800000fe",
+            raw_bytes="ef00010200010001ff00000000800000fe",
             validity_error=EOFException.MISSING_TYPE_HEADER,
         ),
         Container(
             # EOF code containing multiple type headers
             name="multiple_type_headers_1",  # EOF1I4750_0002
-            raw_bytes="ef00010100040100040400000000800000fe",
+            raw_bytes="ef0001010004010004ff00000000800000fe",
             validity_error=EOFException.MISSING_CODE_HEADER,
         ),
         Container(
             # EOF code containing multiple type headers, second one matches code length
             name="multiple_type_headers_2",
-            raw_bytes="ef00010100040100010400000000800000fe",
+            raw_bytes="ef0001010004010001ff00000000800000fe",
             validity_error=EOFException.MISSING_CODE_HEADER,
         ),
         Container(
@@ -399,37 +398,37 @@ def test_valid_containers(
         Container(
             # EOF code containing type section size (Size 1)
             name="EOF1I4750_0003",
-            raw_bytes="ef000101000102000100010400000000800000fe",
+            raw_bytes="ef00010100010200010001ff00000000800000fe",
             validity_error=EOFException.INVALID_TYPE_SECTION_SIZE,
         ),
         Container(
             # EOF code containing type section size (Size 8 - 1 Code section)
             name="EOF1I4750_0004",
-            raw_bytes="ef000101000802000100010400000000800000fe",
+            raw_bytes="ef00010100080200010001ff00000000800000fe",
             validity_error=EOFException.INVALID_SECTION_BODIES_SIZE,
         ),
         Container(
             # EOF code containing type section size (Size 8 - 3 Code sections)
             name="EOF1I4750_0005",
-            raw_bytes="ef0001010008020003000100010001040000000080000000800000fefefe",
+            raw_bytes="ef0001010008020003000100010001ff0000000080000000800000fefefe",
             validity_error=EOFException.INVALID_TYPE_SECTION_SIZE,
         ),
         Container(
             # EOF code containing invalid first section type (1,0)
             name="EOF1I4750_0006",
-            raw_bytes="ef000101000402000100010400000001000000fe",
+            raw_bytes="ef00010100040200010001ff00000001000000fe",
             validity_error=EOFException.INVALID_FIRST_SECTION_TYPE,
         ),
         Container(
             # EOF code containing invalid first section type (0,1)
             name="EOF1I4750_0007",
-            raw_bytes="ef000101000402000100010400000000010000fe",
+            raw_bytes="ef00010100040200010001ff00000000010000fe",
             validity_error=EOFException.INVALID_FIRST_SECTION_TYPE,
         ),
         Container(
             # EOF code containing invalid first section type (2,3)
             name="EOF1I4750_0008",
-            raw_bytes="ef000101000402000100010400000002030000fe",
+            raw_bytes="ef00010100040200010001ff00000002030000fe",
             validity_error=EOFException.INVALID_FIRST_SECTION_TYPE,
         ),
         Container(
@@ -446,7 +445,7 @@ def test_valid_containers(
                 Section(kind=SectionKind.TYPE, data=b"\0\x80\0\0"),
                 Section.Data("0x00"),
             ],
-            expected_bytecode="ef00 01 01 0004 04 0001 00 00800000 00",
+            expected_bytecode="ef00 01 01 0004 ff 0001 00 00800000 00",
             auto_type_section=AutoSection.NONE,
             validity_error=[EOFException.MISSING_CODE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
         ),
@@ -460,7 +459,7 @@ def test_valid_containers(
         ),
         Container(
             name="zero_code_sections_header",
-            raw_bytes="ef00 01 01 0004 02 0000 04 0000 00 00800000",
+            raw_bytes="ef00 01 01 0004 02 0000 ff 0000 00 00800000",
             validity_error=[
                 EOFException.ZERO_SECTION_SIZE,
                 EOFException.INCOMPLETE_SECTION_NUMBER,
@@ -468,7 +467,7 @@ def test_valid_containers(
         ),
         Container(
             name="zero_code_sections_header_empty_type_section",
-            raw_bytes="ef00 01 01 0000 02 0000 04 0000 00",
+            raw_bytes="ef00 01 01 0000 02 0000 ff 0000 00",
             validity_error=[
                 EOFException.ZERO_SECTION_SIZE,
                 EOFException.INCOMPLETE_SECTION_NUMBER,
@@ -563,7 +562,7 @@ def test_valid_containers(
                 Section(kind=SectionKind.TYPE, data=b"", custom_size=4),
                 Section.Code(code=b"", custom_size=0x01),
             ],
-            expected_bytecode="ef00 01 01 0004 02 0001 0001 04 0000 00",
+            expected_bytecode="ef00 01 01 0004 02 0001 0001 ff 0000 00",
             validity_error=EOFException.INVALID_SECTION_BODIES_SIZE,
         ),
         Container(
@@ -572,7 +571,7 @@ def test_valid_containers(
                 Section(kind=SectionKind.TYPE, data=b"\0", custom_size=4),
                 Section.Code(code=b"", custom_size=0x01),
             ],
-            expected_bytecode="ef00 01 01 0004 02 0001 0001 04 0000 00 00",
+            expected_bytecode="ef00 01 01 0004 02 0001 0001 ff 0000 00 00",
             validity_error=EOFException.INVALID_SECTION_BODIES_SIZE,
         ),
         Container(
@@ -581,7 +580,7 @@ def test_valid_containers(
                 Section(kind=SectionKind.TYPE, data=b"\0\x80", custom_size=4),
                 Section.Code(code=b"", custom_size=0x01),
             ],
-            expected_bytecode="ef00 01 01 0004 02 0001 0001 04 0000 00 0080",
+            expected_bytecode="ef00 01 01 0004 02 0001 0001 ff 0000 00 0080",
             validity_error=EOFException.INVALID_SECTION_BODIES_SIZE,
         ),
         Container(
@@ -590,7 +589,7 @@ def test_valid_containers(
                 Section(kind=SectionKind.TYPE, data=b"\0\x80\0", custom_size=4),
                 Section.Code(code=b"", custom_size=0x01),
             ],
-            expected_bytecode="ef00 01 01 0004 02 0001 0001 04 0000 00 008000",
+            expected_bytecode="ef00 01 01 0004 02 0001 0001 ff 0000 00 008000",
             validity_error=EOFException.INVALID_SECTION_BODIES_SIZE,
         ),
         Container(
@@ -649,7 +648,7 @@ def test_valid_containers(
                 Section.Code(Op.STOP),
                 Section.Data(data="0x", custom_size=1),
             ],
-            code="ef0001 010004 0200010001 040001 00 00800000 00",
+            code="ef0001 010004 0200010001 ff0001 00 00800000 00",
             validity_error=EOFException.TOPLEVEL_CONTAINER_TRUNCATED,
         ),
         Container(
@@ -714,7 +713,7 @@ def test_valid_containers(
                 Section.Data(data="0xAABBCC"),
             ],
             expected_bytecode=(
-                "ef00 01 01 0004 02 0001 0003 04 0003 04 0003 00 00800001 600000 AABBCC AABBCC"
+                "ef00 01 01 0004 02 0001 0003 ff 0003 ff 0003 00 00800001 600000 AABBCC AABBCC"
             ),
             validity_error=[EOFException.MISSING_TERMINATOR, EOFException.UNEXPECTED_HEADER_KIND],
         ),
@@ -727,7 +726,7 @@ def test_valid_containers(
             ],
             auto_sort_sections=AutoSection.ONLY_BODY,
             expected_bytecode=(
-                "ef00 01 01 0008 02 0001 0003 04 0001 02 0001 0001 00"
+                "ef00 01 01 0008 02 0001 0003 ff 0001 02 0001 0001 00"
                 "00800000 00800000 E50001 00 AA"
             ),
             validity_error=[EOFException.MISSING_TERMINATOR, EOFException.UNEXPECTED_HEADER_KIND],
@@ -741,7 +740,7 @@ def test_valid_containers(
             ],
             skip_join_concurrent_sections_in_header=True,
             expected_bytecode=(
-                "ef00 01 01 0008 02 0001 0003 02 0001 0001 04 0001 00"
+                "ef00 01 01 0008 02 0001 0003 02 0001 0001 ff 0001 00"
                 "00800000 00800000 E50001 00 AA"
             ),
             validity_error=[
@@ -763,7 +762,7 @@ def test_valid_containers(
             ],
             skip_join_concurrent_sections_in_header=True,
             expected_bytecode=(
-                "ef00 01 01 0004 02 0001 0001 02 0001 0001 04 0001 00 00800000 00 AA"
+                "ef00 01 01 0004 02 0001 0001 02 0001 0001 ff 0001 00 00800000 00 AA"
             ),
             validity_error=[
                 EOFException.MISSING_DATA_SECTION,
@@ -779,7 +778,7 @@ def test_valid_containers(
                 Section.Data(data="0xAA"),
             ],
             expected_bytecode=(
-                "ef00 01 01 0008 02 0002 0003 0001 04 0001 04 0001 00"
+                "ef00 01 01 0008 02 0002 0003 0001 ff 0001 ff 0001 00"
                 "00800000 00800000 E50001 00 AA AA"
             ),
             validity_error=[EOFException.MISSING_TERMINATOR, EOFException.UNEXPECTED_HEADER_KIND],
@@ -794,7 +793,7 @@ def test_valid_containers(
             ],
             skip_join_concurrent_sections_in_header=True,
             expected_bytecode=(
-                "ef00 01 01 0008 02 0001 0003 02 0001 0001 04 0001 04 0001 00"
+                "ef00 01 01 0008 02 0001 0003 02 0001 0001 ff 0001 ff 0001 00"
                 "00800000 00800000 E50001 00 AA AA"
             ),
             validity_error=[
@@ -812,10 +811,10 @@ def test_valid_containers(
             ],
             auto_sort_sections=AutoSection.ONLY_BODY,
             expected_bytecode=(
-                "ef00 01 01 0004 02 0001 0015 03 0001 0014 04 0001 03 0001 0014 00"
+                "ef00 01 01 0004 02 0001 0015 03 0001 0014 ff 0001 03 0001 0014 00"
                 "00800005 6000600060006000ec00 6000600060006000ec01 00"
-                "ef00 01 01 0004 02 0001 0001 04 0000 00 00800000 fe"
-                "ef00 01 01 0004 02 0001 0001 04 0000 00 00800000 fe"
+                "ef00 01 01 0004 02 0001 0001 ff 0000 00 00800000 fe"
+                "ef00 01 01 0004 02 0001 0001 ff 0000 00 00800000 fe"
                 "aa"
             ),
             validity_error=[EOFException.MISSING_TERMINATOR, EOFException.UNEXPECTED_HEADER_KIND],
@@ -830,10 +829,10 @@ def test_valid_containers(
             ],
             skip_join_concurrent_sections_in_header=True,
             expected_bytecode=(
-                "ef00 01 01 0004 02 0001 0015 03 0001 0014 03 0001 0014 04 0001 00"
+                "ef00 01 01 0004 02 0001 0015 03 0001 0014 03 0001 0014 ff 0001 00"
                 "00800005 6000600060006000ec00 6000600060006000ec01 00"
-                "ef00 01 01 0004 02 0001 0001 04 0000 00 00800000 fe"
-                "ef00 01 01 0004 02 0001 0001 04 0000 00 00800000 fe"
+                "ef00 01 01 0004 02 0001 0001 ff 0000 00 00800000 fe"
+                "ef00 01 01 0004 02 0001 0001 ff 0000 00 00800000 fe"
                 "aa"
             ),
             validity_error=[
@@ -851,9 +850,9 @@ def test_valid_containers(
             ],
             skip_join_concurrent_sections_in_header=True,
             expected_bytecode=(
-                "ef00 01 01 0004 02 0001 000b 03 0001 0014 03 0001 0014 04 0001 00"
+                "ef00 01 01 0004 02 0001 000b 03 0001 0014 03 0001 0014 ff 0001 00"
                 "00800004 6000600060006000ec00 00"
-                "ef00 01 01 0004 02 0001 0001 04 0000 00 00800000 fe"
+                "ef00 01 01 0004 02 0001 0001 ff 0000 00 00800000 fe"
                 "aa"
             ),
             validity_error=[
@@ -866,27 +865,30 @@ def test_valid_containers(
             sections=[
                 Section.Code(Op.STOP),
                 Section.Data(data="0x"),
-                Section(kind=VERSION_MAX_SECTION_KIND + 1, data="0x01"),
+                Section(kind=4, data="0x01"),
             ],
+            auto_sort_sections=AutoSection.NONE,
             validity_error=[EOFException.MISSING_TERMINATOR, EOFException.UNEXPECTED_HEADER_KIND],
         ),
         Container(
             name="unknown_section_2",
             sections=[
-                Section(kind=VERSION_MAX_SECTION_KIND + 1, data="0x01"),
+                Section(kind=4, data="0x01"),
                 Section.Data(data="0x"),
                 Section.Code(Op.STOP),
             ],
+            auto_sort_sections=AutoSection.NONE,
             # TODO the exception should be about unknown section definition
-            validity_error=[EOFException.MISSING_TERMINATOR, EOFException.UNEXPECTED_HEADER_KIND],
+            validity_error=[EOFException.MISSING_CODE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
         ),
         Container(
             name="unknown_section_empty",
             sections=[
                 Section.Code(Op.STOP),
                 Section.Data(data="0x"),
-                Section(kind=VERSION_MAX_SECTION_KIND + 1, data="0x"),
+                Section(kind=4, data="0x"),
             ],
+            auto_sort_sections=AutoSection.NONE,
             validity_error=[EOFException.MISSING_TERMINATOR, EOFException.UNEXPECTED_HEADER_KIND],
         ),
         Container(
@@ -916,7 +918,7 @@ def test_valid_containers(
                 Section.Data("0xda"),
             ],
             auto_type_section=AutoSection.NONE,
-            expected_bytecode="ef0001 020001 0001 040001 00 feda",
+            expected_bytecode="ef0001 020001 0001 ff0001 00 feda",
             validity_error=[EOFException.MISSING_TYPE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
         ),
         Container(
@@ -933,9 +935,9 @@ def test_valid_containers(
                 ),
             ],
             auto_type_section=AutoSection.NONE,
-            expected_bytecode="ef0001 020001 0001 030001 0032 040000 00 fe"
-            "ef0001 010004 020001 0006 030001 0014 040000 00 00800002 60006000ee00"
-            "ef0001 010004 020001 0001 040000 00 0080000000",
+            expected_bytecode="ef0001 020001 0001 030001 0032 ff0000 00 fe"
+            "ef0001 010004 020001 0006 030001 0014 ff0000 00 00800002 60006000ee00"
+            "ef0001 010004 020001 0001 ff0000 00 0080000000",
             validity_error=[EOFException.MISSING_TYPE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
         ),
         Container(
@@ -964,7 +966,7 @@ def test_valid_containers(
                 Section(kind=SectionKind.TYPE),
                 Section.Code(),
             ],
-            expected_bytecode="ef00 01 01 0000 02 0001 0000 04 0000 00",
+            expected_bytecode="ef00 01 01 0000 02 0001 0000 ff 0000 00",
             validity_error=[
                 EOFException.ZERO_SECTION_SIZE,
                 EOFException.INVALID_SECTION_BODIES_SIZE,
@@ -976,7 +978,7 @@ def test_valid_containers(
                 Section(kind=SectionKind.TYPE),
                 Section.Code(Op.STOP),
             ],
-            expected_bytecode="ef00 01 01 0000 02 0001 0001 04 0000 00 00",
+            expected_bytecode="ef00 01 01 0000 02 0001 0001 ff 0000 00 00",
             validity_error=[
                 EOFException.ZERO_SECTION_SIZE,
                 EOFException.INVALID_SECTION_BODIES_SIZE,

--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_eof_example.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_eof_example.py
@@ -55,7 +55,7 @@ def test_eof_example(eof_test: EOFTestFiller):
 
     # This will construct a valid EOF container with these bytes
     assert bytes(eof_code) == bytes.fromhex(
-        "ef0001010010020004000500060008000204000100008000010100000100010003020300035fe300010050"
+        "ef00010100100200040005000600080002ff000100008000010100000100010003020300035fe300010050"
         "e3000250e43080e300035050e480e4ef"
     )
 

--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_migrated_valid_invalid.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_migrated_valid_invalid.py
@@ -48,57 +48,57 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
             # Empty code section with non-empty data section
             Container(
                 sections=[Section.Code(code_outputs=0), Section.Data("aabb")],
-                expected_bytecode="ef000101000402000100000400020000000000aabb",
+                expected_bytecode="ef00010100040200010000ff00020000000000aabb",
             ),
             EOFException.ZERO_SECTION_SIZE,
             id="EOF1I3540_0012_empty_code_section_with_non_empty_data_section",
         ),
         pytest.param(
             # No section terminator after data section size
-            Container(raw_bytes=bytes.fromhex("ef00010100040200010001040002")),
+            Container(raw_bytes=bytes.fromhex("ef00010100040200010001ff0002")),
             EOFException.MISSING_HEADERS_TERMINATOR,
             id="EOF1I3540_0020_no_section_terminator_after_data_section_size",
         ),
         pytest.param(
             # No type section contents
-            Container(raw_bytes=bytes.fromhex("ef0001010004020001000104000200")),
+            Container(raw_bytes=bytes.fromhex("ef00010100040200010001ff000200")),
             EOFException.INVALID_SECTION_BODIES_SIZE,
             id="EOF1I3540_0021_no_type_section_contents",
         ),
         pytest.param(
             # Type section contents (no outputs and max stack)
-            Container(raw_bytes=bytes.fromhex("ef000101000402000100010400020000")),
+            Container(raw_bytes=bytes.fromhex("ef00010100040200010001ff00020000")),
             EOFException.INVALID_SECTION_BODIES_SIZE,
             id="EOF1I3540_0022_invalid_type_section_no_outputs_and_max_stack",
         ),
         pytest.param(
             # Type section contents (no max stack)
-            Container(raw_bytes=bytes.fromhex("ef00010100040200010001040002000000")),
+            Container(raw_bytes=bytes.fromhex("ef00010100040200010001ff0002000000")),
             EOFException.INVALID_SECTION_BODIES_SIZE,
             id="EOF1I3540_0023_invalid_type_section_no_max_stack",
         ),
         pytest.param(
             # Type section contents (max stack incomplete)
-            Container(raw_bytes=bytes.fromhex("ef0001010004020001000104000200000000")),
+            Container(raw_bytes=bytes.fromhex("ef00010100040200010001ff000200000000")),
             EOFException.INVALID_SECTION_BODIES_SIZE,
             id="EOF1I3540_0024_invalid_type_section_max_stack_incomplete",
         ),
         pytest.param(
             # No code section contents
-            Container(raw_bytes=bytes.fromhex("ef000101000402000100010400020000000000")),
+            Container(raw_bytes=bytes.fromhex("ef00010100040200010001ff00020000000000")),
             EOFException.INVALID_SECTION_BODIES_SIZE,
             id="EOF1I3540_0025_no_code_section_contents",
         ),
         pytest.param(
             # Code section contents incomplete
-            Container(raw_bytes=bytes.fromhex("ef0001010004020001002904000000000000027f")),
+            Container(raw_bytes=bytes.fromhex("ef00010100040200010029ff000000000000027f")),
             EOFException.INVALID_SECTION_BODIES_SIZE,
             id="EOF1I3540_0026_code_section_contents_incomplete",
         ),
         pytest.param(
             # Trailing bytes after code section
             Container(
-                raw_bytes=bytes.fromhex("ef0001 010004 0200010001 040000 00 00800000 fe aabbcc")
+                raw_bytes=bytes.fromhex("ef0001 010004 0200010001 ff0000 00 00800000 fe aabbcc")
             ),
             EOFException.INVALID_SECTION_BODIES_SIZE,
             id="EOF1I3540_0027_trailing_bytes_after_code_section",
@@ -106,38 +106,38 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
         pytest.param(
             # Trailing bytes after code section with wrong first section type
             Container(
-                raw_bytes=bytes.fromhex("ef0001 010004 0200010001 040000 00 00000000 fe aabbcc")
+                raw_bytes=bytes.fromhex("ef0001 010004 0200010001 ff0000 00 00000000 fe aabbcc")
             ),
             [EOFException.INVALID_FIRST_SECTION_TYPE, EOFException.INVALID_SECTION_BODIES_SIZE],
             id="EOF1I3540_0027_trailing_bytes_after_code_section_with_wrong_first_section_type",
         ),
         pytest.param(
             # Empty code section
-            Container(raw_bytes=bytes.fromhex("ef000101000402000100000400000000000000")),
+            Container(raw_bytes=bytes.fromhex("ef00010100040200010000ff00000000000000")),
             EOFException.ZERO_SECTION_SIZE,
             id="EOF1I3540_0028_empty_code_section",
         ),
         pytest.param(
             # Code section preceding type section
-            Container(raw_bytes=bytes.fromhex("ef000102000100010100040400020000000000feaabb")),
+            Container(raw_bytes=bytes.fromhex("ef00010200010001010004ff00020000000000feaabb")),
             [EOFException.MISSING_TYPE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
             id="EOF1I3540_0030_code_section_preceding_type_section",
         ),
         pytest.param(
             # Data section preceding type section
-            Container(raw_bytes=bytes.fromhex("ef000104000201000402000100010000000000feaabb")),
+            Container(raw_bytes=bytes.fromhex("ef0001ff000201000402000100010000000000feaabb")),
             [EOFException.MISSING_TYPE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
             id="EOF1I3540_0031_data_section_preceding_type_section",
         ),
         pytest.param(
             # Data section preceding code section
-            Container(raw_bytes=bytes.fromhex("ef000101000404000202000100010000000000feaabb")),
+            Container(raw_bytes=bytes.fromhex("ef0001010004ff000202000100010000000000feaabb")),
             [EOFException.MISSING_CODE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
             id="EOF1I3540_0032_data_section_preceding_code_section",
         ),
         pytest.param(
             # Data section without code section
-            Container(raw_bytes=bytes.fromhex("ef00010100040400020000000000aabb")),
+            Container(raw_bytes=bytes.fromhex("ef0001010004ff00020000000000aabb")),
             [EOFException.MISSING_CODE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
             id="EOF1I3540_0033_data_section_without_code_section",
         ),
@@ -155,7 +155,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                     Section.Data("aabb"),
                 ],
                 extra="ccdd",
-                expected_bytecode="ef0001 010004 0200010001 040002 00 00800000 fe aabbccdd",
+                expected_bytecode="ef0001 010004 0200010001 ff0002 00 00800000 fe aabbccdd",
             ),
             EOFException.INVALID_SECTION_BODIES_SIZE,
             id="EOF1I3540_0035_trailing_bytes_after_data_section",
@@ -163,7 +163,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
         pytest.param(
             # Trailing bytes after data section with wrong first section type
             Container(
-                raw_bytes=bytes.fromhex("ef0001 010004 0200010001 040002 00 00000000 fe aabbccdd")
+                raw_bytes=bytes.fromhex("ef0001 010004 0200010001 ff0002 00 00000000 fe aabbccdd")
             ),
             [EOFException.INVALID_FIRST_SECTION_TYPE, EOFException.INVALID_SECTION_BODIES_SIZE],
             id="EOF1I3540_0035_trailing_bytes_after_data_section_with_wrong_first_section_type",
@@ -171,7 +171,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
         pytest.param(
             # Multiple data sections
             Container(
-                raw_bytes=bytes.fromhex("ef000101000402000100010400020400020000000000feaabbaabb")
+                raw_bytes=bytes.fromhex("ef00010100040200010001ff0002ff00020000000000feaabbaabb")
             ),
             [EOFException.MISSING_TERMINATOR, EOFException.UNEXPECTED_HEADER_KIND],
             id="EOF1I3540_0036_multiple_data_sections",
@@ -180,7 +180,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
             # Multiple code and data sections
             Container(
                 raw_bytes=bytes.fromhex(
-                    "ef000101000802000200010001040002040002000000000000000000fefeaabbaabb"
+                    "ef000101000802000200010001ff0002ff0002000000000000000000fefeaabbaabb"
                 )
             ),
             [EOFException.MISSING_TERMINATOR, EOFException.UNEXPECTED_HEADER_KIND],
@@ -188,80 +188,80 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
         ),
         pytest.param(
             # Unknown section ID (at the beginning)
-            Container(raw_bytes=bytes.fromhex("ef000105000101000402000100010400000000000000fe")),
+            Container(raw_bytes=bytes.fromhex("ef00010500010100040200010001ff00000000000000fe")),
             [EOFException.MISSING_TYPE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
             id="EOF1I3540_0038_unknown_section_id_at_the_beginning_05",
         ),
         pytest.param(
             # Unknown section ID (at the beginning)
-            Container(raw_bytes=bytes.fromhex("ef000106000101000402000100010400000000000000fe")),
+            Container(raw_bytes=bytes.fromhex("ef00010600010100040200010001ff00000000000000fe")),
             [EOFException.MISSING_TYPE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
             id="EOF1I3540_0039_unknown_section_id_at_the_beginning_06",
         ),
         pytest.param(
             # Unknown section ID (at the beginning)
-            Container(raw_bytes=bytes.fromhex("ef0001ff000101000402000100010400000000000000fe")),
+            Container(raw_bytes=bytes.fromhex("ef0001ff00010100040200010001ff00000000000000fe")),
             [EOFException.MISSING_TYPE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
             id="EOF1I3540_0040_unknown_section_id_at_the_beginning_ff",
         ),
         pytest.param(
             # Unknown section ID (after types section)
-            Container(raw_bytes=bytes.fromhex("ef000101000405000102000100010400000000000000fe")),
+            Container(raw_bytes=bytes.fromhex("ef00010100040500010200010001ff00000000000000fe")),
             [EOFException.MISSING_CODE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
             id="EOF1I3540_0041_unknown_section_id_after_types_section_05",
         ),
         pytest.param(
             # Unknown section ID (after types section)
-            Container(raw_bytes=bytes.fromhex("ef000101000406000102000100010400000000000000fe")),
+            Container(raw_bytes=bytes.fromhex("ef00010100040600010200010001ff00000000000000fe")),
             [EOFException.MISSING_CODE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
             id="EOF1I3540_0042_unknown_section_id_after_types_section_06",
         ),
         pytest.param(
             # Unknown section ID (after types section)
-            Container(raw_bytes=bytes.fromhex("ef0001010004ff000102000100010400000000000000fe")),
+            Container(raw_bytes=bytes.fromhex("ef0001010004ff00010200010001ff00000000000000fe")),
             [EOFException.MISSING_CODE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
             id="EOF1I3540_0043_unknown_section_id_after_types_section_ff",
         ),
         pytest.param(
             # Unknown section ID (after code section)
-            Container(raw_bytes=bytes.fromhex("ef000101000402000100010500010400000000000000fe")),
+            Container(raw_bytes=bytes.fromhex("ef00010100040200010001050001ff00000000000000fe")),
             [EOFException.MISSING_DATA_SECTION, EOFException.UNEXPECTED_HEADER_KIND],
             id="EOF1I3540_0044_unknown_section_id_after_code_section_05",
         ),
         pytest.param(
             # Unknown section ID (after code section)
-            Container(raw_bytes=bytes.fromhex("ef000101000402000100010600010400000000000000fe")),
+            Container(raw_bytes=bytes.fromhex("ef00010100040200010001060001ff00000000000000fe")),
             [EOFException.MISSING_DATA_SECTION, EOFException.UNEXPECTED_HEADER_KIND],
             id="EOF1I3540_0045_unknown_section_id_after_code_section_06",
         ),
         pytest.param(
             # Unknown section ID (after code section)
-            Container(raw_bytes=bytes.fromhex("ef00010100040200010001ff00010400000000000000fe")),
+            Container(raw_bytes=bytes.fromhex("ef00010100040200010001040001ff00000000000000fe")),
             [EOFException.MISSING_DATA_SECTION, EOFException.UNEXPECTED_HEADER_KIND],
-            id="EOF1I3540_0046_unknown_section_id_after_code_section_ff",
+            id="EOF1I3540_0046_unknown_section_id_after_code_section_04",
         ),
         pytest.param(
             # Unknown section ID (after data section)
-            Container(raw_bytes=bytes.fromhex("ef000101000402000100010400000500010000000000fe")),
+            Container(raw_bytes=bytes.fromhex("ef00010100040200010001ff00000500010000000000fe")),
             [EOFException.MISSING_TERMINATOR, EOFException.UNEXPECTED_HEADER_KIND],
             id="EOF1I3540_0047_unknown_section_id_after_data_section_05",
         ),
         pytest.param(
             # Unknown section ID (after data section)
-            Container(raw_bytes=bytes.fromhex("ef000101000402000100010400000600010000000000fe")),
+            Container(raw_bytes=bytes.fromhex("ef00010100040200010001ff00000600010000000000fe")),
             [EOFException.MISSING_TERMINATOR, EOFException.UNEXPECTED_HEADER_KIND],
             id="EOF1I3540_0048_unknown_section_id_after_data_section_06",
         ),
         pytest.param(
             # Unknown section ID (after data section)
-            Container(raw_bytes=bytes.fromhex("ef00010100040200010001040000ff00010000000000fe")),
+            Container(raw_bytes=bytes.fromhex("ef00010100040200010001ff00000400010000000000fe")),
             [EOFException.MISSING_TERMINATOR, EOFException.UNEXPECTED_HEADER_KIND],
-            id="EOF1I3540_0049_unknown_section_id_after_data_section_ff",
+            id="EOF1I3540_0049_unknown_section_id_after_data_section_04",
         ),
         pytest.param(
             Container(
                 name="EOF1I3540_0002 (Invalid) Invalid magic",
-                raw_bytes="ef010101000402000100010400000000000000fe",
+                raw_bytes="ef01010100040200010001ff00000000000000fe",
             ),
             EOFException.INVALID_MAGIC,
             id="EOF1I3540_0002_invalid_incorrect_magic_01",
@@ -269,7 +269,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
         pytest.param(
             Container(
                 name="EOF1I3540_0003",
-                raw_bytes="ef020101000402000100010400000000000000fe",
+                raw_bytes="ef02010100040200010001ff00000000000000fe",
             ),
             EOFException.INVALID_MAGIC,
             id="EOF1I3540_0003_invalid_incorrect_magic_02",
@@ -277,7 +277,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
         pytest.param(
             Container(
                 name="EOF1I3540_0004",
-                raw_bytes="efff0101000402000100010400000000000000fe",
+                raw_bytes="efff010100040200010001ff00000000000000fe",
             ),
             EOFException.INVALID_MAGIC,
             id="EOF1I3540_0004_invalid_incorrect_magic_ff",
@@ -285,7 +285,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
         pytest.param(
             Container(
                 name="EOF1I3540_0006 (Invalid) Invalid version",
-                raw_bytes="ef000001000402000100010400000000000000fe",
+                raw_bytes="ef00000100040200010001ff00000000000000fe",
             ),
             EOFException.INVALID_VERSION,
             id="EOF1I3540_0006_invalid_incorrect_version_00",
@@ -293,7 +293,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
         pytest.param(
             Container(
                 name="EOF1I3540_0007",
-                raw_bytes="ef000201000402000100010400000000000000fe",
+                raw_bytes="ef00020100040200010001ff00000000000000fe",
             ),
             EOFException.INVALID_VERSION,
             id="EOF1I3540_0007_invalid_incorrect_version_02",
@@ -301,7 +301,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
         pytest.param(
             Container(
                 name="EOF1I3540_0008",
-                raw_bytes="ef00ff01000402000100010400000000000000fe",
+                raw_bytes="ef00ff0100040200010001ff00000000000000fe",
             ),
             EOFException.INVALID_VERSION,
             id="EOF1I3540_0008_invalid_incorrect_version_ff",

--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_section_header_body_mismatch.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_section_header_body_mismatch.py
@@ -30,7 +30,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                 {
                     "skip_header_listing": True,
                     "skip_body_listing": True,
-                    "expected_code": "ef000101000802000100030400040000800001000000003050000bad60A7",  # noqa: E501
+                    "expected_code": "ef00010100080200010003ff00040000800001000000003050000bad60A7",  # noqa: E501
                     "expected_exception": [
                         EOFException.INVALID_TYPE_SECTION_SIZE,
                         EOFException.INVALID_SECTION_BODIES_SIZE,
@@ -42,7 +42,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                 {
                     "skip_header_listing": True,
                     "skip_body_listing": False,
-                    "expected_code": "ef000101000802000100030400040000800001000000003050003050000bad60A7",  # noqa: E501
+                    "expected_code": "ef00010100080200010003ff00040000800001000000003050003050000bad60A7",  # noqa: E501
                     "expected_exception": [
                         EOFException.INVALID_TYPE_SECTION_SIZE,
                         EOFException.INVALID_SECTION_BODIES_SIZE,
@@ -54,7 +54,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                 {
                     "skip_header_listing": False,
                     "skip_body_listing": True,
-                    "expected_code": "ef0001010008020002000300030400040000800001000000003050000bad60A7",  # noqa: E501
+                    "expected_code": "ef000101000802000200030003ff00040000800001000000003050000bad60A7",  # noqa: E501
                     "expected_exception": [
                         EOFException.UNREACHABLE_CODE_SECTIONS,
                         EOFException.TOPLEVEL_CONTAINER_TRUNCATED,
@@ -66,7 +66,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                 {
                     "skip_header_listing": False,
                     "skip_body_listing": False,
-                    "expected_code": "ef0001010008020002000300030400040000800001000000003050003050000bad60A7",  # noqa: E501
+                    "expected_code": "ef000101000802000200030003ff00040000800001000000003050003050000bad60A7",  # noqa: E501
                     "expected_exception": EOFException.UNREACHABLE_CODE_SECTIONS,
                 },
                 id="layout_ok_code_bad",
@@ -76,7 +76,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                     "skip_header_listing": True,
                     "skip_body_listing": True,
                     "skip_types_body_listing": True,
-                    "expected_code": "ef0001010008020001000304000400008000013050000bad60a7",
+                    "expected_code": "ef00010100080200010003ff000400008000013050000bad60a7",
                     "expected_exception": [
                         EOFException.INVALID_TYPE_SECTION_SIZE,
                         EOFException.INVALID_SECTION_BODIES_SIZE,
@@ -90,7 +90,7 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
                     "skip_body_listing": True,
                     "skip_types_body_listing": True,
                     "skip_types_header_listing": True,
-                    "expected_code": "ef0001010004020001000304000400008000013050000bad60a7",
+                    "expected_code": "ef00010100040200010003ff000400008000013050000bad60a7",
                     "expected_exception": None,
                 },
                 id="drop_everything",

--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_section_order.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_section_order.py
@@ -40,12 +40,12 @@ def get_expected_code_exception(
     match (section_kind, section_test, test_position):
         case (SectionKind.TYPE, SectionTest.MISSING, CasePosition.HEADER):
             return (
-                "ef000102000100030400010000800001305000ef",
+                "ef00010200010003ff00010000800001305000ef",
                 [EOFException.MISSING_TYPE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
             )
         case (SectionKind.TYPE, SectionTest.MISSING, CasePosition.BODY):
             return (
-                "ef0001010004020001000304000100305000ef",
+                "ef00010100040200010003ff000100305000ef",
                 [
                     EOFException.INVALID_SECTION_BODIES_SIZE,
                     EOFException.INVALID_FIRST_SECTION_TYPE,
@@ -53,55 +53,55 @@ def get_expected_code_exception(
             )
         case (SectionKind.TYPE, SectionTest.MISSING, CasePosition.BODY_AND_HEADER):
             return (
-                "ef0001020001000304000100305000ef",
+                "ef00010200010003ff000100305000ef",
                 [EOFException.MISSING_TYPE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
             )
         case (SectionKind.TYPE, SectionTest.WRONG_ORDER, CasePosition.HEADER):
             return (
-                "ef000102000100030100040400010000800001305000ef",
+                "ef00010200010003010004ff00010000800001305000ef",
                 [EOFException.MISSING_TYPE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
             )
         case (SectionKind.TYPE, SectionTest.WRONG_ORDER, CasePosition.BODY):
             return (
-                "ef000101000402000100030400010030500000800001ef",
+                "ef00010100040200010003ff00010030500000800001ef",
                 # TODO why invalid first section type? it should say that the body incorrect
                 EOFException.INVALID_FIRST_SECTION_TYPE,
             )
         case (SectionKind.TYPE, SectionTest.WRONG_ORDER, CasePosition.BODY_AND_HEADER):
             return (
-                "ef000102000100030100040400010030500000800001ef",
+                "ef00010200010003010004ff00010030500000800001ef",
                 [EOFException.MISSING_TYPE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
             )
         case (SectionKind.CODE, SectionTest.MISSING, CasePosition.HEADER):
             return (
-                "ef00010100040400010000800001305000ef",
+                "ef0001010004ff00010000800001305000ef",
                 [EOFException.MISSING_CODE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
             )
         case (SectionKind.CODE, SectionTest.MISSING, CasePosition.BODY):
             return (
-                "ef000101000402000100030400010000800001ef",
+                "ef00010100040200010003ff00010000800001ef",
                 # TODO should be an exception of empty code bytes, because it can understand that
                 # last byte is data section byte
                 [EOFException.INVALID_SECTION_BODIES_SIZE, EOFException.UNEXPECTED_HEADER_KIND],
             )
         case (SectionKind.CODE, SectionTest.MISSING, CasePosition.BODY_AND_HEADER):
             return (
-                "ef00010100040400010000800001ef",
+                "ef0001010004ff00010000800001ef",
                 [EOFException.MISSING_CODE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
             )
         case (SectionKind.CODE, SectionTest.WRONG_ORDER, CasePosition.HEADER):
             return (
-                "ef000101000404000102000100030000800001305000ef",
+                "ef0001010004ff000102000100030000800001305000ef",
                 [EOFException.MISSING_CODE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
             )
         case (SectionKind.CODE, SectionTest.WRONG_ORDER, CasePosition.BODY):
             return (
-                "ef000101000402000100030400010000800001ef305000",
+                "ef00010100040200010003ff00010000800001ef305000",
                 EOFException.UNDEFINED_INSTRUCTION,
             )
         case (SectionKind.CODE, SectionTest.WRONG_ORDER, CasePosition.BODY_AND_HEADER):
             return (
-                "ef000101000404000102000100030000800001ef305000",
+                "ef0001010004ff000102000100030000800001ef305000",
                 [EOFException.MISSING_CODE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
             )
         case (SectionKind.DATA, SectionTest.MISSING, CasePosition.HEADER):
@@ -111,7 +111,7 @@ def get_expected_code_exception(
             )
         case (SectionKind.DATA, SectionTest.MISSING, CasePosition.BODY):
             return (
-                "ef000101000402000100030400010000800001305000",
+                "ef00010100040200010003ff00010000800001305000",
                 EOFException.TOPLEVEL_CONTAINER_TRUNCATED,
             )
         case (SectionKind.DATA, SectionTest.MISSING, CasePosition.BODY_AND_HEADER):
@@ -121,17 +121,17 @@ def get_expected_code_exception(
             )
         case (SectionKind.DATA, SectionTest.WRONG_ORDER, CasePosition.HEADER):
             return (
-                "ef000104000101000402000100030000800001305000ef",
+                "ef0001ff000101000402000100030000800001305000ef",
                 [EOFException.MISSING_TYPE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
             )
         case (SectionKind.DATA, SectionTest.WRONG_ORDER, CasePosition.BODY):
             return (
-                "ef0001010004020001000304000100ef00800001305000",
+                "ef00010100040200010003ff000100ef00800001305000",
                 EOFException.INVALID_FIRST_SECTION_TYPE,
             )
         case (SectionKind.DATA, SectionTest.WRONG_ORDER, CasePosition.BODY_AND_HEADER):
             return (
-                "ef0001040001010004020001000300ef00800001305000",
+                "ef0001ff0001010004020001000300ef00800001305000",
                 [EOFException.MISSING_TYPE_HEADER, EOFException.UNEXPECTED_HEADER_KIND],
             )
     return "", None

--- a/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjump.py
+++ b/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjump.py
@@ -278,7 +278,7 @@ def test_rjump_into_self_pre_code(
                     max_stack_height=0,
                 ),
             ],
-            expected_bytecode="ef000101000402000100040400000000800000e0000000",
+            expected_bytecode="ef00010100040200010004ff00000000800000e0000000",
         ),
         Container(
             name="forwards_rjump_1",
@@ -288,7 +288,7 @@ def test_rjump_into_self_pre_code(
                     max_stack_height=2,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000b04000000008000025f6000e10003e000011900",
+            expected_bytecode="ef0001010004020001000bff000000008000025f6000e10003e000011900",
         ),
         Container(
             name="forwards_rjump_2",
@@ -306,7 +306,7 @@ def test_rjump_into_self_pre_code(
                     max_stack_height=2,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001304000000008000025f6000e100086000e10006e00004e000011900",
+            expected_bytecode="ef00010100040200010013ff000000008000025f6000e100086000e10006e00004e000011900",
         ),
         Container(
             name="forwards_rjump_3",
@@ -316,7 +316,7 @@ def test_rjump_into_self_pre_code(
                     max_stack_height=2,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000b04000000008000025f6000e10003e000015f00",
+            expected_bytecode="ef0001010004020001000bff000000008000025f6000e10003e000015f00",
         ),
         Container(
             name="forwards_rjump_4",
@@ -335,7 +335,7 @@ def test_rjump_into_self_pre_code(
                     max_stack_height=2,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001404000000008000025f6000e100086000e10007e000055fe000011900",
+            expected_bytecode="ef00010100040200010014ff000000008000025f6000e100086000e10007e000055fe000011900",
         ),
         Container(
             name="forwards_rjump_variable_stack_0",
@@ -351,7 +351,7 @@ def test_rjump_into_self_pre_code(
                     max_stack_height=3,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000c04000000008000035f6000e100025f5fe0000000",
+            expected_bytecode="ef0001010004020001000cff000000008000035f6000e100025f5fe0000000",
         ),
         Container(
             name="forwards_rjump_variable_stack_1",
@@ -371,7 +371,7 @@ def test_rjump_into_self_pre_code(
                     max_stack_height=5,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001304000000008000055f6000e100025f5f5f6000e10003e000011900",
+            expected_bytecode="ef00010100040200010013ff000000008000055f6000e100025f5f5f6000e10003e000011900",
         ),
         Container(
             name="forwards_rjump_variable_stack_2",
@@ -394,7 +394,7 @@ def test_rjump_into_self_pre_code(
                     max_stack_height=5,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001b04000000008000055f6000e100025f5f5f6000e100086000e10006e00004e000011900",
+            expected_bytecode="ef0001010004020001001bff000000008000055f6000e100025f5f5f6000e100086000e10006e00004e000011900",
         ),
         Container(
             name="forwards_rjump_variable_stack_3",
@@ -414,7 +414,7 @@ def test_rjump_into_self_pre_code(
                     max_stack_height=5,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001304000000008000055f6000e100025f5f5f6000e10003e000015f00",
+            expected_bytecode="ef00010100040200010013ff000000008000055f6000e100025f5f5f6000e10003e000015f00",
         ),
         Container(
             name="forwards_rjump_variable_stack_4",
@@ -437,7 +437,7 @@ def test_rjump_into_self_pre_code(
                     max_stack_height=4,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001b04000000008000045f6000e100025f5f6000e100086000e10007e000055fe000011900",
+            expected_bytecode="ef0001010004020001001bff000000008000045f6000e100025f5f6000e100086000e10007e000055fe000011900",
         ),
     ],
     ids=lambda x: x.name,
@@ -464,7 +464,7 @@ def test_rjump_valid_forward(
                     max_stack_height=1,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000504000000008000015f50e0fffb",
+            expected_bytecode="ef00010100040200010005ff000000008000015f50e0fffb",
         ),
         Container(
             name="backwards_rjump_2",
@@ -479,7 +479,7 @@ def test_rjump_valid_forward(
                     max_stack_height=1,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000d04000000008000015f506001e10003e0fff8e0fff5",
+            expected_bytecode="ef0001010004020001000dff000000008000015f506001e10003e0fff8e0fff5",
         ),
         Container(
             name="backwards_rjump_variable_stack_0",
@@ -494,7 +494,7 @@ def test_rjump_valid_forward(
                     max_stack_height=3,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000b04000000008000035f6000e100025f5fe0fffd",
+            expected_bytecode="ef0001010004020001000bff000000008000035f6000e100025f5fe0fffd",
         ),
         Container(
             name="backwards_rjump_variable_stack_1",
@@ -511,7 +511,7 @@ def test_rjump_valid_forward(
                     max_stack_height=4,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000d04000000008000045f6000e100025f5f5f50e0fffb",
+            expected_bytecode="ef0001010004020001000dff000000008000045f6000e100025f5f5f50e0fffb",
         ),
         Container(
             name="backwards_rjump_variable_stack_2",
@@ -533,7 +533,7 @@ def test_rjump_valid_forward(
                     max_stack_height=4,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001504000000008000045f6000e100025f5f5f506001e10003e0fff8e0fff5",
+            expected_bytecode="ef00010100040200010015ff000000008000045f6000e100025f5f5f506001e10003e0fff8e0fff5",
         ),
     ],
     ids=lambda x: x.name,
@@ -588,7 +588,7 @@ def test_rjump_into_stack_height_diff_2(
                     max_stack_height=1,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000e04000000008000015f506001e10003e0fff85fe0fff4",
+            expected_bytecode="ef0001010004020001000eff000000008000015f506001e10003e0fff85fe0fff4",
         ),
         Container(
             name="backwards_rjump_4",
@@ -598,7 +598,7 @@ def test_rjump_into_stack_height_diff_2(
                     max_stack_height=1,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000404000000008000015fe0fffc",
+            expected_bytecode="ef00010100040200010004ff000000008000015fe0fffc",
         ),
         Container(
             name="backwards_rjump_5",
@@ -608,7 +608,7 @@ def test_rjump_into_stack_height_diff_2(
                     max_stack_height=1,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000504000000008000015f50e0fffc",
+            expected_bytecode="ef00010100040200010005ff000000008000015f50e0fffc",
         ),
         Container(
             name="backwards_rjump_8",
@@ -623,7 +623,7 @@ def test_rjump_into_stack_height_diff_2(
                     max_stack_height=1,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000b04000000008000015f506000e1fff95fe0fff5",
+            expected_bytecode="ef0001010004020001000bff000000008000015f506000e1fff95fe0fff5",
         ),
         Container(
             name="backwards_rjump_variable_stack_3",
@@ -646,7 +646,7 @@ def test_rjump_into_stack_height_diff_2(
                     max_stack_height=4,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001604000000008000045f6000e100025f5f5f506001e10003e0fff85fe0fff4",
+            expected_bytecode="ef00010100040200010016ff000000008000045f6000e100025f5f5f506001e10003e0fff85fe0fff4",
         ),
         Container(
             name="backwards_rjump_variable_stack_4",
@@ -666,7 +666,7 @@ def test_rjump_into_stack_height_diff_2(
                     max_stack_height=4,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001104000000008000045f6000e100025f5f6000e100015fe0fff9",
+            expected_bytecode="ef00010100040200010011ff000000008000045f6000e100025f5f6000e100015fe0fff9",
         ),
         Container(
             name="backwards_rjump_variable_stack_5",
@@ -686,7 +686,7 @@ def test_rjump_into_stack_height_diff_2(
                     max_stack_height=4,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001104000000008000045f6000e100025f5f6000e1000150e0fff9",
+            expected_bytecode="ef00010100040200010011ff000000008000045f6000e100025f5f6000e1000150e0fff9",
         ),
         Container(
             name="backwards_rjump_variable_stack_6",
@@ -702,7 +702,7 @@ def test_rjump_into_stack_height_diff_2(
                     max_stack_height=4,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000c04000000008000045f6000e100025f5f5fe0fffc",
+            expected_bytecode="ef0001010004020001000cff000000008000045f6000e100025f5f5fe0fffc",
         ),
         Container(
             name="backwards_rjump_variable_stack_7",
@@ -719,7 +719,7 @@ def test_rjump_into_stack_height_diff_2(
                     max_stack_height=3,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000d04000000008000035f6000e100025f5f5f50e0fffc",
+            expected_bytecode="ef0001010004020001000dff000000008000035f6000e100025f5f5f50e0fffc",
         ),
         Container(
             name="backwards_rjump_variable_stack_8",
@@ -739,7 +739,7 @@ def test_rjump_into_stack_height_diff_2(
                     max_stack_height=4,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001304000000008000045f6000e100025f5f5f506000e1fff95fe0fff5",
+            expected_bytecode="ef00010100040200010013ff000000008000045f6000e100025f5f5f506000e1fff95fe0fff5",
         ),
     ],
     ids=lambda x: x.name,

--- a/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpi.py
+++ b/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpi.py
@@ -273,7 +273,7 @@ def test_rjumpi_max_backward(
                     max_stack_height=1,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000604000000008000016001e1000000",
+            expected_bytecode="ef00010100040200010006ff000000008000016001e1000000",
         ),
         Container(
             name="forwards_rjumpi_1",
@@ -283,7 +283,7 @@ def test_rjumpi_max_backward(
                     max_stack_height=2,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000804000000008000025f6000e100011900",
+            expected_bytecode="ef00010100040200010008ff000000008000025f6000e100011900",
         ),
         Container(
             name="forwards_rjumpi_10",
@@ -299,7 +299,7 @@ def test_rjumpi_max_backward(
                     max_stack_height=2,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000c04000000008000025f6000e1000450e000011900",
+            expected_bytecode="ef0001010004020001000cff000000008000025f6000e1000450e000011900",
         ),
         Container(
             name="forwards_rjumpi_11",
@@ -309,7 +309,7 @@ def test_rjumpi_max_backward(
                     max_stack_height=2,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000a04000000008000025f6000e10003e0000000",
+            expected_bytecode="ef0001010004020001000aff000000008000025f6000e10003e0000000",
         ),
         Container(
             name="forwards_rjumpi_12",
@@ -319,7 +319,7 @@ def test_rjumpi_max_backward(
                     max_stack_height=2,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000b04000000008000025f6000e100045fe0000000",
+            expected_bytecode="ef0001010004020001000bff000000008000025f6000e100045fe0000000",
         ),
         Container(
             name="forwards_rjumpi_2",
@@ -335,7 +335,7 @@ def test_rjumpi_max_backward(
                     max_stack_height=2,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000d04000000008000025f6000e100066000e100011900",
+            expected_bytecode="ef0001010004020001000dff000000008000025f6000e100066000e100011900",
         ),
         Container(
             name="forwards_rjumpi_3",
@@ -345,7 +345,7 @@ def test_rjumpi_max_backward(
                     max_stack_height=2,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000804000000008000025f6000e100015f00",
+            expected_bytecode="ef00010100040200010008ff000000008000025f6000e100015f00",
         ),
         Container(
             name="forwards_rjumpi_4",
@@ -362,7 +362,7 @@ def test_rjumpi_max_backward(
                     max_stack_height=3,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000e04000000008000035f6000e100075f6000e100011900",
+            expected_bytecode="ef0001010004020001000eff000000008000035f6000e100075f6000e100011900",
         ),
         Container(
             name="forwards_rjumpi_5",
@@ -381,7 +381,7 @@ def test_rjumpi_max_backward(
                     max_stack_height=3,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001004000000008000035f60010180600a11e1000480e1fff200",
+            expected_bytecode="ef00010100040200010010ff000000008000035f60010180600a11e1000480e1fff200",
         ),
         Container(
             name="forwards_rjumpi_6",
@@ -401,7 +401,7 @@ def test_rjumpi_max_backward(
                     max_stack_height=3,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001104000000008000035f60010180600a11e100055f80e1fff300",
+            expected_bytecode="ef00010100040200010011ff000000008000035f60010180600a11e100055f80e1fff300",
         ),
         Container(
             name="forwards_rjumpi_7",
@@ -417,7 +417,7 @@ def test_rjumpi_max_backward(
                     max_stack_height=2,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000c04000000008000025f6000e100045fe000015f00",
+            expected_bytecode="ef0001010004020001000cff000000008000025f6000e100045fe000015f00",
         ),
         Container(
             name="forwards_rjumpi_8",
@@ -433,7 +433,7 @@ def test_rjumpi_max_backward(
                     max_stack_height=2,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000c04000000008000025f6000e100045fe000011900",
+            expected_bytecode="ef0001010004020001000cff000000008000025f6000e100045fe000011900",
         ),
         Container(
             name="forwards_rjumpi_9",
@@ -449,7 +449,7 @@ def test_rjumpi_max_backward(
                     max_stack_height=2,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000c04000000008000025f6000e1000450e000015000",
+            expected_bytecode="ef0001010004020001000cff000000008000025f6000e1000450e000015000",
         ),
         Container(
             name="forwards_rjumpi_variable_stack_0",
@@ -466,7 +466,7 @@ def test_rjumpi_max_backward(
                     max_stack_height=4,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000e04000000008000045f6000e100025f5f6001e1000000",
+            expected_bytecode="ef0001010004020001000eff000000008000045f6000e100025f5f6001e1000000",
         ),
         Container(
             name="forwards_rjumpi_variable_stack_1",
@@ -485,7 +485,7 @@ def test_rjumpi_max_backward(
                     max_stack_height=5,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001004000000008000055f6000e100025f5f5f6000e100011900",
+            expected_bytecode="ef00010100040200010010ff000000008000055f6000e100025f5f5f6000e100011900",
         ),
         Container(
             name="forwards_rjumpi_variable_stack_10",
@@ -506,7 +506,7 @@ def test_rjumpi_max_backward(
                     max_stack_height=5,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001404000000008000055f6000e100025f5f5f6000e1000450e000011900",
+            expected_bytecode="ef00010100040200010014ff000000008000055f6000e100025f5f5f6000e1000450e000011900",
         ),
         Container(
             name="forwards_rjumpi_variable_stack_11",
@@ -525,7 +525,7 @@ def test_rjumpi_max_backward(
                     max_stack_height=5,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001204000000008000055f6000e100025f5f5f6000e10003e0000000",
+            expected_bytecode="ef00010100040200010012ff000000008000055f6000e100025f5f5f6000e10003e0000000",
         ),
         Container(
             name="forwards_rjumpi_variable_stack_12",
@@ -545,7 +545,7 @@ def test_rjumpi_max_backward(
                     max_stack_height=5,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001304000000008000055f6000e100025f5f5f6000e100045fe0000000",
+            expected_bytecode="ef00010100040200010013ff000000008000055f6000e100025f5f5f6000e100045fe0000000",
         ),
         Container(
             name="forwards_rjumpi_variable_stack_2",
@@ -566,7 +566,7 @@ def test_rjumpi_max_backward(
                     max_stack_height=5,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001504000000008000055f6000e100025f5f5f6000e100066000e100011900",
+            expected_bytecode="ef00010100040200010015ff000000008000055f6000e100025f5f5f6000e100066000e100011900",
         ),
         Container(
             name="forwards_rjumpi_variable_stack_3",
@@ -585,7 +585,7 @@ def test_rjumpi_max_backward(
                     max_stack_height=5,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001004000000008000055f6000e100025f5f5f6000e100015f00",
+            expected_bytecode="ef00010100040200010010ff000000008000055f6000e100025f5f5f6000e100015f00",
         ),
         Container(
             name="forwards_rjumpi_variable_stack_4",
@@ -607,7 +607,7 @@ def test_rjumpi_max_backward(
                     max_stack_height=6,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001604000000008000065f6000e100025f5f5f6000e100075f6000e100011900",
+            expected_bytecode="ef00010100040200010016ff000000008000065f6000e100025f5f5f6000e100075f6000e100011900",
         ),
         Container(
             name="forwards_rjumpi_variable_stack_5",
@@ -631,7 +631,7 @@ def test_rjumpi_max_backward(
                     max_stack_height=6,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001804000000008000065f6000e100025f5f5f60010180600a11e1000480e1fff200",
+            expected_bytecode="ef00010100040200010018ff000000008000065f6000e100025f5f5f60010180600a11e1000480e1fff200",
         ),
         Container(
             name="forwards_rjumpi_variable_stack_6",
@@ -656,7 +656,7 @@ def test_rjumpi_max_backward(
                     max_stack_height=6,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001904000000008000065f6000e100025f5f5f60010180600a11e100055f80e1fff300",
+            expected_bytecode="ef00010100040200010019ff000000008000065f6000e100025f5f5f60010180600a11e100055f80e1fff300",
         ),
         Container(
             name="forwards_rjumpi_variable_stack_7",
@@ -677,7 +677,7 @@ def test_rjumpi_max_backward(
                     max_stack_height=5,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001404000000008000055f6000e100025f5f5f6000e100045fe000015f00",
+            expected_bytecode="ef00010100040200010014ff000000008000055f6000e100025f5f5f6000e100045fe000015f00",
         ),
         Container(
             name="forwards_rjumpi_variable_stack_8",
@@ -698,7 +698,7 @@ def test_rjumpi_max_backward(
                     max_stack_height=5,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001404000000008000055f6000e100025f5f5f6000e100045fe000011900",
+            expected_bytecode="ef00010100040200010014ff000000008000055f6000e100025f5f5f6000e100045fe000011900",
         ),
         Container(
             name="forwards_rjumpi_variable_stack_9",
@@ -719,7 +719,7 @@ def test_rjumpi_max_backward(
                     max_stack_height=5,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001404000000008000055f6000e100025f5f5f6000e1000450e000015000",
+            expected_bytecode="ef00010100040200010014ff000000008000055f6000e100025f5f5f6000e1000450e000015000",
         ),
     ],
     ids=lambda x: x.name,
@@ -746,7 +746,7 @@ def test_rjumpi_valid_forward(
                     max_stack_height=1,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000604000000008000016000e1fffb00",
+            expected_bytecode="ef00010100040200010006ff000000008000016000e1fffb00",
         ),
         Container(
             name="backwards_rjumpi_1",
@@ -756,7 +756,7 @@ def test_rjumpi_valid_forward(
                     max_stack_height=1,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000804000000008000015f506000e1fff900",
+            expected_bytecode="ef00010100040200010008ff000000008000015f506000e1fff900",
         ),
         Container(
             name="backwards_rjumpi_2",
@@ -772,7 +772,7 @@ def test_rjumpi_valid_forward(
                     max_stack_height=1,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000d04000000008000015f506000e1fff96000e1fff400",
+            expected_bytecode="ef0001010004020001000dff000000008000015f506000e1fff96000e1fff400",
         ),
         Container(
             name="backwards_rjumpi_4",
@@ -782,7 +782,7 @@ def test_rjumpi_valid_forward(
                     max_stack_height=2,
                 ),
             ],
-            expected_bytecode="ef000101000402000100090400000000800002 5f60010180e1fff900",
+            expected_bytecode="ef00010100040200010009ff00000000800002 5f60010180e1fff900",
         ),
         Container(
             name="backwards_rjumpi_7",
@@ -792,7 +792,7 @@ def test_rjumpi_valid_forward(
                     max_stack_height=1,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000a04000000008000015f506000e1fff9e0fff6",
+            expected_bytecode="ef0001010004020001000aff000000008000015f506000e1fff9e0fff6",
         ),
         Container(
             name="backwards_rjumpi_variable_stack_0",
@@ -809,7 +809,7 @@ def test_rjumpi_valid_forward(
                     max_stack_height=4,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000e04000000008000045f6000e100025f5f6000e1fffb00",
+            expected_bytecode="ef0001010004020001000eff000000008000045f6000e100025f5f6000e1fffb00",
         ),
         Container(
             name="backwards_rjumpi_variable_stack_1",
@@ -828,7 +828,7 @@ def test_rjumpi_valid_forward(
                     max_stack_height=4,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001004000000008000045f6000e100025f5f5f506000e1fff900",
+            expected_bytecode="ef00010100040200010010ff000000008000045f6000e100025f5f5f506000e1fff900",
         ),
         Container(
             name="backwards_rjumpi_variable_stack_2",
@@ -849,7 +849,7 @@ def test_rjumpi_valid_forward(
                     max_stack_height=4,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001504000000008000045f6000e100025f5f5f506000e1fff96000e1fff400",
+            expected_bytecode="ef00010100040200010015ff000000008000045f6000e100025f5f5f506000e1fff96000e1fff400",
         ),
         Container(
             name="backwards_rjumpi_variable_stack_4",
@@ -869,7 +869,7 @@ def test_rjumpi_valid_forward(
                     max_stack_height=5,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001104000000008000055f6000e100025f5f5f60010180e1fff900",
+            expected_bytecode="ef00010100040200010011ff000000008000055f6000e100025f5f5f60010180e1fff900",
         ),
         Container(
             name="backwards_rjumpi_variable_stack_7",
@@ -888,7 +888,7 @@ def test_rjumpi_valid_forward(
                     max_stack_height=4,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001204000000008000045f6000e100025f5f5f506000e1fff9e0fff6",
+            expected_bytecode="ef00010100040200010012ff000000008000045f6000e100025f5f5f506000e1fff9e0fff6",
         ),
     ],
     ids=lambda x: x.name,
@@ -1663,7 +1663,7 @@ def test_double_rjumpi_invalid_max_stack_height(
                     max_stack_height=3,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000e040000000080000360be6000e10001506000e1fff500",
+            expected_bytecode="ef0001010004020001000eff0000000080000360be6000e10001506000e1fff500",
         ),
         Container(
             name="backwards_rjumpi_3",
@@ -1680,7 +1680,7 @@ def test_double_rjumpi_invalid_max_stack_height(
                     max_stack_height=2,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000e04000000008000025f506000e1fff95f6000e1fff300",
+            expected_bytecode="ef0001010004020001000eff000000008000025f506000e1fff95f6000e1fff300",
         ),
         Container(
             name="backwards_rjumpi_5",
@@ -1696,7 +1696,7 @@ def test_double_rjumpi_invalid_max_stack_height(
                     max_stack_height=2,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000a04000000008000025f6001018080e1fff800",
+            expected_bytecode="ef0001010004020001000aff000000008000025f6001018080e1fff800",
         ),
         Container(
             name="backwards_rjumpi_8",
@@ -1726,7 +1726,7 @@ def test_double_rjumpi_invalid_max_stack_height(
                     max_stack_height=3,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000d04000000008000035f6000e100015f6000e1fff500",
+            expected_bytecode="ef0001010004020001000dff000000008000035f6000e100015f6000e1fff500",
         ),
         Container(
             name="backwards_rjumpi_variable_stack_3",
@@ -1748,7 +1748,7 @@ def test_double_rjumpi_invalid_max_stack_height(
                     max_stack_height=5,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001604000000008000055f6000e100025f5f5f506000e1fff95f6000e1fff300",
+            expected_bytecode="ef00010100040200010016ff000000008000055f6000e100025f5f5f506000e1fff95f6000e1fff300",
         ),
         Container(
             name="backwards_rjumpi_variable_stack_5",
@@ -1769,7 +1769,7 @@ def test_double_rjumpi_invalid_max_stack_height(
                     max_stack_height=5,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001204000000008000055f6000e100025f5f5f6001018080e1fff800",
+            expected_bytecode="ef00010100040200010012ff000000008000055f6000e100025f5f5f6001018080e1fff800",
         ),
         Container(
             name="backwards_rjumpi_variable_stack_6",
@@ -1789,7 +1789,7 @@ def test_double_rjumpi_invalid_max_stack_height(
                     max_stack_height=5,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001004000000008000055f6000e100025f5f5f5f5f50e1fffc00",
+            expected_bytecode="ef00010100040200010010ff000000008000055f6000e100025f5f5f5f5f50e1fffc00",
         ),
         Container(
             name="backwards_rjumpi_variable_stack_6a",

--- a/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py
+++ b/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py
@@ -1175,7 +1175,7 @@ def test_double_rjumpv(
                     max_stack_height=1,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000704000000008000016001e200000000",
+            expected_bytecode="ef00010100040200010007ff000000008000016001e200000000",
         ),
         Container(
             name="forwards_rjumpv_1",
@@ -1185,7 +1185,7 @@ def test_double_rjumpv(
                     max_stack_height=2,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000904000000008000025f6000e20000011900",
+            expected_bytecode="ef00010100040200010009ff000000008000025f6000e20000011900",
         ),
         Container(
             name="forwards_rjumpv_2",
@@ -1201,7 +1201,7 @@ def test_double_rjumpv(
                     max_stack_height=2,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000d04000000008000025f6000e201000200035f501900",
+            expected_bytecode="ef0001010004020001000dff000000008000025f6000e201000200035f501900",
         ),
         Container(
             name="forwards_rjumpv_3",
@@ -1211,7 +1211,7 @@ def test_double_rjumpv(
                     max_stack_height=2,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000904000000008000025f6000e20000015f00",
+            expected_bytecode="ef00010100040200010009ff000000008000025f6000e20000015f00",
         ),
         Container(
             name="forwards_rjumpv_4",
@@ -1227,7 +1227,7 @@ def test_double_rjumpv(
                     max_stack_height=3,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000d04000000008000035f6000e201000100025f5f1900",
+            expected_bytecode="ef0001010004020001000dff000000008000035f6000e201000100025f5f1900",
         ),
         Container(
             name="forwards_rjumpv_5",
@@ -1245,7 +1245,7 @@ def test_double_rjumpv(
                     max_stack_height=2,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001604000000008000025f6000e2010005000a6001e000076002e00002600300",
+            expected_bytecode="ef00010100040200010016ff000000008000025f6000e2010005000a6001e000076002e00002600300",
         ),
         Container(
             name="forwards_rjumpv_6",
@@ -1266,7 +1266,7 @@ def test_double_rjumpv(
                     max_stack_height=4,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001604000000008000045f6000e201000400095fe000085f5fe000035f5f5f00",
+            expected_bytecode="ef00010100040200010016ff000000008000045f6000e201000400095fe000085f5fe000035f5f5f00",
         ),
         Container(
             name="forwards_rjumpv_7",
@@ -1290,7 +1290,7 @@ def test_double_rjumpv(
                     max_stack_height=5,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001904000000008000055f5f5f5f6000e2010004000950e000085050e0000350505000",
+            expected_bytecode="ef00010100040200010019ff000000008000055f5f5f5f6000e2010004000950e000085050e0000350505000",
         ),
         Container(
             name="forwards_rjumpv_8",
@@ -1300,7 +1300,7 @@ def test_double_rjumpv(
                     max_stack_height=2,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000b04000000008000025f6000e2000003e0000000",
+            expected_bytecode="ef0001010004020001000bff000000008000025f6000e2000003e0000000",
         ),
         Container(
             name="forwards_rjumpv_9",
@@ -1310,7 +1310,7 @@ def test_double_rjumpv(
                     max_stack_height=2,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000c04000000008000025f6000e20000045fe0000000",
+            expected_bytecode="ef0001010004020001000cff000000008000025f6000e20000045fe0000000",
         ),
         Container(
             name="forwards_rjumpv_variable_stack_0",
@@ -1327,7 +1327,7 @@ def test_double_rjumpv(
                     max_stack_height=4,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000f04000000008000045f6000e100025f5f6001e200000000",
+            expected_bytecode="ef0001010004020001000fff000000008000045f6000e100025f5f6001e200000000",
         ),
         Container(
             name="forwards_rjumpv_variable_stack_1",
@@ -1346,7 +1346,7 @@ def test_double_rjumpv(
                     max_stack_height=5,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001104000000008000055f6000e100025f5f5f6000e20000011900",
+            expected_bytecode="ef00010100040200010011ff000000008000055f6000e100025f5f5f6000e20000011900",
         ),
         Container(
             name="forwards_rjumpv_variable_stack_2",
@@ -1367,7 +1367,7 @@ def test_double_rjumpv(
                     max_stack_height=5,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001504000000008000055f6000e100025f5f5f6000e201000200035f501900",
+            expected_bytecode="ef00010100040200010015ff000000008000055f6000e100025f5f5f6000e201000200035f501900",
         ),
         Container(
             name="forwards_rjumpv_variable_stack_3",
@@ -1386,7 +1386,7 @@ def test_double_rjumpv(
                     max_stack_height=5,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001104000000008000055f6000e100025f5f5f6000e20000015f00",
+            expected_bytecode="ef00010100040200010011ff000000008000055f6000e100025f5f5f6000e20000015f00",
         ),
         Container(
             name="forwards_rjumpv_variable_stack_4",
@@ -1407,7 +1407,7 @@ def test_double_rjumpv(
                     max_stack_height=6,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001504000000008000065f6000e100025f5f5f6000e201000100025f5f1900",
+            expected_bytecode="ef00010100040200010015ff000000008000065f6000e100025f5f5f6000e201000100025f5f1900",
         ),
         Container(
             name="forwards_rjumpv_variable_stack_5",
@@ -1430,7 +1430,7 @@ def test_double_rjumpv(
                     max_stack_height=5,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001e04000000008000055f6000e100025f5f5f6000e2010005000a6001e000076002e00002600300",
+            expected_bytecode="ef0001010004020001001eff000000008000055f6000e100025f5f5f6000e2010005000a6001e000076002e00002600300",
         ),
         Container(
             name="forwards_rjumpv_variable_stack_6",
@@ -1456,7 +1456,7 @@ def test_double_rjumpv(
                     max_stack_height=7,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001e04000000008000075f6000e100025f5f5f6000e201000400095fe000085f5fe000035f5f5f00",
+            expected_bytecode="ef0001010004020001001eff000000008000075f6000e100025f5f5f6000e201000400095fe000085f5fe000035f5f5f00",
         ),
         Container(
             name="forwards_rjumpv_variable_stack_7",
@@ -1485,7 +1485,7 @@ def test_double_rjumpv(
                     max_stack_height=8,
                 ),
             ],
-            expected_bytecode="ef0001010004020001002104000000008000085f6000e100025f5f5f5f5f5f6000e2010004000950e000085050e0000350505000",
+            expected_bytecode="ef00010100040200010021ff000000008000085f6000e100025f5f5f5f5f5f6000e2010004000950e000085050e0000350505000",
         ),
         Container(
             name="forwards_rjumpv_variable_stack_8",
@@ -1504,7 +1504,7 @@ def test_double_rjumpv(
                     max_stack_height=5,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001304000000008000055f6000e100025f5f5f6000e2000003e0000000",
+            expected_bytecode="ef00010100040200010013ff000000008000055f6000e100025f5f5f6000e2000003e0000000",
         ),
         Container(
             name="forwards_rjumpv_variable_stack_9",
@@ -1524,7 +1524,7 @@ def test_double_rjumpv(
                     max_stack_height=5,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001404000000008000055f6000e100025f5f5f6000e20000045fe0000000",
+            expected_bytecode="ef00010100040200010014ff000000008000055f6000e100025f5f5f6000e20000045fe0000000",
         ),
     ],
     ids=lambda x: x.name,
@@ -1551,7 +1551,7 @@ def test_rjumpv_valid_forward(
                     max_stack_height=1,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000704000000008000016000e200fffa00",
+            expected_bytecode="ef00010100040200010007ff000000008000016000e200fffa00",
         ),
         Container(
             name="backwards_rjumpv_1",
@@ -1561,7 +1561,7 @@ def test_rjumpv_valid_forward(
                     max_stack_height=1,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000904000000008000015f506000e200fff800",
+            expected_bytecode="ef00010100040200010009ff000000008000015f506000e200fff800",
         ),
         Container(
             name="backwards_rjumpv_2",
@@ -1577,7 +1577,7 @@ def test_rjumpv_valid_forward(
                     max_stack_height=1,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000f04000000008000015f506000e200fff86000e200fff200",
+            expected_bytecode="ef0001010004020001000fff000000008000015f506000e200fff86000e200fff200",
         ),
         Container(
             name="backwards_rjumpv_4",
@@ -1587,7 +1587,7 @@ def test_rjumpv_valid_forward(
                     max_stack_height=1,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000b04000000008000015f506000e200fff8e0fff5",
+            expected_bytecode="ef0001010004020001000bff000000008000015f506000e200fff8e0fff5",
         ),
         Container(
             name="backwards_rjumpv_variable_stack_0",
@@ -1604,7 +1604,7 @@ def test_rjumpv_valid_forward(
                     max_stack_height=4,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000f04000000008000045f6000e100025f5f6000e200fffa00",
+            expected_bytecode="ef0001010004020001000fff000000008000045f6000e100025f5f6000e200fffa00",
         ),
         Container(
             name="backwards_rjumpv_variable_stack_1",
@@ -1623,7 +1623,7 @@ def test_rjumpv_valid_forward(
                     max_stack_height=4,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001104000000008000045f6000e100025f5f5f506000e200fff800",
+            expected_bytecode="ef00010100040200010011ff000000008000045f6000e100025f5f5f506000e200fff800",
         ),
         Container(
             name="backwards_rjumpv_variable_stack_2",
@@ -1644,7 +1644,7 @@ def test_rjumpv_valid_forward(
                     max_stack_height=4,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001704000000008000045f6000e100025f5f5f506000e200fff86000e200fff200",
+            expected_bytecode="ef00010100040200010017ff000000008000045f6000e100025f5f5f506000e200fff86000e200fff200",
         ),
         Container(
             name="backwards_rjumpv_variable_stack_4",
@@ -1663,7 +1663,7 @@ def test_rjumpv_valid_forward(
                     max_stack_height=4,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001304000000008000045f6000e100025f5f5f506000e200fff8e0fff5",
+            expected_bytecode="ef00010100040200010013ff000000008000045f6000e100025f5f5f506000e200fff8e0fff5",
         ),
     ],
     ids=lambda x: x.name,
@@ -1697,7 +1697,7 @@ def test_rjumpv_valid_backward(
                     max_stack_height=2,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001004000000008000025f506000e200fff85f6000e200fff100",
+            expected_bytecode="ef00010100040200010010ff000000008000025f506000e200fff85f6000e200fff100",
         ),
         Container(
             name="backwards_rjumpv_5",
@@ -1727,7 +1727,7 @@ def test_rjumpv_valid_backward(
                     max_stack_height=3,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000e04000000008000035f6000e100015f6000e200fff400",
+            expected_bytecode="ef0001010004020001000eff000000008000035f6000e100015f6000e200fff400",
         ),
         Container(
             name="backwards_rjumpv_7",
@@ -1743,7 +1743,7 @@ def test_rjumpv_valid_backward(
                     max_stack_height=3,
                 ),
             ],
-            expected_bytecode="ef0001010004020001000f040000000080000360be6000e10001506000e200fff400",
+            expected_bytecode="ef0001010004020001000fff0000000080000360be6000e10001506000e200fff400",
         ),
         Container(
             name="backwards_rjumpv_variable_stack_3",
@@ -1765,7 +1765,7 @@ def test_rjumpv_valid_backward(
                     max_stack_height=5,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001804000000008000055f6000e100025f5f5f506000e200fff85f6000e200fff100",
+            expected_bytecode="ef00010100040200010018ff000000008000055f6000e100025f5f5f506000e200fff85f6000e200fff100",
         ),
         Container(
             name="backwards_rjumpv_variable_stack_5",
@@ -1805,7 +1805,7 @@ def test_rjumpv_valid_backward(
                     max_stack_height=5,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001604000000008000055f6000e100025f5f5f6000e100015f6000e200fff400",
+            expected_bytecode="ef00010100040200010016ff000000008000055f6000e100025f5f5f6000e100015f6000e200fff400",
         ),
         Container(
             name="backwards_rjumpv_variable_stack_7",
@@ -1827,7 +1827,7 @@ def test_rjumpv_valid_backward(
                     max_stack_height=5,
                 ),
             ],
-            expected_bytecode="ef0001010004020001001704000000008000055f6000e100025f5f5f5f6000e10001506000e200fff400",
+            expected_bytecode="ef00010100040200010017ff000000008000055f6000e100025f5f5f5f6000e10001506000e200fff400",
         ),
     ],
     ids=lambda x: x.name,

--- a/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_subcontainer_validation.py
@@ -754,8 +754,8 @@ def test_wide_container(eof_test: EOFTestFiller, width: int, exception: EOFExcep
                     abort_sub_container,
                 ],
                 expected_bytecode="""
-                ef0001010004020001000b0300010014040000000080000436600060ff6000ec005000ef000101000402
-                000100010400000000800000fe""",
+                ef0001010004020001000b0300010014ff0000000080000436600060ff6000ec005000ef000101000402
+                00010001ff00000000800000fe""",
             ),
             id="eofcreate_0",
         ),
@@ -766,7 +766,7 @@ def test_wide_container(eof_test: EOFTestFiller, width: int, exception: EOFExcep
                     abort_sub_container,
                 ],
                 expected_bytecode="""
-                ef00010100040200010006030001001404000000008000016000e0000000ef0001010004020001000104
+                ef000101000402000100060300010014ff000000008000016000e0000000ef00010100040200010001ff
                 00000000800000fe""",
                 # Originally this test was "valid" because it was created
                 # before "orphan subcontainer" rule was introduced.
@@ -782,7 +782,7 @@ def test_wide_container(eof_test: EOFTestFiller, width: int, exception: EOFExcep
                     Section.Data(custom_size=2),
                 ],
                 expected_bytecode="""
-                ef00010100040200010006030001001404000200008000016000e0000000ef0001010004020001000104
+                ef000101000402000100060300010014ff000200008000016000e0000000ef00010100040200010001ff
                 00000000800000fe""",
                 # Originally this test was "valid" but against the current spec
                 # it contains two errors: data section truncated and orphan subcontainer.
@@ -798,7 +798,7 @@ def test_wide_container(eof_test: EOFTestFiller, width: int, exception: EOFExcep
                     Section.Data("aabb"),
                 ],
                 expected_bytecode="""
-                ef00010100040200010006030001001404000200008000016000e0000000ef0001010004020001000104
+                ef000101000402000100060300010014ff000200008000016000e0000000ef00010100040200010001ff
                 00000000800000feaabb""",
                 # Originally this test was "valid" because it was created
                 # before "orphan subcontainer" rule was introduced.
@@ -832,8 +832,8 @@ def test_wide_container(eof_test: EOFTestFiller, width: int, exception: EOFExcep
                 ]
                 + 2 * [abort_sub_container],
                 expected_bytecode="""
-                ef0001010004020001000b03000200140014040000000080000436600060ff6000ec015000ef00010100
-                0402000100010400000000800000feef000101000402000100010400000000800000fe""",
+                ef0001010004020001000b03000200140014ff0000000080000436600060ff6000ec015000ef00010100
+                040200010001ff00000000800000feef00010100040200010001ff00000000800000fe""",
                 # Originally this test was "valid" because it was created
                 # before "orphan subcontainer" rule was introduced.
                 validity_error=EOFException.ORPHAN_SUBCONTAINER,
@@ -848,8 +848,8 @@ def test_wide_container(eof_test: EOFTestFiller, width: int, exception: EOFExcep
                     Section.Container(Container.Code(Op.PUSH0 + Op.PUSH0 + Op.RETURN)),
                 ],
                 expected_bytecode="""
-                ef000101000402000100060300020014001604000000008000016000e0000000ef000101000402000100
-                010400000000800000feef0001010004020001000304000000008000025f5ff3""",
+                ef0001010004020001000603000200140016ff000000008000016000e0000000ef000101000402000100
+                01ff00000000800000feef00010100040200010003ff000000008000025f5ff3""",
                 # Originally this test was "valid" because it was created
                 # before "orphan subcontainer" rule was introduced.
                 validity_error=EOFException.ORPHAN_SUBCONTAINER,


### PR DESCRIPTION
## 🗒️ Description

Align with eof-devnet-1 changes https://github.com/ipsilon/eof/issues/173. Fills with `evmone` after a respective update, will be referenced soon :point_down: 

## 🔗 Related Issues



## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
