### PR TITLE
feat(tests): add consolidations & withdrawal requests with `call_depth>2`

### DIFF
--- a/tests/prague/eip6110_deposits/test_deposits.py
+++ b/tests/prague/eip6110_deposits/test_deposits.py
@@ -692,7 +692,7 @@ pytestmark = pytest.mark.valid_from("Prague")
                     tx_gas_limit=2_500_000_000_000,
                 ),
             ],
-            id="single_deposit_from_contract_call_high_depth",
+            id="single_deposit_from_contract_call_depth_high",
         ),
         # TODO: Send eth with the transaction to the contract
     ],

--- a/tests/prague/eip7002_el_triggerable_withdrawals/test_withdrawal_requests.py
+++ b/tests/prague/eip7002_el_triggerable_withdrawals/test_withdrawal_requests.py
@@ -325,12 +325,12 @@ pytestmark = pytest.mark.valid_from("Prague")
                                 fee=Spec.get_fee(0),
                             ),
                         ],
-                        call_depth=1024,
-                        tx_gas_limit=2_500_000_000_000,
+                        call_depth=100,
+                        tx_gas_limit=30_000_000,
                     ),
                 ],
             ],
-            id="single_block_single_withdrawal_request_from_contract_call_high_depth",
+            id="single_block_single_withdrawal_request_from_contract_call_depth_high",
         ),
         pytest.param(
             [

--- a/tests/prague/eip7002_el_triggerable_withdrawals/test_withdrawal_requests.py
+++ b/tests/prague/eip7002_el_triggerable_withdrawals/test_withdrawal_requests.py
@@ -303,6 +303,41 @@ pytestmark = pytest.mark.valid_from("Prague")
                     WithdrawalRequestContract(
                         requests=[
                             WithdrawalRequest(
+                                validator_pubkey=0x01,
+                                amount=0,
+                                fee=Spec.get_fee(0),
+                            ),
+                        ],
+                        call_depth=3,
+                    ),
+                ],
+            ],
+            id="single_block_single_withdrawal_request_from_contract_call_depth_3",
+        ),
+        pytest.param(
+            [
+                [
+                    WithdrawalRequestContract(
+                        requests=[
+                            WithdrawalRequest(
+                                validator_pubkey=0x01,
+                                amount=0,
+                                fee=Spec.get_fee(0),
+                            ),
+                        ],
+                        call_depth=1024,
+                        tx_gas_limit=2_500_000_000_000,
+                    ),
+                ],
+            ],
+            id="single_block_single_withdrawal_request_from_contract_call_high_depth",
+        ),
+        pytest.param(
+            [
+                [
+                    WithdrawalRequestContract(
+                        requests=[
+                            WithdrawalRequest(
                                 validator_pubkey=i + 1,
                                 amount=Spec.MAX_AMOUNT - 1 if i % 2 == 0 else 0,
                                 fee=Spec.get_fee(0),
@@ -504,6 +539,92 @@ pytestmark = pytest.mark.valid_from("Prague")
                 ],
             ],
             id="single_block_single_withdrawal_request_delegatecall_staticcall_callcode",
+        ),
+        pytest.param(
+            [
+                [
+                    WithdrawalRequestContract(
+                        requests=[
+                            WithdrawalRequest(
+                                validator_pubkey=0x01,
+                                amount=0,
+                                fee=Spec.get_fee(0),
+                                valid=False,
+                            )
+                        ],
+                        call_type=Op.DELEGATECALL,
+                        call_depth=3,
+                    ),
+                    WithdrawalRequestContract(
+                        requests=[
+                            WithdrawalRequest(
+                                validator_pubkey=0x01,
+                                amount=0,
+                                fee=Spec.get_fee(0),
+                                valid=False,
+                            )
+                        ],
+                        call_type=Op.STATICCALL,
+                        call_depth=3,
+                    ),
+                    WithdrawalRequestContract(
+                        requests=[
+                            WithdrawalRequest(
+                                validator_pubkey=0x01,
+                                amount=0,
+                                fee=Spec.get_fee(0),
+                                valid=False,
+                            )
+                        ],
+                        call_type=Op.CALLCODE,
+                        call_depth=3,
+                    ),
+                ],
+            ],
+            id="single_block_single_withdrawal_request_delegatecall_staticcall_callcode_call_depth_3",
+        ),
+        pytest.param(
+            [
+                [
+                    WithdrawalRequestContract(
+                        requests=[
+                            WithdrawalRequest(
+                                validator_pubkey=0x01,
+                                amount=0,
+                                fee=Spec.get_fee(0),
+                                valid=False,
+                            )
+                        ],
+                        call_type=Op.DELEGATECALL,
+                        call_depth=1024,
+                    ),
+                    WithdrawalRequestContract(
+                        requests=[
+                            WithdrawalRequest(
+                                validator_pubkey=0x01,
+                                amount=0,
+                                fee=Spec.get_fee(0),
+                                valid=False,
+                            )
+                        ],
+                        call_type=Op.STATICCALL,
+                        call_depth=1024,
+                    ),
+                    WithdrawalRequestContract(
+                        requests=[
+                            WithdrawalRequest(
+                                validator_pubkey=0x01,
+                                amount=0,
+                                fee=Spec.get_fee(0),
+                                valid=False,
+                            )
+                        ],
+                        call_type=Op.CALLCODE,
+                        call_depth=1024,
+                    ),
+                ],
+            ],
+            id="single_block_single_withdrawal_request_delegatecall_staticcall_callcode_call_depth_high",
         ),
     ],
 )

--- a/tests/prague/eip7251_consolidations/test_consolidations.py
+++ b/tests/prague/eip7251_consolidations/test_consolidations.py
@@ -374,10 +374,11 @@ pytestmark = pytest.mark.valid_from("Prague")
                                 source_pubkey=i * 2,
                                 target_pubkey=i * 2 + 1,
                                 fee=Spec.get_fee(0),
+                                gas_limit=6_000_000,
                             )
                             for i in range(Spec.MAX_CONSOLIDATION_REQUESTS_PER_BLOCK * 5)
                         ],
-                        call_depth=1024,
+                        call_depth=100,
                     ),
                 ],
             ],

--- a/tests/prague/eip7251_consolidations/test_consolidations.py
+++ b/tests/prague/eip7251_consolidations/test_consolidations.py
@@ -353,6 +353,42 @@ pytestmark = pytest.mark.valid_from("Prague")
                     ConsolidationRequestContract(
                         requests=[
                             ConsolidationRequest(
+                                source_pubkey=i * 2,
+                                target_pubkey=i * 2 + 1,
+                                fee=Spec.get_fee(0),
+                            )
+                            for i in range(Spec.MAX_CONSOLIDATION_REQUESTS_PER_BLOCK * 5)
+                        ],
+                        call_depth=3,
+                    ),
+                ],
+            ],
+            id="single_block_multiple_consolidation_requests_from_contract_call_depth_3",
+        ),
+        pytest.param(
+            [
+                [
+                    ConsolidationRequestContract(
+                        requests=[
+                            ConsolidationRequest(
+                                source_pubkey=i * 2,
+                                target_pubkey=i * 2 + 1,
+                                fee=Spec.get_fee(0),
+                            )
+                            for i in range(Spec.MAX_CONSOLIDATION_REQUESTS_PER_BLOCK * 5)
+                        ],
+                        call_depth=1024,
+                    ),
+                ],
+            ],
+            id="single_block_multiple_consolidation_requests_from_contract_call_depth_high",
+        ),
+        pytest.param(
+            [
+                [
+                    ConsolidationRequestContract(
+                        requests=[
+                            ConsolidationRequest(
                                 source_pubkey=0x00,
                                 target_pubkey=0x01,
                                 fee=0,
@@ -533,6 +569,92 @@ pytestmark = pytest.mark.valid_from("Prague")
                 ],
             ],
             id="single_block_single_consolidation_request_delegatecall_staticcall_callcode",
+        ),
+        pytest.param(
+            [
+                [
+                    ConsolidationRequestContract(
+                        requests=[
+                            ConsolidationRequest(
+                                source_pubkey=0x01,
+                                target_pubkey=0x02,
+                                fee=Spec.get_fee(0),
+                                valid=False,
+                            )
+                        ],
+                        call_type=Op.DELEGATECALL,
+                        call_depth=3,
+                    ),
+                    ConsolidationRequestContract(
+                        requests=[
+                            ConsolidationRequest(
+                                source_pubkey=0x01,
+                                target_pubkey=0x02,
+                                fee=Spec.get_fee(0),
+                                valid=False,
+                            )
+                        ],
+                        call_type=Op.STATICCALL,
+                        call_depth=3,
+                    ),
+                    ConsolidationRequestContract(
+                        requests=[
+                            ConsolidationRequest(
+                                source_pubkey=0x01,
+                                target_pubkey=0x02,
+                                fee=Spec.get_fee(0),
+                                valid=False,
+                            )
+                        ],
+                        call_type=Op.CALLCODE,
+                        call_depth=3,
+                    ),
+                ],
+            ],
+            id="single_block_single_consolidation_request_delegatecall_staticcall_callcode_call_depth_3",
+        ),
+        pytest.param(
+            [
+                [
+                    ConsolidationRequestContract(
+                        requests=[
+                            ConsolidationRequest(
+                                source_pubkey=0x01,
+                                target_pubkey=0x02,
+                                fee=Spec.get_fee(0),
+                                valid=False,
+                            )
+                        ],
+                        call_type=Op.DELEGATECALL,
+                        call_depth=1024,
+                    ),
+                    ConsolidationRequestContract(
+                        requests=[
+                            ConsolidationRequest(
+                                source_pubkey=0x01,
+                                target_pubkey=0x02,
+                                fee=Spec.get_fee(0),
+                                valid=False,
+                            )
+                        ],
+                        call_type=Op.STATICCALL,
+                        call_depth=1024,
+                    ),
+                    ConsolidationRequestContract(
+                        requests=[
+                            ConsolidationRequest(
+                                source_pubkey=0x01,
+                                target_pubkey=0x02,
+                                fee=Spec.get_fee(0),
+                                valid=False,
+                            )
+                        ],
+                        call_type=Op.CALLCODE,
+                        call_depth=1024,
+                    ),
+                ],
+            ],
+            id="single_block_single_consolidation_request_delegatecall_staticcall_callcode_call_depth_high",
         ),
     ],
 )


### PR DESCRIPTION
## 🗒️ Description
Running coverage on the test cases themselves revealed that although `helpers.py` handled the case for higher call depths  in `update_pre`:
https://github.com/ethereum/execution-spec-tests/blob/ad5c0ad28b7a31c7449dc6899c04d29a6bac34aa/tests/prague/eip7251_consolidations/helpers.py#L190-L212
the logic was never hit in L197:L212.

This PR adds some tests which trigger requests with a `call_depth > 2`.

#### TODO
- [ ] Understand why this new test fails to fill: `tests/prague/eip7251_consolidations/test_consolidations.py::test_consolidation_requests[fork_Prague-blockchain_test-single_block_multiple_consolidation_requests_from_contract_call_depth_high]` 

## 🔗 Related Issues
- #1299

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
