### PR TITLE
refactor(tests): Merge EOF stack underflow tests

### DIFF
--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_all_opcodes_in_container.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_all_opcodes_in_container.py
@@ -313,65 +313,6 @@ def test_all_unreachable_terminating_opcodes_before_stop(
 
 @pytest.mark.parametrize(
     "opcode",
-    sorted(op for op in valid_eof_opcodes if op.min_stack_height > 0)
-    + [
-        # Opcodes that have variable min_stack_height
-        Op.SWAPN[0x00],
-        Op.SWAPN[0xFF],
-        Op.DUPN[0x00],
-        Op.DUPN[0xFF],
-        Op.EXCHANGE[0x00],
-        Op.EXCHANGE[0xFF],
-    ],
-)
-def test_all_opcodes_stack_underflow(
-    eof_test: EOFTestFiller,
-    opcode: Opcode,
-):
-    """Test stack underflow on all opcodes that require at least one item on the stack."""
-    sections: List[Section]
-    if opcode == Op.EOFCREATE:
-        sections = [
-            Section.Code(code=Op.PUSH0 * (opcode.min_stack_height - 1) + opcode[0] + Op.STOP),
-            Section.Container(
-                container=Container(
-                    sections=[
-                        Section.Code(code=Op.RETURNCODE[0](0, 0)),
-                        Section.Container(Container.Code(code=Op.STOP)),
-                    ]
-                )
-            ),
-        ]
-    elif opcode == Op.RETURNCODE:
-        sections = [
-            Section.Code(code=Op.EOFCREATE[0](0, 0, 0, 0) + Op.STOP),
-            Section.Container(
-                container=Container(
-                    sections=[
-                        Section.Code(code=Op.PUSH0 * (opcode.min_stack_height - 1) + opcode[0]),
-                        Section.Container(Container.Code(code=Op.STOP)),
-                    ]
-                )
-            ),
-        ]
-    else:
-        bytecode = Op.PUSH0 * (opcode.min_stack_height - 1)
-        if opcode.has_data_portion():
-            bytecode += opcode[0]
-        else:
-            bytecode += opcode
-        bytecode += Op.STOP
-        sections = [Section.Code(code=bytecode)]
-    eof_code = Container(sections=sections)
-
-    eof_test(
-        container=eof_code,
-        expect_exception=EOFException.STACK_UNDERFLOW,
-    )
-
-
-@pytest.mark.parametrize(
-    "opcode",
     sorted(op for op in valid_eof_opcodes if op.pushed_stack_items > op.popped_stack_items)
     + [
         Op.DUPN[0xFF],

--- a/tests/osaka/eip7692_eof_v1/eip5450_stack/test_code_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip5450_stack/test_code_validation.py
@@ -2,7 +2,7 @@
 
 import itertools
 from enum import Enum, auto, unique
-from typing import Generator, Tuple
+from typing import Tuple
 
 import pytest
 
@@ -15,6 +15,10 @@ from ethereum_test_vm.bytecode import Bytecode
 
 from .. import EOF_FORK_NAME
 from ..eip3540_eof_v1.test_all_opcodes_in_container import valid_eof_opcodes
+from ..eip7620_eof_create.helpers import (
+    smallest_initcode_subcontainer,
+    smallest_runtime_subcontainer,
+)
 
 REFERENCE_SPEC_GIT_PATH = "EIPS/eip-5450.md"
 REFERENCE_SPEC_VERSION = "f20b164b00ae5553f7536a6d7a83a0f254455e09"
@@ -436,37 +440,42 @@ def test_rjumps_jumpf_nonreturning(
     eof_test(container=Container(sections=sections), expect_exception=possible_exceptions or None)
 
 
-def gen_stack_underflow_params() -> Generator[Tuple[Op, int], None, None]:
+def gen_stack_underflow_params():
     """Generate parameters for stack underflow tests."""
-    for op in sorted(valid_eof_opcodes):
-        if op.min_stack_height == 0:
-            continue
-        if op in (Op.EOFCREATE, Op.RETURNCODE):
-            continue
+    opcodes = sorted(op for op in valid_eof_opcodes if op.min_stack_height > 0) + [
+        # Opcodes that have variable min_stack_height
+        Op.SWAPN[0x00],
+        Op.SWAPN[0xFF],
+        Op.DUPN[0x00],
+        Op.DUPN[0xFF],
+        Op.EXCHANGE[0x00],
+        Op.EXCHANGE[0xFF],
+    ]
+    for op in opcodes:
         yield op, 0
         if op.min_stack_height > 1:
             yield op, op.min_stack_height - 1
 
 
-@pytest.mark.parametrize("spread", [0, 1, MAX_OPERAND_STACK_HEIGHT])
+@pytest.mark.parametrize("spread", [-1, 0, 1, MAX_OPERAND_STACK_HEIGHT])
 @pytest.mark.parametrize("op,stack_height", gen_stack_underflow_params())
-def test_all_opcodes_variadic_stack_underflow(
+def test_all_opcodes_stack_underflow(
     eof_test: EOFTestFiller, op: Op, stack_height: int, spread: int
 ):
     """
     Test EOF validation failing due to stack overflow
     caused by the specific instruction `op`.
-    There is similar non-variadic test variant in test_all_opcodes_stack_underflow().
     """
     code = Bytecode()
 
-    # Check if the op increases the stack height (e.g. DUP instructions).
-    # We need to leave space for this increase not to cause stack overflow.
-    stack_height_increase = max(op.pushed_stack_items - op.popped_stack_items, 0)
-    # Cap the spread if it would exceed the maximum stack height.
-    spread = min(spread, MAX_OPERAND_STACK_HEIGHT - (stack_height + stack_height_increase))
-    # Create a range stack height of 0-spread.
-    code = Op.RJUMPI[spread](Op.CALLVALUE) + Op.PUSH0 * spread
+    if spread >= 0:
+        # Check if the op increases the stack height (e.g. DUP instructions).
+        # We need to leave space for this increase not to cause stack overflow.
+        stack_height_increase = max(op.pushed_stack_items - op.popped_stack_items, 0)
+        # Cap the spread if it would exceed the maximum stack height.
+        spread = min(spread, MAX_OPERAND_STACK_HEIGHT - (stack_height + stack_height_increase))
+        # Create a range stack height of 0-spread.
+        code += Op.RJUMPI[spread](Op.CALLVALUE) + Op.PUSH0 * spread
 
     # Create the desired stack height.
     code += Op.PUSH0 * stack_height
@@ -479,9 +488,35 @@ def test_all_opcodes_variadic_stack_underflow(
     if not op.terminating:
         code += Op.STOP
 
+    sections = [
+        Section.Code(
+            code,
+            # Set reasonable stack height. Don't rely on automatic calculation,
+            # because we are in the invalid stack height scenario.
+            max_stack_height=max(spread, stack_height, int(spread >= 0)),
+        )
+    ]
+
+    if op == Op.EOFCREATE:
+        # Make EOFCREATE valid by adding the target subcontainer.
+        sections.append(Section.Container(smallest_initcode_subcontainer))
+    elif op == Op.RETURNCODE:
+        # Make RETURNCODE valid by wrapping it with a container with EOFCREATE.
+        sections = [
+            Section.Code(Op.EOFCREATE[0](0, 0, 0, 0) + Op.STOP),
+            Section.Container(
+                container=Container(
+                    sections=[
+                        sections[0],
+                        Section.Container(smallest_runtime_subcontainer),
+                    ]
+                )
+            ),
+        ]
+
     eof_test(
         container=Container(
-            sections=[Section.Code(code)],
+            sections=sections,
             validity_error=EOFException.STACK_UNDERFLOW,
         )
     )

--- a/tests/osaka/eip7692_eof_v1/eof_tracker.md
+++ b/tests/osaka/eip7692_eof_v1/eof_tracker.md
@@ -237,10 +237,10 @@
 
 #### Stack underflow
 
-- [x] Stack underflows ([`tests/osaka/eip7692_eof_v1/eip5450_stack/test_code_validation.py::test_all_opcodes_variadic_stack_underflow`](./eip5450_stack/test_code_validation/test_all_opcodes_variadic_stack_underflow.md))
+- [x] Stack underflows ([`tests/osaka/eip7692_eof_v1/eip5450_stack/test_code_validation.py::test_all_opcodes_stack_underflow`](./eip5450_stack/test_code_validation/test_all_opcodes_stack_underflow.md))
 - [x] Stack underflow with enough items available in caller stack - can't dig into caller frame ([`tests/osaka/eip7692_eof_v1/eip4750_functions/test_code_validation.py::test_eof_validity`](./eip4750_functions/test_code_validation/test_eof_validity.md))
-- [x] Stack underflow in variable stack segment, only min underflow ([`tests/osaka/eip7692_eof_v1/eip5450_stack/test_code_validation.py::test_all_opcodes_variadic_stack_underflow`](./eip5450_stack/test_code_validation/test_all_opcodes_variadic_stack_underflow.md))
-- [x] Stack underflow in variable stack segment, both min and max underflow ([`tests/osaka/eip7692_eof_v1/eip5450_stack/test_code_validation.py::test_all_opcodes_variadic_stack_underflow`](./eip5450_stack/test_code_validation/test_all_opcodes_variadic_stack_underflow.md))
+- [x] Stack underflow in variable stack segment, only min underflow ([`tests/osaka/eip7692_eof_v1/eip5450_stack/test_code_validation.py::test_all_opcodes_stack_underflow`](./eip5450_stack/test_code_validation/test_all_opcodes_stack_underflow.md))
+- [x] Stack underflow in variable stack segment, both min and max underflow ([`tests/osaka/eip7692_eof_v1/eip5450_stack/test_code_validation.py::test_all_opcodes_stack_underflow`](./eip5450_stack/test_code_validation/test_all_opcodes_stack_underflow.md))
 
 #### CALLF
 


### PR DESCRIPTION
## 🗒️ Description
This combines the cases of `test_all_opcodes_stack_underflow()` to `test_all_opcodes_variadic_stack_underflow()`.
By the way, this also improves some details, e.g. avoids instruction sequence as `RETURN STOP`.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
