### PR TITLE
chore(types): Refactor and remove misleading comment in `Requests`

### DIFF
--- a/src/ethereum_test_types/types.py
+++ b/src/ethereum_test_types/types.py
@@ -1160,8 +1160,5 @@ class Requests:
 
     def __bytes__(self) -> bytes:
         """Return requests hash."""
-        s: bytes = b""
-        for r in self.requests_list:
-            # Append the index of the request type to the request data before hashing
-            s = s + r.sha256()
+        s: bytes = b"".join(r.sha256() for r in self.requests_list)
         return Bytes(s).sha256()


### PR DESCRIPTION
## 🗒️ Description
Tiny change to refactor the `__bytes__` method in `Requests` to remove a misleading comment and simplify a bit.

## 🔗 Related Issues
None

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] ~~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.