### PR TITLE
fix(tests): Prevent EOF max stack height above number of inputs

### DIFF
--- a/src/ethereum_test_types/eof/v1/__init__.py
+++ b/src/ethereum_test_types/eof/v1/__init__.py
@@ -200,6 +200,8 @@ class Section(CopyValidateModel):
                     auto_code_outputs,
                 )
 
+        assert max_stack_height >= code_inputs, "incorrect max_stack_height value"
+
         return (
             code_inputs.to_bytes(length=TYPES_INPUTS_BYTE_LENGTH, byteorder="big")
             + code_outputs.to_bytes(length=TYPES_OUTPUTS_BYTE_LENGTH, byteorder="big")

--- a/src/ethereum_test_types/tests/test_eof_v1.py
+++ b/src/ethereum_test_types/tests/test_eof_v1.py
@@ -287,12 +287,13 @@ test_cases: List[Tuple[str, Container, str]] = [
                 Section.Code(
                     "0x00",
                     code_inputs=1,
+                    max_stack_height=1,
                 ),
             ],
         ),
         """
             ef0001 01 0004 02 0001 0001 04 0000 00
-            01800000
+            01800001
             00
             """,
     ),
@@ -303,12 +304,13 @@ test_cases: List[Tuple[str, Container, str]] = [
                 Section.Code(
                     "0x00",
                     code_inputs=0xFF,
+                    max_stack_height=0xFF,
                 ),
             ],
         ),
         """
             ef0001 01 0004 02 0001 0001 04 0000 00
-            ff800000
+            ff8000ff
             00
             """,
     ),

--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py
@@ -1081,7 +1081,7 @@ def test_valid_containers(
                     code=(Op.POP * (MAX_CODE_INPUTS + 1)) + Op.RETF,
                     code_inputs=(MAX_CODE_INPUTS + 1),
                     code_outputs=0,
-                    max_stack_height=0,
+                    max_stack_height=(MAX_CODE_INPUTS + 1),
                 ),
             ],
             validity_error=EOFException.INPUTS_OUTPUTS_NUM_ABOVE_LIMIT,

--- a/tests/osaka/eip7692_eof_v1/eip6206_jumpf/test_nonreturning_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip6206_jumpf/test_nonreturning_validation.py
@@ -66,7 +66,14 @@ def test_first_section_with_inputs(
     """Test EOF validation failing because the first section has non-zero number of inputs."""
     eof_test(
         container=Container(
-            sections=[Section.Code(code, code_inputs=inputs, code_outputs=outputs)],
+            sections=[
+                Section.Code(
+                    code,
+                    code_inputs=inputs,
+                    code_outputs=outputs,
+                    max_stack_height=max(inputs, outputs),
+                )
+            ],
             validity_error=EOFException.INVALID_FIRST_SECTION_TYPE,
         )
     )


### PR DESCRIPTION
## 🗒️ Description
When building EOF code section assert that `max_stack_height` is at least `code_inputs`.

## 🔗 Related Issues
It will be impossible to encode such code types after https://github.com/ipsilon/eof/issues/134

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
