### PR TITLE
fix(tests): EIP-7702 verification/merge issue

### DIFF
--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -3513,7 +3513,7 @@ def test_set_code_from_account_with_non_delegating_code(
     But at the same time it has auth tuple that will point this sender account
     To be eoa, delegation, contract .. etc
     """
-    sender = pre.fund_eoa()
+    sender = pre.fund_eoa(nonce=1)
     random_address = pre.fund_eoa(0)
 
     set_code_to_address: Address
@@ -3560,9 +3560,8 @@ def test_set_code_from_account_with_non_delegating_code(
                 if set_code_type == AddressType.EMPTY_ACCOUNT
                 else Account(storage={})
             ),
-            random_address: Account.NONEXISTENT
-            if not self_sponsored
-            else Account(code=Bytes(Op.STOP)),
+            random_address: Account.NONEXISTENT,
+            sender: Account(nonce=1),
             callee_address: Account(storage={0: 0}),
         },
     )


### PR DESCRIPTION
## 🗒️ Description
Fixes a broken test for EIP-7702 introduced in #1288

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.