### PR TITLE
🐞 fix(types): Add missing yParity in Authorization tuple

### DIFF
--- a/src/ethereum_test_fixtures/common.py
+++ b/src/ethereum_test_fixtures/common.py
@@ -57,18 +57,6 @@ class FixtureAuthorizationTuple(
         """Return FixtureAuthorizationTuple from an AuthorizationTuple."""
         return cls(**auth_tuple.model_dump())
 
-    @model_serializer(mode="wrap", when_used="json-unless-none")
-    def duplicate_v_as_y_parity(self, serializer):
-        """
-        Add a duplicate 'yParity' field (same as `v`) in JSON fixtures.
-
-        Background: https://github.com/erigontech/erigon/issues/14073
-        """
-        data = serializer(self)
-        if "v" in data and data["v"] is not None:
-            data["yParity"] = data["v"]
-        return data
-
     def sign(self):
         """Sign the current object for further serialization."""
         # No-op, as the object is always already signed

--- a/src/ethereum_test_fixtures/common.py
+++ b/src/ethereum_test_fixtures/common.py
@@ -2,7 +2,7 @@
 
 from typing import Dict
 
-from pydantic import AliasChoices, Field, model_serializer
+from pydantic import AliasChoices, Field
 
 from ethereum_test_base_types import (
     BlobSchedule,

--- a/src/ethereum_test_types/types.py
+++ b/src/ethereum_test_types/types.py
@@ -461,6 +461,18 @@ class AuthorizationTupleGeneric(CamelModel, Generic[NumberBoundTypeVar], Signabl
         """
         return self.magic.to_bytes(1, byteorder="big")
 
+    @model_serializer(mode="wrap", when_used="json-unless-none")
+    def duplicate_v_as_y_parity(self, serializer):
+        """
+        Add a duplicate 'yParity' field (same as `v`) in JSON fixtures.
+
+        Background: https://github.com/erigontech/erigon/issues/14073
+        """
+        data = serializer(self)
+        if "v" in data and data["v"] is not None:
+            data["yParity"] = data["v"]
+        return data
+
 
 class AuthorizationTuple(AuthorizationTupleGeneric[HexNumber]):
     """Authorization tuple for transactions."""


### PR DESCRIPTION
## 🗒️ Description
EIP-7702 specs requires the signature component `v` to be called `yParity`.  #1286 addressed this issue for fixtures, this PR extends the fix for transaction payload, by moving the code to the parent class `AuthorizationTupleGeneric`.

## 🔗 Related Issues
#1286 

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
