### PR TITLE
Suggestions for #1396, refactor(exceptions,specs): Support general block exceptions - Pydantic context to parse using mapper

### DIFF
--- a/src/ethereum_test_specs/helpers.py
+++ b/src/ethereum_test_specs/helpers.py
@@ -24,7 +24,7 @@ class ExecutionContext(Enum):
     TRANSACTION = "Transaction"
 
 
-class UnexpectedSuccessError(Exception):
+class UnexpectedExecutionSuccessError(Exception):
     """Exception used when the transaction expected to fail succeeded instead."""
 
     def __init__(self, execution_context: ExecutionContext, **kwargs):
@@ -36,7 +36,7 @@ class UnexpectedSuccessError(Exception):
         super().__init__(message)
 
 
-class UnexpectedFailError(Exception):
+class UnexpectedExecutionFailError(Exception):
     """Exception used when a transaction/block expected to succeed failed instead."""
 
     def __init__(
@@ -55,7 +55,7 @@ class UnexpectedFailError(Exception):
         super().__init__(message)
 
 
-class UndefinedExceptionError(Exception):
+class UndefinedExecutionExceptionError(Exception):
     """Exception used when the exception is undefined."""
 
     def __init__(
@@ -77,7 +77,7 @@ class UndefinedExceptionError(Exception):
         super().__init__(message)
 
 
-class ExceptionMismatchError(Exception):
+class ExecutionExceptionMismatchError(Exception):
     """
     Exception used when the actual block/transaction error string differs from
     the expected one.
@@ -167,10 +167,12 @@ class ExceptionInfo:
             self.actual_exception,
         )
         if expected_exception and not actual_exception:
-            raise UnexpectedSuccessError(execution_context=self.execution_context, **self.context)
+            raise UnexpectedExecutionSuccessError(
+                execution_context=self.execution_context, **self.context
+            )
         elif not expected_exception and actual_exception:
             assert self.message is not None
-            raise UnexpectedFailError(
+            raise UnexpectedExecutionFailError(
                 execution_context=self.execution_context,
                 message=self.message,
                 exception=actual_exception,
@@ -178,7 +180,7 @@ class ExceptionInfo:
             )
         elif expected_exception and actual_exception:
             if isinstance(actual_exception, UndefinedException):
-                raise UndefinedExceptionError(
+                raise UndefinedExecutionExceptionError(
                     execution_context=self.execution_context,
                     want_exception=expected_exception,
                     actual_exception=actual_exception,
@@ -188,7 +190,7 @@ class ExceptionInfo:
                 if actual_exception not in expected_exception:
                     got_message = self.message
                     assert got_message is not None
-                    raise ExceptionMismatchError(
+                    raise ExecutionExceptionMismatchError(
                         execution_context=self.execution_context,
                         want_exception=expected_exception,
                         got_exception=actual_exception,

--- a/src/ethereum_test_specs/helpers.py
+++ b/src/ethereum_test_specs/helpers.py
@@ -1,7 +1,8 @@
 """Helper functions."""
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Literal
+from enum import Enum
+from typing import Any, Dict, List
 
 import pytest
 
@@ -16,13 +17,21 @@ from ethereum_test_exceptions import (
 from ethereum_test_types import Transaction, TransactionReceipt
 
 
+class ExecutionContext(Enum):
+    """The execution context in which a test case can fail."""
+
+    BLOCK = "Block"
+    TRANSACTION = "Transaction"
+
+
 class UnexpectedSuccessError(Exception):
     """Exception used when the transaction expected to fail succeeded instead."""
 
-    def __init__(self, ty: Literal["Block", "Transaction"], **kwargs):
+    def __init__(self, execution_context: ExecutionContext, **kwargs):
         """Initialize the unexpected success exception."""
         message = (
-            f"\nUnexpected success on {ty} ({kwargs}):\n  What: {ty} expected to fail succeeded!"
+            f"\nUnexpected success for {execution_context.value} ({kwargs}):"
+            f"\n  What: {execution_context.value} expected to fail succeeded!"
         )
         super().__init__(message)
 
@@ -32,15 +41,15 @@ class UnexpectedFailError(Exception):
 
     def __init__(
         self,
-        ty: Literal["Block", "Transaction"],
+        execution_context: ExecutionContext,
         message: str,
         exception: ExceptionBase | UndefinedException,
         **kwargs,
     ):
         """Initialize the exception."""
         message = (
-            f"Unexpected fail on {ty} ({kwargs}):"
-            f"\n   What: {ty} unexpectedly failed!"
+            f"Unexpected fail for {execution_context.value} ({kwargs}):"
+            f"\n   What: {execution_context.value} unexpectedly failed!"
             f'\n  Error: "{message}" ({exception})'
         )
         super().__init__(message)
@@ -51,15 +60,15 @@ class UndefinedExceptionError(Exception):
 
     def __init__(
         self,
-        ty: Literal["Block", "Transaction"],
+        execution_context: ExecutionContext,
         want_exception: ExceptionBase | List[ExceptionBase],
         got_exception: UndefinedException,
         **kwargs,
     ):
         """Initialize the exception."""
         message = (
-            f"Exception mismatch on {ty} ({kwargs}):"
-            f"\n   What: {ty} exception mismatch!"
+            f"Exception mismatch on {execution_context.value} ({kwargs}):"
+            f"\n   What: {execution_context.value} exception mismatch!"
             f"\n   Want: {want_exception}"
             f'\n    Got: "{got_exception}"'
             "\n No exception defined for error message got, please add it to "
@@ -76,7 +85,7 @@ class ExceptionMismatchError(Exception):
 
     def __init__(
         self,
-        ty: Literal["Block", "Transaction"],
+        execution_context: ExecutionContext,
         want_exception: ExceptionBase | List[ExceptionBase],
         got_exception: ExceptionBase,
         got_message: str,
@@ -84,8 +93,8 @@ class ExceptionMismatchError(Exception):
     ):
         """Initialize the exception."""
         message = (
-            f"Exception mismatch on {ty} ({kwargs}):"
-            f"\n   What: {ty} exception mismatch!"
+            f"Exception mismatch on {execution_context.value} ({kwargs}):"
+            f"\n   What: {execution_context.value} exception mismatch!"
             f"\n   Want: {want_exception}"
             f'\n    Got: "{got_exception}" ({got_message})'
         )
@@ -116,7 +125,7 @@ class TransactionReceiptMismatchError(Exception):
 class ExceptionInfo:
     """Info to print transaction exception error messages."""
 
-    ty: Literal["Block", "Transaction"]
+    execution_context: ExecutionContext
     expected_exception: List[ExceptionBase] | ExceptionBase | None
     actual_exception: ExceptionBase | UndefinedException | None
     message: str | None
@@ -126,14 +135,14 @@ class ExceptionInfo:
     def __init__(
         self,
         *,
-        ty: Literal["Block", "Transaction"],
+        execution_context: ExecutionContext,
         expected_exception: List[ExceptionBase] | ExceptionBase | None,
         actual_exception: ExceptionWithMessage | UndefinedException | None,
         strict_match: bool = False,
         context: Dict[str, Any],
     ):
         """Initialize the exception."""
-        self.ty = ty
+        self.execution_context = execution_context
         self.expected_exception = expected_exception
         self.actual_exception = (
             actual_exception.exception
@@ -158,11 +167,11 @@ class ExceptionInfo:
             self.actual_exception,
         )
         if expected_exception and not actual_exception:
-            raise UnexpectedSuccessError(ty=self.ty, **self.context)
+            raise UnexpectedSuccessError(execution_context=self.execution_context, **self.context)
         elif not expected_exception and actual_exception:
             assert self.message is not None
             raise UnexpectedFailError(
-                ty=self.ty,
+                execution_context=self.execution_context,
                 message=self.message,
                 exception=actual_exception,
                 **self.context,
@@ -170,7 +179,7 @@ class ExceptionInfo:
         elif expected_exception and actual_exception:
             if isinstance(actual_exception, UndefinedException):
                 raise UndefinedExceptionError(
-                    ty=self.ty,
+                    execution_context=self.execution_context,
                     want_exception=expected_exception,
                     actual_exception=actual_exception,
                     **self.context,
@@ -180,7 +189,7 @@ class ExceptionInfo:
                     got_message = self.message
                     assert got_message is not None
                     raise ExceptionMismatchError(
-                        ty=self.ty,
+                        execution_context=self.execution_context,
                         want_exception=expected_exception,
                         got_exception=actual_exception,
                         got_message=got_message,
@@ -201,7 +210,7 @@ class TransactionExceptionInfo(ExceptionInfo):
     ):
         """Initialize the exception."""
         super().__init__(
-            ty="Transaction",
+            execution_context=ExecutionContext.TRANSACTION,
             expected_exception=tx.error,  # type: ignore
             strict_match=False,  # TODO: set to True when EELS t8n returns correct error messages
             context={"index": tx_index, "nonce": tx.nonce},
@@ -219,7 +228,7 @@ class BlockExceptionInfo(ExceptionInfo):
     ):
         """Initialize the exception."""
         super().__init__(
-            ty="Block",
+            execution_context=ExecutionContext.BLOCK,
             strict_match=True,
             context={"number": block_number},
             **kwargs,

--- a/src/ethereum_test_specs/tests/test_expect.py
+++ b/src/ethereum_test_specs/tests/test_expect.py
@@ -14,10 +14,10 @@ from ethereum_test_types import Alloc, Environment, Storage, Transaction, Transa
 
 from ..blockchain import BlockchainEngineFixture, BlockchainTest
 from ..helpers import (
-    ExceptionMismatchError,
+    ExecutionExceptionMismatchError,
     TransactionReceiptMismatchError,
-    UnexpectedFailError,
-    UnexpectedSuccessError,
+    UnexpectedExecutionFailError,
+    UnexpectedExecutionSuccessError,
 )
 from ..state import StateTest
 
@@ -276,8 +276,8 @@ def test_post_account_mismatch(state_test, t8n, fork, exception_type: Type[Excep
                 secret_key=TestPrivateKey,
                 expected_receipt=TransactionReceipt(gas_used=21_000),
             ),
-            ExceptionMismatchError,
-            id="TransactionExceptionMismatchError",
+            ExecutionExceptionMismatchError,
+            id="TransactionExecutionExceptionMismatchError",
             marks=pytest.mark.xfail(
                 reason="Exceptions need to be better described in the t8n tool."
             ),
@@ -288,8 +288,8 @@ def test_post_account_mismatch(state_test, t8n, fork, exception_type: Type[Excep
                 error=TransactionException.INTRINSIC_GAS_TOO_LOW,
                 expected_receipt=TransactionReceipt(gas_used=21_000),
             ),
-            UnexpectedSuccessError,
-            id="TransactionUnexpectedSuccessError",
+            UnexpectedExecutionSuccessError,
+            id="TransactionUnexpectedExecutionSuccessError",
         ),
         pytest.param(
             Transaction(
@@ -297,8 +297,8 @@ def test_post_account_mismatch(state_test, t8n, fork, exception_type: Type[Excep
                 gas_limit=20_999,
                 expected_receipt=TransactionReceipt(gas_used=21_000),
             ),
-            UnexpectedFailError,
-            id="TransactionUnexpectedFailError",
+            UnexpectedExecutionFailError,
+            id="TransactionUnexpectedExecutionFailError",
         ),
         pytest.param(
             Transaction(
@@ -314,8 +314,8 @@ def test_post_account_mismatch(state_test, t8n, fork, exception_type: Type[Excep
                 gas_limit=20_999,
                 expected_receipt=TransactionReceipt(gas_used=21_001),
             ),
-            UnexpectedFailError,
-            id="TransactionUnexpectedFailError+TransactionReceiptMismatchError",
+            UnexpectedExecutionFailError,
+            id="TransactionUnexpectedExecutionFailError+TransactionReceiptMismatchError",
         ),
         pytest.param(
             Transaction(
@@ -323,8 +323,8 @@ def test_post_account_mismatch(state_test, t8n, fork, exception_type: Type[Excep
                 error=TransactionException.INTRINSIC_GAS_TOO_LOW,
                 expected_receipt=TransactionReceipt(gas_used=21_001),
             ),
-            UnexpectedSuccessError,
-            id="TransactionUnexpectedSuccessError+TransactionReceiptMismatchError",
+            UnexpectedExecutionSuccessError,
+            id="TransactionUnexpectedExecutionSuccessError+TransactionReceiptMismatchError",
         ),
     ],
 )


### PR DESCRIPTION
## 🗒️ Description
Couple of suggestions for `src/ethereum_test_specs/helpers.py` in #1396:
1. Define an enum class instead of using string literal for the execution context of the exception.
2. Rename `ty` to `execution_context`.
3. Add more specific exception class names.

## 🔗 Related Issues
#1396 
