### PR TITLE
fix(tests): EIP-2935: change ret_offset to avoid duplicate

### DIFF
--- a/tests/prague/eip2935_historical_block_hashes_from_state/test_block_hashes.py
+++ b/tests/prague/eip2935_historical_block_hashes_from_state/test_block_hashes.py
@@ -81,6 +81,9 @@ def generate_block_check_code(
             store_equal_key, Op.EQ(Op.MLOAD(contract_ret_offset), Op.BLOCKHASH(check_block_number))
         )
 
+    # Reset the contract return value
+    code += Op.MSTORE(contract_ret_offset, 0)
+
     return code
 
 

--- a/tests/prague/eip2935_historical_block_hashes_from_state/test_block_hashes.py
+++ b/tests/prague/eip2935_historical_block_hashes_from_state/test_block_hashes.py
@@ -43,6 +43,8 @@ def generate_block_check_code(
         check_contract_first (bool): Whether to check the contract first, for slot warming checks.
 
     """
+    contract_ret_offset = 32
+
     if check_block_number < 0:
         # Block number outside of range, nothing to check
         return Bytecode()
@@ -63,8 +65,8 @@ def generate_block_check_code(
     check_blockhash = Op.SSTORE(blockhash_key, Op.ISZERO(Op.BLOCKHASH(check_block_number)))
     check_contract = (
         Op.MSTORE(0, check_block_number)
-        + Op.POP(Op.CALL(Op.GAS, Spec.HISTORY_STORAGE_ADDRESS, 0, 0, 32, 0, 32))
-        + Op.SSTORE(contract_key, Op.ISZERO(Op.MLOAD(0)))
+        + Op.POP(Op.CALL(Op.GAS, Spec.HISTORY_STORAGE_ADDRESS, 0, 0, 32, contract_ret_offset, 32))
+        + Op.SSTORE(contract_key, Op.ISZERO(Op.MLOAD(contract_ret_offset)))
     )
 
     if check_contract_first:
@@ -75,7 +77,9 @@ def generate_block_check_code(
     if populated_history_storage_contract and populated_blockhash:
         # Both values must be equal
         store_equal_key = storage.store_next(True)
-        code += Op.SSTORE(store_equal_key, Op.EQ(Op.MLOAD(0), Op.BLOCKHASH(check_block_number)))
+        code += Op.SSTORE(
+            store_equal_key, Op.EQ(Op.MLOAD(contract_ret_offset), Op.BLOCKHASH(check_block_number))
+        )
 
     return code
 


### PR DESCRIPTION
## 🗒️ Description

The `check_contract` uses `MSTORE` to store `check_block_number` at memory offset 0. However, if `CALL` to `HISTORY_STORAGE_ADDRESS` is reverted, `MLOAD(0)` returns the value of `check_block_number` instead of `0x0`, as expected.

I ran this test in `execute` mode and found that it failed. My solution was to change `ret_offset` to avoid duplication with `check_block_number`. I ran it again and it worked as expected.