### PR TITLE
feat(forks,github,tox): Create `future` feature

### DIFF
--- a/.github/configs/evm.yaml
+++ b/.github/configs/evm.yaml
@@ -6,7 +6,7 @@ develop:
   impl: eels
   repo: null
   ref: null
-eip7692:
+future:
   impl: evmone
   repo: ethereum/evmone
   ref: master

--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -7,8 +7,8 @@ develop:
   evm-type: develop
   fill-params: --until=Prague
   solc: 0.8.21
-eip7692:
-  evm-type: eip7692
+future:
+  evm-type: future
   fill-params: --fork=Osaka ./tests/osaka
   solc: 0.8.21
   eofwrap: true

--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -1287,81 +1287,35 @@ class Prague(Cancun):
         return 3
 
 
-class CancunEIP7692(  # noqa: SC200
-    Cancun,
-    transition_tool_name="Prague",  # Evmone enables (only) EOF at Prague
-    blockchain_test_network_name="Prague",  # Evmone enables (only) EOF at Prague
-    solc_name="cancun",
-):
-    """Cancun + EIP-7692 (EOF) fork (Deprecated)."""
-
-    @classmethod
-    def evm_code_types(cls, block_number: int = 0, timestamp: int = 0) -> List[EVMCodeType]:
-        """EOF V1 is supported starting from this fork."""
-        return super(CancunEIP7692, cls).evm_code_types(  # noqa: SC200
-            block_number,
-            timestamp,
-        ) + [EVMCodeType.EOF_V1]
-
-    @classmethod
-    def call_opcodes(
-        cls, block_number: int = 0, timestamp: int = 0
-    ) -> List[Tuple[Opcodes, EVMCodeType]]:
-        """EOF V1 introduces EXTCALL, EXTSTATICCALL, EXTDELEGATECALL."""
-        return [
-            (Opcodes.EXTCALL, EVMCodeType.EOF_V1),
-            (Opcodes.EXTSTATICCALL, EVMCodeType.EOF_V1),
-            (Opcodes.EXTDELEGATECALL, EVMCodeType.EOF_V1),
-        ] + super(
-            CancunEIP7692,
-            cls,  # noqa: SC200
-        ).call_opcodes(block_number, timestamp)
-
-    @classmethod
-    def create_opcodes(
-        cls, block_number: int = 0, timestamp: int = 0
-    ) -> List[Tuple[Opcodes, EVMCodeType]]:
-        """EOF V1 introduces `EOFCREATE`."""
-        return [(Opcodes.EOFCREATE, EVMCodeType.EOF_V1)] + super(
-            CancunEIP7692,
-            cls,  # noqa: SC200
-        ).create_opcodes(block_number, timestamp)
-
-    @classmethod
-    def is_deployed(cls) -> bool:
-        """
-        Flag that the fork has not been deployed to mainnet; it is under active
-        development.
-        """
-        return False
-
-    @classmethod
-    def solc_min_version(cls) -> Version:
-        """Return minimum version of solc that supports this fork."""
-        return Version.parse("1.0.0")  # set a high version; currently unknown
-
-
 class Osaka(Prague, solc_name="cancun"):
     """Osaka fork."""
 
     @classmethod
     def evm_code_types(cls, block_number: int = 0, timestamp: int = 0) -> List[EVMCodeType]:
         """EOF V1 is supported starting from Osaka."""
-        return super(Osaka, cls).evm_code_types(
-            block_number,
-            timestamp,
-        ) + [EVMCodeType.EOF_V1]
+        return super(Osaka, cls).evm_code_types(block_number, timestamp) + [
+            EVMCodeType.EOF_V1,
+        ]
 
     @classmethod
     def call_opcodes(
         cls, block_number: int = 0, timestamp: int = 0
     ) -> List[Tuple[Opcodes, EVMCodeType]]:
         """EOF V1 introduces EXTCALL, EXTSTATICCALL, EXTDELEGATECALL."""
-        return [
+        return super(Osaka, cls).call_opcodes(block_number, timestamp) + [
             (Opcodes.EXTCALL, EVMCodeType.EOF_V1),
             (Opcodes.EXTSTATICCALL, EVMCodeType.EOF_V1),
             (Opcodes.EXTDELEGATECALL, EVMCodeType.EOF_V1),
-        ] + super(Osaka, cls).call_opcodes(block_number, timestamp)
+        ]
+
+    @classmethod
+    def create_opcodes(
+        cls, block_number: int = 0, timestamp: int = 0
+    ) -> List[Tuple[Opcodes, EVMCodeType]]:
+        """EOF V1 introduces `EOFCREATE`."""
+        return super(Osaka, cls).create_opcodes(block_number, timestamp) + [
+            (Opcodes.EOFCREATE, EVMCodeType.EOF_V1),
+        ]
 
     @classmethod
     def is_deployed(cls) -> bool:

--- a/tests/osaka/eip7692_eof_v1/__init__.py
+++ b/tests/osaka/eip7692_eof_v1/__init__.py
@@ -19,4 +19,4 @@ abstract: Test cases for [EIP-7692: EVM Object Format (EOFv1) Meta](https://eips
 - [ethpandaops/eof-devnet-0](https://notes.ethereum.org/@ethpandaops/eof-devnet-0).
 """  # noqa: E501
 
-EOF_FORK_NAME = "CancunEIP7692,Osaka"
+EOF_FORK_NAME = "Osaka"

--- a/tox.ini
+++ b/tox.ini
@@ -64,7 +64,7 @@ commands =
 
 [forks]
 develop = Prague
-eip7692 = Osaka
+future = Osaka
 
 [testenv:tests-deployed]
 description = Fill test cases in ./tests/ for deployed mainnet forks.
@@ -75,20 +75,20 @@ commands_pre = solc-select use {[testenv]solc_version} --always-install
 commands = pytest -n auto -k "not slow" --skip-evm-dump
 
 [testenv:tests-develop]
-description = Fill test cases in ./tests/ for deployed and development mainnet forks
+description = Fill test cases in ./tests/ for deployed and deployed+1 mainnet forks
 setenv =
     # Use custom EELS_RESOLUTIONS_FILE if it is set via the environment (eg, in CI)
     EELS_RESOLUTIONS_FILE = {env:EELS_RESOLUTIONS_FILE:}
 commands_pre = solc-select use {[testenv]solc_version} --always-install
 commands = pytest -n auto --until={[forks]develop} -k "not slow" --skip-evm-dump
 
-[testenv:tests-eip7692]
-description = Fill test cases in ./tests/ for EIP-7692 (EOF) on Osaka
+[testenv:tests-future]
+description = Fill test cases in ./tests/ for deployed, deployed+1 and deployed+2 mainnet forks
 setenv =
     # Use custom EELS_RESOLUTIONS_FILE if it is set via the environment (eg, in CI)
     EELS_RESOLUTIONS_FILE = {env:EELS_RESOLUTIONS_FILE:}
 commands_pre = solc-select use {[testenv]solc_version} --always-install
-commands =  pytest -n auto --evm-bin=evmone-t8n --fork={[forks]eip7692} -k "not slow" ./tests/osaka --skip-evm-dump
+commands =  pytest -n auto --evm-bin=evmone-t8n --fork={[forks]future} -k "not slow" ./tests/osaka --skip-evm-dump
 
 # ----------------------------------------------------------------------------------------------
 # ALIAS ENVIRONMENTS


### PR DESCRIPTION
## 🗒️ Description
Renames `eip7692` to `future`, which will now onwards point to the current mainnet deployed hardfork + 2.

- `stable`: Current mainnet deployed hardfork (Currently Cancun)
- `develop`: Current mainnet deployed hardfork + 1 (Currently Prague)
- `future`: Current mainnet deployed hardfork + 2 (Currently Osaka)

## 🔗 Related Issues
None

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.