### PR TITLE
feat(execute): Use test spec names as markers for `execute`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -43,7 +43,7 @@ consume cache --help
 
 #### `execute`
 
-- 🔀 Test IDs have changed to include the name of the test spec where the test came from (e.g. state_test, blockchain_test, etc) ([#1367](https://github.com/ethereum/execution-spec-tests/pull/1367)).
+- 🔀 Test IDs have changed to include the name of the test spec where the test came from (e.g. `state_test`, `blockchain_test`, etc) ([#1367](https://github.com/ethereum/execution-spec-tests/pull/1367)).
 - ✨ Markers can now be used to execute only tests from a specific test spec type (e.g. `-m state_test`, `-m blockchain_test`, etc) ([#1367](https://github.com/ethereum/execution-spec-tests/pull/1367)).
 
 ### 📋 Misc

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -41,6 +41,11 @@ consume cache --help
 - 🐞 Fix `--fork/from/until` for transition forks when using `fill` [#1311](https://github.com/ethereum/execution-spec-tests/pull/1311).
 - 🐞 Fix the node id for state tests marked by transition forks ([#1313](https://github.com/ethereum/execution-spec-tests/pull/1313)).
 
+#### `execute`
+
+- 🔀 Test IDs have changed to include the name of the test spec where the test came from (e.g. state_test, blockchain_test, etc) ([#1367](https://github.com/ethereum/execution-spec-tests/pull/1367)).
+- ✨ Markers can now be used to execute only tests from a specific test spec type (e.g. `-m state_test`, `-m blockchain_test`, etc) ([#1367](https://github.com/ethereum/execution-spec-tests/pull/1367)).
+
 ### 📋 Misc
 
 - 🔀 Bump the version of `execution-specs` used by the framework to the package [`ethereum-execution==1.17.0rc6.dev1`](https://pypi.org/project/ethereum-execution/1.17.0rc6.dev1/); bump the version used for test fixture generation for forks < Prague to current `execution-specs` master, [fa847a0](https://github.com/ethereum/execution-specs/commit/fa847a0e48309debee8edc510ceddb2fd5db2f2e) ([#1310](https://github.com/ethereum/execution-spec-tests/pull/1310)).

--- a/src/ethereum_test_specs/base.py
+++ b/src/ethereum_test_specs/base.py
@@ -52,7 +52,7 @@ class BaseTest(BaseModel):
     _t8n_call_counter: Iterator[int] = count(0)
 
     supported_fixture_formats: ClassVar[Sequence[FixtureFormat | LabeledFixtureFormat]] = []
-    supported_execute_formats: ClassVar[Sequence[ExecuteFormat | LabeledExecuteFormat]] = []
+    supported_execute_formats: ClassVar[Sequence[LabeledExecuteFormat]] = []
 
     supported_markers: ClassVar[Dict[str, str]] = {}
 

--- a/src/ethereum_test_specs/blockchain.py
+++ b/src/ethereum_test_specs/blockchain.py
@@ -297,8 +297,12 @@ class BlockchainTest(BaseTest):
         BlockchainFixture,
         BlockchainEngineFixture,
     ]
-    supported_execute_formats: ClassVar[Sequence[ExecuteFormat | LabeledExecuteFormat]] = [
-        TransactionPost,
+    supported_execute_formats: ClassVar[Sequence[LabeledExecuteFormat]] = [
+        LabeledExecuteFormat(
+            TransactionPost,
+            "blockchain_test",
+            "An execute test derived from a blockchain test",
+        ),
     ]
 
     supported_markers: ClassVar[Dict[str, str]] = {

--- a/src/ethereum_test_specs/eof.py
+++ b/src/ethereum_test_specs/eof.py
@@ -241,11 +241,11 @@ class EOFTest(BaseTest):
         for fixture_format in StateTest.supported_fixture_formats
     ]
 
-    supported_execute_formats: ClassVar[Sequence[ExecuteFormat | LabeledExecuteFormat]] = [
+    supported_execute_formats: ClassVar[Sequence[LabeledExecuteFormat]] = [
         LabeledExecuteFormat(
             execute_format,
-            f"{execute_format.format_name}_from_eof_test",
-            f"A {execute_format.format_name} generated from an eof_test.",
+            f"{execute_format.label}_from_eof_test",
+            f"A {execute_format.label} generated from an eof_test.",
         )
         for execute_format in StateTest.supported_execute_formats
     ]
@@ -526,11 +526,11 @@ class EOFStateTest(EOFTest, Transaction):
         for fixture_format in StateTest.supported_fixture_formats
     ]
 
-    supported_execute_formats: ClassVar[Sequence[ExecuteFormat | LabeledExecuteFormat]] = [
+    supported_execute_formats: ClassVar[Sequence[LabeledExecuteFormat]] = [
         LabeledExecuteFormat(
             execute_format,
-            f"eof_{execute_format.format_name}",
-            f"Tests that generate an EOF {execute_format.format_name}.",
+            f"eof_{execute_format.label}",
+            f"Tests that generate an EOF {execute_format.label}.",
         )
         for execute_format in StateTest.supported_execute_formats
     ]

--- a/src/ethereum_test_specs/state.py
+++ b/src/ethereum_test_specs/state.py
@@ -58,8 +58,12 @@ class StateTest(BaseTest):
         )
         for fixture_format in BlockchainTest.supported_fixture_formats
     ]
-    supported_execute_formats: ClassVar[Sequence[ExecuteFormat | LabeledExecuteFormat]] = [
-        TransactionPost,
+    supported_execute_formats: ClassVar[Sequence[LabeledExecuteFormat]] = [
+        LabeledExecuteFormat(
+            TransactionPost,
+            "state_test",
+            "An execute test derived from a state test",
+        ),
     ]
 
     supported_markers: ClassVar[Dict[str, str]] = {

--- a/src/ethereum_test_specs/transaction.py
+++ b/src/ethereum_test_specs/transaction.py
@@ -33,8 +33,12 @@ class TransactionTest(BaseTest):
     supported_fixture_formats: ClassVar[Sequence[FixtureFormat | LabeledFixtureFormat]] = [
         TransactionFixture,
     ]
-    supported_execute_formats: ClassVar[Sequence[ExecuteFormat | LabeledExecuteFormat]] = [
-        TransactionPost,
+    supported_execute_formats: ClassVar[Sequence[LabeledExecuteFormat]] = [
+        LabeledExecuteFormat(
+            TransactionPost,
+            "transaction_test",
+            "An execute test derived from a transaction test",
+        ),
     ]
 
     def make_transaction_test_fixture(


### PR DESCRIPTION
## 🗒️ Description
Adds labeled markers and names to all execute formats, derived from the test spec type names of the test where they came from.

Since we only have a single execute format that matches all specs we have, all execute test names contain "transaction_post" in the ID, and no reference or marker to the specification that was used to fill it:
```
test_set_code_from_account_with_non_delegating_code[fork_Prague-transaction_post-self_sponsored_True-EMPTY_ACCOUNT]
```

With this change the test IDs now contain the name of the test spec that was used to produce the test:
```
test_set_code_from_account_with_non_delegating_code[fork_Prague-state_test-self_sponsored_True-EMPTY_ACCOUNT]
```

Also we can now narrow execution to a specific type of test using markers.

E.g.
```
uv run execute hive --fork=Prague -m transaction_test
```
will run only transaction tests.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
