### PR TITLE
docs: update EOF Test and state test documentation

### DIFF
--- a/docs/consuming_tests/eof_test.md
+++ b/docs/consuming_tests/eof_test.md
@@ -20,7 +20,7 @@ The EOF test fixture format is designed to be consumed by Ethereum client implem
 4. Compare the validation result (valid or invalid) against the expected result specified in the test
 5. If the validation result matches the expected result, the test passes; otherwise, it fails
 
-When validating EOF code, clients should follow the rules for EOF container validation as defined in the Ethereum execution specifications, particularly EIP-7692 (EOF v1) and related EIPs like EIP-4750 (Functions), EIP-7620 (EOF CREATE), and EIP-663 (DUPN/SWAPN/EXCHANGE).
+When validating EOF code, clients should follow the rules for EOF container validation as defined in the Ethereum execution specifications, particularly [EIP-7692](https://eips.ethereum.org/EIPS/eip-7692) (EOF v1) and related EIPs like [EIP-4750](https://eips.ethereum.org/EIPS/eip-4750) (Functions), [EIP-7620](https://eips.ethereum.org/EIPS/eip-7620) (EOF CREATE), and [EIP-663](https://eips.ethereum.org/EIPS/eip-663) (DUPN/SWAPN/EXCHANGE).
 
 ## Structures
 

--- a/docs/consuming_tests/eof_test.md
+++ b/docs/consuming_tests/eof_test.md
@@ -12,7 +12,15 @@ It simply defines a binary code in hexadecimal format and a boolean value that i
 
 ## Consumption
 
-TODO: Update this section
+The EOF test fixture format is designed to be consumed by Ethereum client implementations to verify their EOF container validation logic. Clients should:
+
+1. Parse the test fixture file (typically JSON format)
+2. Extract the binary code in hexadecimal format
+3. Validate the code according to EOF container validation rules
+4. Compare the validation result (valid or invalid) against the expected result specified in the test
+5. If the validation result matches the expected result, the test passes; otherwise, it fails
+
+When validating EOF code, clients should follow the rules for EOF container validation as defined in the Ethereum execution specifications, particularly EIP-7692 (EOF v1) and related EIPs like EIP-4750 (Functions), EIP-7620 (EOF CREATE), and EIP-663 (DUPN/SWAPN/EXCHANGE).
 
 ## Structures
 


### PR DESCRIPTION
## 🗒️ Description

Added detailed information on how to consume EOF tests, explaining the process and validation rules

## 🔗 Related Issues

TODO

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
