### PR TITLE
fix(tests): EIP-7702: send tx of eoa after setcode tx is mined

### DIFF
--- a/src/ethereum_test_execution/transaction_post.py
+++ b/src/ethereum_test_execution/transaction_post.py
@@ -14,7 +14,7 @@ from .base import BaseExecute
 class TransactionPost(BaseExecute):
     """Represents a simple transaction-send then post-check execution format."""
 
-    transactions: List[Transaction]
+    blocks: List[List[Transaction]]
     post: Alloc
 
     format_name: ClassVar[str] = "transaction_post"
@@ -24,20 +24,20 @@ class TransactionPost(BaseExecute):
 
     def execute(self, eth_rpc: EthRPC):
         """Execute the format."""
-        assert not any(tx.ty == 3 for tx in self.transactions), (
+        assert not any(tx.ty == 3 for block in self.blocks for tx in block), (
             "Transaction type 3 is not supported in execute mode."
         )
-        if any(tx.error is not None for tx in self.transactions):
-            for transaction in self.transactions:
-                if transaction.error is None:
-                    eth_rpc.send_wait_transaction(transaction.with_signature_and_sender())
-                else:
-                    with pytest.raises(SendTransactionExceptionError):
-                        eth_rpc.send_transaction(transaction.with_signature_and_sender())
+        if any(tx.error is not None for block in self.blocks for tx in block):
+            for block in self.blocks:
+                for transaction in block:
+                    if transaction.error is None:
+                        eth_rpc.send_wait_transaction(transaction.with_signature_and_sender())
+                    else:
+                        with pytest.raises(SendTransactionExceptionError):
+                            eth_rpc.send_transaction(transaction.with_signature_and_sender())
         else:
-            eth_rpc.send_wait_transactions(
-                [tx.with_signature_and_sender() for tx in self.transactions]
-            )
+            for block in self.blocks:
+                eth_rpc.send_wait_transactions([tx.with_signature_and_sender() for tx in block])
 
         for address, account in self.post.root.items():
             balance = eth_rpc.get_balance(address)

--- a/src/ethereum_test_execution/transaction_post.py
+++ b/src/ethereum_test_execution/transaction_post.py
@@ -27,16 +27,15 @@ class TransactionPost(BaseExecute):
         assert not any(tx.ty == 3 for block in self.blocks for tx in block), (
             "Transaction type 3 is not supported in execute mode."
         )
-        if any(tx.error is not None for block in self.blocks for tx in block):
-            for block in self.blocks:
+        for block in self.blocks:
+            if any(tx.error is not None for tx in block):
                 for transaction in block:
                     if transaction.error is None:
                         eth_rpc.send_wait_transaction(transaction.with_signature_and_sender())
                     else:
                         with pytest.raises(SendTransactionExceptionError):
                             eth_rpc.send_transaction(transaction.with_signature_and_sender())
-        else:
-            for block in self.blocks:
+            else:
                 eth_rpc.send_wait_transactions([tx.with_signature_and_sender() for tx in block])
 
         for address, account in self.post.root.items():

--- a/src/ethereum_test_specs/blockchain.py
+++ b/src/ethereum_test_specs/blockchain.py
@@ -750,11 +750,11 @@ class BlockchainTest(BaseTest):
     ) -> BaseExecute:
         """Generate the list of test fixtures."""
         if execute_format == TransactionPost:
-            txs: List[Transaction] = []
+            blocks: List[List[Transaction]] = []
             for block in self.blocks:
-                txs += block.txs
+                blocks += [block.txs]
             return TransactionPost(
-                transactions=txs,
+                blocks=blocks,
                 post=self.post,
             )
         raise Exception(f"Unsupported execute format: {execute_format}")

--- a/src/ethereum_test_specs/state.py
+++ b/src/ethereum_test_specs/state.py
@@ -239,7 +239,7 @@ class StateTest(BaseTest):
         """Generate the list of test fixtures."""
         if execute_format == TransactionPost:
             return TransactionPost(
-                transactions=[self.tx],
+                blocks=[[self.tx]],
                 post=self.post,
             )
         raise Exception(f"Unsupported execute format: {execute_format}")

--- a/src/ethereum_test_specs/transaction.py
+++ b/src/ethereum_test_specs/transaction.py
@@ -100,7 +100,7 @@ class TransactionTest(BaseTest):
         """Execute the transaction test by sending it to the live network."""
         if execute_format == TransactionPost:
             return TransactionPost(
-                transactions=[self.tx],
+                blocks=[[self.tx]],
                 post={},
             )
         raise Exception(f"Unsupported execute format: {execute_format}")

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -2732,88 +2732,106 @@ def test_eoa_tx_after_set_code(
     set_code = Op.SSTORE(1, Op.ADD(Op.SLOAD(1), 1)) + Op.STOP
     set_code_to_address = pre.deploy_contract(set_code)
 
-    txs = [
-        Transaction(
-            sender=pre.fund_eoa(),
-            gas_limit=500_000,
-            to=auth_signer,
-            value=0,
-            authorization_list=[
-                AuthorizationTuple(
-                    address=set_code_to_address,
-                    nonce=0,
-                    signer=auth_signer,
-                ),
-            ],
+    blocks = [
+        Block(
+            txs=[
+                Transaction(
+                    sender=pre.fund_eoa(),
+                    gas_limit=500_000,
+                    to=auth_signer,
+                    value=0,
+                    authorization_list=[
+                        AuthorizationTuple(
+                            address=set_code_to_address,
+                            nonce=0,
+                            signer=auth_signer,
+                        ),
+                    ],
+                )
+            ]
         )
     ]
     auth_signer.nonce += 1  # type: ignore
 
     match tx_type:
         case 0:
-            txs.append(
-                Transaction(
-                    type=tx_type,
-                    sender=auth_signer,
-                    gas_limit=500_000,
-                    to=auth_signer,
-                    value=0,
-                    protected=True,
-                ),
-            )
-            txs.append(
-                Transaction(
-                    type=tx_type,
-                    sender=auth_signer,
-                    gas_limit=500_000,
-                    to=auth_signer,
-                    value=0,
-                    protected=False,
+            blocks.append(
+                Block(
+                    txs=[
+                        Transaction(
+                            type=tx_type,
+                            sender=auth_signer,
+                            gas_limit=500_000,
+                            to=auth_signer,
+                            value=0,
+                            protected=True,
+                        ),
+                        Transaction(
+                            type=tx_type,
+                            sender=auth_signer,
+                            gas_limit=500_000,
+                            to=auth_signer,
+                            value=0,
+                            protected=False,
+                        ),
+                    ]
                 ),
             )
         case 1:
-            txs.append(
-                Transaction(
-                    type=tx_type,
-                    sender=auth_signer,
-                    gas_limit=500_000,
-                    to=auth_signer,
-                    value=0,
-                    access_list=[
-                        AccessList(
-                            address=auth_signer,
-                            storage_keys=[1],
+            blocks.append(
+                Block(
+                    txs=[
+                        Transaction(
+                            type=tx_type,
+                            sender=auth_signer,
+                            gas_limit=500_000,
+                            to=auth_signer,
+                            value=0,
+                            access_list=[
+                                AccessList(
+                                    address=auth_signer,
+                                    storage_keys=[1],
+                                )
+                            ],
                         )
-                    ],
+                    ]
                 ),
             )
         case 2:
-            txs.append(
-                Transaction(
-                    type=tx_type,
-                    sender=auth_signer,
-                    gas_limit=500_000,
-                    to=auth_signer,
-                    value=0,
-                    max_fee_per_gas=1_000,
-                    max_priority_fee_per_gas=1_000,
+            blocks.append(
+                Block(
+                    txs=[
+                        Transaction(
+                            type=tx_type,
+                            sender=auth_signer,
+                            gas_limit=500_000,
+                            to=auth_signer,
+                            value=0,
+                            max_fee_per_gas=1_000,
+                            max_priority_fee_per_gas=1_000,
+                        )
+                    ]
                 ),
             )
         case 3:
-            txs.append(
-                Transaction(
-                    type=tx_type,
-                    sender=auth_signer,
-                    gas_limit=500_000,
-                    to=auth_signer,
-                    value=0,
-                    max_fee_per_gas=1_000,
-                    max_priority_fee_per_gas=1_000,
-                    max_fee_per_blob_gas=fork.min_base_fee_per_blob_gas() * 10,
-                    blob_versioned_hashes=add_kzg_version(
-                        [Hash(1)],
-                        Spec4844.BLOB_COMMITMENT_VERSION_KZG,
-                    ),
+            blocks.append(
+                Block(
+                    txs=[
+                        Transaction(
+                            type=tx_type,
+                            sender=auth_signer,
+                            gas_limit=500_000,
+                            to=auth_signer,
+                            value=0,
+                            max_fee_per_gas=1_000,
+                            max_priority_fee_per_gas=1_000,
+                            max_fee_per_blob_gas=fork.min_base_fee_per_blob_gas() * 10,
+                            blob_versioned_hashes=add_kzg_version(
+                                [Hash(1)],
+                                Spec4844.BLOB_COMMITMENT_VERSION_KZG,
+                            ),
+                        )
+                    ]
                 ),
             )
         case _:
@@ -2821,7 +2839,7 @@ def test_eoa_tx_after_set_code(
 
     blockchain_test(
         pre=pre,
-        blocks=[Block(txs=txs)],
+        blocks=blocks,
         post={
             auth_signer: Account(
                 nonce=3 if tx_type == 0 else 2,


### PR DESCRIPTION
## 🗒️ Description

Currently, the test `test_eoa_tx_after_set_code` is including both setcode tx that sets code for an EOA and tx using EOA as sender in same block. However, it is invalid due to changes introduced in this PR https://github.com/ethereum/go-ethereum/pull/31430. When I try to run this test in `execute` mode, the second tx is rejected with the error `gapped-nonce tx from delegated accounts`

Here is my solution to fix it:
- I split txs into two blocks; the first includes setcode tx that set code for an EOA, and the second is the tx from that EOA
- We need to ensure txs of two different blocks must be included in different block as their order in node, so I refactored `TransactionPost` a little bit to send batches of txs by block.