### PR TITLE
feat(fw,tests): change EOF to stack_height_increase

### DIFF
--- a/src/ethereum_clis/clis/besu.py
+++ b/src/ethereum_clis/clis/besu.py
@@ -266,12 +266,12 @@ class BesuExceptionMapper(ExceptionMapper):
         EOFException.INVALID_RJUMP_DESTINATION: "err: invalid_rjump_destination",
         EOFException.UNREACHABLE_CODE_SECTIONS: "err: unreachable_code_sections",
         EOFException.STACK_UNDERFLOW: "err: stack_underflow",
-        EOFException.MAX_STACK_HEIGHT_ABOVE_LIMIT: "err: max_stack_height_above_limit",
+        EOFException.MAX_STACK_INCREASE_ABOVE_LIMIT: "err: max_stack_increase_above_limit",
         EOFException.STACK_HIGHER_THAN_OUTPUTS: "err: stack_higher_than_outputs_required",
         EOFException.JUMPF_DESTINATION_INCOMPATIBLE_OUTPUTS: (
             "err: jumpf_destination_incompatible_outputs"
         ),
-        EOFException.INVALID_MAX_STACK_HEIGHT: "err: invalid_max_stack_height",
+        EOFException.INVALID_MAX_STACK_INCREASE: "err: invalid_max_stack_increase",
         EOFException.INVALID_DATALOADN_INDEX: "err: invalid_dataloadn_index",
         EOFException.TRUNCATED_INSTRUCTION: "err: truncated_instruction",
         EOFException.TOPLEVEL_CONTAINER_TRUNCATED: "err: toplevel_container_truncated",

--- a/src/ethereum_clis/clis/ethereumjs.py
+++ b/src/ethereum_clis/clis/ethereumjs.py
@@ -96,12 +96,12 @@ class EthereumJSExceptionMapper(ExceptionMapper):
         EOFException.INVALID_RJUMP_DESTINATION: "err: invalid_rjump_destination",
         EOFException.UNREACHABLE_CODE_SECTIONS: "err: unreachable_code_sections",
         EOFException.STACK_UNDERFLOW: "err: stack_underflow",
-        EOFException.MAX_STACK_HEIGHT_ABOVE_LIMIT: "err: max_stack_height_above_limit",
+        EOFException.MAX_STACK_INCREASE_ABOVE_LIMIT: "err: max_stack_increase_above_limit",
         EOFException.STACK_HIGHER_THAN_OUTPUTS: "err: stack_higher_than_outputs_required",
         EOFException.JUMPF_DESTINATION_INCOMPATIBLE_OUTPUTS: (
             "err: jumpf_destination_incompatible_outputs"
         ),
-        EOFException.INVALID_MAX_STACK_HEIGHT: "err: invalid_max_stack_height",
+        EOFException.INVALID_MAX_STACK_INCREASE: "err: invalid_max_stack_increase",
         EOFException.INVALID_DATALOADN_INDEX: "err: invalid_dataloadn_index",
         EOFException.TRUNCATED_INSTRUCTION: "err: truncated_instruction",
         EOFException.TOPLEVEL_CONTAINER_TRUNCATED: "err: toplevel_container_truncated",

--- a/src/ethereum_clis/clis/evmone.py
+++ b/src/ethereum_clis/clis/evmone.py
@@ -105,12 +105,12 @@ class EvmoneExceptionMapper(ExceptionMapper):
         EOFException.UNREACHABLE_CODE_SECTIONS: "err: unreachable_code_sections",
         EOFException.STACK_UNDERFLOW: "err: stack_underflow",
         EOFException.STACK_OVERFLOW: "err: stack_overflow",
-        EOFException.MAX_STACK_HEIGHT_ABOVE_LIMIT: "err: max_stack_height_above_limit",
+        EOFException.MAX_STACK_INCREASE_ABOVE_LIMIT: "err: max_stack_increase_above_limit",
         EOFException.STACK_HIGHER_THAN_OUTPUTS: "err: stack_higher_than_outputs_required",
         EOFException.JUMPF_DESTINATION_INCOMPATIBLE_OUTPUTS: (
             "err: jumpf_destination_incompatible_outputs"
         ),
-        EOFException.INVALID_MAX_STACK_HEIGHT: "err: invalid_max_stack_height",
+        EOFException.INVALID_MAX_STACK_INCREASE: "err: invalid_max_stack_increase",
         EOFException.INVALID_DATALOADN_INDEX: "err: invalid_dataloadn_index",
         EOFException.TRUNCATED_INSTRUCTION: "err: truncated_instruction",
         EOFException.TOPLEVEL_CONTAINER_TRUNCATED: "err: toplevel_container_truncated",

--- a/src/ethereum_clis/clis/execution_specs.py
+++ b/src/ethereum_clis/clis/execution_specs.py
@@ -182,12 +182,12 @@ class ExecutionSpecsExceptionMapper(ExceptionMapper):
         EOFException.INVALID_RJUMP_DESTINATION: "err: invalid_rjump_destination",
         EOFException.UNREACHABLE_CODE_SECTIONS: "err: unreachable_code_sections",
         EOFException.STACK_UNDERFLOW: "err: stack_underflow",
-        EOFException.MAX_STACK_HEIGHT_ABOVE_LIMIT: "err: max_stack_height_above_limit",
+        EOFException.MAX_STACK_INCREASE_ABOVE_LIMIT: "err: max_stack_increase_above_limit",
         EOFException.STACK_HIGHER_THAN_OUTPUTS: "err: stack_higher_than_outputs_required",
         EOFException.JUMPF_DESTINATION_INCOMPATIBLE_OUTPUTS: (
             "err: jumpf_destination_incompatible_outputs"
         ),
-        EOFException.INVALID_MAX_STACK_HEIGHT: "err: invalid_max_stack_height",
+        EOFException.INVALID_MAX_STACK_INCREASE: "err: invalid_max_stack_increase",
         EOFException.INVALID_DATALOADN_INDEX: "err: invalid_dataloadn_index",
         EOFException.TRUNCATED_INSTRUCTION: "err: truncated_instruction",
         EOFException.TOPLEVEL_CONTAINER_TRUNCATED: "err: toplevel_container_truncated",

--- a/src/ethereum_clis/clis/geth.py
+++ b/src/ethereum_clis/clis/geth.py
@@ -75,12 +75,12 @@ class GethExceptionMapper(ExceptionMapper):
         EOFException.INVALID_RJUMP_DESTINATION: "err: invalid_rjump_destination",
         EOFException.UNREACHABLE_CODE_SECTIONS: "err: unreachable_code_sections",
         EOFException.STACK_UNDERFLOW: "err: stack_underflow",
-        EOFException.MAX_STACK_HEIGHT_ABOVE_LIMIT: "err: max_stack_height_above_limit",
+        EOFException.MAX_STACK_INCREASE_ABOVE_LIMIT: "err: max_stack_increase_above_limit",
         EOFException.STACK_HIGHER_THAN_OUTPUTS: "err: stack_higher_than_outputs_required",
         EOFException.JUMPF_DESTINATION_INCOMPATIBLE_OUTPUTS: (
             "err: jumpf_destination_incompatible_outputs"
         ),
-        EOFException.INVALID_MAX_STACK_HEIGHT: "err: invalid_max_stack_height",
+        EOFException.INVALID_MAX_STACK_INCREASE: "err: invalid_max_stack_increase",
         EOFException.INVALID_DATALOADN_INDEX: "err: invalid_dataloadn_index",
         EOFException.TRUNCATED_INSTRUCTION: "err: truncated_instruction",
         EOFException.TOPLEVEL_CONTAINER_TRUNCATED: "err: toplevel_container_truncated",

--- a/src/ethereum_clis/clis/nimbus.py
+++ b/src/ethereum_clis/clis/nimbus.py
@@ -114,12 +114,12 @@ class NimbusExceptionMapper(ExceptionMapper):
         EOFException.INVALID_RJUMP_DESTINATION: "err: invalid_rjump_destination",
         EOFException.UNREACHABLE_CODE_SECTIONS: "err: unreachable_code_sections",
         EOFException.STACK_UNDERFLOW: "err: stack_underflow",
-        EOFException.MAX_STACK_HEIGHT_ABOVE_LIMIT: "err: max_stack_height_above_limit",
+        EOFException.MAX_STACK_INCREASE_ABOVE_LIMIT: "err: max_stack_increase_above_limit",
         EOFException.STACK_HIGHER_THAN_OUTPUTS: "err: stack_higher_than_outputs_required",
         EOFException.JUMPF_DESTINATION_INCOMPATIBLE_OUTPUTS: (
             "err: jumpf_destination_incompatible_outputs"
         ),
-        EOFException.INVALID_MAX_STACK_HEIGHT: "err: invalid_max_stack_height",
+        EOFException.INVALID_MAX_STACK_INCREASE: "err: invalid_max_stack_increase",
         EOFException.INVALID_DATALOADN_INDEX: "err: invalid_dataloadn_index",
         EOFException.TRUNCATED_INSTRUCTION: "err: truncated_instruction",
         EOFException.TOPLEVEL_CONTAINER_TRUNCATED: "err: toplevel_container_truncated",

--- a/src/ethereum_test_exceptions/exceptions.py
+++ b/src/ethereum_test_exceptions/exceptions.py
@@ -710,9 +710,9 @@ class EOFException(ExceptionBase):
     """
     EOF container section stack height mismatch.
     """
-    MAX_STACK_HEIGHT_ABOVE_LIMIT = auto()
+    MAX_STACK_INCREASE_ABOVE_LIMIT = auto()
     """
-    EOF container's specified max stack height is above the limit.
+    EOF container's specified max stack increase is above the limit.
     """
     STACK_HIGHER_THAN_OUTPUTS = auto()
     """
@@ -723,9 +723,9 @@ class EOFException(ExceptionBase):
     """
     EOF container section JUMPF's to a destination section with incompatible outputs.
     """
-    INVALID_MAX_STACK_HEIGHT = auto()
+    INVALID_MAX_STACK_INCREASE = auto()
     """
-    EOF container section's specified max stack height does not match the actual stack height.
+    EOF container section's specified max stack increase does not match the actual stack height.
     """
     INVALID_DATALOADN_INDEX = auto()
     """

--- a/src/ethereum_test_types/eof/v1/__init__.py
+++ b/src/ethereum_test_types/eof/v1/__init__.py
@@ -199,12 +199,12 @@ class Section(CopyValidateModel):
                     auto_code_outputs,
                 )
 
-        assert max_stack_height >= code_inputs, "incorrect max_stack_height value"
-
+        max_stack_increase = max_stack_height - code_inputs
+        assert max_stack_increase >= 0, "incorrect max stack height value"
         return (
             code_inputs.to_bytes(length=TYPES_INPUTS_BYTE_LENGTH, byteorder="big")
             + code_outputs.to_bytes(length=TYPES_OUTPUTS_BYTE_LENGTH, byteorder="big")
-            + max_stack_height.to_bytes(length=TYPES_STACK_BYTE_LENGTH, byteorder="big")
+            + max_stack_increase.to_bytes(length=TYPES_STACK_BYTE_LENGTH, byteorder="big")
         )
 
     def with_max_stack_height(self, max_stack_height) -> "Section":

--- a/src/ethereum_test_types/tests/test_eof_v1.py
+++ b/src/ethereum_test_types/tests/test_eof_v1.py
@@ -293,7 +293,7 @@ test_cases: List[Tuple[str, Container, str]] = [
         ),
         """
             ef0001 01 0004 02 0001 0001 ff 0000 00
-            01800001
+            01800000
             00
             """,
     ),
@@ -310,7 +310,7 @@ test_cases: List[Tuple[str, Container, str]] = [
         ),
         """
             ef0001 01 0004 02 0001 0001 ff 0000 00
-            ff8000ff
+            ff800000
             00
             """,
     ),

--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_all_opcodes_in_container.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_all_opcodes_in_container.py
@@ -326,7 +326,7 @@ def test_all_unreachable_terminating_opcodes_before_stop(
     #    for stack overflow.
     # 2. Max stack height above limit, where we don't modify the `max_stack_height` field of the
     #    code section, so the actual code doesn't have to be verified for the stack overflow.
-    [EOFException.INVALID_MAX_STACK_HEIGHT, EOFException.MAX_STACK_HEIGHT_ABOVE_LIMIT],
+    [EOFException.INVALID_MAX_STACK_INCREASE, EOFException.MAX_STACK_INCREASE_ABOVE_LIMIT],
 )
 def test_all_opcodes_stack_overflow(
     eof_test: EOFTestFiller,
@@ -345,7 +345,7 @@ def test_all_opcodes_stack_overflow(
 
     kwargs: Dict[str, Any] = {"code": bytecode}
 
-    if exception == EOFException.INVALID_MAX_STACK_HEIGHT:
+    if exception == EOFException.INVALID_MAX_STACK_INCREASE:
         # Lie about the max stack height to make the code be checked for stack overflow.
         kwargs["max_stack_height"] = MAX_OPERAND_STACK_HEIGHT
 

--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_container_validation.py
@@ -1156,7 +1156,7 @@ def test_valid_containers(
                 ),
             ],
             # TODO auto types section generation probably failed, the exception must be about code
-            validity_error=EOFException.MAX_STACK_HEIGHT_ABOVE_LIMIT,
+            validity_error=EOFException.MAX_STACK_INCREASE_ABOVE_LIMIT,
         ),
     ],
     ids=lambda c: c.name,

--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_eof_example.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_eof_example.py
@@ -51,12 +51,9 @@ def test_eof_example(eof_test: EOFTestFiller):
             # DATA section
             Section.Data("0xef"),
         ],
-    )
-
-    # This will construct a valid EOF container with these bytes
-    assert bytes(eof_code) == bytes.fromhex(
-        "ef00010100100200040005000600080002ff000100008000010100000100010003020300035fe300010050"
-        "e3000250e43080e300035050e480e4ef"
+        expected_bytecode="ef00010100100200040005000600080002ff000100"
+        "00800001 01000000 00010003 02030001"
+        "5fe300010050e3000250e43080e300035050e480e4ef",
     )
 
     eof_test(

--- a/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpi.py
+++ b/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpi.py
@@ -1642,7 +1642,7 @@ def test_double_rjumpi_invalid_max_stack_height(
                 ),
             ],
         ),
-        expect_exception=EOFException.INVALID_MAX_STACK_HEIGHT,
+        expect_exception=EOFException.INVALID_MAX_STACK_INCREASE,
     )
 
 

--- a/tests/osaka/eip7692_eof_v1/eip4750_functions/test_code_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip4750_functions/test_code_validation.py
@@ -305,7 +305,7 @@ INVALID: List[Container] = [
                 max_stack_height=1,
             ),
         ],
-        validity_error=EOFException.INVALID_MAX_STACK_HEIGHT,
+        validity_error=EOFException.INVALID_MAX_STACK_INCREASE,
     ),
     Container(
         name="stack_shorter_than_code_outputs_1",
@@ -321,7 +321,7 @@ INVALID: List[Container] = [
                 max_stack_height=1,
             ),
         ],
-        validity_error=EOFException.INVALID_MAX_STACK_HEIGHT,
+        validity_error=EOFException.INVALID_MAX_STACK_INCREASE,
     ),
     Container(
         name="stack_shorter_than_code_outputs_2",
@@ -666,7 +666,7 @@ def test_callf_stack_height_limit_exceeded(eof_test, callee_outputs):
             ),
         ],
     )
-    eof_test(container=container, expect_exception=EOFException.MAX_STACK_HEIGHT_ABOVE_LIMIT)
+    eof_test(container=container, expect_exception=EOFException.MAX_STACK_INCREASE_ABOVE_LIMIT)
 
 
 @pytest.mark.parametrize("stack_height", [512, 513, 1023])
@@ -934,7 +934,7 @@ def test_callf_with_inputs_stack_overflow(
     elif push_stack - code_section.code_inputs + code_section.code_outputs - pop_stack < 2:
         exception = EOFException.STACK_UNDERFLOW
     elif push_stack != container.sections[0].max_stack_height:
-        exception = EOFException.INVALID_MAX_STACK_HEIGHT
+        exception = EOFException.INVALID_MAX_STACK_INCREASE
 
     eof_test(container=container, expect_exception=exception)
 
@@ -1062,7 +1062,7 @@ def test_callf_with_inputs_stack_overflow_variable_stack(
     ):
         exception = EOFException.STACK_OVERFLOW
     elif push_stack + initial_stack > 1023:
-        exception = EOFException.INVALID_MAX_STACK_HEIGHT
+        exception = EOFException.INVALID_MAX_STACK_INCREASE
 
     eof_test(container=container, expect_exception=exception)
 

--- a/tests/osaka/eip7692_eof_v1/eip5450_stack/test_code_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip5450_stack/test_code_validation.py
@@ -471,9 +471,9 @@ def test_all_opcodes_stack_underflow(
     if spread >= 0:
         # Check if the op increases the stack height (e.g. DUP instructions).
         # We need to leave space for this increase not to cause stack overflow.
-        stack_height_increase = max(op.pushed_stack_items - op.popped_stack_items, 0)
+        max_stack_increase = max(op.pushed_stack_items - op.popped_stack_items, 0)
         # Cap the spread if it would exceed the maximum stack height.
-        spread = min(spread, MAX_OPERAND_STACK_HEIGHT - (stack_height + stack_height_increase))
+        spread = min(spread, MAX_OPERAND_STACK_HEIGHT - (stack_height + max_stack_increase))
         # Create a range stack height of 0-spread.
         code += Op.RJUMPI[spread](Op.CALLVALUE) + Op.PUSH0 * spread
 

--- a/tests/osaka/eip7692_eof_v1/eip663_dupn_swapn_exchange/test_dupn.py
+++ b/tests/osaka/eip7692_eof_v1/eip663_dupn_swapn_exchange/test_dupn.py
@@ -88,10 +88,10 @@ def test_dupn_stack_underflow(
 @pytest.mark.parametrize(
     "dupn_operand,max_stack_height,expect_exception",
     [
-        [0, MAX_OPERAND_STACK_HEIGHT, EOFException.INVALID_MAX_STACK_HEIGHT],
-        [0, MAX_OPERAND_STACK_HEIGHT + 1, EOFException.MAX_STACK_HEIGHT_ABOVE_LIMIT],
-        [2**8 - 1, MAX_OPERAND_STACK_HEIGHT, EOFException.INVALID_MAX_STACK_HEIGHT],
-        [2**8 - 1, MAX_OPERAND_STACK_HEIGHT + 1, EOFException.MAX_STACK_HEIGHT_ABOVE_LIMIT],
+        [0, MAX_OPERAND_STACK_HEIGHT, EOFException.INVALID_MAX_STACK_INCREASE],
+        [0, MAX_OPERAND_STACK_HEIGHT + 1, EOFException.MAX_STACK_INCREASE_ABOVE_LIMIT],
+        [2**8 - 1, MAX_OPERAND_STACK_HEIGHT, EOFException.INVALID_MAX_STACK_INCREASE],
+        [2**8 - 1, MAX_OPERAND_STACK_HEIGHT + 1, EOFException.MAX_STACK_INCREASE_ABOVE_LIMIT],
     ],
 )
 def test_dupn_stack_overflow(


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
