### PR TITLE
🧹 chore(tests): remove duplicate fixture in EIP-7623

### DIFF
--- a/tests/prague/eip7623_increase_calldata_cost/test_execution_gas.py
+++ b/tests/prague/eip7623_increase_calldata_cost/test_execution_gas.py
@@ -36,12 +36,6 @@ def data_test_type() -> DataTestType:
     return DataTestType.FLOOR_GAS_COST_GREATER_THAN_INTRINSIC_GAS
 
 
-@pytest.fixture
-def authorization_refund() -> bool:
-    """Disable the refunds on these tests (see ./test_refunds.py)."""
-    return False
-
-
 class TestGasConsumption:
     """Test gas consumption with EIP-7623 active."""
 


### PR DESCRIPTION
## 🗒️ Description
This PR removes a duplicate reference of the [`authorization_refund` fixture.](https://github.com/ethereum/execution-spec-tests/blob/935b3e3de56546500b1a3f3c11190696369e162d/tests/prague/eip7623_increase_calldata_cost/conftest.py#L69-L72)

## 🔗 Related Issues
This effort is part of #1299

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.

