### PR TITLE
new(tests): EIP-7702 more RLP tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -62,6 +62,7 @@ consume cache --help
 ### 🧪 Test Cases
 
 - ✨ Add additional test coverage for EIP-152 Blake2 precompiles ([#1244](https://github.com/ethereum/execution-spec-tests/pull/1244)).
+- ✨ Add EIP-7702 incorrect-rlp-encoding tests ([#1347](https://github.com/ethereum/execution-spec-tests/pull/1347)).
 
 ## [v4.1.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v4.1.0) - 2025-03-11
 

--- a/src/ethereum_test_types/types.py
+++ b/src/ethereum_test_types/types.py
@@ -442,7 +442,7 @@ class AuthorizationTupleGeneric(CamelModel, Generic[NumberBoundTypeVar], Signabl
 
     chain_id: NumberBoundTypeVar = Field(0)  # type: ignore
     address: Address
-    nonce: List[NumberBoundTypeVar] | NumberBoundTypeVar = Field(0)  # type: ignore
+    nonce: NumberBoundTypeVar = Field(0)  # type: ignore
 
     v: NumberBoundTypeVar = Field(default=0, validation_alias=AliasChoices("v", "yParity"))  # type: ignore
     r: NumberBoundTypeVar = Field(0)  # type: ignore

--- a/tests/prague/eip7702_set_code_tx/test_invalid_tx.py
+++ b/tests/prague/eip7702_set_code_tx/test_invalid_tx.py
@@ -3,10 +3,12 @@ abstract: Tests invalid set-code transactions from [EIP-7702: Set EOA account co
     Tests invalid set-code transactions from [EIP-7702: Set EOA account code for one transaction](https://eips.ethereum.org/EIPS/eip-7702).
 """  # noqa: E501
 
-from typing import List
+from typing import Any, List, Type
 
 import pytest
+from ethereum_types.numeric import Uint
 
+from ethereum_test_base_types import FixedSizeBytes, HexNumber
 from ethereum_test_tools import (
     Address,
     Alloc,
@@ -24,6 +26,28 @@ REFERENCE_SPEC_VERSION = ref_spec_7702.version
 pytestmark = pytest.mark.valid_from("Prague")
 
 auth_account_start_balance = 0
+
+
+class OversizedInt(FixedSizeBytes[2]):  # type: ignore
+    """
+    Oversized 2-byte int.
+
+    Will only fail if the int value is less than 2**8.
+    """
+
+    pass
+
+
+class OversizedAddress(FixedSizeBytes[21]):  # type: ignore
+    """Oversized Address Type."""
+
+    pass
+
+
+class UndersizedAddress(FixedSizeBytes[19]):  # type: ignore
+    """Undersized Address Type."""
+
+    pass
 
 
 def test_empty_authorization_list(
@@ -143,12 +167,76 @@ def test_invalid_tx_invalid_auth_chain_id(
 
 
 @pytest.mark.parametrize(
+    "auth_chain_id",
+    [pytest.param(0), pytest.param(1)],
+)
+@pytest.mark.parametrize(
+    "delegate_address",
+    [
+        pytest.param(Spec.RESET_DELEGATION_ADDRESS, id="reset_delegation_address"),
+        pytest.param(Address(1), id="non_zero_address"),
+    ],
+)
+def test_invalid_tx_invalid_auth_chain_id_encoding(
+    transaction_test: TransactionTestFiller,
+    pre: Alloc,
+    delegate_address: Address,
+    auth_chain_id: int,
+):
+    """
+    Test sending a transaction where the chain id field of an authorization has an incorrect
+    encoding.
+    """
+
+    class ModifiedAuthorizationTuple(AuthorizationTuple):
+        chain_id: OversizedInt  # type: ignore
+
+        def to_list(self) -> List[Any]:
+            """Return authorization tuple as a list of serializable elements."""
+            return [
+                self.chain_id,
+                self.address,
+                Uint(self.nonce),
+                Uint(self.v),
+                Uint(self.r),
+                Uint(self.s),
+            ]
+
+        def to_signing_list(self) -> List[Any]:
+            """Return the authorization list as a list of serializable elements for signing."""
+            return [
+                self.chain_id,
+                self.address,
+                Uint(self.nonce),
+            ]
+
+    authorization = ModifiedAuthorizationTuple(
+        address=delegate_address,
+        nonce=0,
+        chain_id=auth_chain_id,
+        signer=pre.fund_eoa(auth_account_start_balance),
+    )
+
+    tx = Transaction(
+        gas_limit=100_000,
+        to=0,
+        value=0,
+        authorization_list=[authorization],
+        error=TransactionException.TYPE_4_INVALID_AUTHORIZATION_FORMAT,
+        sender=pre.fund_eoa(),
+    )
+
+    transaction_test(
+        pre=pre,
+        tx=tx,
+    )
+
+
+@pytest.mark.parametrize(
     "nonce",
     [
         pytest.param(Spec.MAX_NONCE + 1, id="nonce=2**64"),
         pytest.param(2**256, id="nonce=2**256"),
-        pytest.param([], id="nonce=empty-list"),
-        pytest.param([0], id="nonce=non-empty-list"),
     ],
 )
 @pytest.mark.parametrize(
@@ -161,7 +249,7 @@ def test_invalid_tx_invalid_auth_chain_id(
 def test_invalid_tx_invalid_nonce(
     transaction_test: TransactionTestFiller,
     pre: Alloc,
-    nonce: int | List[int],
+    nonce: int,
     delegate_address: Address,
 ):
     """
@@ -179,6 +267,313 @@ def test_invalid_tx_invalid_nonce(
                 address=delegate_address,
                 nonce=nonce,
                 signer=auth_signer,
+            ),
+        ],
+        error=TransactionException.TYPE_4_INVALID_AUTHORIZATION_FORMAT,
+        sender=pre.fund_eoa(),
+    )
+
+    transaction_test(
+        pre=pre,
+        tx=tx,
+    )
+
+
+@pytest.mark.parametrize(
+    "nonce",
+    [
+        pytest.param([], id="nonce=empty-list"),
+        pytest.param([0], id="nonce=non-empty-list"),
+        pytest.param([0, 0], id="nonce=multi-element-list"),
+    ],
+)
+@pytest.mark.parametrize(
+    "delegate_address",
+    [
+        pytest.param(Spec.RESET_DELEGATION_ADDRESS, id="reset_delegation_address"),
+        pytest.param(Address(1), id="non_zero_address"),
+    ],
+)
+def test_invalid_tx_invalid_nonce_as_list(
+    transaction_test: TransactionTestFiller,
+    pre: Alloc,
+    nonce: List[int],
+    delegate_address: Address,
+):
+    """
+    Test sending a transaction where the nonce field of an authorization overflows the maximum
+    value.
+    """
+    auth_signer = pre.fund_eoa()
+
+    class AuthorizationTupleWithNonceAsList(AuthorizationTuple):
+        nonce: List[HexNumber]  # type: ignore
+
+        def to_list(self) -> List[Any]:
+            """Return authorization tuple as a list of serializable elements."""
+            return [
+                Uint(self.chain_id),
+                self.address,
+                [Uint(nonce) for nonce in self.nonce],
+                Uint(self.v),
+                Uint(self.r),
+                Uint(self.s),
+            ]
+
+        def to_signing_list(self) -> List[Any]:
+            """Return the authorization list as a list of serializable elements for signing."""
+            return [
+                Uint(self.chain_id),
+                self.address,
+                [Uint(nonce) for nonce in self.nonce],
+            ]
+
+    tx = Transaction(
+        gas_limit=100_000,
+        to=0,
+        value=0,
+        authorization_list=[
+            AuthorizationTupleWithNonceAsList(
+                address=delegate_address,
+                nonce=nonce,
+                signer=auth_signer,
+            ),
+        ],
+        error=TransactionException.TYPE_4_INVALID_AUTHORIZATION_FORMAT,
+        sender=pre.fund_eoa(),
+    )
+
+    transaction_test(
+        pre=pre,
+        tx=tx,
+    )
+
+
+@pytest.mark.parametrize(
+    "delegate_address",
+    [
+        pytest.param(Spec.RESET_DELEGATION_ADDRESS, id="reset_delegation_address"),
+        pytest.param(Address(1), id="non_zero_address"),
+    ],
+)
+def test_invalid_tx_invalid_nonce_encoding(
+    transaction_test: TransactionTestFiller,
+    pre: Alloc,
+    delegate_address: Address,
+):
+    """
+    Test sending a transaction where the chain id field of an authorization has an incorrect
+    encoding.
+    """
+
+    class ModifiedAuthorizationTuple(AuthorizationTuple):
+        nonce: OversizedInt  # type: ignore
+
+        def to_list(self) -> List[Any]:
+            """Return authorization tuple as a list of serializable elements."""
+            return [
+                Uint(self.chain_id),
+                self.address,
+                self.nonce,
+                Uint(self.v),
+                Uint(self.r),
+                Uint(self.s),
+            ]
+
+        def to_signing_list(self) -> List[Any]:
+            """Return the authorization list as a list of serializable elements for signing."""
+            return [
+                Uint(self.chain_id),
+                self.address,
+                self.nonce,
+            ]
+
+    authorization = ModifiedAuthorizationTuple(
+        address=delegate_address,
+        nonce=0,
+        signer=pre.fund_eoa(auth_account_start_balance),
+    )
+
+    tx = Transaction(
+        gas_limit=100_000,
+        to=0,
+        value=0,
+        authorization_list=[authorization],
+        error=TransactionException.TYPE_4_INVALID_AUTHORIZATION_FORMAT,
+        sender=pre.fund_eoa(),
+    )
+
+    transaction_test(
+        pre=pre,
+        tx=tx,
+    )
+
+
+@pytest.mark.parametrize(
+    "address_type",
+    [
+        pytest.param(
+            OversizedAddress,
+            id="oversized",
+        ),
+        pytest.param(
+            UndersizedAddress,
+            id="undersized",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "delegate_address",
+    [
+        pytest.param(
+            int.from_bytes(Spec.RESET_DELEGATION_ADDRESS, byteorder="big"),
+            id="reset_delegation_address",
+        ),
+        pytest.param(1, id="non_zero_address"),
+    ],
+)
+def test_invalid_tx_invalid_address(
+    transaction_test: TransactionTestFiller,
+    pre: Alloc,
+    delegate_address: int,
+    address_type: Type[FixedSizeBytes],
+):
+    """
+    Test sending a transaction where the address field of an authorization is incorrectly
+    serialized.
+    """
+    auth_signer = pre.fund_eoa()
+
+    class ModifiedAuthorizationTuple(AuthorizationTuple):
+        address: address_type  # type: ignore
+
+    tx = Transaction(
+        gas_limit=100_000,
+        to=0,
+        value=0,
+        authorization_list=[
+            ModifiedAuthorizationTuple(
+                address=delegate_address,
+                nonce=0,
+                signer=auth_signer,
+            ),
+        ],
+        error=TransactionException.TYPE_4_INVALID_AUTHORIZATION_FORMAT,
+        sender=pre.fund_eoa(),
+    )
+
+    transaction_test(
+        pre=pre,
+        tx=tx,
+    )
+
+
+@pytest.mark.parametrize("extra_element_value", [0, 1])
+@pytest.mark.parametrize(
+    "delegate_address",
+    [
+        pytest.param(Spec.RESET_DELEGATION_ADDRESS, id="reset_delegation_address"),
+        pytest.param(Address(1), id="non_zero_address"),
+    ],
+)
+def test_invalid_tx_invalid_authorization_tuple_extra_element(
+    transaction_test: TransactionTestFiller,
+    pre: Alloc,
+    delegate_address: Address,
+    extra_element_value: int,
+):
+    """
+    Test sending a transaction where the authorization tuple field of the type-4 transaction
+    is serialized to contain an extra element.
+    """
+    auth_signer = pre.fund_eoa()
+
+    class ExtraElementAuthorizationTuple(AuthorizationTuple):
+        extra_element: HexNumber  # type: ignore
+
+        def to_list(self) -> List[Any]:
+            """Return authorization tuple as a list of serializable elements."""
+            return [
+                Uint(self.chain_id),
+                self.address,
+                Uint(self.nonce),
+                Uint(self.v),
+                Uint(self.r),
+                Uint(self.s),
+                Uint(self.extra_element),
+            ]
+
+    tx = Transaction(
+        gas_limit=100_000,
+        to=0,
+        value=0,
+        authorization_list=[
+            ExtraElementAuthorizationTuple(
+                address=delegate_address,
+                nonce=0,
+                signer=auth_signer,
+                extra_element=extra_element_value,
+            ),
+        ],
+        error=TransactionException.TYPE_4_INVALID_AUTHORIZATION_FORMAT,
+        sender=pre.fund_eoa(),
+    )
+
+    transaction_test(
+        pre=pre,
+        tx=tx,
+    )
+
+
+@pytest.mark.parametrize(
+    "missing_index",
+    [
+        pytest.param(0, id="missing_chain_id"),
+        pytest.param(1, id="missing_address"),
+        pytest.param(2, id="missing_nonce"),
+        pytest.param(3, id="missing_signature_y_parity"),
+        pytest.param(4, id="missing_signature_r"),
+        pytest.param(5, id="missing_signature_s"),
+    ],
+)
+@pytest.mark.parametrize(
+    "delegate_address",
+    [
+        pytest.param(Spec.RESET_DELEGATION_ADDRESS, id="reset_delegation_address"),
+        pytest.param(Address(1), id="non_zero_address"),
+    ],
+)
+def test_invalid_tx_invalid_authorization_tuple_missing_element(
+    transaction_test: TransactionTestFiller,
+    pre: Alloc,
+    delegate_address: Address,
+    missing_index: int,
+):
+    """
+    Test sending a transaction where the authorization tuple field of the type-4 transaction
+    is serialized to miss one element.
+    """
+    auth_signer = pre.fund_eoa()
+
+    class MissingElementAuthorizationTuple(AuthorizationTuple):
+        missing_element_index: int
+
+        def to_list(self) -> List[Any]:
+            """Return authorization tuple as a list of serializable elements."""
+            missing_element_list = super().to_list()
+            missing_element_list.pop(self.missing_element_index)
+            return missing_element_list
+
+    tx = Transaction(
+        gas_limit=100_000,
+        to=0,
+        value=0,
+        authorization_list=[
+            MissingElementAuthorizationTuple(
+                address=delegate_address,
+                nonce=0,
+                signer=auth_signer,
+                missing_element_index=missing_index,
             ),
         ],
         error=TransactionException.TYPE_4_INVALID_AUTHORIZATION_FORMAT,


### PR DESCRIPTION
## 🗒️ Description
Adds more serialization tests.

Requires #1359

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.