### PR TITLE
new(tests): Aggregate EOF tests for invalid first section type

### DIFF
--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py
@@ -415,24 +415,6 @@ def test_valid_containers(
             validity_error=EOFException.INVALID_TYPE_SECTION_SIZE,
         ),
         Container(
-            # EOF code containing invalid first section type (1,0)
-            name="EOF1I4750_0006",
-            raw_bytes="ef000101000402000100010400000001000000fe",
-            validity_error=EOFException.INVALID_FIRST_SECTION_TYPE,
-        ),
-        Container(
-            # EOF code containing invalid first section type (0,1)
-            name="EOF1I4750_0007",
-            raw_bytes="ef000101000402000100010400000000010000fe",
-            validity_error=EOFException.INVALID_FIRST_SECTION_TYPE,
-        ),
-        Container(
-            # EOF code containing invalid first section type (2,3)
-            name="EOF1I4750_0008",
-            raw_bytes="ef000101000402000100010400000002030000fe",
-            validity_error=EOFException.INVALID_FIRST_SECTION_TYPE,
-        ),
-        Container(
             name="no_sections",
             sections=[],
             auto_data_section=False,
@@ -1038,41 +1020,6 @@ def test_valid_containers(
             ],
             auto_type_section=AutoSection.NONE,
             validity_error=EOFException.INVALID_TYPE_SECTION_SIZE,
-        ),
-        Container(
-            name="invalid_first_code_section_inputs_0x01",
-            sections=[Section.Code(code=Op.POP + Op.RETF, code_inputs=1)],
-            validity_error=EOFException.INVALID_FIRST_SECTION_TYPE,
-        ),
-        Container(
-            name="invalid_first_code_section_inputs_0x80",
-            sections=[Section.Code(code=Op.POP + Op.RETF, code_inputs=0x80)],
-            validity_error=EOFException.INVALID_FIRST_SECTION_TYPE,
-        ),
-        Container(
-            name="invalid_first_code_section_inputs_0xff",
-            sections=[Section.Code(code=Op.POP + Op.RETF, code_inputs=0xFF)],
-            validity_error=EOFException.INVALID_FIRST_SECTION_TYPE,
-        ),
-        Container(
-            name="invalid_first_code_section_outputs_0x00",
-            sections=[Section.Code(code=Op.PUSH0 + Op.RETF, code_outputs=0)],
-            validity_error=EOFException.INVALID_FIRST_SECTION_TYPE,
-        ),
-        Container(
-            name="invalid_first_code_section_outputs_0x7f",
-            sections=[Section.Code(code=Op.PUSH0 + Op.RETF, code_outputs=0x7F)],
-            validity_error=EOFException.INVALID_FIRST_SECTION_TYPE,
-        ),
-        Container(
-            name="invalid_first_code_section_outputs_0x81",
-            sections=[Section.Code(code=Op.PUSH0 + Op.RETF, code_outputs=0x81)],
-            validity_error=EOFException.INVALID_FIRST_SECTION_TYPE,
-        ),
-        Container(
-            name="invalid_first_code_section_outputs_0xff",
-            sections=[Section.Code(code=Op.PUSH0 + Op.RETF, code_outputs=0xFF)],
-            validity_error=EOFException.INVALID_FIRST_SECTION_TYPE,
         ),
         Container(
             name="multiple_code_section_non_zero_inputs",


### PR DESCRIPTION
## 🗒️ Description
Move some basic tests for invalid first section type to the parametrized tests of EIP-6206. Extend the test coverage by using more exhaustive combination of params.

## 🔗 Related Issues
This helps with later spec change of https://github.com/ipsilon/eof/issues/134.

## ✅ Checklist
- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
