### PR TITLE
fix(github): Pin cmake to a pre-4.0.0 version

### DIFF
--- a/.github/actions/build-evm-client/evmone/action.yaml
+++ b/.github/actions/build-evm-client/evmone/action.yaml
@@ -25,6 +25,8 @@ runs:
         submodules: true
     - name: Setup cmake
       uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be
+      with:
+        cmake-version: '3.x'
     - name: "Install GMP"
       shell: bash
       run: sudo apt-get -q update && sudo apt-get -qy install libgmp-dev


### PR DESCRIPTION
## 🗒️ Description
Attempt to fix this failure:

https://github.com/ethereum/execution-spec-tests/actions/runs/14119176442/job/39594538181

It's running with version 4.0.0 now, which I'm assuming it's not supported by the version checker contained in evmone, so pinning to the latest v3 should do the trick.
## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] ~~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.