### PR TITLE
feat(fill,execute): add new `zkevm` marker

### DIFF
--- a/src/pytest_plugins/shared/execute_fill.py
+++ b/src/pytest_plugins/shared/execute_fill.py
@@ -81,6 +81,10 @@ def pytest_configure(config: pytest.Config):
         "markers",
         "execute: Markers to be added in execute mode only.",
     )
+    config.addinivalue_line(
+        "markers",
+        "zkvm: Tests that are relevant to zkVM.",
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/src/pytest_plugins/shared/execute_fill.py
+++ b/src/pytest_plugins/shared/execute_fill.py
@@ -83,7 +83,7 @@ def pytest_configure(config: pytest.Config):
     )
     config.addinivalue_line(
         "markers",
-        "zkvm: Tests that are relevant to zkVM.",
+        "zkevm: Tests that are relevant to zkEVM.",
     )
 
 


### PR DESCRIPTION
## 🗒️ Description
Adds a marker that we can apply to tests that are relevant to zkEVM by using:

```python
@pytest.mark.zkevm
```

We can run fill for every fork but only tests that use this marker, e.g.:
```
uv run fill --from=Cancun --until=Osaka -m zkevm
```

@kevaundray

## 🔗 Related Issues
None

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.