### PR TITLE
fix(docs): fix bad links in readme and elsewhere

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,7 @@
 <!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->
 
 ## ✅ Checklist
+
 - [ ] All: Set appropriate labels for the changes.
 - [ ] All: Considered squashing commits to improve commit history.
 - [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
@@ -12,4 +13,4 @@
 - [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
 - [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
 - [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
-- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
+- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -45,7 +45,7 @@
         // * Fill, see the output of:
         //   `fill --help` for eest specific options, or,
         //   `fill --pytest-help` for all pytest available options, or,
-        //   https://ethereum.github.io/execution-spec-tests/main/filling_tests/filling_tests_command_line/
+        //   https://eest.ethereum.org/main/filling_tests/filling_tests_command_line/
         "-c", "pytest.ini", "--fork=Prague",
         //
         // * Consume (works, but the output of VS Code's Testing View is broken due to nested

--- a/README.md
+++ b/README.md
@@ -157,16 +157,16 @@ By default, JSON test fixtures are generated from this repository's Python test 
 
 More information on how to obtain and consume the [released test fixtures](https://github.com/ethereum/execution-spec-tests/releases) can be found in the [documentation](https://ethereum.github.io/execution-spec-tests/main/consuming_tests/).
 
-For further help with working with this codebase, see the [online documentation](https://ethereum.github.io/execution-spec-tests/):
+For further help with working with this codebase, see the [online documentation](https://ethereum.github.io/execution-spec-tests/main/):
 
-1. Learn [useful command-line flags](https://ethereum.github.io/execution-spec-tests/getting_started/executing_tests_command_line/).
-2. [Execute tests for features under development](https://ethereum.github.io/execution-spec-tests/getting_started/executing_tests_dev_fork/) via the `--from=FORK1` and `--until=FORK2` flags.
-3. _Optional:_ [Configure VS Code](https://ethereum.github.io/execution-spec-tests/getting_started/setup_vs_code/) to auto-format Python code and [execute tests within VS Code](https://ethereum.github.io/execution-spec-tests/getting_started/executing_tests_vs_code/#executing-and-debugging-test-cases).
-4. Implement a new test case, see [Writing Tests](https://ethereum.github.io/execution-spec-tests/writing_tests/).
+1. Learn [useful command-line flags](https://ethereum.github.io/execution-spec-tests/main/filling_tests/filling_tests_command_line/).
+2. [Execute tests for features under development](https://ethereum.github.io/execution-spec-tests/main/filling_tests/executing_tests_dev_fork/) via the `--from=FORK1` and `--until=FORK2` flags.
+3. _Optional:_ [Configure VS Code](https://ethereum.github.io/execution-spec-tests/main/getting_started/setup_vs_code/) to auto-format Python code and [execute tests within VS Code](https://ethereum.github.io//main/filling_tests/filling_tests_vs_code/).
+4. Implement a new test case, see [Writing Tests](https://ethereum.github.io/execution-spec-tests/main/writing_tests/).
 
 ## Coverage
 
-The available test cases can be browsed in the [Test Case Reference doc](https://ethereum.github.io/execution-spec-tests/tests/).
+The available test cases can be browsed in the [Test Case Reference doc](https://ethereum.github.io/execution-spec-tests/main/tests/).
 
 ## Installation Troubleshooting
 
@@ -174,7 +174,7 @@ If you encounter issues during the installation process, please refer to the [In
 
 ## Contributing
 
-Contributions and feedback are welcome. Please see the [online documentation](https://ethereum.github.io/execution-spec-tests/writing_tests/) for this repository's coding standards and help on implementing new tests.
+Contributions and feedback are welcome. Please see the [online documentation](https://ethereum.github.io/execution-spec-tests/main/writing_tests/) for this repository's coding standards and help on implementing new tests.
 
 Pull requests containing only typo fixes will not be merged and must be accompanied by documentation, test or framework improvements.
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ For further help with working with this codebase, see the [online documentation]
 
 1. Learn [useful command-line flags](https://ethereum.github.io/execution-spec-tests/main/filling_tests/filling_tests_command_line/).
 2. [Execute tests for features under development](https://ethereum.github.io/execution-spec-tests/main/filling_tests/executing_tests_dev_fork/) via the `--from=FORK1` and `--until=FORK2` flags.
-3. _Optional:_ [Configure VS Code](https://ethereum.github.io/execution-spec-tests/main/getting_started/setup_vs_code/) to auto-format Python code and [execute tests within VS Code](https://ethereum.github.io//main/filling_tests/filling_tests_vs_code/).
+3. _Optional:_ [Configure VS Code](https://ethereum.github.io/execution-spec-tests/main/getting_started/setup_vs_code/) to auto-format Python code and [execute tests within VS Code](https://ethereum.github.io/main/filling_tests/filling_tests_vs_code/).
 4. Implement a new test case, see [Writing Tests](https://ethereum.github.io/execution-spec-tests/main/writing_tests/).
 
 ## Coverage

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -128,13 +128,13 @@ The following changes may be potentially breaking (all clients were tested with 
 - ✨ Adds reproducible consume commands to hiveview ([#717](https://github.com/ethereum/execution-spec-tests/pull/717)).
 - 💥 Added multiple exceptions to the EOF fixture format ([#759](https://github.com/ethereum/execution-spec-tests/pull/759)).
 - ✨ Added optional parameter to all `with_all_*` markers to specify a lambda function that filters the parametrized values ([#739](https://github.com/ethereum/execution-spec-tests/pull/739)).
-- ✨ Added [`extend_with_defaults` utility function](https://ethereum.github.io/execution-spec-tests/main/writing_tests/writing_a_new_test/#ethereum_test_tools.utility.pytest.extend_with_defaults), which helps extend test case parameter sets with default values. `@pytest.mark.parametrize` ([#739](https://github.com/ethereum/execution-spec-tests/pull/739)).
+- ✨ Added [`extend_with_defaults` utility function](https://eest.ethereum.org/main/writing_tests/writing_a_new_test/#ethereum_test_tools.utility.pytest.extend_with_defaults), which helps extend test case parameter sets with default values. `@pytest.mark.parametrize` ([#739](https://github.com/ethereum/execution-spec-tests/pull/739)).
 - ✨ Added `Container.Init` to `ethereum_test_types.EOF.V1` package, which allows generation of an EOF init container more easily ([#739](https://github.com/ethereum/execution-spec-tests/pull/739)).
 - ✨ Introduce method valid_opcodes() to the fork class ([#748](https://github.com/ethereum/execution-spec-tests/pull/748)).
 - 🐞 Fixed `consume` exit code return values, ensuring that pytest's return value is correctly propagated to the shell. This allows the shell to accurately reflect the test results (e.g., failures) based on the pytest exit code ([#765](https://github.com/ethereum/execution-spec-tests/pull/765)).
 - ✨ Added a new flag `--solc-version` to the `fill` command, which allows the user to specify the version of the Solidity compiler to use when compiling Yul source code; this version will now be automatically downloaded by `fill` via [`solc-select`](https://github.com/crytic/solc-select) ([#772](https://github.com/ethereum/execution-spec-tests/pull/772)).
 - 🐞 Fix usage of multiple `@pytest.mark.with_all*` markers which shared parameters, such as `with_all_call_opcodes` and `with_all_create_opcodes` which shared `evm_code_type`, and now only parametrize compatible values ([#762](https://github.com/ethereum/execution-spec-tests/pull/762)).
-- ✨ Added `selector` and `marks` fields to all `@pytest.mark.with_all*` markers, which allows passing lambda functions to select or mark specific parametrized values (see [documentation](https://ethereum.github.io/execution-spec-tests/main/writing_tests/test_markers/#covariant-marker-keyword-arguments) for more information) ([#762](https://github.com/ethereum/execution-spec-tests/pull/762)).
+- ✨ Added `selector` and `marks` fields to all `@pytest.mark.with_all*` markers, which allows passing lambda functions to select or mark specific parametrized values (see [documentation](https://eest.ethereum.org/main/writing_tests/test_markers/#covariant-marker-keyword-arguments) for more information) ([#762](https://github.com/ethereum/execution-spec-tests/pull/762)).
 - ✨ Improves consume input flags for develop and stable fixture releases, fixes `--help` flag for consume ([#745](https://github.com/ethereum/execution-spec-tests/pull/745)).
 - 🔀 Return exit-code from `consume` commands ([#766](https://github.com/ethereum/execution-spec-tests/pull/766)).
 - 🔀 Remove duplicate EOF container tests, automatically check for duplicates ([#800](https://github.com/ethereum/execution-spec-tests/pull/800)).
@@ -175,7 +175,7 @@ The following changes may be potentially breaking (all clients were tested with 
 - ✨ Generate Transaction Test type ([#933](https://github.com/ethereum/execution-spec-tests/pull/933)).
 - ✨ Add a default location for evm logs (`--evm-dump-dir`) when filling tests ([#999](https://github.com/ethereum/execution-spec-tests/pull/999)).
 - ✨ Slow tests now have greater timeout when making a request to the T8N server ([#1037](https://github.com/ethereum/execution-spec-tests/pull/1037)).
-- ✨ Introduce [`pytest.mark.parametrize_by_fork`](https://ethereum.github.io/execution-spec-tests/main/writing_tests/test_markers/#pytestmarkfork_parametrize) helper marker ([#1019](https://github.com/ethereum/execution-spec-tests/pull/1019), [#1057](https://github.com/ethereum/execution-spec-tests/pull/1057)).
+- ✨ Introduce [`pytest.mark.parametrize_by_fork`](https://eest.ethereum.org/main/writing_tests/test_markers/#pytestmarkfork_parametrize) helper marker ([#1019](https://github.com/ethereum/execution-spec-tests/pull/1019), [#1057](https://github.com/ethereum/execution-spec-tests/pull/1057)).
 - 🐞 fix(consume): allow absolute paths with `--evm-bin` ([#1052](https://github.com/ethereum/execution-spec-tests/pull/1052)).
 - ✨ Disable EIP-7742 framework changes for Prague ([#1023](https://github.com/ethereum/execution-spec-tests/pull/1023)).
 - ✨ Allow verification of the transaction receipt on executed test transactions ([#1068](https://github.com/ethereum/execution-spec-tests/pull/1068)).
@@ -353,7 +353,7 @@ The following changes may be potentially breaking (all clients were tested with 
 - ✨ Add "description" and "url" fields containing test case documentation and a source code permalink to fixtures during `fill` and use them in `consume`-generated Hive test reports ([#579](https://github.com/ethereum/execution-spec-tests/pull/579)).
 - ✨ Add git workflow evmone coverage script for any new lines mentioned in converted_ethereum_tests.txt ([#503](https://github.com/ethereum/execution-spec-tests/pull/503)).
 - ✨ Add a new covariant marker `with_all_contract_creating_tx_types` that allows automatic parametrization of a test with all contract-creating transaction types at the current executing fork ([#602](https://github.com/ethereum/execution-spec-tests/pull/602)).
-- ✨ Tests are now encouraged to declare a `pre: Alloc` parameter to get the pre-allocation object for the test, and use `pre.deploy_contract` and `pre.fund_eoa` to deploy contracts and fund accounts respectively, instead of declaring the `pre` as a dictionary or modifying its contents directly (see the [state test tutorial](https://ethereum.github.io/execution-spec-tests/main/tutorials/state_transition/) for an updated example) ([#584](https://github.com/ethereum/execution-spec-tests/pull/584)).
+- ✨ Tests are now encouraged to declare a `pre: Alloc` parameter to get the pre-allocation object for the test, and use `pre.deploy_contract` and `pre.fund_eoa` to deploy contracts and fund accounts respectively, instead of declaring the `pre` as a dictionary or modifying its contents directly (see the [state test tutorial](https://eest.ethereum.org/main/tutorials/state_transition/) for an updated example) ([#584](https://github.com/ethereum/execution-spec-tests/pull/584)).
 - ✨ Enable loading of [ethereum/tests/BlockchainTests](https://github.com/ethereum/tests/tree/develop/BlockchainTests) ([#596](https://github.com/ethereum/execution-spec-tests/pull/596)).
 - 🔀 Refactor `gentest` to use `ethereum_test_tools.rpc.rpc` by adding to `get_transaction_by_hash`, `debug_trace_call` to `EthRPC` ([#568](https://github.com/ethereum/execution-spec-tests/pull/568)).
 - ✨ Write a properties file to the output directory and enable direct generation of a fixture tarball from `fill` via `--output=fixtures.tgz`([#627](https://github.com/ethereum/execution-spec-tests/pull/627)).
@@ -469,7 +469,7 @@ Due to changes in the framework, there is a breaking change in the directory str
 
 ### 📋 Misc
 
-- ✨ Docs: Add a ["Consuming Tests"](https://ethereum.github.io/execution-spec-tests/main/consuming_tests/) section to the docs, where each test fixture format is described, along with the steps to consume them, and the description of the structures used in each format ([#375](https://github.com/ethereum/execution-spec-tests/pull/375)).
+- ✨ Docs: Add a ["Consuming Tests"](https://eest.ethereum.org/main/consuming_tests/) section to the docs, where each test fixture format is described, along with the steps to consume them, and the description of the structures used in each format ([#375](https://github.com/ethereum/execution-spec-tests/pull/375)).
 - 🔀 Docs: Update `t8n` tool branch to fill tests for development features in the [readme](https://github.com/ethereum/execution-spec-test) ([#338](https://github.com/ethereum/execution-spec-tests/pull/338)).
 - 🔀 Filling tool: Updated the default filling tool (`t8n`) to go-ethereum@master ([#368](https://github.com/ethereum/execution-spec-tests/pull/368)).
 - 🐞 Docs: Fix error banner in online docs due to mermaid syntax error ([#398](https://github.com/ethereum/execution-spec-tests/pull/398)).
@@ -560,7 +560,7 @@ The fixture renaming provides a more consistent naming scheme between the pytest
 - ✨ Tooling: Add Python 3.12 support ([#309](https://github.com/ethereum/execution-spec-tests/pull/309)).
 - ✨ Process: Added a Github pull request template ([#308](https://github.com/ethereum/execution-spec-tests/pull/308)).
 - ✨ Docs: Changelog updated post release ([#321](https://github.com/ethereum/execution-spec-tests/pull/321)).
-- ✨ Docs: Add [a section explaining execution-spec-tests release artifacts](https://ethereum.github.io/execution-spec-tests/main/getting_started/using_fixtures/) ([#334](https://github.com/ethereum/execution-spec-tests/pull/334)).
+- ✨ Docs: Add [a section explaining execution-spec-tests release artifacts](https://eest.ethereum.org/main/getting_started/using_fixtures/) ([#334](https://github.com/ethereum/execution-spec-tests/pull/334)).
 - 🔀 T8N Tool: Branch used to generate the tests for Cancun is now [lightclient/go-ethereum@devnet-10](https://github.com/lightclient/go-ethereum/tree/devnet-10) ([#336](https://github.com/ethereum/execution-spec-tests/pull/336))
 
 ### 💥 Breaking Change

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -353,7 +353,7 @@ The following changes may be potentially breaking (all clients were tested with 
 - ✨ Add "description" and "url" fields containing test case documentation and a source code permalink to fixtures during `fill` and use them in `consume`-generated Hive test reports ([#579](https://github.com/ethereum/execution-spec-tests/pull/579)).
 - ✨ Add git workflow evmone coverage script for any new lines mentioned in converted_ethereum_tests.txt ([#503](https://github.com/ethereum/execution-spec-tests/pull/503)).
 - ✨ Add a new covariant marker `with_all_contract_creating_tx_types` that allows automatic parametrization of a test with all contract-creating transaction types at the current executing fork ([#602](https://github.com/ethereum/execution-spec-tests/pull/602)).
-- ✨ Tests are now encouraged to declare a `pre: Alloc` parameter to get the pre-allocation object for the test, and use `pre.deploy_contract` and `pre.fund_eoa` to deploy contracts and fund accounts respectively, instead of declaring the `pre` as a dictionary or modifying its contents directly (see the [state test tutorial](https://eest.ethereum.org/main/tutorials/state_transition/) for an updated example) ([#584](https://github.com/ethereum/execution-spec-tests/pull/584)).
+- ✨ Tests are now encouraged to declare a `pre: Alloc` parameter to get the pre-allocation object for the test, and use `pre.deploy_contract` and `pre.fund_eoa` to deploy contracts and fund accounts respectively, instead of declaring the `pre` as a dictionary or modifying its contents directly (see the [state test tutorial](https://eest.ethereum.org/v4.1.0/writing_tests/tutorials/state_transition/) for an updated example) ([#584](https://github.com/ethereum/execution-spec-tests/pull/584)).
 - ✨ Enable loading of [ethereum/tests/BlockchainTests](https://github.com/ethereum/tests/tree/develop/BlockchainTests) ([#596](https://github.com/ethereum/execution-spec-tests/pull/596)).
 - 🔀 Refactor `gentest` to use `ethereum_test_tools.rpc.rpc` by adding to `get_transaction_by_hash`, `debug_trace_call` to `EthRPC` ([#568](https://github.com/ethereum/execution-spec-tests/pull/568)).
 - ✨ Write a properties file to the output directory and enable direct generation of a fixture tarball from `fill` via `--output=fixtures.tgz`([#627](https://github.com/ethereum/execution-spec-tests/pull/627)).
@@ -470,7 +470,7 @@ Due to changes in the framework, there is a breaking change in the directory str
 ### 📋 Misc
 
 - ✨ Docs: Add a ["Consuming Tests"](https://eest.ethereum.org/main/consuming_tests/) section to the docs, where each test fixture format is described, along with the steps to consume them, and the description of the structures used in each format ([#375](https://github.com/ethereum/execution-spec-tests/pull/375)).
-- 🔀 Docs: Update `t8n` tool branch to fill tests for development features in the [readme](https://github.com/ethereum/execution-spec-test) ([#338](https://github.com/ethereum/execution-spec-tests/pull/338)).
+- 🔀 Docs: Update `t8n` tool branch to fill tests for development features in the [readme](https://github.com/ethereum/execution-spec-tests) ([#338](https://github.com/ethereum/execution-spec-tests/pull/338)).
 - 🔀 Filling tool: Updated the default filling tool (`t8n`) to go-ethereum@master ([#368](https://github.com/ethereum/execution-spec-tests/pull/368)).
 - 🐞 Docs: Fix error banner in online docs due to mermaid syntax error ([#398](https://github.com/ethereum/execution-spec-tests/pull/398)).
 - 🐞 Docs: Fix incorrectly formatted nested lists in online doc ([#403](https://github.com/ethereum/execution-spec-tests/pull/403)).
@@ -560,7 +560,7 @@ The fixture renaming provides a more consistent naming scheme between the pytest
 - ✨ Tooling: Add Python 3.12 support ([#309](https://github.com/ethereum/execution-spec-tests/pull/309)).
 - ✨ Process: Added a Github pull request template ([#308](https://github.com/ethereum/execution-spec-tests/pull/308)).
 - ✨ Docs: Changelog updated post release ([#321](https://github.com/ethereum/execution-spec-tests/pull/321)).
-- ✨ Docs: Add [a section explaining execution-spec-tests release artifacts](https://eest.ethereum.org/main/getting_started/using_fixtures/) ([#334](https://github.com/ethereum/execution-spec-tests/pull/334)).
+- ✨ Docs: Add [a section explaining execution-spec-tests release artifacts](https://eest.ethereum.org/v4.1.0/consuming_tests/) ([#334](https://github.com/ethereum/execution-spec-tests/pull/334)).
 - 🔀 T8N Tool: Branch used to generate the tests for Cancun is now [lightclient/go-ethereum@devnet-10](https://github.com/lightclient/go-ethereum/tree/devnet-10) ([#336](https://github.com/ethereum/execution-spec-tests/pull/336))
 
 ### 💥 Breaking Change

--- a/docs/consuming_tests/index.md
+++ b/docs/consuming_tests/index.md
@@ -6,7 +6,7 @@
 | --- | --- | --- |
 | [State Tests](./state_test.md) | directly via a `statetest`-like command<br/> (e.g., [go-ethereum/cmd/evm/staterunner.go](https://github.com/ethereum/go-ethereum/blob/509a64ffb9405942396276ae111d06f9bded9221/cmd/evm/staterunner.go#L35)) | `./fixtures/state_tests/` |
 | [Blockchain Tests](./blockchain_test.md) | directly via a `blocktest`-like command<br/> (e.g., [go-ethereum/cmd/evm/blockrunner.go](https://github.com/ethereum/go-ethereum/blob/509a64ffb9405942396276ae111d06f9bded9221/cmd/evm/blockrunner.go#L39)) | `./fixtures/blockchain_tests/` |
-| [Blockchain Engine Tests](./blockchain_test_engine.md) | in the [Hive `pyspec` simulator](https://github.com/ethereum/hive/tree/master/simulators/ethereum/pyspec#readme) via the Engine API and other RPC endpoints  | `./fixtures/blockchain_tests_engine/` |
+| [Blockchain Engine Tests](./blockchain_test_engine.md) | in the [Hive `pyspec` simulator](https://github.com/ethereum/execution-spec-tests/blob/main/src/pytest_plugins/consume/hive_simulators/engine/test_via_engine.py) via the Engine API and other RPC endpoints  | `./fixtures/blockchain_tests_engine/` |
 | [Transaction Tests](./transaction_test.md) | directly via a `t9`-like command<br/> (e.g., [go-ethereum's `evm t9`](https://github.com/ethereum/go-ethereum/tree/67a3b087951a3f3a8e341ae32b6ec18f3553e5cc/cmd/evm#transaction-tool)) | `./fixtures/transaction_tests/` |
 
 Here's a top-level comparison of the different methods of consuming tests:

--- a/docs/dev/docs.md
+++ b/docs/dev/docs.md
@@ -174,4 +174,4 @@ All pages that are to be included in the documentation and the navigation bar mu
 
 ## Read the Docs
 
-Originally, documentation was hosted at readthedocs.io. Currently, this now defunct page ([execution-spec-tests.readthedocs.io](https://execution-spec-tests.readthedocs.io)) is configured to redirect to the Github Pages site. This is achieved by following the steps listed in the second half of [this answer](https://stackoverflow.com/a/69928404) on stackoverflow. A public repo with a dummy Sphinx project is required to achieve this: [danceratopz/est-docs-redirect](https://github.com/danceratopz/est-docs-redirect).
+Originally, before June 2023, documentation was hosted at readthedocs.io. Currently, this page no longer exists (execution-spec-tests.readthedocs.io).

--- a/docs/dev/docs.md
+++ b/docs/dev/docs.md
@@ -1,6 +1,6 @@
 # Documentation
 
-The `execution-spec-tests` documentation is generated via [`mkdocs`](https://www.mkdocs.org/) and hosted remotely on Github Pages at [ethereum.github.io/execution-spec-tests](https://ethereum.github.io/execution-spec-tests/).
+The `execution-spec-tests` documentation is generated via [`mkdocs`](https://www.mkdocs.org/) and hosted remotely on Github Pages at [eest.ethereum.org](https://eest.ethereum.org/).
 
 ## Prerequisites
 
@@ -38,7 +38,7 @@ For more help (including ensuring a clean build), see the `gen_test_doc` pytest 
 
 ## Remote Deployment and Versioning
 
-The execution-specs-test docs are hosted on Github pages at the [repo's Github pages](https://ethereum.github.io/execution-spec-tests/). Versions are updated/deployed automatically as part of Github Actions, but this can also be performed on the command-line.
+The execution-specs-test docs are hosted using Github pages at [eest.ethereum.org](https://eest.ethereum.org/). Versions are updated/deployed automatically as part of Github Actions, but this can also be performed on the command-line.
 
 Our mkdocs configuration uses [mike](https://github.com/jimporter/mike) as a version provider. All deployments should be made via `mike` (whether as part of CI/CD or executed locally).
 
@@ -48,16 +48,16 @@ The deployed versions of the docs managed via `mike` are kept in the [gh-pages](
 
 We currently have two aliases (which both point to `main` as of [#998](https://github.com/ethereum/execution-spec-tests/pull/998)):
 
-- [`latest`](https://ethereum.github.io/execution-spec-tests/latest): the current state of the main branch.
-- [`development`](https://ethereum.github.io/execution-spec-tests/development): the current state of the main branch.
+- [`latest`](https://eest.ethereum.org/latest): the current state of the main branch.
+- [`development`](https://eest.ethereum.org/development): the current state of the main branch.
 
 These aliases point to specific versions, as configured below. It's possible to share links containing either of these aliases or to specific versions, i.e, the following are all valid links:
 
-- https://ethereum.github.io/execution-spec-tests/ (redirects to latest/main)
-- https://ethereum.github.io/execution-spec-tests/latest (redirects to main)
-- https://ethereum.github.io/execution-spec-tests/development (redirects main)
-- https://ethereum.github.io/execution-spec-tests/main
-- https://ethereum.github.io/execution-spec-tests/v1.0.0
+- https://eest.ethereum.org/ (redirects to latest/main)
+- https://eest.ethereum.org/latest (redirects to main)
+- https://eest.ethereum.org/development (redirects main)
+- https://eest.ethereum.org/main
+- https://eest.ethereum.org/v1.0.0
 
 ### CI/CD: Doc Deployment via Github Actions
 

--- a/docs/writing_tests/tutorials/blockchain.md
+++ b/docs/writing_tests/tutorials/blockchain.md
@@ -15,7 +15,7 @@ Before proceeding with this tutorial, it is assumed that you have prior knowledg
 
 ## Example Tests
 
-In this tutorial we will go over [test_block_number] in `test_block_example.py`(https://github.com/ethereum/execution-spec-tests/tree/main/tests/example/test_block_example.py#L19).
+In this tutorial we will go over [test_block_number] in `test_block_example.py`.
 
 It is assumed you have already gone through the state transition test tutorial. Only new concepts will be discussed.
 
@@ -75,7 +75,7 @@ Each integer in the `tx_per_block` array is the number of transactions in a bloc
 tx_per_block = [2, 0, 4, 8, 0, 0, 20, 1, 50]
 ```
 
-The code section that creates the blocks is a bit complex in this test. For some simpler definitions of Block creation you can browse tests within [`test_withdrawals.py`](https://github.com/ethereum/execution-spec-tests/blob/main/tests/withdrawals/test_withdrawals.py).
+The code section that creates the blocks is a bit complex in this test. For some simpler definitions of Block creation you can browse tests within [`test_withdrawals.py`](https://github.com/ethereum/execution-spec-tests/blob/main/tests/shanghai/eip4895_withdrawals/test_withdrawals.py).
 
 ```python
 blocks = map(

--- a/docs/writing_tests/tutorials/state_transition_bad_opcode.md
+++ b/docs/writing_tests/tutorials/state_transition_bad_opcode.md
@@ -1,6 +1,8 @@
 # Bad Opcode Test
 
-The source code for this test is [here](https://github.com/ethereum/execution-spec-tests/tree/main/tests/vm/test_opcode_tests.py).
+TODO: This content is out-of-date (it's not included in the docs)
+
+The source code for this test was TODO here tests/vm/test_opcode_tests.py.
 We will only go over the parts that are new.
 
 We use [Python string templates](https://docs.python.org/3/library/string.html#template-strings), so we need to import that library.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Ethereum Execution Spec Tests
 site_description: A collection of test cases implemented in Python for Ethereum execution clients
-site_url: https://ethereum.github.io/execution-spec-tests/
+site_url: https://eest.ethereum.org/
 repo_url: https://github.com/ethereum/execution-spec-tests
 repo_name: execution-spec-tests
 edit_uri: edit/main/docs/
@@ -120,7 +120,7 @@ extra_javascript:
   - https://cdn.datatables.net/buttons/3.1.2/js/dataTables.buttons.js
   - https://cdn.datatables.net/buttons/3.1.2/js/buttons.dataTables.js
   - https://cdn.datatables.net/buttons/3.1.2/js/buttons.colVis.min.js
-  - javascripts/site.js    
+  - javascripts/site.js
 
 extra_css:
   - https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,8 @@ dependencies = [
     "typing-extensions>=4.12.2,<5",
     # TODO: bump questionary to a newer release, when it becomes available.
     # The current release questionary 2.0.1 requires `prompt_toolkit = ">=2.0,<=3.0.36"`.
-    # This conflicts with ipython; while not an EEST dependency, ipython a very useful tool:
-    # https://ethereum.github.io/execution-spec-tests/main/dev/interactive_usage/
+    # This conflicts with ipython; while not an EEST dependency, ipython is a very useful tool:
+    # https://eest.ethereum.org/main/dev/interactive_usage/
     "questionary @ git+https://github.com/tmbo/questionary@ff22aeae1cd9c1c734f14329934e349bec7873bc",
     "prompt_toolkit>=3.0.48,<4", # ensure we have a new enough version for ipython
     "ethereum-rlp>=0.1.3,<0.2",
@@ -58,10 +58,10 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://github.com/ethereum/execution-spec-tests"
-Documentation = "https://ethereum.github.io/execution-spec-tests"
+Documentation = "https://eest.ethereum.org"
 Repository = "https://github.com/ethereum/execution-spec-tests"
 Issues = "https://github.com/ethereum/execution-spec-tests/issues"
-Changelog = "https://ethereum.github.io/execution-spec-tests/main/CHANGELOG/"
+Changelog = "https://eest.ethereum.org/main/CHANGELOG/"
 
 [project.optional-dependencies]
 test = ["pytest-cov>=4.1.0,<5"]

--- a/src/cli/input/questionary_input_repository.py
+++ b/src/cli/input/questionary_input_repository.py
@@ -12,36 +12,21 @@ class QuestionaryInputRepository(InputRepository):
     """Repository for handling various types of user inputs using the Questionary library."""
 
     def input_text(self, question: str) -> str:
-        """
-        Ask a text input question.
-        See: https://questionary.readthedocs.io/en/stable/api.html#questionary.text.
-        """
+        """Ask a text input question."""
         return text(message=question).ask()
 
     def input_password(self, question: str) -> str:
-        """
-        Ask a password input question (hidden).
-        See: https://questionary.readthedocs.io/en/stable/api.html#questionary.password.
-        """
+        """Ask a password input question (hidden)."""
         return password(message=question).ask()
 
     def input_select(self, question: str, choices: list) -> str:
-        """
-        Ask a single-choice selection question.
-        See: https://questionary.readthedocs.io/en/stable/api.html#questionary.select.
-        """
+        """Ask a single-choice selection question."""
         return select(message=question, choices=choices).ask()
 
     def input_checkbox(self, question: str, choices: list) -> list:
-        """
-        Ask a multi-choice question.
-        See: https://questionary.readthedocs.io/en/stable/api.html#questionary.checkbox.
-        """
+        """Ask a multi-choice question."""
         return checkbox(message=question, choices=choices).ask()
 
     def input_confirm(self, question: str) -> bool:
-        """
-        Ask a yes/no confirmation question.
-        See: https://questionary.readthedocs.io/en/stable/api.html#questionary.confirm.
-        """
+        """Ask a yes/no confirmation question."""
         return confirm(message=question).ask()

--- a/src/config/docs.py
+++ b/src/config/docs.py
@@ -17,7 +17,7 @@ class DocsConfig(BaseModel):
     GENERATE_UNTIL_FORK: str = "Osaka"
     """The fork until which documentation should be generated."""
 
-    DOCS_BASE_URL: str = "https://ethereum.github.io/execution-spec-tests"
+    DOCS_BASE_URL: str = "https://eest.ethereum.org"
 
     # Documentation URLs prefixed with `DOCS_URL__` to avoid conflicts with other URLs
     DOCS_URL__WRITING_TESTS: str = f"{DOCS_BASE_URL}/main/writing_tests/"

--- a/src/pytest_plugins/filler/gen_test_doc/gen_test_doc.py
+++ b/src/pytest_plugins/filler/gen_test_doc/gen_test_doc.py
@@ -310,12 +310,12 @@ class TestDocsGenerator:
         mike deploys a version of the site underneath a sub-directory named
         after the version, e.g.:
 
-        - https://ethereum.github.io/execution-spec-tests/main/
-        - https://ethereum.github.io/execution-spec-tests/v1.2.3/
+        - https://eest.ethereum.org/main/
+        - https://eest.ethereum.org/v4.1.0/
 
         We need to be able to include the javascript available at:
 
-        - https://ethereum.github.io/execution-spec-tests/main/javascripts/site.js
+        - https://eest.ethereum.org/main/javascripts/site.js
         """
         ci = os.getenv("CI", None)
         github_ref_name = os.getenv("GITHUB_REF_NAME", None)

--- a/tests/cancun/eip6780_selfdestruct/test_dynamic_create2_selfdestruct_collision.py
+++ b/tests/cancun/eip6780_selfdestruct/test_dynamic_create2_selfdestruct_collision.py
@@ -76,8 +76,8 @@ def test_dynamic_create2_selfdestruct_collision(
     Then:
         a) on the same tx, attempt to recreate the contract
         b) on a different tx, attempt to recreate the contract
-    Verify that the test case described
-    in https://wiki.hyperledger.org/pages/viewpage.action?pageId=117440824 is covered
+    Verify that the test case described in
+    https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156575/2024-01-06+Mainnet+Halting+Event
     """
     assert call_create2_contract_in_between or call_create2_contract_at_the_end, "invalid test"
 
@@ -261,8 +261,8 @@ def test_dynamic_create2_selfdestruct_collision_two_different_transactions(
     Then:
         a) on the same tx, attempt to recreate the contract
         b) on a different tx, attempt to recreate the contract
-    Verify that the test case described
-    in https://wiki.hyperledger.org/pages/viewpage.action?pageId=117440824 is covered
+    Verify that the test case described in
+    https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156575/2024-01-06+Mainnet+Halting+Event
     """
     # assert call_create2_contract_at_the_end, "invalid test"
 
@@ -504,8 +504,8 @@ def test_dynamic_create2_selfdestruct_collision_multi_tx(
     Then:
         a) on the same tx, attempt to recreate the contract       <=== Covered in this test
         b) on a different tx, attempt to recreate the contract    <=== Covered in this test
-    Verify that the test case described
-    in https://wiki.hyperledger.org/pages/viewpage.action?pageId=117440824 is covered
+    Verify that the test case described in
+    https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156575/2024-01-06+Mainnet+Halting+Event
     """
     if recreate_on_first_tx:
         assert selfdestruct_on_first_tx, "invalid test"

--- a/tests/frontier/opcodes/test_calldatacopy.py
+++ b/tests/frontier/opcodes/test_calldatacopy.py
@@ -142,7 +142,7 @@ def test_calldatacopy(
     """
     Test `CALLDATACOPY` opcode.
 
-    Based on https://github.com/ethereum/tests/blob/ae4791077e8fcf716136e70fe8392f1a1f1495fb/src/GeneralStateTestsFiller/VMTests/vmTests/calldatacopyFiller.ym
+    Based on https://github.com/ethereum/tests/blob/ae4791077e8fcf716136e70fe8392f1a1f1495fb/src/GeneralStateTestsFiller/VMTests/vmTests/calldatacopyFiller.yml
     """
     code_address = pre.deploy_contract(code)
     to = pre.deploy_contract(

--- a/tests/frontier/opcodes/test_dup.py
+++ b/tests/frontier/opcodes/test_dup.py
@@ -44,7 +44,7 @@ def test_dup(
     Test the DUP1-DUP16 opcodes.
 
     Note: Test case ported from [ethereum/tests](https://github.com/ethereum/tests)
-        Test ported from [ethereum/tests/GeneralStateTests/VMTests/vmTests/dup.json](https://github.com/ethereum/tests/blob/develop/GeneralStateTests/VMTests/vmTests/dup.json) by Ori Pomerantz.
+        Test ported from [ethereum/tests/GeneralStateTests/VMTests/vmTests/dup.json](https://github.com/ethereum/tests/blob/v14.0/GeneralStateTests/VMTests/vmTests/dup.json) by Ori Pomerantz.
     """  # noqa: E501
     env = Environment()
     sender = pre.fund_eoa()


### PR DESCRIPTION
## 🗒️ Description
- The README had links pointing to an unversioned (and very out-dated) version of our docs in the root of the `gh-pages` branch; these now point to the `main` version. Thanks @jochem-brouwer for reporting!
- Update domain from github pages to eest.ethereum.org.
- Fixes bad links detected via https://github.com/lycheeverse/lychee

## 🔗 Related Issues
None

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] ~~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~ skipped

