### PR TITLE
feat(consume): enable logging, propagate logs to hive results

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,7 +31,9 @@ consume cache --help
 - ✨ Allow filtering of test cases by fork via pytest marks (e.g., `-m "Cancun or Prague"`) ([#1304](https://github.com/ethereum/execution-spec-tests/pull/1304), [#1318](https://github.com/ethereum/execution-spec-tests/pull/1318)).
 - ✨ Allow filtering of test cases by fixture format via pytest marks (e.g., `-m blockchain_test`) ([#1314](https://github.com/ethereum/execution-spec-tests/pull/1314)).
 - ✨ Add top-level entries `forks` and `fixture_formats` to the index file that list all the forks and fixture formats used in the indexed fixtures ([#1318](https://github.com/ethereum/execution-spec-tests/pull/1318)).
-- 🐞 Don't parametrize tests for unsupported fixture formats; improve `consume` test collection ([#1315](https://github.com/ethereum/execution-spec-tests/pull/1314)).
+- ✨ Enable logging from `consume` commands ([#1361](https://github.com/ethereum/execution-spec-tests/pull/1361)).
+- ✨ Propagate stdout and stderr (including logs) captured during test execution to the Hive test result ([#1361](https://github.com/ethereum/execution-spec-tests/pull/1361)).
+- 🐞 Don't parametrize tests for unsupported fixture formats; improve `consume` test collection ([#1315](https://github.com/ethereum/execution-spec-tests/pull/1315)).
 - 🐞 Fix the the hive command printed in test reports to reproduce tests in isolation by prefixing the `--sim.limit` flag value with `id:` ([#1333](https://github.com/ethereum/execution-spec-tests/pull/1333)).
 - 🐞 Improve index generation of [ethereum/tests](https://github.com/ethereum/tests) fixtures: Allow generation at any directory level and include `generatedTestHash` in the index file for the `fixture_hash` ([#1303](https://github.com/ethereum/execution-spec-tests/pull/1303)).
 - 🐞 Fix loading of [ethereum/tests](https://github.com/ethereum/tests) and [ethereum/legacytests](https://github.com/ethereum/legacytests) fixtures for the case of mixed `0x0` and `0x1` transaction types in multi-index (`data`, `gas`, `value`) state test fixtures ([#1330](https://github.com/ethereum/execution-spec-tests/pull/1330)).

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -7,6 +7,7 @@ This documentation is aimed at maintainers of `execution-spec-tests` but may be 
 - [Generating documentation](./docs.md): Steps to create and build documentation for the project.
 - [Documenting CLI commands](./documenting_clis.md): Instructions for documenting command line interfaces (CLIs).
 - [Coding style](./coding_style.md): Standards and best practices for code formatting and to maintain consistency across the repository.
+- [Logging](./logging.md): Documentation on using the custom logging system with enhanced features.
 - [Enabling pre-commit checks](./precommit.md): A guide for setting up pre-commit hooks to enforce code quality before commits.
 - [Running github actions locally](./test_actions_locally.md): Instructions for testing GitHub Actions workflows on your local machine to streamline development and debugging.
 - [Porting tests](./porting_legacy_tests.md): A guide to porting legacy ethereum tests to EEST.

--- a/docs/dev/logging.md
+++ b/docs/dev/logging.md
@@ -89,6 +89,35 @@ Example: `consume-engine-20240101-123456-main.log`
 
 The log file path is displayed in the pytest header and summary.
 
+### Using the Standalone Configuration in Non-Pytest Projects
+
+The logging module can also be used in non-pytest projects by using the `configure_logging` function:
+
+```python
+from pytest_plugins.logging import configure_logging, get_logger
+
+# Configure logging with custom settings
+configure_logging(
+    log_level="VERBOSE",
+    log_file="my_application.log",
+    log_to_stdout=True,
+    log_format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    use_color=True
+)
+
+# Get a logger and use it
+logger = get_logger(__name__)
+logger.verbose("Logging configured in standalone application!")
+```
+
+The `configure_logging` function accepts the following parameters:
+
+- `log_level`: A string or numeric log level (default: "INFO")
+- `log_file`: Path to a log file, or None to disable file logging (default: None)
+- `log_to_stdout`: Whether to log to stdout (default: True)
+- `log_format`: The format string for log messages (default: "%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+- `use_color`: Whether to use colors in stdout output, or None to auto-detect (default: None)
+
 ## Implementation Details
 
 ### The EESTLogger Class

--- a/docs/dev/logging.md
+++ b/docs/dev/logging.md
@@ -1,0 +1,146 @@
+# Logging
+
+This document describes the logging system used in the Ethereum Execution Spec Tests project. Currently, logging is only supported for `consume` commands.
+
+## Overview
+
+The project uses Python's standard logging module with custom extensions to provide enhanced logging capabilities. Our logging system is implemented in the `src/pytest_plugins/logging.py` module and provides the following features:
+
+- Custom log levels between the standard Python log levels
+- Timestamps with millisecond precision in UTC
+- Color-coded log output (when not running in Docker)
+- File logging with a consistent naming pattern
+- Integration with pytest's output capture
+- Support for distributed test execution with pytest-xdist
+
+## Custom Log Levels
+
+In addition to the standard Python log levels (DEBUG, INFO, WARNING, ERROR, CRITICAL), we've added the following custom levels:
+
+| Level | Numeric Value | Purpose |
+|-------|--------------|---------|
+| VERBOSE | 15 | For messages more detailed than INFO but less verbose than DEBUG |
+| FAIL | 35 | For test failures and related issues (between WARNING and ERROR) |
+
+## Using the Logger
+
+### Getting a Logger
+
+To use the custom logger in your code, import the `get_logger` function from the logging module:
+
+```python
+from pytest_plugins.logging import get_logger
+
+# Create a logger with your module's name
+logger = get_logger(__name__)
+```
+
+### Logging at Different Levels
+
+You can use all standard Python log methods plus our custom methods:
+
+```python
+# Standard log levels
+logger.debug("Detailed debug information")
+logger.info("General information")
+logger.warning("Warning message")
+logger.error("Error message")
+logger.critical("Critical failure")
+
+# Custom log levels
+logger.verbose("More detailed than INFO, less than DEBUG")
+logger.fail("Test failure or similar issue")
+```
+
+### When to Use Each Level
+
+- **DEBUG (10)**: For very detailed diagnostic information useful for debugging
+- **VERBOSE (15)**: For information that's useful during development but more detailed than INFO
+- **INFO (20)**: For general information about program operation
+- **WARNING (30)**: For potential issues that don't prevent program execution
+- **FAIL (35)**: For test failures and related issues
+- **ERROR (40)**: For errors that prevent an operation from completing
+- **CRITICAL (50)**: For critical errors that may prevent the program from continuing
+
+## Configuration
+
+### Setting Log Level on the Command Line
+
+You can adjust the log level when running pytest with the `--eest-log-level` option:
+
+```bash
+consume engine --input=latest@stable --eest-log-level=VERBOSE -s --sim.limit=".*chainid.*"
+```
+
+The argument accepts both log level names (e.g., "DEBUG", "VERBOSE", "INFO") and numeric values.
+
+Adding pytest's `-s` flag writes the logging messages to the terminal; otherwise output will be written to the log file that is reported in the test session header at the end of the test session.
+
+### Log File Output
+
+Log files are automatically created in the `logs/` directory with a naming pattern that includes:
+
+- The command name, e.g. `consume`,
+- An optional subcommand (e.g., `engine`),
+- A timestamp in UTC,
+- The worker ID (when using pytest-xdist).
+
+Example: `consume-engine-20240101-123456-main.log`
+
+The log file path is displayed in the pytest header and summary.
+
+## Implementation Details
+
+### The EESTLogger Class
+
+The `EESTLogger` class extends Python's `Logger` class to add the custom log methods. The main module logger is automatically configured to use this class.
+
+### Formatters
+
+Two formatter classes are available:
+
+- `UTCFormatter`: Formats timestamps with millisecond precision in UTC
+- `ColorFormatter`: Extends `UTCFormatter` to add ANSI colors to log level names in terminal output
+
+### Pytest and Hive Integration
+
+The logging module includes several pytest hooks to:
+
+- Configure logging at the start of a test session
+- Record logs during test execution
+- Display the log file path in the test report
+- Ensure logs are captured properly during fixture teardown
+
+The `hive_pytest` plugin has been extended to propagate the logs to the `hiveview` UI via the test case's `details` ("description" in `hiveview`).
+
+## Example Usage
+
+A complete example of using the logging system in a `consume` test (or plugin):
+
+```python
+from pytest_plugins.logging import get_logger
+
+# Get a properly typed logger for your module
+logger = get_logger(__name__)
+
+def test_something():
+    # Use standard log levels
+    logger.debug("Setting up test variables")
+    logger.info("Starting test")
+    
+    # Use custom log levels
+    logger.verbose("Additional details about test execution")
+    
+    # Log warnings or errors as needed
+    if something_concerning:
+        logger.warning("Something looks suspicious")
+    
+    if something_failed:
+        logger.fail("Test condition not met")
+        assert False, "Test failed"
+    
+    # Log successful completion
+    logger.info("Test completed successfully")
+```
+
+All log messages will be displayed according to the configured log level and captured in the log file.

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -38,6 +38,7 @@
     * [Generating Documentation](dev/docs.md)
     * [Documenting CLI Commands](dev/documenting_clis.md)
     * [Coding Style](dev/coding_style.md)
+    * [Logging](dev/logging.md)
     * [Enabling Precommit Checks](dev/precommit.md)
     * [Running Github Actions Locally](dev/test_actions_locally.md)
     * [Porting Legacy Tests](dev/porting_legacy_tests.md)

--- a/pytest-consume.ini
+++ b/pytest-consume.ini
@@ -2,11 +2,11 @@
 console_output_style = count
 minversion = 7.0
 python_files = test_*
- # disable pytest built-in logging entirely `-p no:logging`
 addopts = 
     -rxXs
     --tb short
     -p pytest_plugins.concurrency
+    # disable pytest built-in logging entirely `-p no:logging`
     -p no:logging
     -p pytest_plugins.logging
     -p pytest_plugins.consume.consume

--- a/pytest-consume.ini
+++ b/pytest-consume.ini
@@ -8,6 +8,6 @@ addopts =
     -p pytest_plugins.concurrency
     # disable pytest built-in logging entirely `-p no:logging`
     -p no:logging
-    -p pytest_plugins.logging
+    -p pytest_plugins.logging.logging
     -p pytest_plugins.consume.consume
     -p pytest_plugins.help.help

--- a/pytest-consume.ini
+++ b/pytest-consume.ini
@@ -2,9 +2,12 @@
 console_output_style = count
 minversion = 7.0
 python_files = test_*
+ # disable pytest built-in logging entirely `-p no:logging`
 addopts = 
     -rxXs
     --tb short
     -p pytest_plugins.concurrency
+    -p no:logging
+    -p pytest_plugins.logging
     -p pytest_plugins.consume.consume
     -p pytest_plugins.help.help

--- a/src/pytest_plugins/consume/hive_simulators/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/conftest.py
@@ -2,6 +2,7 @@
 
 import io
 import json
+import logging
 from pathlib import Path
 from typing import Dict, Generator, List, Literal, cast
 
@@ -23,6 +24,8 @@ from pytest_plugins.consume.hive_simulators.ruleset import ruleset  # TODO: gene
 from pytest_plugins.pytest_hive.hive_info import ClientInfo
 
 from .timing import TimingData
+
+logger = logging.getLogger(__name__)
 
 
 def pytest_addoption(parser):
@@ -202,6 +205,7 @@ def client(
     total_timing_data: TimingData,
 ) -> Generator[Client, None, None]:
     """Initialize the client with the appropriate files and environment variables."""
+    logger.info(f"Starting client ({client_type.name})...")
     with total_timing_data.time("Start client"):
         client = hive_test.start_client(
             client_type=client_type, environment=environment, files=client_files
@@ -211,9 +215,12 @@ def client(
         "setup. Check the client or Hive server logs for more information."
     )
     assert client is not None, error_message
+    logger.info(f"Client ({client_type.name}) ready!")
     yield client
+    logger.info(f"Stopping client ({client_type.name})...")
     with total_timing_data.time("Stop client"):
         client.stop()
+    logger.info(f"Client ({client_type.name}) stopped!")
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/src/pytest_plugins/consume/hive_simulators/engine/test_via_engine.py
+++ b/src/pytest_plugins/consume/hive_simulators/engine/test_via_engine.py
@@ -9,8 +9,11 @@ from ethereum_test_fixtures import BlockchainEngineFixture
 from ethereum_test_rpc import EngineRPC, EthRPC
 from ethereum_test_rpc.types import ForkchoiceState, JSONRPCError, PayloadStatusEnum
 from pytest_plugins.consume.hive_simulators.exceptions import GenesisBlockMismatchExceptionError
+from pytest_plugins.logging import get_logger
 
 from ..timing import TimingData
+
+logger = get_logger(__name__)
 
 
 def test_blockchain_via_engine(
@@ -27,6 +30,7 @@ def test_blockchain_via_engine(
     """
     # Send a initial forkchoice update
     with timing_data.time("Initial forkchoice update"):
+        logger.info("Sending initial forkchoice update to genesis block...")
         forkchoice_response = engine_rpc.forkchoice_updated(
             forkchoice_state=ForkchoiceState(
                 head_block_hash=fixture.genesis.block_hash,
@@ -34,41 +38,64 @@ def test_blockchain_via_engine(
             payload_attributes=None,
             version=fixture.payloads[0].forkchoice_updated_version,
         )
+        status = forkchoice_response.payload_status.status
+        logger.info(f"Initial forkchoice update response: {status}")
         assert forkchoice_response.payload_status.status == PayloadStatusEnum.VALID, (
             f"unexpected status on forkchoice updated to genesis: {forkchoice_response}"
         )
 
     with timing_data.time("Get genesis block"):
+        logger.info("Calling getBlockByNumber to get genesis block...")
         genesis_block = eth_rpc.get_block_by_number(0)
         if genesis_block["hash"] != str(fixture.genesis.block_hash):
+            expected = fixture.genesis.block_hash
+            got = genesis_block["hash"]
+            logger.fail(f"Genesis block hash mismatch. Expected: {expected}, Got: {got}")
             raise GenesisBlockMismatchExceptionError(
                 expected_header=fixture.genesis,
                 got_genesis_block=genesis_block,
             )
 
     with timing_data.time("Payloads execution") as total_payload_timing:
+        logger.info(f"Starting execution of {len(fixture.payloads)} payloads...")
         for i, payload in enumerate(fixture.payloads):
+            logger.info(f"Processing payload {i + 1}/{len(fixture.payloads)}...")
             with total_payload_timing.time(f"Payload {i + 1}") as payload_timing:
                 with payload_timing.time(f"engine_newPayloadV{payload.new_payload_version}"):
+                    logger.info(f"Sending engine_newPayloadV{payload.new_payload_version}...")
+                    expected_validity = "VALID" if payload.valid() else "INVALID"
+                    logger.info(f"Expected payload validity: {expected_validity}")
                     try:
                         payload_response = engine_rpc.new_payload(
                             *payload.params,
                             version=payload.new_payload_version,
                         )
+                        logger.info(f"Payload response status: {payload_response.status}")
                         assert payload_response.status == (
                             PayloadStatusEnum.VALID
                             if payload.valid()
                             else PayloadStatusEnum.INVALID
                         ), f"unexpected status: {payload_response}"
                         if payload.error_code is not None:
+                            error_code = payload.error_code
+                            logger.fail(
+                                f"Client failed to raise expected Engine API error code: "
+                                f"{error_code}"
+                            )
                             raise Exception(
                                 "Client failed to raise expected Engine API error code: "
                                 f"{payload.error_code}"
                             )
                     except JSONRPCError as e:
+                        logger.info(f"JSONRPC error encountered: {e.code} - {e.message}")
                         if payload.error_code is None:
+                            logger.fail(f"Unexpected error: {e.code} - {e.message}")
                             raise Exception(f"unexpected error: {e.code} - {e.message}") from e
                         if e.code != payload.error_code:
+                            expected_code = payload.error_code
+                            logger.fail(
+                                f"Unexpected error code: {e.code}, expected: {expected_code}"
+                            )
                             raise Exception(
                                 f"unexpected error code: {e.code}, expected: {payload.error_code}"
                             ) from e
@@ -78,6 +105,8 @@ def test_blockchain_via_engine(
                         f"engine_forkchoiceUpdatedV{payload.forkchoice_updated_version}"
                     ):
                         # Send a forkchoice update to the engine
+                        version = payload.forkchoice_updated_version
+                        logger.info(f"Sending engine_forkchoiceUpdatedV{version}...")
                         forkchoice_response = engine_rpc.forkchoice_updated(
                             forkchoice_state=ForkchoiceState(
                                 head_block_hash=payload.params[0].block_hash,
@@ -85,6 +114,9 @@ def test_blockchain_via_engine(
                             payload_attributes=None,
                             version=payload.forkchoice_updated_version,
                         )
+                        status = forkchoice_response.payload_status.status
+                        logger.info(f"Forkchoice update response: {status}")
                         assert (
                             forkchoice_response.payload_status.status == PayloadStatusEnum.VALID
                         ), f"unexpected status: {forkchoice_response}"
+        logger.info("All payloads processed successfully.")

--- a/src/pytest_plugins/consume/hive_simulators/rlp/test_via_rlp.py
+++ b/src/pytest_plugins/consume/hive_simulators/rlp/test_via_rlp.py
@@ -28,7 +28,7 @@ def test_via_rlp(
     with timing_data.time("Get genesis block"):
         logger.info("Calling getBlockByNumber to get genesis block...")
         genesis_block = eth_rpc.get_block_by_number(0)
-        assert genesis_block, "`getBlockByNumber`didn't return a block."
+        assert genesis_block, "`getBlockByNumber` didn't return a block."
         if genesis_block["hash"] != str(fixture.genesis.block_hash):
             raise GenesisBlockMismatchExceptionError(
                 expected_header=fixture.genesis,
@@ -37,5 +37,5 @@ def test_via_rlp(
     with timing_data.time("Get latest block"):
         logger.info("Calling getBlockByNumber to get latest block...")
         block = eth_rpc.get_block_by_number("latest")
-        assert block, "`getBlockByNumber`didn't return a block."
+        assert block, "`getBlockByNumber` didn't return a block."
         assert block["hash"] == str(fixture.last_block_hash), "hash mismatch in last block"

--- a/src/pytest_plugins/consume/hive_simulators/rlp/test_via_rlp.py
+++ b/src/pytest_plugins/consume/hive_simulators/rlp/test_via_rlp.py
@@ -5,11 +5,15 @@ A hive based simulator that executes RLP-encoded blocks against clients. The sim
 Clients consume the genesis and RLP-encoded blocks from input files upon start-up.
 """
 
+import logging
+
 from ethereum_test_fixtures import BlockchainFixture
 from ethereum_test_rpc import EthRPC
 from pytest_plugins.consume.hive_simulators.exceptions import GenesisBlockMismatchExceptionError
 
 from ..timing import TimingData
+
+logger = logging.getLogger(__name__)
 
 
 def test_via_rlp(
@@ -22,12 +26,16 @@ def test_via_rlp(
     2. Check the client last block hash matches `fixture.last_block_hash`.
     """
     with timing_data.time("Get genesis block"):
+        logger.info("Calling getBlockByNumber to get genesis block...")
         genesis_block = eth_rpc.get_block_by_number(0)
+        assert genesis_block, "`getBlockByNumber`didn't return a block."
         if genesis_block["hash"] != str(fixture.genesis.block_hash):
             raise GenesisBlockMismatchExceptionError(
                 expected_header=fixture.genesis,
                 got_genesis_block=genesis_block,
             )
     with timing_data.time("Get latest block"):
+        logger.info("Calling getBlockByNumber to get latest block...")
         block = eth_rpc.get_block_by_number("latest")
+        assert block, "`getBlockByNumber`didn't return a block."
         assert block["hash"] == str(fixture.last_block_hash), "hash mismatch in last block"

--- a/src/pytest_plugins/consume/tests/test_consume_args.py
+++ b/src/pytest_plugins/consume/tests/test_consume_args.py
@@ -171,12 +171,9 @@ def test_consume_simlimit_collectonly(
     result = pytester.runpytest(*args)
     assert result.ret == 0
     stdout_lines = str(result.stdout).splitlines()
+    test_id_pattern = r"^(?:\s*)([^:\s]+\.py::[^:\s]+(?:::[^:\s]+)?)(?:\[[^\]]*\])?(?:\s*)$"
     collected_test_ids = [
-        line
-        for line in stdout_lines
-        if line.strip()
-        and "tests collected in" not in line
-        and "pytest-regex selected" not in line
+        line for line in stdout_lines if line.strip() and re.match(test_id_pattern, line)
     ]
     expected_collected_test_ids = [
         line for line in consume_test_case_ids if expected_filter_pattern.search(line)

--- a/src/pytest_plugins/logging.py
+++ b/src/pytest_plugins/logging.py
@@ -63,9 +63,16 @@ class ColorFormatter(UTCFormatter):
 
     def format(self, record: LogRecord) -> str:
         """Apply colorful formatting."""
+        if self.running_in_docker():
+            return super().format(record)
         color = self.COLORS.get(record.levelno, self.RESET)
         record.levelname = f"{color}{record.levelname}{self.RESET}"
         return super().format(record)
+
+    @staticmethod
+    def running_in_docker() -> bool:
+        """Return True if `/.dockerenv` exists."""
+        return Path("/.dockerenv").exists()
 
 
 class LogLevel:

--- a/src/pytest_plugins/logging.py
+++ b/src/pytest_plugins/logging.py
@@ -110,7 +110,7 @@ def pytest_addoption(parser):  # noqa: D103
         type=LogLevel.from_cli,
         dest="eest_log_level",
         help=(
-            "The logging level to use in the test session: DEBUG INFO WARNING ERROR or "
+            "The logging level to use in the test session: DEBUG, INFO, WARNING, ERROR or "
             "CRITICAL, default - INFO. An integer in [0, 50] may be also provided."
         ),
     )

--- a/src/pytest_plugins/logging.py
+++ b/src/pytest_plugins/logging.py
@@ -219,7 +219,6 @@ def pytest_configure(config: pytest.Config) -> None:
 
     file_handler = logging.FileHandler(config.option.eest_log_file_path, mode="w")
     file_handler.setFormatter(formatter)
-    config._eest_file_handler = file_handler  # type: ignore[attr-defined]
     root_logger.addHandler(file_handler)
 
     stream_handler = logging.StreamHandler(sys.stdout)

--- a/src/pytest_plugins/logging.py
+++ b/src/pytest_plugins/logging.py
@@ -1,0 +1,255 @@
+"""
+A Pytest plugin to configure logging for pytest sessions.
+
+Note: While pytest's builtin logging is generally amazing, it does not write timestamps
+when log output is written to pytest's caplog (the captured output for a test). And having
+timestamps in this output is the main use case for adding logging to our plugins.
+This output gets shown in the `FAILURES` summary section, which is shown as the
+"simulator log" in hive simulations. For this use case, timestamps are essential to verify
+timing issues against the clients log.
+"""
+
+import functools
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+from logging import LogRecord
+from pathlib import Path
+from typing import Optional
+
+import pytest
+from _pytest.terminal import TerminalReporter
+
+logger = logging.getLogger(__name__)
+
+# global that gets set in pytest_configure()
+file_handler: Optional[logging.FileHandler] = None
+
+FAIL_LEVEL = 35  # Between WARNING (30) and ERROR (40)
+
+
+def fail(self, message, *args, **kwargs):
+    """Define a new log level for failing tests."""
+    if self.isEnabledFor(FAIL_LEVEL):
+        self._log(FAIL_LEVEL, message, args, **kwargs)
+
+
+if not hasattr(logging.Logger, "fail"):
+    logging.addLevelName(FAIL_LEVEL, "FAIL")
+    logging.Logger.fail = fail  # type: ignore[attr-defined]
+
+
+class UTCFormatter(logging.Formatter):
+    """Log formatter that formats UTC timestamps with milliseconds and +00:00 suffix."""
+
+    def formatTime(self, record, datefmt=None):  # noqa: D102,N802  # camelcase required
+        dt = datetime.fromtimestamp(record.created, tz=timezone.utc)
+        return dt.strftime("%Y-%m-%d %H:%M:%S.%f")[:-3] + "+00:00"
+
+
+class ColorFormatter(UTCFormatter):
+    """Formatter that adds ANSI color codes to log level names for terminal output."""
+
+    COLORS = {
+        logging.DEBUG: "\033[37m",  # Gray
+        logging.INFO: "\033[36m",  # Cyan
+        logging.WARNING: "\033[33m",  # Yellow
+        FAIL_LEVEL: "\033[35m",  # Magenta
+        logging.ERROR: "\033[31m",  # Red
+        logging.CRITICAL: "\033[41m",  # Red background
+    }
+    RESET = "\033[0m"
+
+    def format(self, record: LogRecord) -> str:
+        """Apply colorful formatting."""
+        color = self.COLORS.get(record.levelno, self.RESET)
+        record.levelname = f"{color}{record.levelname}{self.RESET}"
+        return super().format(record)
+
+
+class LogLevel:
+    """Help parse a log-level provided on the command-line."""
+
+    @classmethod
+    def from_cli(cls, value: str) -> int:
+        """
+        Parse a logging level from CLI.
+
+        Accepts standard level names (e.g. 'INFO', 'debug') or numeric values.
+        """
+        try:
+            return int(value)
+        except ValueError:
+            pass
+
+        level_name = value.upper()
+        if level_name in logging._nameToLevel:
+            return logging._nameToLevel[level_name]
+
+        valid = ", ".join(logging._nameToLevel.keys())
+        raise ValueError(f"Invalid log level '{value}'. Expected one of: {valid} or a number.")
+
+
+def pytest_addoption(parser):  # noqa: D103
+    logging_group = parser.getgroup(
+        "logging", "Arguments related to logging from test fixtures and tests."
+    )
+    logging_group.addoption(
+        "--eest-log-level",  # --log-level is defined by pytest's built-in logging
+        "--eestloglevel",
+        action="store",
+        default="INFO",
+        type=LogLevel.from_cli,
+        dest="eest_log_level",
+        help=(
+            "The logging level to use in the test session: DEBUG INFO WARNING ERROR or "
+            "CRITICAL, default - INFO. An integer in [0, 50] may be also provided."
+        ),
+    )
+
+
+@functools.cache
+def get_log_stem(argv0: str, argv1: Optional[str]) -> str:
+    """Generate the stem (prefix-subcommand-timestamp) for log files."""
+    stem = Path(argv0).stem
+    prefix = "pytest" if stem in ("", "-c", "__main__") else stem
+    subcommand = argv1 if argv1 and not argv1.startswith("-") else None
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+
+    name_parts = [prefix]
+    if subcommand:
+        name_parts.append(subcommand)
+    name_parts.append(timestamp)
+
+    return "-".join(name_parts)
+
+
+def pytest_configure_node(node):
+    """Initialize a variable for use in the worker (xdist hook)."""
+    potential_subcommand = None
+    if len(sys.argv) > 1:
+        potential_subcommand = sys.argv[1]
+    node.workerinput["log_stem"] = get_log_stem(sys.argv[0], potential_subcommand)
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_configure(config: pytest.Config) -> None:
+    """
+    Initialize logging.
+
+    This goes to a lot of effort to ensure that a log file is created per worker
+    if xdist is used and that the timestamp used in the filename is the same across
+    main and all workers.
+    """
+    global file_handler
+
+    potential_subcommand = None
+    if len(sys.argv) > 1:
+        potential_subcommand = sys.argv[1]
+    log_stem = getattr(config, "workerinput", {}).get("log_stem") or get_log_stem(
+        sys.argv[0], potential_subcommand
+    )
+
+    worker_id = os.getenv("PYTEST_XDIST_WORKER", "main")
+    log_filename = f"{log_stem}-{worker_id}.log"
+    log_path = Path("logs")
+    log_path.mkdir(exist_ok=True)
+    config.option.eest_log_file_path = log_path / log_filename
+
+    formatter = UTCFormatter(fmt="%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(config.getoption("eest_log_level"))
+
+    file_handler = logging.FileHandler(config.option.eest_log_file_path, mode="w")
+    file_handler.setFormatter(formatter)
+    config._eest_file_handler = file_handler  # type: ignore[attr-defined]
+    root_logger.addHandler(file_handler)
+
+    stream_handler = logging.StreamHandler(sys.stdout)
+    stream_handler.setFormatter(
+        ColorFormatter(fmt="%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+    )
+    root_logger.addHandler(stream_handler)
+
+
+def pytest_report_header(config: pytest.Config) -> list[str]:
+    """Show the log file path in the test session header."""
+    if eest_log_file_path := config.option.eest_log_file_path:
+        return [f"Log file: {eest_log_file_path}"]
+    return []
+
+
+def pytest_terminal_summary(terminalreporter: TerminalReporter, exitstatus: int) -> None:
+    """Display the log file path in the terminal summary like the HTML report does."""
+    if terminalreporter.config.option.collectonly:
+        return
+    if eest_log_file_path := terminalreporter.config.option.eest_log_file_path:
+        terminalreporter.write_sep("-", f"Log file: {eest_log_file_path.resolve()}", yellow=True)
+
+
+def log_only_to_file(level: int, msg: str, *args, **kwargs) -> None:
+    """Log a message only to the file handler, bypassing stdout."""
+    if not file_handler:
+        return
+    handler: logging.Handler = file_handler  # type: ignore[attr-defined]
+    logger = logging.getLogger(__name__)
+    if not logger.isEnabledFor(level):
+        return
+    record: LogRecord = logger.makeRecord(
+        logger.name,
+        level,
+        fn=__file__,
+        lno=0,
+        msg=msg,
+        args=args,
+        exc_info=None,
+        func=None,
+        extra=None,
+    )
+    handler.handle(record)
+
+
+def pytest_runtest_logstart(nodeid: str, location: tuple[str, int, str]) -> None:
+    """Log test start to file."""
+    log_only_to_file(logging.INFO, f"ℹ️  - START TEST: {nodeid}")
+
+
+def pytest_runtest_logreport(report: pytest.TestReport) -> None:
+    """Log test status and duration to file after it runs."""
+    if report.when != "call":
+        return
+
+    nodeid = report.nodeid
+    duration = report.duration
+
+    log_level = logging.INFO
+    if hasattr(report, "wasxfail"):
+        if report.skipped:
+            status = "XFAIL"
+            emoji = "💤"
+        elif report.passed:
+            status = "XPASS"
+            emoji = "🚨"
+        else:
+            status = "XFAIL ERROR"
+            emoji = "💣"
+            log_level = logging.ERROR
+    elif report.skipped:
+        status = "SKIPPED"
+        emoji = "⏭️"
+    elif report.failed:
+        status = "FAILED"
+        emoji = "❌"
+        log_level = FAIL_LEVEL
+    else:
+        status = "PASSED"
+        emoji = "✅"
+
+    log_only_to_file(log_level, f"{emoji} - {status} in {duration:.2f}s: {nodeid}")
+
+
+def pytest_runtest_logfinish(nodeid: str, location: tuple[str, int, str]) -> None:
+    """Log end of test to file."""
+    log_only_to_file(logging.INFO, f"ℹ️  - END TEST: {nodeid}")

--- a/src/pytest_plugins/logging.py
+++ b/src/pytest_plugins/logging.py
@@ -62,12 +62,13 @@ class ColorFormatter(UTCFormatter):
     RESET = "\033[0m"
 
     def format(self, record: LogRecord) -> str:
-        """Apply colorful formatting."""
-        if self.running_in_docker():
-            return super().format(record)
-        color = self.COLORS.get(record.levelno, self.RESET)
-        record.levelname = f"{color}{record.levelname}{self.RESET}"
-        return super().format(record)
+        """Apply colorful formatting only when not running in Docker."""
+        # First make a copy of the record to avoid modifying the original
+        record_copy = logging.makeLogRecord(record.__dict__)
+        if not self.running_in_docker():
+            color = self.COLORS.get(record_copy.levelno, self.RESET)
+            record_copy.levelname = f"{color}{record_copy.levelname}{self.RESET}"
+        return super().format(record_copy)
 
     @staticmethod
     def running_in_docker() -> bool:

--- a/src/pytest_plugins/logging/__init__.py
+++ b/src/pytest_plugins/logging/__init__.py
@@ -1,0 +1,23 @@
+"""Import the logging module content to make it available from pytest_plugins.logging."""
+
+from .logging import (
+    FAIL_LEVEL,
+    VERBOSE_LEVEL,
+    ColorFormatter,
+    EESTLogger,
+    LogLevel,
+    UTCFormatter,
+    configure_logging,
+    get_logger,
+)
+
+__all__ = [
+    "VERBOSE_LEVEL",
+    "FAIL_LEVEL",
+    "EESTLogger",
+    "UTCFormatter",
+    "ColorFormatter",
+    "LogLevel",
+    "get_logger",
+    "configure_logging",
+]

--- a/src/pytest_plugins/logging/logging.py
+++ b/src/pytest_plugins/logging/logging.py
@@ -20,7 +20,7 @@ import sys
 from datetime import datetime, timezone
 from logging import LogRecord
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, Optional, Union, cast
 
 import pytest
 from _pytest.terminal import TerminalReporter
@@ -158,6 +158,7 @@ class LogLevel:
 # Standalone logging configuration (usable without pytest)
 # ==============================================================================
 
+
 def configure_logging(
     log_level: Union[int, str] = "INFO",
     log_file: Optional[Union[str, Path]] = None,
@@ -180,46 +181,47 @@ def configure_logging(
 
     Returns:
         The file handler if log_file is provided, otherwise None
+
     """
     # Initialize root logger
     root_logger = logging.getLogger()
-    
+
     # Convert log level if it's a string
     if isinstance(log_level, str):
         log_level = LogLevel.from_cli(log_level)
-    
+
     # Set log level
     root_logger.setLevel(log_level)
-    
+
     # Remove any existing handlers
     for handler in root_logger.handlers[:]:
         root_logger.removeHandler(handler)
-    
+
     # File handler (optional)
     file_handler_instance = None
     if log_file:
         log_path = Path(log_file)
         log_path.parent.mkdir(exist_ok=True, parents=True)
-        
+
         file_handler_instance = logging.FileHandler(log_path, mode="w")
         file_handler_instance.setFormatter(UTCFormatter(fmt=log_format))
         root_logger.addHandler(file_handler_instance)
-    
+
     # Stdout handler (optional)
     if log_to_stdout:
         stream_handler = logging.StreamHandler(sys.stdout)
-        
+
         # Determine whether to use color
         if use_color is None:
             use_color = not ColorFormatter.running_in_docker()
-        
+
         if use_color:
             stream_handler.setFormatter(ColorFormatter(fmt=log_format))
         else:
             stream_handler.setFormatter(UTCFormatter(fmt=log_format))
-            
+
         root_logger.addHandler(stream_handler)
-    
+
     logger.verbose("Logging configured successfully.")
     return file_handler_instance
 
@@ -227,6 +229,7 @@ def configure_logging(
 # ==============================================================================
 # Pytest plugin integration
 # ==============================================================================
+
 
 def pytest_addoption(parser):  # noqa: D103
     logging_group = parser.getgroup(
@@ -294,7 +297,7 @@ def pytest_configure(config: pytest.Config) -> None:
     log_path = Path("logs")
     log_path.mkdir(exist_ok=True)
     log_file_path = log_path / log_filename
-    
+
     # Store the log file path in the pytest config
     config.option.eest_log_file_path = log_file_path
 

--- a/src/pytest_plugins/logging/tests/__init__.py
+++ b/src/pytest_plugins/logging/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package for the logging module."""

--- a/src/pytest_plugins/logging/tests/test_logging.py
+++ b/src/pytest_plugins/logging/tests/test_logging.py
@@ -98,11 +98,9 @@ class TestFormatters:
         formatted = formatter.format(record)
         assert re.match(r"2021-01-01 00:00:00\.\d{3}\+00:00: Test message", formatted)
 
-    @patch("pytest_plugins.logging.logging.ColorFormatter.running_in_docker")
-    def test_color_formatter(self, mock_running_in_docker):
+    def test_color_formatter(self, monkeypatch):
         """Test that ColorFormatter adds color codes to the log level."""
-        mock_running_in_docker.return_value = False
-
+        # Create the formatter and test record
         formatter = ColorFormatter(fmt="[%(levelname)s] %(message)s")
         record = logging.makeLogRecord(
             {
@@ -112,11 +110,14 @@ class TestFormatters:
             }
         )
 
+        # Test case 1: When not running in Docker, colors should be applied
+        # Override the class variable directly with monkeypatch
+        monkeypatch.setattr(ColorFormatter, "running_in_docker", False)
         formatted = formatter.format(record)
         assert "\033[31mERROR\033[0m" in formatted  # Red color for ERROR
 
-        # Test with Docker environment (should not have colors)
-        mock_running_in_docker.return_value = True
+        # Test case 2: When running in Docker, colors should not be applied
+        monkeypatch.setattr(ColorFormatter, "running_in_docker", True)
         formatted = formatter.format(record)
         assert "\033[31mERROR\033[0m" not in formatted
         assert "ERROR" in formatted

--- a/src/pytest_plugins/logging/tests/test_logging.py
+++ b/src/pytest_plugins/logging/tests/test_logging.py
@@ -1,0 +1,259 @@
+"""
+Tests for the logging module.
+
+These tests verify the functionality of the custom logging system,
+including both the standalone configuration and the pytest integration.
+"""
+
+import io
+import logging
+import re
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from ..logging import (
+    FAIL_LEVEL,
+    VERBOSE_LEVEL,
+    ColorFormatter,
+    EESTLogger,
+    UTCFormatter,
+    configure_logging,
+    get_logger,
+)
+
+
+class TestLoggerSetup:
+    """Test the basic setup of loggers and custom levels."""
+
+    def test_custom_levels_registered(self):
+        """Test that custom log levels are properly registered."""
+        assert logging.getLevelName(VERBOSE_LEVEL) == "VERBOSE"
+        assert logging.getLevelName(FAIL_LEVEL) == "FAIL"
+        assert logging.getLevelName("VERBOSE") == VERBOSE_LEVEL
+        assert logging.getLevelName("FAIL") == FAIL_LEVEL
+
+    def test_get_logger(self):
+        """Test that get_logger returns a properly typed logger."""
+        logger = get_logger("test_logger")
+        assert isinstance(logger, EESTLogger)
+        assert logger.name == "test_logger"
+        assert hasattr(logger, "verbose")
+        assert hasattr(logger, "fail")
+
+
+class TestEESTLogger:
+    """Test the custom logger methods."""
+
+    def setup_method(self):
+        """Set up a logger and string stream for capturing log output."""
+        self.log_output = io.StringIO()
+        self.logger = get_logger("test_eest_logger")
+
+        # Remove any existing handlers
+        for handler in self.logger.handlers[:]:
+            self.logger.removeHandler(handler)
+
+        # Configure a basic handler that writes to our string stream
+        handler = logging.StreamHandler(self.log_output)
+        handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+        self.logger.addHandler(handler)
+        self.logger.setLevel(logging.DEBUG)  # Set to lowest possible level for testing
+
+    def test_verbose_method(self):
+        """Test the verbose() method logs at the expected level."""
+        self.logger.verbose("This is a verbose message")
+        assert "VERBOSE: This is a verbose message" in self.log_output.getvalue()
+
+    def test_fail_method(self):
+        """Test the fail() method logs at the expected level."""
+        self.logger.fail("This is a fail message")
+        assert "FAIL: This is a fail message" in self.log_output.getvalue()
+
+    def test_standard_methods(self):
+        """Test that standard log methods still work."""
+        self.logger.debug("Debug message")
+        self.logger.info("Info message")
+        self.logger.warning("Warning message")
+
+        log_output = self.log_output.getvalue()
+        assert "DEBUG: Debug message" in log_output
+        assert "INFO: Info message" in log_output
+        assert "WARNING: Warning message" in log_output
+
+
+class TestFormatters:
+    """Test the custom log formatters."""
+
+    def test_utc_formatter(self):
+        """Test that UTCFormatter formats timestamps correctly."""
+        formatter = UTCFormatter(fmt="%(asctime)s: %(message)s")
+        record = logging.makeLogRecord(
+            {
+                "msg": "Test message",
+                "created": 1609459200.0,  # 2021-01-01 00:00:00 UTC
+            }
+        )
+
+        formatted = formatter.format(record)
+        assert re.match(r"2021-01-01 00:00:00\.\d{3}\+00:00: Test message", formatted)
+
+    @patch("pytest_plugins.logging.logging.ColorFormatter.running_in_docker")
+    def test_color_formatter(self, mock_running_in_docker):
+        """Test that ColorFormatter adds color codes to the log level."""
+        mock_running_in_docker.return_value = False
+
+        formatter = ColorFormatter(fmt="[%(levelname)s] %(message)s")
+        record = logging.makeLogRecord(
+            {
+                "levelno": logging.ERROR,
+                "levelname": "ERROR",
+                "msg": "Error message",
+            }
+        )
+
+        formatted = formatter.format(record)
+        assert "\033[31mERROR\033[0m" in formatted  # Red color for ERROR
+
+        # Test with Docker environment (should not have colors)
+        mock_running_in_docker.return_value = True
+        formatted = formatter.format(record)
+        assert "\033[31mERROR\033[0m" not in formatted
+        assert "ERROR" in formatted
+
+
+class TestStandaloneConfiguration:
+    """Test the standalone logging configuration function."""
+
+    def test_configure_logging_defaults(self):
+        """Test configure_logging with default parameters."""
+        with patch("sys.stdout", new=io.StringIO()):
+            # Configure logging with default settings
+            handler = configure_logging()
+
+            # Should log to stdout by default
+            root_logger = logging.getLogger()
+            assert any(isinstance(h, logging.StreamHandler) for h in root_logger.handlers)
+
+            # Should set INFO level by default
+            assert root_logger.level == logging.INFO
+
+            # Should not return a file handler
+            assert handler is None
+
+    def test_configure_logging_with_file(self):
+        """Test configure_logging with file output."""
+        # Create a temporary directory for log files
+        with tempfile.TemporaryDirectory() as temp_dir:
+            log_file = Path(temp_dir) / "test.log"
+
+            # Configure logging with a file
+            handler = configure_logging(log_file=log_file, log_to_stdout=False)
+
+            try:
+                # Should return a file handler
+                assert isinstance(handler, logging.FileHandler)
+
+                # Should create the log file
+                assert log_file.exists()
+
+                # Log a message and check it appears in the file
+                logger = get_logger("test_config")
+                logger.info("Test log message")
+
+                with open(log_file, "r") as f:
+                    log_content = f.read()
+                    assert "Test log message" in log_content
+            finally:
+                # Clean up
+                if handler:
+                    handler.close()
+                logging.getLogger().handlers = []  # Remove all handlers
+
+    def test_configure_logging_with_level(self):
+        """Test configure_logging with custom log level."""
+        # Test with string level name
+        configure_logging(log_level="DEBUG", log_to_stdout=False)
+        assert logging.getLogger().level == logging.DEBUG
+
+        # Test with numeric level
+        configure_logging(log_level=VERBOSE_LEVEL, log_to_stdout=False)
+        assert logging.getLogger().level == VERBOSE_LEVEL
+
+        # Clean up
+        logging.getLogger().handlers = []
+
+
+# Only the TestPytestIntegration class tests require pytest to run properly
+# We'll put the skip marker on that class instead of the whole module
+
+
+class TestPytestIntegration:
+    """Test the pytest integration of the logging module."""
+
+    def test_pytest_configure(self, monkeypatch, tmpdir):
+        """Test that pytest_configure sets up logging correctly."""
+        from pytest_plugins.logging.logging import pytest_configure
+
+        # Create logs directory if it doesn't exist
+        log_dir = Path("logs")
+        if not log_dir.exists():
+            log_dir.mkdir()
+
+        # Save the original handlers to restore later
+        original_handlers = logging.getLogger().handlers.copy()
+
+        try:
+            # Remove existing handlers to start clean
+            for handler in logging.getLogger().handlers[:]:
+                logging.getLogger().removeHandler(handler)
+
+            # Create a mock pytest config
+            class MockConfig:
+                def __init__(self):
+                    self.option = MagicMock()
+                    self.option.eest_log_level = logging.INFO
+                    self.workerinput = {}
+
+                def getoption(self, name):
+                    if name == "eest_log_level":
+                        return logging.INFO
+
+            # Set up environment
+            monkeypatch.setattr("sys.argv", ["pytest"])
+            monkeypatch.setenv("PYTEST_XDIST_WORKER", "worker1")
+
+            # Call pytest_configure
+            config = MockConfig()
+            pytest_configure(config)
+
+            # Check that logging is configured
+            assert hasattr(config.option, "eest_log_file_path")
+
+            # Check that a file handler was added to the root logger
+            file_handlers = [
+                h for h in logging.getLogger().handlers if isinstance(h, logging.FileHandler)
+            ]
+            assert len(file_handlers) > 0
+
+            # Find the log file handler's file
+            log_file = Path(file_handlers[0].baseFilename)
+
+            # Check that the log file was created
+            assert log_file.exists()
+
+            # Verify the file is in the logs directory
+            assert log_file.parent.resolve() == log_dir.resolve()
+
+            # Clean up the test log file
+            log_file.unlink()
+
+        finally:
+            # Clean up: Remove any handlers we added
+            for handler in logging.getLogger().handlers[:]:
+                handler.close()
+                logging.getLogger().removeHandler(handler)
+
+            # Restore original handlers
+            for handler in original_handlers:
+                logging.getLogger().addHandler(handler)

--- a/src/pytest_plugins/pytest_hive/pytest_hive.py
+++ b/src/pytest_plugins/pytest_hive/pytest_hive.py
@@ -261,8 +261,8 @@ def hive_test(request, test_suite: HiveTestSuite):
         for phase in ("setup", "call", "teardown"):
             report = getattr(request.node, f"result_{phase}", None)
             if report:
-                stdout = report.capstdout or ""
-                stderr = report.capstderr or ""
+                stdout = report.capstdout or "None"
+                stderr = report.capstderr or "None"
 
                 # Remove setup output from call phase output
                 if phase == "setup":
@@ -274,21 +274,24 @@ def hive_test(request, test_suite: HiveTestSuite):
                         stdout = call_out[len(setup_out) :]
 
                 captured.append(
-                    f"=== {phase.upper()} PHASE ===\nstdout:\n{stdout}\nstderr:\n{stderr}\n"
+                    f"\n# Captured Output from Test {phase.capitalize()}\n\n"
+                    f"## stdout:\n{stdout}\n"
+                    f"## stderr:\n{stderr}\n"
                 )
 
         captured_output = "\n".join(captured)
 
         if hasattr(request.node, "result_call") and request.node.result_call.passed:
             test_passed = True
-            test_result_details = "Test passed.\n" + captured_output
+            test_result_details = "Test passed.\n\n" + captured_output
         elif hasattr(request.node, "result_call") and not request.node.result_call.passed:
             test_passed = False
+            test_result_details = "Test failed.\n\n" + captured_output
             test_result_details = request.node.result_call.longreprtext + "\n" + captured_output
         elif hasattr(request.node, "result_setup") and not request.node.result_setup.passed:
             test_passed = False
             test_result_details = (
-                "Test setup failed.\n"
+                "Test setup failed.\n\n"
                 + request.node.result_setup.longreprtext
                 + "\n"
                 + captured_output
@@ -296,7 +299,7 @@ def hive_test(request, test_suite: HiveTestSuite):
         elif hasattr(request.node, "result_teardown") and not request.node.result_teardown.passed:
             test_passed = False
             test_result_details = (
-                "Test teardown failed.\n"
+                "Test teardown failed.\n\n"
                 + request.node.result_teardown.longreprtext
                 + "\n"
                 + captured_output
@@ -304,7 +307,7 @@ def hive_test(request, test_suite: HiveTestSuite):
         else:
             test_passed = False
             test_result_details = (
-                "Test failed for unknown reason (setup or call status unknown).\n"
+                "Test failed for unknown reason (setup or call status unknown).\n\n"
                 + captured_output
             )
 

--- a/src/pytest_plugins/pytest_hive/pytest_hive.py
+++ b/src/pytest_plugins/pytest_hive/pytest_hive.py
@@ -30,7 +30,6 @@ an unpredictable order relative to fixture teardown.
 """
 
 import json
-import logging
 import os
 import warnings
 from dataclasses import asdict
@@ -43,9 +42,10 @@ from hive.client import ClientRole
 from hive.simulation import Simulation
 from hive.testing import HiveTest, HiveTestResult, HiveTestSuite
 
+from ..logging import get_logger
 from .hive_info import ClientInfo, HiveInfo
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def pytest_configure(config):  # noqa: D103
@@ -309,10 +309,10 @@ def hive_test(request, test_suite: HiveTestSuite):
             )
 
         test.end(result=HiveTestResult(test_pass=test_passed, details=test_result_details))
-        logger.debug(f"Finished processing logs for test: {request.node.nodeid}")
+        logger.verbose(f"Finished processing logs for test: {request.node.nodeid}")
 
     except Exception as e:
-        logger.error(f"Error processing logs for test {request.node.nodeid}: {str(e)}")
+        logger.verbose(f"Error processing logs for test {request.node.nodeid}: {str(e)}")
         test_passed = False
         test_result_details = f"Exception whilst processing test result: {str(e)}"
         test.end(result=HiveTestResult(test_pass=test_passed, details=test_result_details))

--- a/src/pytest_plugins/pytest_hive/pytest_hive.py
+++ b/src/pytest_plugins/pytest_hive/pytest_hive.py
@@ -255,7 +255,7 @@ def hive_test(request, test_suite: HiveTestSuite):
 
     try:
         # Collect all logs from all phases
-        captured = []
+        captured = ["\n"]
         setup_out = ""
         call_out = ""
         for phase in ("setup", "call", "teardown"):
@@ -274,7 +274,7 @@ def hive_test(request, test_suite: HiveTestSuite):
                         stdout = call_out[len(setup_out) :]
 
                 captured.append(
-                    f"\n# Captured Output from Test {phase.capitalize()}\n\n"
+                    f"# Captured Output from Test {phase.capitalize()}\n\n"
                     f"## stdout:\n{stdout}\n"
                     f"## stderr:\n{stderr}\n"
                 )

--- a/src/pytest_plugins/pytest_hive/pytest_hive.py
+++ b/src/pytest_plugins/pytest_hive/pytest_hive.py
@@ -255,7 +255,7 @@ def hive_test(request, test_suite: HiveTestSuite):
 
     try:
         # Collect all logs from all phases
-        captured = ["\n"]
+        captured = []
         setup_out = ""
         call_out = ""
         for phase in ("setup", "call", "teardown"):

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -868,3 +868,4 @@ eestloglevel
 caplog
 workerinput
 dockerenv
+stderr

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -872,3 +872,4 @@ stderr
 EESTLogger
 Formatters
 UI
+asctime

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -859,3 +859,11 @@ fibonacci
 CPython
 legacytests
 pycryptodome
+pytest_sessionfinish
+levelname
+pytest_runtest_logstart
+pytest_runtest_logreport
+pytest_runtest_logfinish
+eestloglevel
+caplog
+workerinput

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -869,3 +869,6 @@ caplog
 workerinput
 dockerenv
 stderr
+EESTLogger
+Formatters
+UI

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -867,3 +867,4 @@ pytest_runtest_logfinish
 eestloglevel
 caplog
 workerinput
+dockerenv


### PR DESCRIPTION
## 🗒️ Description
The Besu Team reported some flaky looking `eest/consume-rlp` results in the Pectra dashboard, without any logging from the simulator side, we're essentially blind as to the timing of the simulator setup with regards to client startup. This PR adds logging to help debug this.

### Changes
1. Use pytest's `--tb short` to only show relevant tracebacks for unexpected exceptions in test execution (e.g., timeout on rpc call; requests exceptions are notoriously noisy).
2. Add a new logging plugin. This is pretty ugly stuff, but the complexity seems necessary to achieve:
  a. Getting timestamps in pytest's capd output (pytest has amazing logging, but this seemed unachievable with the built-in plugin, would be happy to be wrong).
  b. Clean logging to file per logger with xdist.
  c. Adding log lines to the file for start and end of test. 
3. Propagates stdout and stderr capd from pytest to the pytest test result so it's available in the test result in hiveview.

#### Example of Hiveview test case fail
Still with a bug; setup stdout is duplicated in call stdout.
![image](https://github.com/user-attachments/assets/45ae5b42-126f-4959-b204-9c4c41c3bd5b)

#### Example of Hiveview test case pass
With bug fix (setup stdout no longer duplicated to call stdout).
![image](https://github.com/user-attachments/assets/da78bd1d-531e-437e-aaec-2392d023ef1e)

#### Example of file logging

```
2025-03-27 09:42:00.502+00:00 [INFO] pytest_plugins.logging: ℹ️  - START TEST: src/pytest_plugins/consume/hive_simulators/rlp/test_via_rlp.py::test_via_rlp[tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Cancun-blockchain_test_from_state_test]-go-ethereum_default]
2025-03-27 09:42:00.531+00:00 [INFO] pytest_plugins.consume.hive_simulators.conftest: Starting client (go-ethereum_default)...
2025-03-27 09:42:01.409+00:00 [INFO] pytest_plugins.consume.hive_simulators.conftest: Client (go-ethereum_default) ready!
2025-03-27 09:42:01.411+00:00 [INFO] pytest_plugins.consume.hive_simulators.rlp.test_via_rlp: Calling getBlockByNumber to get genesis block...
2025-03-27 09:42:01.416+00:00 [INFO] pytest_plugins.consume.hive_simulators.rlp.test_via_rlp: Calling getBlockByNumber to get latest block...
2025-03-27 09:42:01.421+00:00 [INFO] pytest_plugins.logging: ✅ - PASSED in 0.01s: src/pytest_plugins/consume/hive_simulators/rlp/test_via_rlp.py::test_via_rlp[tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Cancun-blockchain_test_from_state_test]-go-ethereum_default]
2025-03-27 09:42:01.421+00:00 [INFO] pytest_plugins.consume.hive_simulators.conftest: Stopping client (go-ethereum_default)...
2025-03-27 09:42:01.564+00:00 [INFO] pytest_plugins.consume.hive_simulators.conftest: Client (go-ethereum_default) stopped!
2025-03-27 09:42:01.569+00:00 [INFO] pytest_plugins.logging: ℹ️  - END TEST: src/pytest_plugins/consume/hive_simulators/rlp/test_via_rlp.py::test_via_rlp[tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Cancun-blockchain_test_from_state_test]-go-ethereum_default]
2025-03-27 09:42:01.569+00:00 [INFO] pytest_plugins.logging: ℹ️  - START TEST: src/pytest_plugins/consume/hive_simulators/rlp/test_via_rlp.py::test_via_rlp[tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Shanghai-blockchain_test_from_state_test]-go-ethereum_default]
2025-03-27 09:42:01.575+00:00 [INFO] pytest_plugins.consume.hive_simulators.conftest: Starting client (go-ethereum_default)...
2025-03-27 09:42:02.500+00:00 [INFO] pytest_plugins.consume.hive_simulators.conftest: Client (go-ethereum_default) ready!
2025-03-27 09:42:02.502+00:00 [INFO] pytest_plugins.consume.hive_simulators.rlp.test_via_rlp: Calling getBlockByNumber to get genesis block...
2025-03-27 09:42:02.507+00:00 [INFO] pytest_plugins.consume.hive_simulators.rlp.test_via_rlp: Calling getBlockByNumber to get latest block...
2025-03-27 09:42:02.512+00:00 [INFO] pytest_plugins.logging: ✅ - PASSED in 0.01s: src/pytest_plugins/consume/hive_simulators/rlp/test_via_rlp.py::test_via_rlp[tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Shanghai-blockchain_test_from_state_test]-go-ethereum_default]
2025-03-27 09:42:02.513+00:00 [INFO] pytest_plugins.consume.hive_simulators.conftest: Stopping client (go-ethereum_default)...
2025-03-27 09:42:02.677+00:00 [INFO] pytest_plugins.consume.hive_simulators.conftest: Client (go-ethereum_default) stopped!
2025-03-27 09:42:02.688+00:00 [INFO] pytest_plugins.logging: ℹ️  - END TEST: src/pytest_plugins/consume/hive_simulators/rlp/test_via_rlp.py::test_via_rlp[tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Shanghai-blockchain_test_from_state_test]-go-ethereum_default]
```

#### Example of console logging with fail

Pytest provides this out the box, but without timestamps :sob: 
![image](https://github.com/user-attachments/assets/7d52d895-db3f-4285-9b06-46da253d2f9a)

## 🔗 Related Issues

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).

