### PR TITLE
chore(deps): add version specifier for `types-requests`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,11 @@ Changelog = "https://eest.ethereum.org/main/CHANGELOG/"
 
 [project.optional-dependencies]
 test = ["pytest-cov>=4.1.0,<5"]
-lint = ["ruff==0.9.4", "mypy>=1.15.0,<1.16", "types-requests"]
+lint = [
+    "ruff==0.9.4",
+    "mypy>=1.15.0,<1.16",
+    "types-requests>=2.31,<2.33",
+]
 docs = [
     "cairosvg>=2.7.0,<3",
     "mike>=1.1.2,<2",

--- a/uv.lock
+++ b/uv.lock
@@ -600,7 +600,7 @@ requires-dist = [
     { name = "tenacity", specifier = ">8.2.0,<9" },
     { name = "trie", specifier = ">=3.1.0,<4" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20240917,<7" },
-    { name = "types-requests", marker = "extra == 'lint'" },
+    { name = "types-requests", marker = "extra == 'lint'", specifier = ">=2.31,<2.33" },
     { name = "typing-extensions", specifier = ">=4.12.2,<5" },
 ]
 provides-extras = ["test", "lint", "docs"]


### PR DESCRIPTION
## 🗒️ Description
Adds a version specifier for the `types-requests` package which fixes the `uv` warning:
```
warning: Missing version constraint (e.g., a lower bound) for types-requests
```

Achieved via:
```
uv add --optional lint "types-requests>=2.31,<2.33"
```


## 🔗 Related Issues
None

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] ~~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~ skipped