### PR TITLE
feat(tests): Blake2 test spec refactor

### DIFF
--- a/converted-ethereum-tests.txt
+++ b/converted-ethereum-tests.txt
@@ -104,3 +104,4 @@ GeneralStateTests/stPreCompiledContracts/idPrecomps.json
 ([#1244](https://github.com/ethereum/execution-spec-tests/pull/1244))
 GeneralStateTests/stPreCompiledContracts/delegatecall09Undefined.json
 GeneralStateTests/stPreCompiledContracts2/CALLBlake2f.json
+GeneralStateTests/stPreCompiledContracts2/CALLCODEBlake2f.json

--- a/tests/istanbul/eip152_blake2/common.py
+++ b/tests/istanbul/eip152_blake2/common.py
@@ -1,0 +1,72 @@
+"""Common classes used in the BLAKE2b precompile tests."""
+
+from dataclasses import dataclass
+
+from ethereum_test_types.helpers import TestParameterGroup
+
+from .spec import Spec
+
+
+@dataclass(kw_only=True, frozen=True, repr=False)
+class Blake2bInput(TestParameterGroup):
+    """
+    Helper class that defines the BLAKE2b precompile inputs and creates the
+    call data from them. Returns all inputs encoded as bytes.
+
+    Attributes:
+        rounds_length (int): An optional integer representing the bytes length
+            for the number of rounds. Defaults to the expected length of 4.
+        rounds (int | str): A hex string or integer value representing the number of rounds.
+        h (str): A hex string that represents the state vector.
+        m (str): A hex string that represents the message block vector.
+        t_0 (int | str): A hex string or integer value that represents the first offset counter.
+        t_1 (int | str): A hex string or integer value that represents the second offset counter.
+        f (bool): An optional boolean that represents the final block indicator flag.
+            Defaults to True.
+
+    """
+
+    rounds_length: int = Spec.BLAKE2_PRECOMPILE_ROUNDS_LENGTH
+    rounds: int | str = Spec.BLAKE2B_PRECOMPILE_ROUNDS
+    h: str
+    m: str
+    t_0: int | str
+    t_1: int | str
+    f: bool | int = True
+
+    def create_blake2b_tx_data(self):
+        """Generate input for the BLAKE2b precompile."""
+        _rounds = self.rounds.to_bytes(length=self.rounds_length, byteorder="big")
+        _h = bytes.fromhex(self.h)
+        _m = bytes.fromhex(self.m)
+        _t_0 = (
+            bytes.fromhex(self.t_0)
+            if isinstance(self.t_0, str)
+            else self.t_0.to_bytes(length=Spec.BLAKE2_PRECOMPILE_T_0_LENGTH, byteorder="little")
+        )
+        _t_1 = (
+            bytes.fromhex(self.t_1)
+            if isinstance(self.t_1, str)
+            else self.t_1.to_bytes(length=Spec.BLAKE2_PRECOMPILE_T_1_LENGTH, byteorder="little")
+        )
+        _f = int(self.f).to_bytes(length=Spec.BLAKE2_PRECOMPILE_F_LENGTH, byteorder="big")
+
+        return _rounds + _h + _m + _t_0 + _t_1 + _f
+
+
+@dataclass(kw_only=True, frozen=True, repr=False)
+class ExpectedOutput(TestParameterGroup):
+    """
+    Expected test result.
+
+    Attributes:
+        call_succeeds (str | bool): A hex string or boolean to indicate whether the call was
+            successful or not.
+        data_1 (str): String value of the first updated state vector.
+        data_2 (str): String value of the second updated state vector.
+
+    """
+
+    call_succeeds: str | bool
+    data_1: str
+    data_2: str

--- a/tests/istanbul/eip152_blake2/conftest.py
+++ b/tests/istanbul/eip152_blake2/conftest.py
@@ -1,0 +1,32 @@
+"""pytest fixtures for testing the BLAKE2b precompile."""
+
+import pytest
+
+from ethereum_test_tools.vm.opcode import Opcodes as Op
+from ethereum_test_vm.bytecode import Bytecode
+
+from .spec import Spec
+
+
+@pytest.fixture
+def blake2b_contract_bytecode(call_opcode: Op) -> Bytecode:
+    """
+    Contract code that performs the provided opcode (CALL or CALLCODE) to the BLAKE2b precompile
+    and stores the result.
+    """
+    return (
+        Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE())
+        + Op.SSTORE(
+            0,
+            call_opcode(
+                address=Spec.BLAKE2_PRECOMPILE_ADDRESS,
+                args_offset=0,
+                args_size=Op.CALLDATASIZE(),
+                ret_offset=0x200,
+                ret_size=0x40,
+            ),
+        )
+        + Op.SSTORE(1, Op.MLOAD(0x200))
+        + Op.SSTORE(2, Op.MLOAD(0x220))
+        + Op.STOP()
+    )

--- a/tests/istanbul/eip152_blake2/spec.py
+++ b/tests/istanbul/eip152_blake2/spec.py
@@ -1,0 +1,54 @@
+"""Defines EIP-152 specification constants and functions."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ReferenceSpec:
+    """Defines the reference spec version and git path."""
+
+    git_path: str
+    version: str
+
+
+ref_spec_152 = ReferenceSpec("EIPS/eip-152.md", "2762bfcff3e549ef263342e5239ef03ac2b07400")
+
+
+# Constants
+@dataclass(frozen=True)
+class Spec:
+    """
+    Parameters from the EIP-152 specifications as defined at
+    https://eips.ethereum.org/EIPS/eip-152#specification.
+
+    If the parameter is not currently used within the tests, it is commented
+    out.
+    """
+
+    BLAKE2_PRECOMPILE_ADDRESS = 0x09
+
+    # The following constants are used to define the bytes length of the
+    # parameters passed to the BLAKE2 precompile.
+    BLAKE2_PRECOMPILE_ROUNDS_LENGTH = 4
+    # BLAKE2_PRECOMPILE_M_LENGTH = 128
+    BLAKE2_PRECOMPILE_T_0_LENGTH = 8
+    BLAKE2_PRECOMPILE_T_1_LENGTH = 8
+    BLAKE2_PRECOMPILE_F_LENGTH = 1
+
+    # Constants for BLAKE2b and BLAKE2s spec defined at https://datatracker.ietf.org/doc/html/rfc7693#section-3.2
+    BLAKE2B_PRECOMPILE_ROUNDS = 12
+    BLAKE2B_PRECOMPILE_H_LENGTH = 64
+
+    # BLAKE2S_PRECOMPILE_ROUNDS = 10
+    # BLAKE2S_PRECOMPILE_H_LENGTH = 32
+
+
+class SpecTestVectors:
+    """Defines common test parameters for the BLAKE2b precompile."""
+
+    # The following constants are used to define common test parameters
+    # Origin of vectors defined at https://datatracker.ietf.org/doc/html/rfc7693.html#appendix-A
+    BLAKE2_STATE_VECTOR = "48c9bdf267e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5d182e6ad7f520e511f6c3e2b8c68059b6bbd41fbabd9831f79217e1319cde05b"  # noqa:E501
+    BLAKE2_MESSAGE_BLOCK_VECTOR = "6162630000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"  # noqa:E501
+    BLAKE2_OFFSET_COUNTER_0 = 3
+    BLAKE2_OFFSET_COUNTER_1 = 0


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
Follow on to #1244 to add a spec file with common variables and constants.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist

- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
