### PR TITLE
chore: update hive ruleset and add osaka

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,6 +35,7 @@ consume cache --help
 - 🐞 Fix the the hive command printed in test reports to reproduce tests in isolation by prefixing the `--sim.limit` flag value with `id:` ([#1333](https://github.com/ethereum/execution-spec-tests/pull/1333)).
 - 🐞 Improve index generation of [ethereum/tests](https://github.com/ethereum/tests) fixtures: Allow generation at any directory level and include `generatedTestHash` in the index file for the `fixture_hash` ([#1303](https://github.com/ethereum/execution-spec-tests/pull/1303)).
 - 🐞 Fix loading of [ethereum/tests](https://github.com/ethereum/tests) and [ethereum/legacytests](https://github.com/ethereum/legacytests) fixtures for the case of mixed `0x0` and `0x1` transaction types in multi-index (`data`, `gas`, `value`) state test fixtures ([#1330](https://github.com/ethereum/execution-spec-tests/pull/1330)).
+- ✨ Add Osaka to the hive ruleset, includes a small ruleset refactor ([#1355](https://github.com/ethereum/execution-spec-tests/pull/1355)).
 
 #### `fill`
 

--- a/src/pytest_plugins/consume/hive_simulators/ruleset.py
+++ b/src/pytest_plugins/consume/hive_simulators/ruleset.py
@@ -24,7 +24,7 @@ def get_blob_schedule_entries(fork: Fork) -> Dict[str, int]:
     current_fork = fork
     while current_fork.supports_blobs():
         forks_with_blobs.append(current_fork)
-        current_fork = current_fork.parent()
+        current_fork = current_fork.parent()  # type: ignore
 
     for fork_to_process in forks_with_blobs:
         prefix = fork_to_process.__name__.upper()

--- a/src/pytest_plugins/consume/hive_simulators/ruleset.py
+++ b/src/pytest_plugins/consume/hive_simulators/ruleset.py
@@ -5,6 +5,37 @@ TODO: Create the ruleset dynamically per fixture test case based on the fork.
 Remove this file afterwards.
 """
 
+from typing import Dict, List
+
+from ethereum_test_forks import Cancun, Fork, Osaka, Prague
+
+
+def get_blob_schedule_entries(fork: Fork) -> Dict[str, int]:
+    """
+    Generate blob schedule entries for each fork (and respective parent forks).
+
+    Adds the following entries to the ruleset for the given fork (and parent forks):
+        HIVE_{FORK}_BLOB_TARGET: target_blobs_per_block()
+        HIVE_{FORK}_BLOB_MAX: max_blobs_per_block()
+        HIVE_{FORK}_BLOB_BASE_FEE_UPDATE_FRACTION: blob_base_fee_update_fraction()
+    """
+    entries: Dict = {}
+    forks_with_blobs: List[Fork] = []
+    current_fork = fork
+    while current_fork.supports_blobs():
+        forks_with_blobs.append(current_fork)
+        current_fork = current_fork.parent()
+
+    for fork_to_process in forks_with_blobs:
+        prefix = fork_to_process.__name__.upper()
+        entries[f"HIVE_{prefix}_BLOB_TARGET"] = fork_to_process.target_blobs_per_block()
+        entries[f"HIVE_{prefix}_BLOB_MAX"] = fork_to_process.max_blobs_per_block()
+        entries[f"HIVE_{prefix}_BLOB_BASE_FEE_UPDATE_FRACTION"] = (
+            fork_to_process.blob_base_fee_update_fraction()
+        )
+    return entries
+
+
 ruleset = {
     "Frontier": {
         "HIVE_FORK_HOMESTEAD": 2000,
@@ -121,7 +152,6 @@ ruleset = {
     },
     "HomesteadToEIP150At5": {
         "HIVE_FORK_HOMESTEAD": 0,
-        # "HIVE_FORK_DAO_BLOCK":      2000,
         "HIVE_FORK_TANGERINE": 5,
         "HIVE_FORK_SPURIOUS": 2000,
         "HIVE_FORK_BYZANTIUM": 2000,
@@ -145,7 +175,6 @@ ruleset = {
     },
     "EIP158ToByzantiumAt5": {
         "HIVE_FORK_HOMESTEAD": 0,
-        # "HIVE_FORK_DAO_BLOCK":      2000,
         "HIVE_FORK_TANGERINE": 0,
         "HIVE_FORK_SPURIOUS": 0,
         "HIVE_FORK_BYZANTIUM": 5,
@@ -157,7 +186,6 @@ ruleset = {
     },
     "ByzantiumToConstantinopleAt5": {
         "HIVE_FORK_HOMESTEAD": 0,
-        # "HIVE_FORK_DAO_BLOCK":      2000,
         "HIVE_FORK_TANGERINE": 0,
         "HIVE_FORK_SPURIOUS": 0,
         "HIVE_FORK_BYZANTIUM": 0,
@@ -169,7 +197,6 @@ ruleset = {
     },
     "ByzantiumToConstantinopleFixAt5": {
         "HIVE_FORK_HOMESTEAD": 0,
-        # "HIVE_FORK_DAO_BLOCK":      2000,
         "HIVE_FORK_TANGERINE": 0,
         "HIVE_FORK_SPURIOUS": 0,
         "HIVE_FORK_BYZANTIUM": 0,
@@ -181,7 +208,6 @@ ruleset = {
     },
     "ConstantinopleFixToIstanbulAt5": {
         "HIVE_FORK_HOMESTEAD": 0,
-        # "HIVE_FORK_DAO_BLOCK":      2000,
         "HIVE_FORK_TANGERINE": 0,
         "HIVE_FORK_SPURIOUS": 0,
         "HIVE_FORK_BYZANTIUM": 0,
@@ -193,7 +219,6 @@ ruleset = {
     },
     "IstanbulToBerlinAt5": {
         "HIVE_FORK_HOMESTEAD": 0,
-        # "HIVE_FORK_DAO_BLOCK":      2000,
         "HIVE_FORK_TANGERINE": 0,
         "HIVE_FORK_SPURIOUS": 0,
         "HIVE_FORK_BYZANTIUM": 0,
@@ -205,7 +230,6 @@ ruleset = {
     },
     "BerlinToLondonAt5": {
         "HIVE_FORK_HOMESTEAD": 0,
-        # "HIVE_FORK_DAO_BLOCK":      2000,
         "HIVE_FORK_TANGERINE": 0,
         "HIVE_FORK_SPURIOUS": 0,
         "HIVE_FORK_BYZANTIUM": 0,
@@ -306,9 +330,7 @@ ruleset = {
         "HIVE_TERMINAL_TOTAL_DIFFICULTY": 0,
         "HIVE_SHANGHAI_TIMESTAMP": 0,
         "HIVE_CANCUN_TIMESTAMP": 0,
-        "HIVE_CANCUN_BLOB_TARGET": 3,
-        "HIVE_CANCUN_BLOB_MAX": 6,
-        "HIVE_CANCUN_BLOB_BASE_FEE_UPDATE_FRACTION": 3338477,
+        **get_blob_schedule_entries(Cancun),
     },
     "ShanghaiToCancunAtTime15k": {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -324,9 +346,7 @@ ruleset = {
         "HIVE_TERMINAL_TOTAL_DIFFICULTY": 0,
         "HIVE_SHANGHAI_TIMESTAMP": 0,
         "HIVE_CANCUN_TIMESTAMP": 15000,
-        "HIVE_CANCUN_BLOB_TARGET": 3,
-        "HIVE_CANCUN_BLOB_MAX": 6,
-        "HIVE_CANCUN_BLOB_BASE_FEE_UPDATE_FRACTION": 3338477,
+        **get_blob_schedule_entries(Cancun),
     },
     "Prague": {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -342,13 +362,8 @@ ruleset = {
         "HIVE_TERMINAL_TOTAL_DIFFICULTY": 0,
         "HIVE_SHANGHAI_TIMESTAMP": 0,
         "HIVE_CANCUN_TIMESTAMP": 0,
-        "HIVE_CANCUN_BLOB_TARGET": 3,
-        "HIVE_CANCUN_BLOB_MAX": 6,
-        "HIVE_CANCUN_BLOB_BASE_FEE_UPDATE_FRACTION": 3338477,
         "HIVE_PRAGUE_TIMESTAMP": 0,
-        "HIVE_PRAGUE_BLOB_TARGET": 6,
-        "HIVE_PRAGUE_BLOB_MAX": 9,
-        "HIVE_PRAGUE_BLOB_BASE_FEE_UPDATE_FRACTION": 5007716,
+        **get_blob_schedule_entries(Prague),
     },
     "CancunToPragueAtTime15k": {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -364,12 +379,43 @@ ruleset = {
         "HIVE_TERMINAL_TOTAL_DIFFICULTY": 0,
         "HIVE_SHANGHAI_TIMESTAMP": 0,
         "HIVE_CANCUN_TIMESTAMP": 0,
-        "HIVE_CANCUN_BLOB_TARGET": 3,
-        "HIVE_CANCUN_BLOB_MAX": 6,
-        "HIVE_CANCUN_BLOB_BASE_FEE_UPDATE_FRACTION": 3338477,
         "HIVE_PRAGUE_TIMESTAMP": 15000,
-        "HIVE_PRAGUE_BLOB_TARGET": 6,
-        "HIVE_PRAGUE_BLOB_MAX": 9,
-        "HIVE_PRAGUE_BLOB_BASE_FEE_UPDATE_FRACTION": 5007716,
+        **get_blob_schedule_entries(Prague),
+    },
+    "Osaka": {
+        "HIVE_FORK_HOMESTEAD": 0,
+        "HIVE_FORK_TANGERINE": 0,
+        "HIVE_FORK_SPURIOUS": 0,
+        "HIVE_FORK_BYZANTIUM": 0,
+        "HIVE_FORK_CONSTANTINOPLE": 0,
+        "HIVE_FORK_PETERSBURG": 0,
+        "HIVE_FORK_ISTANBUL": 0,
+        "HIVE_FORK_BERLIN": 0,
+        "HIVE_FORK_LONDON": 0,
+        "HIVE_FORK_MERGE": 0,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 0,
+        "HIVE_SHANGHAI_TIMESTAMP": 0,
+        "HIVE_CANCUN_TIMESTAMP": 0,
+        "HIVE_PRAGUE_TIMESTAMP": 0,
+        "HIVE_OSAKA_TIMESTAMP": 0,
+        **get_blob_schedule_entries(Osaka),
+    },
+    "PragueToOsakaAtTime15k": {
+        "HIVE_FORK_HOMESTEAD": 0,
+        "HIVE_FORK_TANGERINE": 0,
+        "HIVE_FORK_SPURIOUS": 0,
+        "HIVE_FORK_BYZANTIUM": 0,
+        "HIVE_FORK_CONSTANTINOPLE": 0,
+        "HIVE_FORK_PETERSBURG": 0,
+        "HIVE_FORK_ISTANBUL": 0,
+        "HIVE_FORK_BERLIN": 0,
+        "HIVE_FORK_LONDON": 0,
+        "HIVE_FORK_MERGE": 0,
+        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 0,
+        "HIVE_SHANGHAI_TIMESTAMP": 0,
+        "HIVE_CANCUN_TIMESTAMP": 0,
+        "HIVE_PRAGUE_TIMESTAMP": 0,
+        "HIVE_OSAKA_TIMESTAMP": 15000,
+        **get_blob_schedule_entries(Osaka),
     },
 }


### PR DESCRIPTION
## 🗒️ Description
Primarily adds Osaka to the hive ruleset file. Additional refactoring includes a blob schedule function to prevent things getting messy (a quick addition while adding Osaka).

### Before

Previously, you had to manually write out blob schedule keys like this:
```python
    "Prague": {
        "HIVE_FORK_HOMESTEAD": 0,
        ...
        "HIVE_CANCUN_TIMESTAMP": 0,
        "HIVE_CANCUN_BLOB_TARGET": 3,
        "HIVE_CANCUN_BLOB_MAX": 6,
        "HIVE_CANCUN_BLOB_BASE_FEE_UPDATE_FRACTION": 3338477,
        "HIVE_PRAGUE_TIMESTAMP": 0,
        "HIVE_PRAGUE_BLOB_TARGET": 6,
        "HIVE_PRAGUE_BLOB_MAX": 9,
        "HIVE_PRAGUE_BLOB_BASE_FEE_UPDATE_FRACTION": 5007716,
    },
```

### After 

Now, you can simply write:
```python
    "Prague": {
        "HIVE_FORK_HOMESTEAD": 0,
        ...
        "HIVE_CANCUN_TIMESTAMP": 0,
        "HIVE_PRAGUE_TIMESTAMP": 0,
        **get_blob_schedule_entries(Prague),
    },
```

## 🔗 Related Issues
N/A

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.