### PR TITLE
Add simple swap/dup/exchange tests

### DIFF
--- a/tests/osaka/eip7692_eof_v1/eip663_dupn_swapn_exchange/test_dupn.py
+++ b/tests/osaka/eip7692_eof_v1/eip663_dupn_swapn_exchange/test_dupn.py
@@ -25,8 +25,9 @@ from . import REFERENCE_SPEC_GIT_PATH, REFERENCE_SPEC_VERSION
 REFERENCE_SPEC_GIT_PATH = REFERENCE_SPEC_GIT_PATH
 REFERENCE_SPEC_VERSION = REFERENCE_SPEC_VERSION
 
+pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
 
-@pytest.mark.valid_from(EOF_FORK_NAME)
+
 def test_dupn_all_valid_immediates(eof_state_test: EOFStateTestFiller):
     """Test case for all valid DUPN immediates."""
     n = 2**8
@@ -62,7 +63,6 @@ def test_dupn_all_valid_immediates(eof_state_test: EOFStateTestFiller):
         [2**8 - 1, 2**8],
     ],
 )
-@pytest.mark.valid_from(EOF_FORK_NAME)
 def test_dupn_stack_underflow(
     stack_height: int,
     max_stack_height: int,
@@ -94,7 +94,6 @@ def test_dupn_stack_underflow(
         [2**8 - 1, MAX_OPERAND_STACK_HEIGHT + 1, EOFException.MAX_STACK_HEIGHT_ABOVE_LIMIT],
     ],
 )
-@pytest.mark.valid_from(EOF_FORK_NAME)
 def test_dupn_stack_overflow(
     dupn_operand: int,
     max_stack_height: int,

--- a/tests/osaka/eip7692_eof_v1/eip663_dupn_swapn_exchange/test_dupn.py
+++ b/tests/osaka/eip7692_eof_v1/eip663_dupn_swapn_exchange/test_dupn.py
@@ -5,7 +5,16 @@ abstract: Tests [EIP-663: SWAPN, DUPN and EXCHANGE instructions](https://eips.et
 
 import pytest
 
-from ethereum_test_tools import Account, EOFException, EOFStateTestFiller, EOFTestFiller
+from ethereum_test_tools import (
+    Account,
+    Alloc,
+    Environment,
+    EOFException,
+    EOFStateTestFiller,
+    EOFTestFiller,
+    StateTestFiller,
+    Transaction,
+)
 from ethereum_test_tools.eof.v1 import Container, Section
 from ethereum_test_tools.eof.v1.constants import MAX_OPERAND_STACK_HEIGHT
 from ethereum_test_tools.vm.opcode import Opcodes as Op
@@ -107,3 +116,38 @@ def test_dupn_stack_overflow(
         container=eof_code,
         expect_exception=expect_exception,
     )
+
+
+@pytest.mark.parametrize(
+    "dupn_arg,stack_height", [pytest.param(5, 9, id="5_of_9"), pytest.param(12, 30, id="12_of_30")]
+)
+def test_dupn_simple(
+    stack_height: int,
+    dupn_arg: int,
+    pre: Alloc,
+    state_test: StateTestFiller,
+):
+    """Test case for simple DUPN operations."""
+    sender = pre.fund_eoa()
+    contract_address = pre.deploy_contract(
+        code=Container(
+            sections=[
+                Section.Code(
+                    code=sum(Op.PUSH2[v] for v in range(stack_height, 0, -1))
+                    + Op.DUPN[dupn_arg]
+                    + sum((Op.PUSH1(v) + Op.SSTORE) for v in range(0, stack_height + 1))
+                    + Op.STOP,
+                    max_stack_height=stack_height + 2,
+                )
+            ],
+        )
+    )
+
+    storage = {v: v for v in range(1, stack_height + 1)}
+    storage[0] = dupn_arg + 1
+    print(storage)
+    post = {contract_address: Account(storage=storage)}
+
+    tx = Transaction(to=contract_address, sender=sender, gas_limit=10_000_000)
+
+    state_test(env=Environment(), pre=pre, post=post, tx=tx)

--- a/tests/osaka/eip7692_eof_v1/eip663_dupn_swapn_exchange/test_exchange.py
+++ b/tests/osaka/eip7692_eof_v1/eip663_dupn_swapn_exchange/test_exchange.py
@@ -24,8 +24,9 @@ from . import REFERENCE_SPEC_GIT_PATH, REFERENCE_SPEC_VERSION
 REFERENCE_SPEC_GIT_PATH = REFERENCE_SPEC_GIT_PATH
 REFERENCE_SPEC_VERSION = REFERENCE_SPEC_VERSION
 
+pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
 
-@pytest.mark.valid_from(EOF_FORK_NAME)
+
 def test_exchange_all_valid_immediates(eof_state_test: EOFStateTestFiller):
     """Test case for all valid EXCHANGE immediates."""
     n = 256
@@ -74,7 +75,6 @@ def test_exchange_all_valid_immediates(eof_state_test: EOFStateTestFiller):
         pytest.param(32, 17, 33, id="stack_height=32_n=16_m=16"),
     ],
 )
-@pytest.mark.valid_from(EOF_FORK_NAME)
 def test_exchange_all_invalid_immediates(
     eof_test: EOFTestFiller,
     stack_height: int,

--- a/tests/osaka/eip7692_eof_v1/eip663_dupn_swapn_exchange/test_exchange.py
+++ b/tests/osaka/eip7692_eof_v1/eip663_dupn_swapn_exchange/test_exchange.py
@@ -5,7 +5,16 @@ abstract: Tests [EIP-663: SWAPN, DUPN and EXCHANGE instructions](https://eips.et
 
 import pytest
 
-from ethereum_test_tools import Account, EOFException, EOFStateTestFiller, EOFTestFiller
+from ethereum_test_tools import (
+    Account,
+    Alloc,
+    Environment,
+    EOFException,
+    EOFStateTestFiller,
+    EOFTestFiller,
+    StateTestFiller,
+    Transaction,
+)
 from ethereum_test_tools.eof.v1 import Container, Section
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
@@ -89,3 +98,43 @@ def test_exchange_all_invalid_immediates(
         container=eof_code,
         expect_exception=EOFException.STACK_UNDERFLOW,
     )
+
+
+@pytest.mark.parametrize(
+    "m_arg,n_arg,extra_stack",
+    [pytest.param(0, 0, 3, id="m0_n0_extra3"), pytest.param(2, 3, 7, id="m2_n3_extra7")],
+)
+def test_exchange_simple(
+    m_arg: int,
+    n_arg: int,
+    extra_stack: int,
+    pre: Alloc,
+    state_test: StateTestFiller,
+):
+    """Test case for simple EXCHANGE operations."""
+    sender = pre.fund_eoa()
+    stack_height = m_arg + n_arg + 2 + extra_stack
+    contract_address = pre.deploy_contract(
+        code=Container(
+            sections=[
+                Section.Code(
+                    code=sum(Op.PUSH2[v] for v in range(stack_height, 0, -1))
+                    + Op.EXCHANGE[m_arg << 4 | n_arg]
+                    + sum((Op.PUSH1(v) + Op.SSTORE) for v in range(1, stack_height + 1))
+                    + Op.STOP,
+                    max_stack_height=stack_height + 1,
+                )
+            ],
+        )
+    )
+
+    storage = {v: v for v in range(1, stack_height + 1)}
+    first = m_arg + 2  # one based index, plus m=0 means first non-top item
+    second = first + n_arg + 1  # n+1 past m
+    storage[first], storage[second] = storage[second], storage[first]
+    print(storage)
+    post = {contract_address: Account(storage=storage)}
+
+    tx = Transaction(to=contract_address, sender=sender, gas_limit=10_000_000)
+
+    state_test(env=Environment(), pre=pre, post=post, tx=tx)

--- a/tests/osaka/eip7692_eof_v1/eip663_dupn_swapn_exchange/test_swapn.py
+++ b/tests/osaka/eip7692_eof_v1/eip663_dupn_swapn_exchange/test_swapn.py
@@ -25,8 +25,9 @@ from . import REFERENCE_SPEC_GIT_PATH, REFERENCE_SPEC_VERSION
 REFERENCE_SPEC_GIT_PATH = REFERENCE_SPEC_GIT_PATH
 REFERENCE_SPEC_VERSION = REFERENCE_SPEC_VERSION
 
+pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
 
-@pytest.mark.valid_from(EOF_FORK_NAME)
+
 def test_swapn_all_valid_immediates(eof_state_test: EOFStateTestFiller):
     """Test case for all valid SWAPN immediates."""
     n = 256
@@ -59,7 +60,6 @@ def test_swapn_all_valid_immediates(eof_state_test: EOFStateTestFiller):
         2**8 - 1,
     ],
 )
-@pytest.mark.valid_from(EOF_FORK_NAME)
 def test_swapn_on_max_stack(
     swapn_operand: int,
     eof_test: EOFTestFiller,
@@ -88,7 +88,6 @@ def test_swapn_on_max_stack(
         2**8 - 1,
     ],
 )
-@pytest.mark.valid_from(EOF_FORK_NAME)
 def test_swapn_stack_underflow(
     stack_height: int,
     eof_test: EOFTestFiller,

--- a/tests/osaka/eip7692_eof_v1/eip663_dupn_swapn_exchange/test_swapn.py
+++ b/tests/osaka/eip7692_eof_v1/eip663_dupn_swapn_exchange/test_swapn.py
@@ -5,7 +5,16 @@ abstract: Tests [EIP-663: SWAPN, DUPN and EXCHANGE instructions](https://eips.et
 
 import pytest
 
-from ethereum_test_tools import Account, EOFException, EOFStateTestFiller, EOFTestFiller
+from ethereum_test_tools import (
+    Account,
+    Alloc,
+    Environment,
+    EOFException,
+    EOFStateTestFiller,
+    EOFTestFiller,
+    StateTestFiller,
+    Transaction,
+)
 from ethereum_test_tools.eof.v1 import Container, Section
 from ethereum_test_tools.eof.v1.constants import MAX_OPERAND_STACK_HEIGHT
 from ethereum_test_tools.vm.opcode import Opcodes as Op
@@ -99,3 +108,39 @@ def test_swapn_stack_underflow(
         container=eof_code,
         expect_exception=EOFException.STACK_UNDERFLOW,
     )
+
+
+@pytest.mark.parametrize(
+    "swapn_arg,stack_height",
+    [pytest.param(5, 9, id="5_of_9"), pytest.param(12, 30, id="12_of_30")],
+)
+def test_swapn_simple(
+    stack_height: int,
+    swapn_arg: int,
+    pre: Alloc,
+    state_test: StateTestFiller,
+):
+    """Test case for simple SWAPN operations."""
+    sender = pre.fund_eoa()
+    contract_address = pre.deploy_contract(
+        code=Container(
+            sections=[
+                Section.Code(
+                    code=sum(Op.PUSH2[v] for v in range(stack_height, 0, -1))
+                    + Op.SWAPN[swapn_arg]
+                    + sum((Op.PUSH1(v) + Op.SSTORE) for v in range(1, stack_height + 1))
+                    + Op.STOP,
+                    max_stack_height=stack_height + 1,
+                )
+            ],
+        )
+    )
+
+    storage = {v: v for v in range(1, stack_height + 1)}
+    storage[1], storage[swapn_arg + 2] = storage[swapn_arg + 2], storage[1]
+    print(storage)
+    post = {contract_address: Account(storage=storage)}
+
+    tx = Transaction(to=contract_address, sender=sender, gas_limit=10_000_000)
+
+    state_test(env=Environment(), pre=pre, post=post, tx=tx)


### PR DESCRIPTION
## 🗒️ Description
Add simple and asymmetric tests for swap/dup/exchange, to detect when operations are performed on the wrong end of the stack.


## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
