### PR TITLE
new(tests): EOF validation RETF stack overflow

### DIFF
--- a/converted-ethereum-tests.txt
+++ b/converted-ethereum-tests.txt
@@ -23,6 +23,8 @@ EOFTests/efStack/backwards_rjumpi_variable_stack_.json
 EOFTests/efStack/backwards_rjumpv_.json
 EOFTests/efStack/backwards_rjumpv_variable_stack_.json
 EOFTests/efStack/jumpf_stack_overflow_.json
+EOFTests/efStack/retf_stack_validation_.json
+EOFTests/efStack/retf_variable_stack_.json
 EOFTests/efStack/forwards_rjump_.json
 EOFTests/efStack/forwards_rjump_variable_stack_.json
 EOFTests/efStack/forwards_rjumpi_.json

--- a/tests/osaka/eip7692_eof_v1/eip4750_functions/test_code_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip4750_functions/test_code_validation.py
@@ -25,6 +25,32 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
 
 VALID: List[Container] = [
     Container(
+        name="retf_stack_validation_0",
+        sections=[
+            Section.Code(code=Op.CALLF[1] + Op.STOP, max_stack_height=2),
+            Section.Code(
+                code=Op.PUSH0 * 2 + Op.RETF,
+                code_outputs=2,
+                max_stack_height=2,
+            ),
+        ],
+    ),
+    Container(
+        name="retf_stack_validation_3",
+        sections=[
+            Section.Code(
+                code=Op.PUSH0 + Op.CALLF[1] + Op.STOP,
+                max_stack_height=2,
+            ),
+            Section.Code(
+                code=Op.RJUMPI[7] + Op.PUSH1[1] * 2 + Op.RJUMP[2] + Op.PUSH0 * 2 + Op.RETF,
+                code_inputs=1,
+                code_outputs=2,
+                max_stack_height=2,
+            ),
+        ],
+    ),
+    Container(
         name="retf_code_input_output",
         sections=[
             Section.Code(code=Op.PUSH0 + Op.CALLF[1] + Op.POP + Op.POP + Op.STOP),
@@ -91,6 +117,72 @@ VALID: List[Container] = [
 
 INVALID: List[Container] = [
     Container(
+        name="retf_stack_validation_1",
+        sections=[
+            Section.Code(code=Op.CALLF[1] + Op.STOP, max_stack_height=2),
+            Section.Code(
+                code=Op.PUSH0 + Op.RETF,
+                code_outputs=2,
+                max_stack_height=1,
+            ),
+        ],
+        validity_error=EOFException.STACK_UNDERFLOW,
+    ),
+    Container(
+        name="retf_variable_stack_0",
+        sections=[
+            Section.Code(code=Op.CALLF[1] + Op.STOP, max_stack_height=5),
+            Section.Code(
+                code=Op.PUSH0 + Op.PUSH1[0] + Op.RJUMPI[2] + Op.PUSH0 * 2 + Op.RETF,
+                code_outputs=5,
+                max_stack_height=3,
+            ),
+        ],
+        validity_error=EOFException.STACK_UNDERFLOW,
+    ),
+    Container(
+        name="retf_variable_stack_1",
+        sections=[
+            Section.Code(code=Op.CALLF[1] + Op.STOP, max_stack_height=3),
+            Section.Code(
+                code=Op.PUSH0 + Op.PUSH1[0] + Op.RJUMPI[2] + Op.PUSH0 * 2 + Op.RETF,
+                code_outputs=3,
+                max_stack_height=3,
+            ),
+        ],
+        validity_error=EOFException.STACK_UNDERFLOW,
+    ),
+    Container(
+        name="retf_variable_stack_4",
+        sections=[
+            Section.Code(code=Op.CALLF[1] + Op.STOP, max_stack_height=3),
+            Section.Code(
+                code=Op.PUSH0 * 3 + Op.PUSH1[0] + Op.RJUMPI[2] + Op.POP * 2 + Op.RETF,
+                code_outputs=3,
+                max_stack_height=4,
+            ),
+        ],
+        validity_error=EOFException.STACK_UNDERFLOW,
+    ),
+    Container(
+        name="callf_inputs_underflow_0",
+        sections=[
+            Section.Code(code=Op.CALLF[1] + Op.STOP, max_stack_height=1),
+            Section.Code(
+                code=Op.PUSH0 + Op.CALLF[2] + Op.RETF,
+                code_outputs=1,
+                max_stack_height=1,
+            ),
+            Section.Code(
+                code=Op.POP + Op.RETF,
+                code_inputs=2,
+                code_outputs=1,
+                max_stack_height=2,
+            ),
+        ],
+        validity_error=EOFException.STACK_UNDERFLOW,
+    ),
+    Container(
         # CALLF to function with incorrectly specified number of inputs
         name="code_inputs_underflow_1",  # EOF1I4750_0020
         sections=[
@@ -127,6 +219,66 @@ INVALID: List[Container] = [
             ),
         ],
         validity_error=EOFException.STACK_UNDERFLOW,
+    ),
+    Container(
+        name="retf_stack_validation_2",
+        sections=[
+            Section.Code(code=Op.CALLF[1] + Op.STOP, max_stack_height=2),
+            Section.Code(
+                code=Op.PUSH0 * 3 + Op.RETF,
+                code_outputs=2,
+                max_stack_height=3,
+            ),
+        ],
+        validity_error=EOFException.STACK_HIGHER_THAN_OUTPUTS,
+    ),
+    Container(
+        name="retf_variable_stack_2",
+        sections=[
+            Section.Code(code=Op.CALLF[1] + Op.STOP, max_stack_height=1),
+            Section.Code(
+                code=Op.PUSH0 + Op.PUSH1[0] + Op.RJUMPI[2] + Op.PUSH0 * 2 + Op.RETF,
+                code_outputs=1,
+                max_stack_height=3,
+            ),
+        ],
+        validity_error=EOFException.STACK_HIGHER_THAN_OUTPUTS,
+    ),
+    Container(
+        name="retf_variable_stack_5",
+        sections=[
+            Section.Code(code=Op.CALLF[1] + Op.STOP, max_stack_height=1),
+            Section.Code(
+                code=Op.PUSH0 + Op.PUSH1[0] + Op.RJUMPI[1] + Op.PUSH0 + Op.RETF,
+                code_outputs=1,
+                max_stack_height=3,
+            ),
+        ],
+        validity_error=EOFException.STACK_HIGHER_THAN_OUTPUTS,
+    ),
+    Container(
+        name="retf_variable_stack_6",
+        sections=[
+            Section.Code(code=Op.CALLF[1] + Op.STOP, max_stack_height=1),
+            Section.Code(
+                code=Op.PUSH0 * 2 + Op.PUSH1[0] + Op.RJUMPI[1] + Op.POP + Op.RETF,
+                code_outputs=1,
+                max_stack_height=3,
+            ),
+        ],
+        validity_error=EOFException.STACK_HIGHER_THAN_OUTPUTS,
+    ),
+    Container(
+        name="retf_variable_stack_3",
+        sections=[
+            Section.Code(code=Op.CALLF[1] + Op.STOP),
+            Section.Code(
+                code=Op.PUSH0 + Op.PUSH1[0] + Op.RJUMPI[2] + Op.PUSH0 * 2 + Op.RETF,
+                code_outputs=0,
+                max_stack_height=3,
+            ),
+        ],
+        validity_error=EOFException.STACK_HIGHER_THAN_OUTPUTS,
     ),
     Container(
         name="stack_higher_than_code_outputs",

--- a/tests/osaka/eip7692_eof_v1/eof_tracker.md
+++ b/tests/osaka/eip7692_eof_v1/eof_tracker.md
@@ -253,11 +253,13 @@
 
 #### RETF
 
-- [ ] Valid RETF with correct number of items on stack (ethereum/tests: src/EOFTestsFiller/efStack/retf_stack_validation_Copier.json src/EOFTestsFiller/EIP5450/validInvalidFiller.yml)
-- [ ] Invalid RETF with extra items on stack (ethereum/tests: src/EOFTestsFiller/efStack/retf_stack_validation_Copier.json ./src/EOFTestsFiller/efExample/validInvalidFiller.yml)
-- [ ] RETF stack underflow (ethereum/tests: src/EOFTestsFiller/efStack/retf_stack_validation_Copier.json)
-- [ ] RETF reached via different paths (ethereum/tests: src/EOFTestsFiller/efStack/retf_stack_validation_Copier.json)
-- [ ] RETF in variable stack segment is not allowed (ethereum/tests: src/EOFTestsFiller/efStack/retf_variable_stack_Copier.json)
+- [ ] Valid RETF with correct number of items on stack ([`tests/osaka/eip7692_eof_v1/eip4750_functions/test_code_validation.py::test_eof_validity`](./eip4750_functions/test_code_validation/test_eof_validity.md))
+    - [ ] src/EOFTestsFiller/EIP5450/validInvalidFiller.yml
+- [ ] Invalid RETF with extra items on stack ([`tests/osaka/eip7692_eof_v1/eip4750_functions/test_code_validation.py::test_eof_validity`](./eip4750_functions/test_code_validation/test_eof_validity.md))
+    - [ ] ./src/EOFTestsFiller/efExample/validInvalidFiller.yml
+- [x] RETF stack underflow ([`tests/osaka/eip7692_eof_v1/eip4750_functions/test_code_validation.py::test_eof_validity`](./eip4750_functions/test_code_validation/test_eof_validity.md))
+- [x] RETF reached via different paths ([`tests/osaka/eip7692_eof_v1/eip4750_functions/test_code_validation.py::test_eof_validity`](./eip4750_functions/test_code_validation/test_eof_validity.md))
+- [x] RETF in variable stack segment is not allowed ([`tests/osaka/eip7692_eof_v1/eip4750_functions/test_code_validation.py::test_eof_validity`](./eip4750_functions/test_code_validation/test_eof_validity.md))
 - [ ] Extra items on stack allowed for terminating instructions other than RETF (ethereum/tests: src/EOFTestsFiller/EIP5450/validInvalidFiller.yml)
 - [x] Invalid RETF in a non-returning function ([`tests/osaka/eip7692_eof_v1/eip6206_jumpf/test_nonreturning_validation.py::test_first_section_returning`](./eip6206_jumpf/test_nonreturning_validation/test_first_section_returning.md))
 


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened. https://github.com/ethereum/tests/pull/1478
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
