### PR TITLE
fix(tests): de-duplicate EOF stack underflow tests

### DIFF
--- a/tests/osaka/eip7692_eof_v1/eip663_dupn_swapn_exchange/test_dupn.py
+++ b/tests/osaka/eip7692_eof_v1/eip663_dupn_swapn_exchange/test_dupn.py
@@ -55,7 +55,7 @@ def test_dupn_all_valid_immediates(eof_state_test: EOFStateTestFiller):
 @pytest.mark.parametrize(
     "stack_height,max_stack_height",
     [
-        [0, 0],
+        # [0, 0] is tested in test_all_opcodes_stack_underflow()
         [0, 1],
         [1, 1],
         [1, 2],

--- a/tests/osaka/eip7692_eof_v1/eip663_dupn_swapn_exchange/test_exchange.py
+++ b/tests/osaka/eip7692_eof_v1/eip663_dupn_swapn_exchange/test_exchange.py
@@ -65,9 +65,9 @@ def test_exchange_all_valid_immediates(eof_state_test: EOFStateTestFiller):
 @pytest.mark.parametrize(
     "stack_height,x,y",
     [
-        # 2 and 3 are the lowest valid values for x and y, which translates to a
-        # zero immediate value.
-        pytest.param(0, 2, 3, id="stack_height=0_n=1_m=1"),
+        # 2 and 3 are the lowest valid values for x and y,
+        # which translates to the zero immediate value.
+        # (0, 2, 3) is tested in test_all_opcodes_stack_underflow()
         pytest.param(1, 2, 3, id="stack_height=1_n=1_m=1"),
         pytest.param(2, 2, 3, id="stack_height=2_n=1_m=1"),
         pytest.param(17, 2, 18, id="stack_height=17_n=1_m=16"),
@@ -75,13 +75,13 @@ def test_exchange_all_valid_immediates(eof_state_test: EOFStateTestFiller):
         pytest.param(32, 17, 33, id="stack_height=32_n=16_m=16"),
     ],
 )
-def test_exchange_all_invalid_immediates(
+def test_exchange_stack_underflow(
     eof_test: EOFTestFiller,
     stack_height: int,
     x: int,
     y: int,
 ):
-    """Test case for all invalid EXCHANGE immediates."""
+    """Test case the EXCHANGE causing stack underflow."""
     eof_code = Container(
         sections=[
             Section.Code(

--- a/tests/osaka/eip7692_eof_v1/eip663_dupn_swapn_exchange/test_swapn.py
+++ b/tests/osaka/eip7692_eof_v1/eip663_dupn_swapn_exchange/test_swapn.py
@@ -99,7 +99,9 @@ def test_swapn_stack_underflow(
                 code=sum(Op.PUSH2[v] for v in range(0, stack_height))
                 + Op.SWAPN[stack_height]
                 + Op.STOP,
-                max_stack_height=stack_height,
+                # This is also tested in test_all_opcodes_stack_underflow()
+                # so make it differ by the declared stack height.
+                max_stack_height=stack_height + 1,
             )
         ],
     )


### PR DESCRIPTION
## 🗒️ Description
Some EOF stack underflow tests are duplicated.

## 🔗 Related Issues
The https://github.com/ethereum/execution-spec-tests/pull/1384 introduced duplicated EOF stack underflow tests by modifying the max_stack_height calculation.

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
