### PR TITLE
feat(consume): add `ExceptionMapper` support to the consume-engine simulator

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,7 +36,9 @@ This feature can be disabled by using `--disable-strict-exception-matching` for 
 
 #### Exceptions
 
-- ✨ New exceptions `BlockException.SYSTEM_CONTRACT_EMPTY` and `BlockException.SYSTEM_CONTRACT_CALL_FAILED` to handle EIP updates [#9508](https://github.com/ethereum/EIPs/pull/9508) and [#9582](https://github.com/ethereum/EIPs/pull/9582) ([#1394](https://github.com/ethereum/execution-spec-tests/pull/1394)).
+- ✨ `BlockException.SYSTEM_CONTRACT_EMPTY`: Raised when a required system contract was not found in the state by the time it was due to execution with a system transaction call ([#1394](https://github.com/ethereum/execution-spec-tests/pull/1394)).
+- ✨ `BlockException.SYSTEM_CONTRACT_CALL_FAILED`: Raised when a system contract call made by a system transaction fails ([#1394](https://github.com/ethereum/execution-spec-tests/pull/1394)).
+- ✨ `BlockException.INVALID_BLOCK_HASH`: Raised when the calculated block hash does not match the expectation (Currently only during Engine API calls) ([#1416](https://github.com/ethereum/execution-spec-tests/pull/1416)).
 
 ### 🧪 Test Cases
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -39,6 +39,7 @@ This feature can be disabled by using `--disable-strict-exception-matching` for 
 - ✨ `BlockException.SYSTEM_CONTRACT_EMPTY`: Raised when a required system contract was not found in the state by the time it was due to execution with a system transaction call ([#1394](https://github.com/ethereum/execution-spec-tests/pull/1394)).
 - ✨ `BlockException.SYSTEM_CONTRACT_CALL_FAILED`: Raised when a system contract call made by a system transaction fails ([#1394](https://github.com/ethereum/execution-spec-tests/pull/1394)).
 - ✨ `BlockException.INVALID_BLOCK_HASH`: Raised when the calculated block hash does not match the expectation (Currently only during Engine API calls) ([#1416](https://github.com/ethereum/execution-spec-tests/pull/1416)).
+- ✨ `BlockException.INVALID_VERSIONED_HASHES`: Raised when a discrepancy is found between versioned hashes in the payload and the ones found in the transactions ([#1416](https://github.com/ethereum/execution-spec-tests/pull/1416)).
 
 ### 🧪 Test Cases
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,14 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 ### 💥 Breaking Change
 
+#### Consume engine strict exception checking
+
+`consume engine` now checks exceptions returned by the execution clients in their Engine API responses, specifically in the `validationError`field of the `engine_newPayloadVX` method.
+
+While not strictly a breaking change since tests will continue to run normally, failures are expected if a client modifies their exception messages.
+
+This feature can be disabled by using `--disable-strict-exception-matching` for specific clients or forks.
+
 ### 🛠️ Framework
 
 #### `fill`
@@ -19,6 +27,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 #### `consume`
 
 - 🐞 Fix fixture tarball downloading with regular, non-Github release URLS and with numerical versions in regular release specs, e.g., `stable@v4.2.0` ([#1437](https://github.com/ethereum/execution-spec-tests/pull/1437)).
+- ✨ `consume engine` now has strict exception mapping enabled by default ([#1416](https://github.com/ethereum/execution-spec-tests/pull/1416)).
 
 #### Tools
 
@@ -37,6 +46,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ [EIP-7623](https://eips.ethereum.org/EIPS/eip-7623): Additionally parametrize transaction validity tests with the `to` set to an EOA account (previously only contracts) ([#1422](https://github.com/ethereum/execution-spec-tests/pull/1422)).
 - ✨ [EIP-7251](https://eips.ethereum.org/EIPS/eip-7251): Add EIP-7251 test cases for modified consolidations contract that allows more consolidations ([#1465](https://github.com/ethereum/execution-spec-tests/pull/1465)).
 - ✨ [EIP-6110](https://eips.ethereum.org/EIPS/eip-6110): Add extra deposit request edge cases, sending eth to the deposit contract while sending a deposit request ([#1467](https://github.com/ethereum/execution-spec-tests/pull/1467)).
+- ✨ [EIP-6110](https://eips.ethereum.org/EIPS/eip-6110): Add cases for deposit log layout and other topics (ERC-20) transfer ([#1371](https://github.com/ethereum/execution-spec-tests/pull/1371)).
 - ✨ [EIP-7251](https://eips.ethereum.org/EIPS/eip-7251): Remove pytest skips for consolidation request cases ([#1449](https://github.com/ethereum/execution-spec-tests/pull/1449)).
 - ✨ [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002), [EIP-7251](https://eips.ethereum.org/EIPS/eip-7251): Add cases to verify behavior of contracts missing at fork ([#1394](https://github.com/ethereum/execution-spec-tests/pull/1394)).
 - ✨ [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002), [EIP-7251](https://eips.ethereum.org/EIPS/eip-7251): Add cases to verify behavior of system contract errors invalidating a block ([#1394](https://github.com/ethereum/execution-spec-tests/pull/1394)).

--- a/src/ethereum_clis/clis/besu.py
+++ b/src/ethereum_clis/clis/besu.py
@@ -244,6 +244,9 @@ class BesuExceptionMapper(ExceptionMapper):
         TransactionException.TYPE_4_TX_CONTRACT_CREATION: (
             "transaction invalid transaction code delegation transactions must have a to address"
         ),
+        TransactionException.TYPE_4_TX_PRE_FORK: (
+            "transaction invalid Transaction type DELEGATE_CODE is invalid"
+        ),
         BlockException.RLP_STRUCTURES_ENCODING: (
             "Failed to decode transactions from block parameter"
         ),

--- a/src/ethereum_clis/clis/besu.py
+++ b/src/ethereum_clis/clis/besu.py
@@ -13,6 +13,7 @@ import requests
 
 from ethereum_test_base_types import BlobSchedule
 from ethereum_test_exceptions import (
+    BlockException,
     EOFException,
     ExceptionBase,
     ExceptionMapper,
@@ -212,36 +213,50 @@ class BesuExceptionMapper(ExceptionMapper):
     """Translate between EEST exceptions and error strings returned by Besu."""
 
     mapping_substring: ClassVar[Dict[ExceptionBase, str]] = {
-        TransactionException.TYPE_4_TX_CONTRACT_CREATION: (
-            "transaction code delegation transactions must have a non-empty code delegation list"
-        ),
-        TransactionException.INSUFFICIENT_ACCOUNT_FUNDS: (
-            "exceeds transaction sender account balance"
-        ),
-        TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED: (
-            "would exceed block maximum"
-        ),
         TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS: (
-            "max fee per blob gas less than block blob gas fee"
+            "transaction invalid tx max fee per blob gas less than block blob gas fee"
         ),
         TransactionException.INSUFFICIENT_MAX_FEE_PER_GAS: (
-            "gasPrice is less than the current BaseFee"
+            "transaction invalid gasPrice is less than the current BaseFee"
         ),
+        TransactionException.PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS: (
+            "transaction invalid max priority fee per gas cannot be greater than max fee per gas"
+        ),
+        TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH: "Invalid versionedHash",
+        TransactionException.TYPE_3_TX_CONTRACT_CREATION: (
+            "transaction invalid transaction blob transactions must have a to address"
+        ),
+        TransactionException.TYPE_3_TX_WITH_FULL_BLOBS: (
+            "Failed to decode transactions from block parameter"
+        ),
+        TransactionException.TYPE_3_TX_ZERO_BLOBS: (
+            "Failed to decode transactions from block parameter"
+        ),
+        TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED: "Invalid Blob Count",
+        TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED: "Invalid Blob Count",
         TransactionException.TYPE_3_TX_PRE_FORK: (
             "Transaction type BLOB is invalid, accepted transaction types are "
             "[EIP1559, ACCESS_LIST, FRONTIER]"
         ),
-        TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH: (
-            "Only supported hash version is 0x01, sha256 hash."
+        TransactionException.TYPE_4_EMPTY_AUTHORIZATION_LIST: (
+            "transaction invalid transaction code delegation transactions must have a "
+            "non-empty code delegation list"
         ),
-        # This message is the same as TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED
-        TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED: "exceed block maximum",
-        TransactionException.TYPE_3_TX_ZERO_BLOBS: (
-            "Blob transaction must have at least one versioned hash"
+        TransactionException.TYPE_4_TX_CONTRACT_CREATION: (
+            "transaction invalid transaction code delegation transactions must have a to address"
         ),
-        TransactionException.INTRINSIC_GAS_TOO_LOW: "intrinsic gas",
-        TransactionException.INITCODE_SIZE_EXCEEDED: "exceeds maximum size",
-        TransactionException.NONCE_MISMATCH_TOO_LOW: "below sender account nonce",
+        BlockException.RLP_STRUCTURES_ENCODING: (
+            "Failed to decode transactions from block parameter"
+        ),
+        BlockException.INCORRECT_EXCESS_BLOB_GAS: (
+            "Payload excessBlobGas does not match calculated excessBlobGas"
+        ),
+        BlockException.BLOB_GAS_USED_ABOVE_LIMIT: (
+            "Payload BlobGasUsed does not match calculated BlobGasUsed"
+        ),
+        BlockException.INCORRECT_BLOB_GAS_USED: (
+            "Payload BlobGasUsed does not match calculated BlobGasUsed"
+        ),
         # TODO EVMONE needs to differentiate when the section is missing in the header or body
         EOFException.MISSING_STOP_OPCODE: "err: no_terminating_instruction",
         EOFException.MISSING_CODE_HEADER: "err: code_section_missing",
@@ -283,4 +298,29 @@ class BesuExceptionMapper(ExceptionMapper):
         EOFException.TOO_MANY_CONTAINERS: "err: too_many_container_sections",
         EOFException.INVALID_CODE_SECTION_INDEX: "err: invalid_code_section_index",
     }
-    mapping_regex: ClassVar[Dict[ExceptionBase, str]] = {}
+    mapping_regex = {
+        BlockException.INVALID_REQUESTS: (
+            r"Invalid execution requests|Requests hash mismatch, calculated: 0x[0-9a-f]+ header: "
+            r"0x[0-9a-f]+"
+        ),
+        BlockException.INVALID_BLOCK_HASH: (
+            r"Computed block hash 0x[0-9a-f]+ does not match block hash parameter 0x[0-9a-f]+"
+        ),
+        TransactionException.INITCODE_SIZE_EXCEEDED: (
+            r"transaction invalid Initcode size of \d+ exceeds maximum size of \d+"
+        ),
+        TransactionException.INSUFFICIENT_ACCOUNT_FUNDS: (
+            r"transaction invalid transaction up-front cost 0x[0-9a-f]+ exceeds transaction "
+            r"sender account balance 0x[0-9a-f]+"
+        ),
+        TransactionException.INTRINSIC_GAS_TOO_LOW: (
+            r"transaction invalid intrinsic gas cost \d+ exceeds gas limit \d+"
+        ),
+        TransactionException.SENDER_NOT_EOA: (
+            r"transaction invalid Sender 0x[0-9a-f]+ has deployed code and so is not authorized "
+            r"to send transactions"
+        ),
+        TransactionException.NONCE_MISMATCH_TOO_LOW: (
+            r"transaction invalid transaction nonce \d+ below sender account nonce \d+"
+        ),
+    }

--- a/src/ethereum_clis/clis/besu.py
+++ b/src/ethereum_clis/clis/besu.py
@@ -235,8 +235,7 @@ class BesuExceptionMapper(ExceptionMapper):
         TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED: "Invalid Blob Count",
         TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED: "Invalid Blob Count",
         TransactionException.TYPE_3_TX_PRE_FORK: (
-            "Transaction type BLOB is invalid, accepted transaction types are "
-            "[EIP1559, ACCESS_LIST, FRONTIER]"
+            "Transaction type BLOB is invalid, accepted transaction types are"
         ),
         TransactionException.TYPE_4_EMPTY_AUTHORIZATION_LIST: (
             "transaction invalid transaction code delegation transactions must have a "

--- a/src/ethereum_clis/clis/besu.py
+++ b/src/ethereum_clis/clis/besu.py
@@ -247,6 +247,7 @@ class BesuExceptionMapper(ExceptionMapper):
         TransactionException.TYPE_4_TX_PRE_FORK: (
             "transaction invalid Transaction type DELEGATE_CODE is invalid"
         ),
+        TransactionException.INVALID_DEPOSIT_EVENT_LAYOUT: "Invalid deposit log",
         BlockException.RLP_STRUCTURES_ENCODING: (
             "Failed to decode transactions from block parameter"
         ),
@@ -307,6 +308,9 @@ class BesuExceptionMapper(ExceptionMapper):
         ),
         BlockException.INVALID_BLOCK_HASH: (
             r"Computed block hash 0x[0-9a-f]+ does not match block hash parameter 0x[0-9a-f]+"
+        ),
+        BlockException.SYSTEM_CONTRACT_CALL_FAILED: (
+            r"System call halted|System call did not execute to completion"
         ),
         TransactionException.INITCODE_SIZE_EXCEEDED: (
             r"transaction invalid Initcode size of \d+ exceeds maximum size of \d+"

--- a/src/ethereum_clis/clis/erigon.py
+++ b/src/ethereum_clis/clis/erigon.py
@@ -1,10 +1,39 @@
 """Erigon execution client transition tool."""
 
-from ethereum_test_exceptions import ExceptionMapper
+from ethereum_test_exceptions import BlockException, ExceptionMapper, TransactionException
 
 
 class ErigonExceptionMapper(ExceptionMapper):
     """Erigon exception mapper."""
 
-    mapping_substring = {}
-    mapping_regex = {}
+    mapping_substring = {
+        TransactionException.SENDER_NOT_EOA: "sender not an eoa",
+        TransactionException.INITCODE_SIZE_EXCEEDED: "max initcode size exceeded",
+        TransactionException.INSUFFICIENT_ACCOUNT_FUNDS: (
+            "insufficient funds for gas * price + value"
+        ),
+        TransactionException.INTRINSIC_GAS_TOO_LOW: "intrinsic gas too low",
+        TransactionException.INSUFFICIENT_MAX_FEE_PER_GAS: "fee cap less than block base fee",
+        TransactionException.PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS: "tip higher than fee cap",
+        TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS: "max fee per blob gas too low",
+        TransactionException.NONCE_MISMATCH_TOO_LOW: "nonce too low",
+        TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH: (
+            "invalid blob versioned hash, must start with VERSIONED_HASH_VERSION_KZG"
+        ),
+        TransactionException.TYPE_3_TX_ZERO_BLOBS: "a blob stx must contain at least one blob",
+        TransactionException.TYPE_3_TX_WITH_FULL_BLOBS: "rlp: expected String or Byte",
+        TransactionException.TYPE_3_TX_CONTRACT_CREATION: "wrong size for To: 0",
+        TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED: (
+            "blobs/blobgas exceeds max"
+        ),
+        TransactionException.TYPE_4_EMPTY_AUTHORIZATION_LIST: (
+            "SetCodeTransaction without authorizations is invalid"
+        ),
+        TransactionException.TYPE_4_TX_CONTRACT_CREATION: "wrong size for To: 0",
+        BlockException.INVALID_REQUESTS: "invalid requests root hash in header",
+        BlockException.INVALID_BLOCK_HASH: "invalid block hash",
+    }
+    mapping_regex = {
+        BlockException.INCORRECT_BLOB_GAS_USED: r"blobGasUsed by execution: \d+, in header: \d+",
+        BlockException.INCORRECT_EXCESS_BLOB_GAS: r"invalid excessBlobGas: have \d+, want \d+",
+    }

--- a/src/ethereum_clis/clis/erigon.py
+++ b/src/ethereum_clis/clis/erigon.py
@@ -1,0 +1,10 @@
+"""Erigon execution client transition tool."""
+
+from ethereum_test_exceptions import ExceptionMapper
+
+
+class ErigonExceptionMapper(ExceptionMapper):
+    """Erigon exception mapper."""
+
+    mapping_substring = {}
+    mapping_regex = {}

--- a/src/ethereum_clis/clis/erigon.py
+++ b/src/ethereum_clis/clis/erigon.py
@@ -31,6 +31,7 @@ class ErigonExceptionMapper(ExceptionMapper):
             "SetCodeTransaction without authorizations is invalid"
         ),
         TransactionException.TYPE_4_TX_CONTRACT_CREATION: "wrong size for To: 0",
+        TransactionException.TYPE_4_TX_PRE_FORK: "setCode tx is not supported by signer",
         BlockException.INVALID_REQUESTS: "invalid requests root hash in header",
         BlockException.INVALID_BLOCK_HASH: "invalid block hash",
     }

--- a/src/ethereum_clis/clis/erigon.py
+++ b/src/ethereum_clis/clis/erigon.py
@@ -17,6 +17,7 @@ class ErigonExceptionMapper(ExceptionMapper):
         TransactionException.PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS: "tip higher than fee cap",
         TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS: "max fee per blob gas too low",
         TransactionException.NONCE_MISMATCH_TOO_LOW: "nonce too low",
+        TransactionException.TYPE_3_TX_PRE_FORK: "blob txn is not supported by signer",
         TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH: (
             "invalid blob versioned hash, must start with VERSIONED_HASH_VERSION_KZG"
         ),

--- a/src/ethereum_clis/clis/erigon.py
+++ b/src/ethereum_clis/clis/erigon.py
@@ -32,6 +32,7 @@ class ErigonExceptionMapper(ExceptionMapper):
         ),
         TransactionException.TYPE_4_TX_CONTRACT_CREATION: "wrong size for To: 0",
         TransactionException.TYPE_4_TX_PRE_FORK: "setCode tx is not supported by signer",
+        TransactionException.INVALID_DEPOSIT_EVENT_LAYOUT: "could not parse requests logs",
         BlockException.INVALID_REQUESTS: "invalid requests root hash in header",
         BlockException.INVALID_BLOCK_HASH: "invalid block hash",
     }

--- a/src/ethereum_clis/clis/ethereumjs.py
+++ b/src/ethereum_clis/clis/ethereumjs.py
@@ -71,6 +71,9 @@ class EthereumJSExceptionMapper(ExceptionMapper):
         TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED: "exceed maximum allowance",
         TransactionException.TYPE_3_TX_ZERO_BLOBS: "tx should contain at least one blob",
         TransactionException.TYPE_3_TX_WITH_FULL_BLOBS: "Invalid EIP-4844 transaction",
+        TransactionException.TYPE_4_TX_CONTRACT_CREATION: (
+            'tx should have a "to" field and cannot be used to create contracts'
+        ),
         TransactionException.TYPE_4_EMPTY_AUTHORIZATION_LIST: (
             "Invalid EIP-7702 transaction: authorization list is empty"
         ),

--- a/src/ethereum_clis/clis/ethereumjs.py
+++ b/src/ethereum_clis/clis/ethereumjs.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import ClassVar, Dict, Optional
 
 from ethereum_test_exceptions import (
+    BlockException,
     EOFException,
     ExceptionBase,
     ExceptionMapper,
@@ -48,30 +49,44 @@ class EthereumJSExceptionMapper(ExceptionMapper):
     """Translate between EEST exceptions and error strings returned by EthereumJS."""
 
     mapping_substring: ClassVar[Dict[ExceptionBase, str]] = {
-        TransactionException.TYPE_4_TX_CONTRACT_CREATION: (
-            "set code transaction must not be a create transaction"
-        ),
-        TransactionException.INSUFFICIENT_ACCOUNT_FUNDS: (
-            "insufficient funds for gas * price + value"
-        ),
         TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED: (
             "would exceed maximum allowance"
         ),
         TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS: (
-            "max fee per blob gas less than block blob gas fee"
+            "Invalid 4844 transactions: undefined"
         ),
         TransactionException.INSUFFICIENT_MAX_FEE_PER_GAS: (
-            "max fee per gas less than block base fee"
+            "tx unable to pay base fee (EIP-1559 tx)"
+        ),
+        TransactionException.PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS: (
+            "maxFeePerGas cannot be less than maxPriorityFeePerGas"
         ),
         TransactionException.TYPE_3_TX_PRE_FORK: (
             "blob tx used but field env.ExcessBlobGas missing"
         ),
-        TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH: "has invalid hash version",
+        TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH: (
+            "versioned hash does not start with KZG commitment version"
+        ),
         # This message is the same as TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED
         TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED: "exceed maximum allowance",
-        TransactionException.TYPE_3_TX_ZERO_BLOBS: "blob transaction missing blob hashes",
+        TransactionException.TYPE_3_TX_ZERO_BLOBS: "tx should contain at least one blob",
+        TransactionException.TYPE_3_TX_WITH_FULL_BLOBS: "Invalid EIP-4844 transaction",
+        TransactionException.TYPE_4_EMPTY_AUTHORIZATION_LIST: (
+            "Invalid EIP-7702 transaction: authorization list is empty"
+        ),
         TransactionException.INTRINSIC_GAS_TOO_LOW: "is lower than the minimum gas limit of",
-        TransactionException.INITCODE_SIZE_EXCEEDED: "max initcode size exceeded",
+        TransactionException.INITCODE_SIZE_EXCEEDED: (
+            "the initcode size of this transaction is too large"
+        ),
+        TransactionException.TYPE_4_TX_CONTRACT_CREATION: (
+            'tx should have a "to" field and cannot be used to create contracts'
+        ),
+        TransactionException.INSUFFICIENT_ACCOUNT_FUNDS: (
+            "sender doesn't have enough funds to send tx"
+        ),
+        TransactionException.NONCE_MISMATCH_TOO_LOW: "the tx doesn't have the correct nonce",
+        BlockException.INCORRECT_EXCESS_BLOB_GAS: "Invalid 4844 transactions",
+        BlockException.INVALID_RECEIPTS_ROOT: "invalid receipttrie",
         # TODO EVMONE needs to differentiate when the section is missing in the header or body
         EOFException.MISSING_STOP_OPCODE: "err: no_terminating_instruction",
         EOFException.MISSING_CODE_HEADER: "err: code_section_missing",
@@ -113,4 +128,19 @@ class EthereumJSExceptionMapper(ExceptionMapper):
         EOFException.TOO_MANY_CONTAINERS: "err: too_many_container_sections",
         EOFException.INVALID_CODE_SECTION_INDEX: "err: invalid_code_section_index",
     }
-    mapping_regex: ClassVar[Dict[ExceptionBase, str]] = {}
+    mapping_regex: ClassVar[Dict[ExceptionBase, str]] = {
+        TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED: (
+            r"tx causes total blob gas of \d+ to exceed maximum blob gas per block of \d+|"
+            r"tx can contain at most \d+ blobs"
+        ),
+        TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED: (
+            r"tx causes total blob gas of \d+ to exceed maximum blob gas per block of \d+|"
+            r"tx can contain at most \d+ blobs"
+        ),
+        BlockException.BLOB_GAS_USED_ABOVE_LIMIT: r"invalid blobGasUsed expected=\d+ actual=\d+",
+        BlockException.INCORRECT_BLOB_GAS_USED: r"invalid blobGasUsed expected=\d+ actual=\d+",
+        BlockException.INVALID_BLOCK_HASH: (
+            r"Invalid blockHash, expected: 0x[0-9a-f]+, received: 0x[0-9a-f]+"
+        ),
+        BlockException.INVALID_REQUESTS: r"Unknown request identifier|invalid requestshash",
+    }

--- a/src/ethereum_clis/clis/ethereumjs.py
+++ b/src/ethereum_clis/clis/ethereumjs.py
@@ -61,9 +61,6 @@ class EthereumJSExceptionMapper(ExceptionMapper):
         TransactionException.PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS: (
             "maxFeePerGas cannot be less than maxPriorityFeePerGas"
         ),
-        TransactionException.TYPE_3_TX_PRE_FORK: (
-            "blob tx used but field env.ExcessBlobGas missing"
-        ),
         TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH: (
             "versioned hash does not start with KZG commitment version"
         ),
@@ -71,7 +68,7 @@ class EthereumJSExceptionMapper(ExceptionMapper):
         TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED: "exceed maximum allowance",
         TransactionException.TYPE_3_TX_ZERO_BLOBS: "tx should contain at least one blob",
         TransactionException.TYPE_3_TX_WITH_FULL_BLOBS: "Invalid EIP-4844 transaction",
-        TransactionException.TYPE_4_TX_CONTRACT_CREATION: (
+        TransactionException.TYPE_3_TX_CONTRACT_CREATION: (
             'tx should have a "to" field and cannot be used to create contracts'
         ),
         TransactionException.TYPE_4_EMPTY_AUTHORIZATION_LIST: (
@@ -139,6 +136,9 @@ class EthereumJSExceptionMapper(ExceptionMapper):
         TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED: (
             r"tx causes total blob gas of \d+ to exceed maximum blob gas per block of \d+|"
             r"tx can contain at most \d+ blobs"
+        ),
+        TransactionException.TYPE_3_TX_PRE_FORK: (
+            r"blob tx used but field env.ExcessBlobGas missing|EIP-4844 not enabled on Common"
         ),
         BlockException.BLOB_GAS_USED_ABOVE_LIMIT: r"invalid blobGasUsed expected=\d+ actual=\d+",
         BlockException.INCORRECT_BLOB_GAS_USED: r"invalid blobGasUsed expected=\d+ actual=\d+",

--- a/src/ethereum_clis/clis/ethereumjs.py
+++ b/src/ethereum_clis/clis/ethereumjs.py
@@ -85,6 +85,7 @@ class EthereumJSExceptionMapper(ExceptionMapper):
             "sender doesn't have enough funds to send tx"
         ),
         TransactionException.NONCE_MISMATCH_TOO_LOW: "the tx doesn't have the correct nonce",
+        TransactionException.INVALID_DEPOSIT_EVENT_LAYOUT: "Error verifying block while running",
         BlockException.INCORRECT_EXCESS_BLOB_GAS: "Invalid 4844 transactions",
         BlockException.INVALID_RECEIPTS_ROOT: "invalid receipttrie",
         # TODO EVMONE needs to differentiate when the section is missing in the header or body

--- a/src/ethereum_clis/clis/geth.py
+++ b/src/ethereum_clis/clis/geth.py
@@ -44,9 +44,7 @@ class GethExceptionMapper(ExceptionMapper):
         TransactionException.PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS: (
             "max priority fee per gas higher than max fee per gas"
         ),
-        TransactionException.TYPE_3_TX_PRE_FORK: (
-            "blob tx used but field env.ExcessBlobGas missing"
-        ),
+        TransactionException.TYPE_3_TX_PRE_FORK: ("transaction type not supported"),
         TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH: "has invalid hash version",
         # This message is the same as TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED
         TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED: "exceed maximum allowance",
@@ -67,6 +65,7 @@ class GethExceptionMapper(ExceptionMapper):
         TransactionException.NONCE_MISMATCH_TOO_LOW: "nonce too low",
         BlockException.INCORRECT_BLOB_GAS_USED: "blob gas used mismatch",
         BlockException.INCORRECT_EXCESS_BLOB_GAS: "invalid excessBlobGas",
+        BlockException.INVALID_VERSIONED_HASHES: "invalid number of versionedHashes",
         BlockException.INVALID_REQUESTS: "invalid requests hash",
         BlockException.INVALID_BLOCK_HASH: "blockhash mismatch",
         # TODO EVMONE needs to differentiate when the section is missing in the header or body

--- a/src/ethereum_clis/clis/geth.py
+++ b/src/ethereum_clis/clis/geth.py
@@ -64,6 +64,7 @@ class GethExceptionMapper(ExceptionMapper):
         TransactionException.TYPE_4_TX_PRE_FORK: ("transaction type not supported"),
         TransactionException.INITCODE_SIZE_EXCEEDED: "max initcode size exceeded",
         TransactionException.NONCE_MISMATCH_TOO_LOW: "nonce too low",
+        TransactionException.INVALID_DEPOSIT_EVENT_LAYOUT: "unable to parse deposit data",
         BlockException.INCORRECT_BLOB_GAS_USED: "blob gas used mismatch",
         BlockException.INCORRECT_EXCESS_BLOB_GAS: "invalid excessBlobGas",
         BlockException.INVALID_VERSIONED_HASHES: "invalid number of versionedHashes",

--- a/src/ethereum_clis/clis/geth.py
+++ b/src/ethereum_clis/clis/geth.py
@@ -61,6 +61,7 @@ class GethExceptionMapper(ExceptionMapper):
         TransactionException.TYPE_4_TX_CONTRACT_CREATION: (
             "input string too short for common.Address, decoding into (types.SetCodeTx).To"
         ),
+        TransactionException.TYPE_4_TX_PRE_FORK: ("transaction type not supported"),
         TransactionException.INITCODE_SIZE_EXCEEDED: "max initcode size exceeded",
         TransactionException.NONCE_MISMATCH_TOO_LOW: "nonce too low",
         BlockException.INCORRECT_BLOB_GAS_USED: "blob gas used mismatch",

--- a/src/ethereum_clis/clis/geth.py
+++ b/src/ethereum_clis/clis/geth.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, ClassVar, Dict, List, Optional
 
 from ethereum_test_exceptions import (
+    BlockException,
     EOFException,
     ExceptionBase,
     ExceptionMapper,
@@ -27,9 +28,7 @@ class GethExceptionMapper(ExceptionMapper):
     """Translate between EEST exceptions and error strings returned by Geth."""
 
     mapping_substring: ClassVar[Dict[ExceptionBase, str]] = {
-        TransactionException.TYPE_4_TX_CONTRACT_CREATION: (
-            "set code transaction must not be a create transaction"
-        ),
+        TransactionException.SENDER_NOT_EOA: "sender not an eoa",
         TransactionException.INSUFFICIENT_ACCOUNT_FUNDS: (
             "insufficient funds for gas * price + value"
         ),
@@ -42,6 +41,9 @@ class GethExceptionMapper(ExceptionMapper):
         TransactionException.INSUFFICIENT_MAX_FEE_PER_GAS: (
             "max fee per gas less than block base fee"
         ),
+        TransactionException.PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS: (
+            "max priority fee per gas higher than max fee per gas"
+        ),
         TransactionException.TYPE_3_TX_PRE_FORK: (
             "blob tx used but field env.ExcessBlobGas missing"
         ),
@@ -49,8 +51,24 @@ class GethExceptionMapper(ExceptionMapper):
         # This message is the same as TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED
         TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED: "exceed maximum allowance",
         TransactionException.TYPE_3_TX_ZERO_BLOBS: "blob transaction missing blob hashes",
-        TransactionException.INTRINSIC_GAS_TOO_LOW: "intrinsic gas too low",
+        TransactionException.TYPE_3_TX_WITH_FULL_BLOBS: (
+            "unexpected blob sidecar in transaction at index"
+        ),
+        TransactionException.TYPE_3_TX_CONTRACT_CREATION: (
+            "input string too short for common.Address, decoding into (types.BlobTx).To"
+        ),
+        TransactionException.TYPE_4_EMPTY_AUTHORIZATION_LIST: (
+            "EIP-7702 transaction with empty auth list"
+        ),
+        TransactionException.TYPE_4_TX_CONTRACT_CREATION: (
+            "input string too short for common.Address, decoding into (types.SetCodeTx).To"
+        ),
         TransactionException.INITCODE_SIZE_EXCEEDED: "max initcode size exceeded",
+        TransactionException.NONCE_MISMATCH_TOO_LOW: "nonce too low",
+        BlockException.INCORRECT_BLOB_GAS_USED: "blob gas used mismatch",
+        BlockException.INCORRECT_EXCESS_BLOB_GAS: "invalid excessBlobGas",
+        BlockException.INVALID_REQUESTS: "invalid requests hash",
+        BlockException.INVALID_BLOCK_HASH: "blockhash mismatch",
         # TODO EVMONE needs to differentiate when the section is missing in the header or body
         EOFException.MISSING_STOP_OPCODE: "err: no_terminating_instruction",
         EOFException.MISSING_CODE_HEADER: "err: code_section_missing",
@@ -92,7 +110,17 @@ class GethExceptionMapper(ExceptionMapper):
         EOFException.TOO_MANY_CONTAINERS: "err: too_many_container_sections",
         EOFException.INVALID_CODE_SECTION_INDEX: "err: invalid_code_section_index",
     }
-    mapping_regex: ClassVar[Dict[ExceptionBase, str]] = {}
+    mapping_regex: ClassVar[Dict[ExceptionBase, str]] = {
+        TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED: (
+            r"blob gas used \d+ exceeds maximum allowance \d+"
+        ),
+        TransactionException.INTRINSIC_GAS_TOO_LOW: (
+            r"intrinsic gas too low|insufficient gas for floor data gas cost"
+        ),
+        BlockException.BLOB_GAS_USED_ABOVE_LIMIT: (
+            r"blob gas used \d+ exceeds maximum allowance \d+"
+        ),
+    }
 
 
 class GethEvm(EthereumCLI):

--- a/src/ethereum_clis/clis/nethermind.py
+++ b/src/ethereum_clis/clis/nethermind.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import pytest
 
-from ethereum_test_exceptions import ExceptionMapper
+from ethereum_test_exceptions import BlockException, ExceptionMapper, TransactionException
 from ethereum_test_fixtures import BlockchainFixture, EOFFixture, FixtureFormat, StateFixture
 
 from ..ethereum_cli import EthereumCLI
@@ -316,3 +316,55 @@ class NethtestFixtureConsumer(
             raise Exception(
                 f"Fixture format {fixture_format.format_name} not supported by {self.binary}"
             )
+
+
+class NethermindExceptionMapper(ExceptionMapper):
+    """Nethermind exception mapper."""
+
+    mapping_substring = {
+        TransactionException.SENDER_NOT_EOA: "sender has deployed code",
+        TransactionException.INSUFFICIENT_ACCOUNT_FUNDS: "insufficient sender balance",
+        TransactionException.INTRINSIC_GAS_TOO_LOW: "intrinsic gas too low",
+        TransactionException.INSUFFICIENT_MAX_FEE_PER_GAS: "miner premium is negative",
+        TransactionException.PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS: (
+            "InvalidMaxPriorityFeePerGas: Cannot be higher than maxFeePerGas"
+        ),
+        TransactionException.INITCODE_SIZE_EXCEEDED: "max initcode size exceeded",
+        TransactionException.NONCE_MISMATCH_TOO_LOW: "wrong transaction nonce",
+        TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS: (
+            "InsufficientMaxFeePerBlobGas: Not enough to cover blob gas fee"
+        ),
+        TransactionException.TYPE_3_TX_ZERO_BLOBS: "blob transaction missing blob hashes",
+        TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH: (
+            "InvalidBlobVersionedHashVersion: Blob version not supported"
+        ),
+        TransactionException.TYPE_3_TX_CONTRACT_CREATION: "blob transaction of type create",
+        TransactionException.TYPE_4_EMPTY_AUTHORIZATION_LIST: (
+            "MissingAuthorizationList: Must be set"
+        ),
+        TransactionException.TYPE_4_TX_CONTRACT_CREATION: (
+            "NotAllowedCreateTransaction: To must be set"
+        ),
+        BlockException.INCORRECT_BLOB_GAS_USED: (
+            "HeaderBlobGasMismatch: Blob gas in header does not match calculated"
+        ),
+        BlockException.INVALID_REQUESTS: "InvalidRequestsHash: Requests hash mismatch in block",
+    }
+    mapping_regex = {
+        TransactionException.TYPE_3_TX_WITH_FULL_BLOBS: r"Transaction \d+ is not valid",
+        TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED: (
+            r"BlobTxGasLimitExceeded: Transaction's totalDataGas=\d+ "
+            r"exceeded MaxBlobGas per transaction=\d+"
+        ),
+        TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED: (
+            r"BlockBlobGasExceeded: A block cannot have more than \d+ blob gas, blobs count \d+, "
+            r"blobs gas used: \d+"
+        ),
+        BlockException.INCORRECT_EXCESS_BLOB_GAS: (
+            r"HeaderExcessBlobGasMismatch: Excess blob gas in header does not match calculated"
+            r"|Overflow in excess blob gas"
+        ),
+        BlockException.INVALID_BLOCK_HASH: (
+            r"Invalid block hash 0x[0-9a-f]+ does not match calculated hash 0x[0-9a-f]+"
+        ),
+    }

--- a/src/ethereum_clis/clis/nethermind.py
+++ b/src/ethereum_clis/clis/nethermind.py
@@ -323,7 +323,6 @@ class NethermindExceptionMapper(ExceptionMapper):
 
     mapping_substring = {
         TransactionException.SENDER_NOT_EOA: "sender has deployed code",
-        TransactionException.INSUFFICIENT_ACCOUNT_FUNDS: "insufficient sender balance",
         TransactionException.INTRINSIC_GAS_TOO_LOW: "intrinsic gas too low",
         TransactionException.INSUFFICIENT_MAX_FEE_PER_GAS: "miner premium is negative",
         TransactionException.PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS: (
@@ -333,6 +332,9 @@ class NethermindExceptionMapper(ExceptionMapper):
         TransactionException.NONCE_MISMATCH_TOO_LOW: "wrong transaction nonce",
         TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS: (
             "InsufficientMaxFeePerBlobGas: Not enough to cover blob gas fee"
+        ),
+        TransactionException.TYPE_3_TX_PRE_FORK: (
+            "InvalidTxType: Transaction type in Custom is not supported"
         ),
         TransactionException.TYPE_3_TX_ZERO_BLOBS: "blob transaction missing blob hashes",
         TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH: (
@@ -351,6 +353,9 @@ class NethermindExceptionMapper(ExceptionMapper):
         BlockException.INVALID_REQUESTS: "InvalidRequestsHash: Requests hash mismatch in block",
     }
     mapping_regex = {
+        TransactionException.INSUFFICIENT_ACCOUNT_FUNDS: (
+            r"insufficient sender balance|insufficient MaxFeePerGas for sender balance"
+        ),
         TransactionException.TYPE_3_TX_WITH_FULL_BLOBS: r"Transaction \d+ is not valid",
         TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED: (
             r"BlobTxGasLimitExceeded: Transaction's totalDataGas=\d+ "

--- a/src/ethereum_clis/clis/nethermind.py
+++ b/src/ethereum_clis/clis/nethermind.py
@@ -347,6 +347,9 @@ class NethermindExceptionMapper(ExceptionMapper):
         TransactionException.TYPE_4_TX_CONTRACT_CREATION: (
             "NotAllowedCreateTransaction: To must be set"
         ),
+        TransactionException.TYPE_4_TX_PRE_FORK: (
+            "InvalidTxType: Transaction type in Custom is not supported"
+        ),
         BlockException.INCORRECT_BLOB_GAS_USED: (
             "HeaderBlobGasMismatch: Blob gas in header does not match calculated"
         ),

--- a/src/ethereum_clis/clis/reth.py
+++ b/src/ethereum_clis/clis/reth.py
@@ -1,0 +1,46 @@
+"""Reth execution client transition tool."""
+
+from ethereum_test_exceptions import BlockException, ExceptionMapper, TransactionException
+
+
+class RethExceptionMapper(ExceptionMapper):
+    """Reth exception mapper."""
+
+    mapping_substring = {
+        TransactionException.SENDER_NOT_EOA: (
+            "reject transactions from senders with deployed code"
+        ),
+        TransactionException.INSUFFICIENT_ACCOUNT_FUNDS: "lack of funds",
+        TransactionException.INITCODE_SIZE_EXCEEDED: "create initcode size limit",
+        TransactionException.INSUFFICIENT_MAX_FEE_PER_GAS: "gas price is less than basefee",
+        TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS: (
+            "blob gas price is greater than max fee per blob gas"
+        ),
+        TransactionException.PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS: (
+            "priority fee is greater than max fee"
+        ),
+        TransactionException.TYPE_3_TX_CONTRACT_CREATION: "unexpected length",
+        TransactionException.TYPE_3_TX_WITH_FULL_BLOBS: "unexpected list",
+        TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH: "blob version not supported",
+        TransactionException.TYPE_3_TX_ZERO_BLOBS: "empty blobs",
+        TransactionException.TYPE_4_EMPTY_AUTHORIZATION_LIST: "empty authorization list",
+        TransactionException.TYPE_4_TX_CONTRACT_CREATION: "unexpected length",
+        BlockException.INVALID_REQUESTS: "mismatched block requests hash",
+        BlockException.INVALID_RECEIPTS_ROOT: "receipt root mismatch",
+        BlockException.INVALID_STATE_ROOT: "mismatched block state root",
+        BlockException.INVALID_BLOCK_HASH: "block hash mismatch",
+        BlockException.INVALID_GAS_USED: "block gas used mismatch",
+    }
+    mapping_regex = {
+        TransactionException.NONCE_MISMATCH_TOO_LOW: r"nonce \d+ too low, expected \d+",
+        TransactionException.INTRINSIC_GAS_TOO_LOW: (
+            r"(call gas cost|gas floor) \(\d+\) exceeds the gas limit \(\d+\)"
+        ),
+        TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED: r"too many blobs, have \d+, max \d+",
+        BlockException.INCORRECT_BLOB_GAS_USED: (
+            r"blob gas used mismatch|blob gas used \d+ is not a multiple of blob gas per blob"
+        ),
+        BlockException.INCORRECT_EXCESS_BLOB_GAS: (
+            r"excess blob gas \d+ is not a multiple of blob gas per blob|invalid excess blob gas"
+        ),
+    }

--- a/src/ethereum_clis/clis/reth.py
+++ b/src/ethereum_clis/clis/reth.py
@@ -27,6 +27,9 @@ class RethExceptionMapper(ExceptionMapper):
         ),
         TransactionException.TYPE_4_EMPTY_AUTHORIZATION_LIST: "empty authorization list",
         TransactionException.TYPE_4_TX_CONTRACT_CREATION: "unexpected length",
+        TransactionException.TYPE_4_TX_PRE_FORK: (
+            "eip 7702 transactions present in pre-prague payload"
+        ),
         BlockException.INVALID_REQUESTS: "mismatched block requests hash",
         BlockException.INVALID_RECEIPTS_ROOT: "receipt root mismatch",
         BlockException.INVALID_STATE_ROOT: "mismatched block state root",

--- a/src/ethereum_clis/clis/reth.py
+++ b/src/ethereum_clis/clis/reth.py
@@ -22,7 +22,9 @@ class RethExceptionMapper(ExceptionMapper):
         TransactionException.TYPE_3_TX_CONTRACT_CREATION: "unexpected length",
         TransactionException.TYPE_3_TX_WITH_FULL_BLOBS: "unexpected list",
         TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH: "blob version not supported",
-        TransactionException.TYPE_3_TX_ZERO_BLOBS: "empty blobs",
+        TransactionException.TYPE_3_TX_ZERO_BLOBS: (
+            "blob transactions present in pre-cancun payload"
+        ),
         TransactionException.TYPE_4_EMPTY_AUTHORIZATION_LIST: "empty authorization list",
         TransactionException.TYPE_4_TX_CONTRACT_CREATION: "unexpected length",
         BlockException.INVALID_REQUESTS: "mismatched block requests hash",

--- a/src/ethereum_clis/clis/reth.py
+++ b/src/ethereum_clis/clis/reth.py
@@ -36,7 +36,9 @@ class RethExceptionMapper(ExceptionMapper):
         TransactionException.INTRINSIC_GAS_TOO_LOW: (
             r"(call gas cost|gas floor) \(\d+\) exceeds the gas limit \(\d+\)"
         ),
-        TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED: r"too many blobs, have \d+, max \d+",
+        TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED: (
+            r"blob gas used \d+ exceeds maximum allowance \d+"
+        ),
         BlockException.INCORRECT_BLOB_GAS_USED: (
             r"blob gas used mismatch|blob gas used \d+ is not a multiple of blob gas per blob"
         ),

--- a/src/ethereum_clis/clis/reth.py
+++ b/src/ethereum_clis/clis/reth.py
@@ -22,13 +22,13 @@ class RethExceptionMapper(ExceptionMapper):
         TransactionException.TYPE_3_TX_CONTRACT_CREATION: "unexpected length",
         TransactionException.TYPE_3_TX_WITH_FULL_BLOBS: "unexpected list",
         TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH: "blob version not supported",
-        TransactionException.TYPE_3_TX_ZERO_BLOBS: (
-            "blob transactions present in pre-cancun payload"
-        ),
         TransactionException.TYPE_4_EMPTY_AUTHORIZATION_LIST: "empty authorization list",
         TransactionException.TYPE_4_TX_CONTRACT_CREATION: "unexpected length",
         TransactionException.TYPE_4_TX_PRE_FORK: (
             "eip 7702 transactions present in pre-prague payload"
+        ),
+        TransactionException.INVALID_DEPOSIT_EVENT_LAYOUT: (
+            "failed to decode deposit requests from receipts"
         ),
         BlockException.INVALID_REQUESTS: "mismatched block requests hash",
         BlockException.INVALID_RECEIPTS_ROOT: "receipt root mismatch",
@@ -44,6 +44,10 @@ class RethExceptionMapper(ExceptionMapper):
         TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED: (
             r"blob gas used \d+ exceeds maximum allowance \d+"
         ),
+        TransactionException.TYPE_3_TX_ZERO_BLOBS: (
+            r"blob transactions present in pre-cancun payload|empty blobs"
+        ),
+        BlockException.SYSTEM_CONTRACT_CALL_FAILED: (r"failed to apply .* requests contract call"),
         BlockException.INCORRECT_BLOB_GAS_USED: (
             r"blob gas used mismatch|blob gas used \d+ is not a multiple of blob gas per blob"
         ),

--- a/src/ethereum_test_exceptions/exception_mapper.py
+++ b/src/ethereum_test_exceptions/exception_mapper.py
@@ -2,7 +2,7 @@
 
 import re
 from abc import ABC
-from typing import Any, ClassVar, Dict, Generic
+from typing import Any, ClassVar, Dict, Generic, List
 
 from pydantic import BaseModel, BeforeValidator, ValidationInfo
 
@@ -48,14 +48,19 @@ class ExceptionMapper(ABC):
             exception: re.compile(message) for exception, message in self.mapping_regex.items()
         }
 
-    def message_to_exception(self, exception_string: str) -> ExceptionBase | UndefinedException:
+    def message_to_exception(
+        self, exception_string: str
+    ) -> List[ExceptionBase] | UndefinedException:
         """Match a formatted string to an exception."""
+        exceptions: List[ExceptionBase] = []
         for exception, substring in self.mapping_substring.items():
             if substring in exception_string:
-                return exception
+                exceptions.append(exception)
         for exception, pattern in self._mapping_compiled_regex.items():
             if pattern.search(exception_string):
-                return exception
+                exceptions.append(exception)
+        if exceptions:
+            return exceptions
         return UndefinedException(exception_string, mapper_name=self.mapper_name)
 
 
@@ -65,8 +70,18 @@ class ExceptionWithMessage(BaseModel, Generic[ExceptionBoundTypeVar]):
     tool/client.
     """
 
-    exception: ExceptionBoundTypeVar
+    exceptions: List[ExceptionBoundTypeVar]
     message: str
+
+    def __contains__(self, item: Any) -> bool:
+        """Check if the item is in the exceptions list."""
+        if isinstance(item, list):
+            return any(exception in self.exceptions for exception in item)
+        return item in self.exceptions
+
+    def __str__(self):
+        """Return the string representation of the exception message."""
+        return f"[{' | '.join(str(e) for e in self.exceptions)}] {self.message}"
 
 
 def mapper_validator(v: str, info: ValidationInfo) -> Dict[str, Any] | UndefinedException | None:
@@ -84,11 +99,11 @@ def mapper_validator(v: str, info: ValidationInfo) -> Dict[str, Any] | Undefined
     assert isinstance(exception_mapper, ExceptionMapper), (
         f"Invalid mapper provided {exception_mapper}"
     )
-    exception = exception_mapper.message_to_exception(v)
-    if isinstance(exception, UndefinedException):
-        return exception
+    exceptions = exception_mapper.message_to_exception(v)
+    if isinstance(exceptions, UndefinedException):
+        return exceptions
     return {
-        "exception": exception,
+        "exceptions": exceptions,
         "message": v,
     }
 

--- a/src/ethereum_test_exceptions/exception_mapper.py
+++ b/src/ethereum_test_exceptions/exception_mapper.py
@@ -76,8 +76,11 @@ def mapper_validator(v: str, info: ValidationInfo) -> Dict[str, Any] | Undefined
     """
     if v is None:
         return v
-    assert isinstance(info.context, dict), f"Invalid context provided: {info.context}"
+    if not isinstance(info.context, dict):
+        return UndefinedException(v, mapper_name="UndefinedExceptionMapper: No context")
     exception_mapper = info.context.get("exception_mapper")
+    if exception_mapper is None:
+        return UndefinedException(v, mapper_name="UndefinedExceptionMapper: No mapper")
     assert isinstance(exception_mapper, ExceptionMapper), (
         f"Invalid mapper provided {exception_mapper}"
     )

--- a/src/ethereum_test_exceptions/exceptions.py
+++ b/src/ethereum_test_exceptions/exceptions.py
@@ -516,6 +516,10 @@ class BlockException(ExceptionBase):
     """
     Block's excess blob gas in header is incorrect.
     """
+    INVALID_VERSIONED_HASHES = auto()
+    """
+    Incorrect number of versioned hashes in a payload.
+    """
     RLP_STRUCTURES_ENCODING = auto()
     """
     Block's rlp encoding is valid but ethereum structures in it are invalid.

--- a/src/ethereum_test_exceptions/exceptions.py
+++ b/src/ethereum_test_exceptions/exceptions.py
@@ -93,6 +93,8 @@ class UndefinedException(str):
 
     def __new__(cls, value: str, *, mapper_name: str | None = None) -> "UndefinedException":
         """Create a new UndefinedException instance."""
+        if isinstance(value, UndefinedException):
+            return value
         assert isinstance(value, str)
         instance = super().__new__(cls, value)
         instance.mapper_name = mapper_name

--- a/src/ethereum_test_exceptions/exceptions.py
+++ b/src/ethereum_test_exceptions/exceptions.py
@@ -584,6 +584,10 @@ class BlockException(ExceptionBase):
     """
     A system contract call at the end of block execution (from the system address) fails.
     """
+    INVALID_BLOCK_HASH = auto()
+    """
+    Block header's hash does not match the actually computed hash of the block.
+    """
 
 
 @unique

--- a/src/ethereum_test_rpc/rpc.py
+++ b/src/ethereum_test_rpc/rpc.py
@@ -50,14 +50,21 @@ class BaseRPC:
     """Represents a base RPC class for every RPC call used within EEST based hive simulators."""
 
     namespace: ClassVar[str]
+    response_validation_context: Any | None
 
-    def __init__(self, url: str, extra_headers: Dict | None = None):
+    def __init__(
+        self,
+        url: str,
+        extra_headers: Dict | None = None,
+        response_validation_context: Any | None = None,
+    ):
         """Initialize BaseRPC class with the given url."""
         if extra_headers is None:
             extra_headers = {}
         self.url = url
         self.request_id_counter = count(1)
         self.extra_headers = extra_headers
+        self.response_validation_context = response_validation_context
 
     def __init_subclass__(cls) -> None:
         """Set namespace of the RPC class to the lowercase of the class name."""
@@ -106,12 +113,19 @@ class EthRPC(BaseRPC):
     BlockNumberType = Union[int, Literal["latest", "earliest", "pending"]]
 
     def __init__(
-        self, url: str, extra_headers: Dict | None = None, *, transaction_wait_timeout: int = 60
+        self,
+        url: str,
+        extra_headers: Dict | None = None,
+        *,
+        transaction_wait_timeout: int = 60,
+        response_validation_context: Any | None = None,
     ):
         """Initialize EthRPC class with the given url and transaction wait timeout."""
         if extra_headers is None:
             extra_headers = {}
-        super().__init__(url, extra_headers)
+        super().__init__(
+            url, extra_headers, response_validation_context=response_validation_context
+        )
         self.transaction_wait_timeout = transaction_wait_timeout
 
     def get_block_by_number(self, block_number: BlockNumberType = "latest", full_txs: bool = True):
@@ -142,7 +156,9 @@ class EthRPC(BaseRPC):
             response = self.post_request("getTransactionByHash", f"{transaction_hash}")
             if response is None:
                 return None
-            return TransactionByHashResponse(**response)
+            return TransactionByHashResponse.model_validate(
+                response, context=self.response_validation_context
+            )
         except ValidationError as e:
             pprint(e.errors())
             raise e
@@ -289,8 +305,9 @@ class EngineRPC(BaseRPC):
 
     def new_payload(self, *params: Any, version: int) -> PayloadStatus:
         """`engine_newPayloadVX`: Attempts to execute the given payload on an execution client."""
-        return PayloadStatus(
-            **self.post_request(f"newPayloadV{version}", *[to_json(param) for param in params])
+        return PayloadStatus.model_validate(
+            self.post_request(f"newPayloadV{version}", *[to_json(param) for param in params]),
+            context=self.response_validation_context,
         )
 
     def forkchoice_updated(
@@ -301,12 +318,13 @@ class EngineRPC(BaseRPC):
         version: int,
     ) -> ForkchoiceUpdateResponse:
         """`engine_forkchoiceUpdatedVX`: Updates the forkchoice state of the execution client."""
-        return ForkchoiceUpdateResponse(
-            **self.post_request(
+        return ForkchoiceUpdateResponse.model_validate(
+            self.post_request(
                 f"forkchoiceUpdatedV{version}",
                 to_json(forkchoice_state),
                 to_json(payload_attributes) if payload_attributes is not None else None,
-            )
+            ),
+            context=self.response_validation_context,
         )
 
     def get_payload(
@@ -319,9 +337,10 @@ class EngineRPC(BaseRPC):
         `engine_getPayloadVX`: Retrieves a payload that was requested through
         `engine_forkchoiceUpdatedVX`.
         """
-        return GetPayloadResponse(
-            **self.post_request(
+        return GetPayloadResponse.model_validate(
+            self.post_request(
                 f"getPayloadV{version}",
                 f"{payload_id}",
-            )
+            ),
+            context=self.response_validation_context,
         )

--- a/src/ethereum_test_rpc/types.py
+++ b/src/ethereum_test_rpc/types.py
@@ -1,11 +1,18 @@
 """Types used in the RPC module for `eth` and `engine` namespaces' requests."""
 
 from enum import Enum
-from typing import Any, List
+from typing import Annotated, Any, List, Union
 
 from pydantic import AliasChoices, Field, model_validator
 
 from ethereum_test_base_types import Address, Bytes, CamelModel, Hash, HexNumber
+from ethereum_test_exceptions import (
+    BlockException,
+    ExceptionMapperValidator,
+    ExceptionWithMessage,
+    TransactionException,
+    UndefinedException,
+)
 from ethereum_test_fixtures.blockchain import FixtureExecutionPayload
 from ethereum_test_types import Transaction, Withdrawal
 
@@ -79,12 +86,25 @@ class PayloadStatusEnum(str, Enum):
     INVALID_BLOCK_HASH = "INVALID_BLOCK_HASH"
 
 
+class BlockTransactionExceptionWithMessage(
+    ExceptionWithMessage[Union[BlockException, TransactionException]]  # type: ignore
+):
+    """Exception returned from the execution client with a message."""
+
+    pass
+
+
 class PayloadStatus(CamelModel):
     """Represents the status of a payload after execution."""
 
     status: PayloadStatusEnum
     latest_valid_hash: Hash | None
-    validation_error: str | None
+    validation_error: (
+        Annotated[
+            BlockTransactionExceptionWithMessage | UndefinedException, ExceptionMapperValidator
+        ]
+        | None
+    )
 
 
 class ForkchoiceUpdateResponse(CamelModel):

--- a/src/ethereum_test_specs/helpers.py
+++ b/src/ethereum_test_specs/helpers.py
@@ -41,7 +41,7 @@ class UnexpectedExecutionFailError(Exception):
         self,
         execution_context: ExecutionContext,
         message: str,
-        exception: ExceptionBase | UndefinedException,
+        exception: ExceptionWithMessage | UndefinedException,
         **kwargs,
     ):
         """Initialize the exception."""
@@ -85,7 +85,7 @@ class ExecutionExceptionMismatchError(Exception):
         self,
         execution_context: ExecutionContext,
         want_exception: ExceptionBase | List[ExceptionBase],
-        got_exception: ExceptionBase,
+        got_exception: ExceptionWithMessage,
         got_message: str,
         **kwargs,
     ):
@@ -125,7 +125,7 @@ class ExceptionInfo:
 
     execution_context: ExecutionContext
     want_exception: List[ExceptionBase] | ExceptionBase | None
-    got_exception: ExceptionBase | UndefinedException | None
+    got_exception: ExceptionWithMessage | UndefinedException | None
     got_message: str | None
     context: Dict[str, Any]
 
@@ -140,11 +140,7 @@ class ExceptionInfo:
         """Initialize the exception."""
         self.execution_context = execution_context
         self.want_exception = want_exception
-        self.got_exception = (
-            got_exception.exception
-            if isinstance(got_exception, ExceptionWithMessage)
-            else got_exception
-        )
+        self.got_exception = got_exception
         if self.got_exception is None:
             self.got_message = None
         else:

--- a/src/ethereum_test_specs/helpers.py
+++ b/src/ethereum_test_specs/helpers.py
@@ -178,7 +178,7 @@ class ExceptionInfo:
                     **self.context,
                 )
             if strict_match:
-                if got_exception not in want_exception:
+                if want_exception not in got_exception:
                     got_message = self.got_message
                     assert got_message is not None
                     raise ExecutionExceptionMismatchError(

--- a/src/pytest_plugins/consume/hive_simulators/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/conftest.py
@@ -42,6 +42,16 @@ def pytest_addoption(parser):
         default=False,
         help="Log the timing data for each test case execution.",
     )
+    consume_group.addoption(
+        "--strict-exception-matching",
+        action="store",
+        dest="strict_exception_matching",
+        default="",
+        help=(
+            "Comma-separated list of the names of clients which should use strict "
+            "exception matching."
+        ),
+    )
 
 
 @pytest.fixture(scope="function")
@@ -207,6 +217,22 @@ def client_exception_mapper(
         if client in client_type.name:
             return EXCEPTION_MAPPERS[client]
     return None
+
+
+@pytest.fixture(scope="session")
+def strict_exception_matching(request: pytest.FixtureRequest) -> List[str]:
+    """Return the list of clients that should use strict exception matching."""
+    config_string = request.config.getoption("strict_exception_matching")
+    return config_string.split(",") if config_string else []
+
+
+@pytest.fixture(scope="function")
+def client_strict_exception_matching(
+    client_type: ClientType,
+    strict_exception_matching: List[str],
+) -> bool:
+    """Return True if the client type should use strict exception matching."""
+    return any(client in client_type.name for client in strict_exception_matching)
 
 
 @pytest.fixture(scope="function")

--- a/src/pytest_plugins/consume/hive_simulators/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/conftest.py
@@ -12,6 +12,7 @@ from hive.client import Client, ClientType
 from hive.testing import HiveTest
 
 from ethereum_test_base_types import Number, to_json
+from ethereum_test_exceptions import ExceptionMapper
 from ethereum_test_fixtures import (
     BaseFixture,
     BlockchainFixtureCommon,
@@ -23,6 +24,7 @@ from pytest_plugins.consume.consume import FixturesSource
 from pytest_plugins.consume.hive_simulators.ruleset import ruleset  # TODO: generate dynamically
 from pytest_plugins.pytest_hive.hive_info import ClientInfo
 
+from .exceptions import EXCEPTION_MAPPERS
 from .timing import TimingData
 
 logger = logging.getLogger(__name__)
@@ -194,6 +196,17 @@ def buffered_genesis(client_genesis: dict) -> io.BufferedReader:
     genesis_json = json.dumps(client_genesis)
     genesis_bytes = genesis_json.encode("utf-8")
     return io.BufferedReader(cast(io.RawIOBase, io.BytesIO(genesis_bytes)))
+
+
+@pytest.fixture(scope="function")
+def client_exception_mapper(
+    client_type: ClientType,
+) -> ExceptionMapper | None:
+    """Return the exception mapper for the client type."""
+    for client in EXCEPTION_MAPPERS:
+        if client in client_type.name:
+            return EXCEPTION_MAPPERS[client]
+    return None
 
 
 @pytest.fixture(scope="function")

--- a/src/pytest_plugins/consume/hive_simulators/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/conftest.py
@@ -243,7 +243,9 @@ def client_strict_exception_matching(
     disable_strict_exception_matching: List[str],
 ) -> bool:
     """Return True if the client type should use strict exception matching."""
-    return not any(client in client_type.name for client in disable_strict_exception_matching)
+    return not any(
+        client.lower() in client_type.name.lower() for client in disable_strict_exception_matching
+    )
 
 
 @pytest.fixture(scope="function")

--- a/src/pytest_plugins/consume/hive_simulators/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/conftest.py
@@ -208,15 +208,26 @@ def buffered_genesis(client_genesis: dict) -> io.BufferedReader:
     return io.BufferedReader(cast(io.RawIOBase, io.BytesIO(genesis_bytes)))
 
 
+@pytest.fixture(scope="session")
+def client_exception_mapper_cache():
+    """Cache for exception mappers by client type."""
+    return {}
+
+
 @pytest.fixture(scope="function")
 def client_exception_mapper(
-    client_type: ClientType,
+    client_type: ClientType, client_exception_mapper_cache
 ) -> ExceptionMapper | None:
-    """Return the exception mapper for the client type."""
-    for client in EXCEPTION_MAPPERS:
-        if client in client_type.name:
-            return EXCEPTION_MAPPERS[client]
-    return None
+    """Return the exception mapper for the client type, with caching."""
+    if client_type.name not in client_exception_mapper_cache:
+        for client in EXCEPTION_MAPPERS:
+            if client in client_type.name:
+                client_exception_mapper_cache[client_type.name] = EXCEPTION_MAPPERS[client]
+                break
+        else:
+            client_exception_mapper_cache[client_type.name] = None
+
+    return client_exception_mapper_cache[client_type.name]
 
 
 @pytest.fixture(scope="session")

--- a/src/pytest_plugins/consume/hive_simulators/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/conftest.py
@@ -261,6 +261,15 @@ def fork_strict_exception_matching(
 
 
 @pytest.fixture(scope="function")
+def strict_exception_matching(
+    client_strict_exception_matching: bool,
+    fork_strict_exception_matching: bool,
+) -> bool:
+    """Return True if the test should use strict exception matching."""
+    return client_strict_exception_matching and fork_strict_exception_matching
+
+
+@pytest.fixture(scope="function")
 def client(
     hive_test: HiveTest,
     client_files: dict,  # configured within: rlp/conftest.py & engine/conftest.py

--- a/src/pytest_plugins/consume/hive_simulators/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/conftest.py
@@ -43,12 +43,12 @@ def pytest_addoption(parser):
         help="Log the timing data for each test case execution.",
     )
     consume_group.addoption(
-        "--strict-exception-matching",
+        "--disable-strict-exception-matching",
         action="store",
-        dest="strict_exception_matching",
+        dest="disable_strict_exception_matching",
         default="",
         help=(
-            "Comma-separated list of the names of clients which should use strict "
+            "Comma-separated list of the names of clients which should NOT use strict "
             "exception matching."
         ),
     )
@@ -220,19 +220,19 @@ def client_exception_mapper(
 
 
 @pytest.fixture(scope="session")
-def strict_exception_matching(request: pytest.FixtureRequest) -> List[str]:
-    """Return the list of clients that should use strict exception matching."""
-    config_string = request.config.getoption("strict_exception_matching")
+def disable_strict_exception_matching(request: pytest.FixtureRequest) -> List[str]:
+    """Return the list of clients that should NOT use strict exception matching."""
+    config_string = request.config.getoption("disable_strict_exception_matching")
     return config_string.split(",") if config_string else []
 
 
 @pytest.fixture(scope="function")
 def client_strict_exception_matching(
     client_type: ClientType,
-    strict_exception_matching: List[str],
+    disable_strict_exception_matching: List[str],
 ) -> bool:
     """Return True if the client type should use strict exception matching."""
-    return any(client in client_type.name for client in strict_exception_matching)
+    return not any(client in client_type.name for client in disable_strict_exception_matching)
 
 
 @pytest.fixture(scope="function")

--- a/src/pytest_plugins/consume/hive_simulators/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/conftest.py
@@ -48,7 +48,7 @@ def pytest_addoption(parser):
         dest="disable_strict_exception_matching",
         default="",
         help=(
-            "Comma-separated list of the names of clients which should NOT use strict "
+            "Comma-separated list of client names and/or forks which should NOT use strict "
             "exception matching."
         ),
     )
@@ -232,7 +232,7 @@ def client_exception_mapper(
 
 @pytest.fixture(scope="session")
 def disable_strict_exception_matching(request: pytest.FixtureRequest) -> List[str]:
-    """Return the list of clients that should NOT use strict exception matching."""
+    """Return the list of clients or forks that should NOT use strict exception matching."""
     config_string = request.config.getoption("disable_strict_exception_matching")
     return config_string.split(",") if config_string else []
 
@@ -245,6 +245,18 @@ def client_strict_exception_matching(
     """Return True if the client type should use strict exception matching."""
     return not any(
         client.lower() in client_type.name.lower() for client in disable_strict_exception_matching
+    )
+
+
+@pytest.fixture(scope="function")
+def fork_strict_exception_matching(
+    fixture: BlockchainFixtureCommon,
+    disable_strict_exception_matching: List[str],
+) -> bool:
+    """Return True if the fork should use strict exception matching."""
+    # NOTE: `in` makes it easier for transition forks ("Prague" in "CancunToPragueAtTime15k")
+    return not any(
+        fork.lower() in fixture.fork.lower() for fork in disable_strict_exception_matching
     )
 
 

--- a/src/pytest_plugins/consume/hive_simulators/engine/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/engine/conftest.py
@@ -10,6 +10,7 @@ from typing import Mapping
 import pytest
 from hive.client import Client
 
+from ethereum_test_exceptions import ExceptionMapper
 from ethereum_test_fixtures import BlockchainEngineFixture
 from ethereum_test_rpc import EngineRPC
 
@@ -20,8 +21,15 @@ def pytest_configure(config):
 
 
 @pytest.fixture(scope="function")
-def engine_rpc(client: Client) -> EngineRPC:
+def engine_rpc(client: Client, client_exception_mapper: ExceptionMapper | None) -> EngineRPC:
     """Initialize engine RPC client for the execution client under test."""
+    if client_exception_mapper:
+        return EngineRPC(
+            f"http://{client.ip}:8551",
+            response_validation_context={
+                "exception_mapper": client_exception_mapper,
+            },
+        )
     return EngineRPC(f"http://{client.ip}:8551")
 
 

--- a/src/pytest_plugins/consume/hive_simulators/engine/test_via_engine.py
+++ b/src/pytest_plugins/consume/hive_simulators/engine/test_via_engine.py
@@ -101,6 +101,7 @@ def test_blockchain_via_engine(
                                     f'(mapper: "{payload_response.validation_error.mapper_name}")'
                                 )
                                 if client_strict_exception_matching:
+                                    logger.fail(message)
                                     raise Exception(message)
                                 else:
                                     logger.warning(message)

--- a/src/pytest_plugins/consume/hive_simulators/engine/test_via_engine.py
+++ b/src/pytest_plugins/consume/hive_simulators/engine/test_via_engine.py
@@ -17,6 +17,15 @@ from ..timing import TimingData
 logger = get_logger(__name__)
 
 
+class LoggedError(Exception):
+    """Exception that uses the logger to log the failure."""
+
+    def __init__(self, *args: object) -> None:
+        """Initialize the exception and log the failure."""
+        super().__init__(*args)
+        logger.fail(str(self))
+
+
 def test_blockchain_via_engine(
     timing_data: TimingData,
     eth_rpc: EthRPC,
@@ -42,9 +51,10 @@ def test_blockchain_via_engine(
         )
         status = forkchoice_response.payload_status.status
         logger.info(f"Initial forkchoice update response: {status}")
-        assert forkchoice_response.payload_status.status == PayloadStatusEnum.VALID, (
-            f"unexpected status on forkchoice updated to genesis: {forkchoice_response}"
-        )
+        if forkchoice_response.payload_status.status != PayloadStatusEnum.VALID:
+            raise LoggedError(
+                f"unexpected status on forkchoice updated to genesis: {forkchoice_response}"
+            )
 
     with timing_data.time("Get genesis block"):
         logger.info("Calling getBlockByNumber to get genesis block...")
@@ -65,32 +75,30 @@ def test_blockchain_via_engine(
             with total_payload_timing.time(f"Payload {i + 1}") as payload_timing:
                 with payload_timing.time(f"engine_newPayloadV{payload.new_payload_version}"):
                     logger.info(f"Sending engine_newPayloadV{payload.new_payload_version}...")
-                    expected_validity = "VALID" if payload.valid() else "INVALID"
-                    logger.info(f"Expected payload validity: {expected_validity}")
                     try:
                         payload_response = engine_rpc.new_payload(
                             *payload.params,
                             version=payload.new_payload_version,
                         )
                         logger.info(f"Payload response status: {payload_response.status}")
-                        assert payload_response.status == (
+                        expected_validity = (
                             PayloadStatusEnum.VALID
                             if payload.valid()
                             else PayloadStatusEnum.INVALID
-                        ), f"unexpected status: {payload_response}"
-                        if payload.error_code is not None:
-                            error_code = payload.error_code
-                            logger.fail(
-                                f"Client failed to raise expected Engine API error code: "
-                                f"{error_code}"
+                        )
+                        if payload_response.status != expected_validity:
+                            raise LoggedError(
+                                f"unexpected status: want {expected_validity},"
+                                f" got {payload_response.status}"
                             )
-                            raise Exception(
-                                "Client failed to raise expected Engine API error code: "
+                        if payload.error_code is not None:
+                            raise LoggedError(
+                                f"Client failed to raise expected Engine API error code: "
                                 f"{payload.error_code}"
                             )
                         elif payload_response.status == PayloadStatusEnum.INVALID:
                             if payload_response.validation_error is None:
-                                raise Exception(
+                                raise LoggedError(
                                     "Client returned INVALID but no validation error was provided."
                                 )
                             if isinstance(payload_response.validation_error, UndefinedException):
@@ -101,8 +109,7 @@ def test_blockchain_via_engine(
                                     f'(mapper: "{payload_response.validation_error.mapper_name}")'
                                 )
                                 if strict_exception_matching:
-                                    logger.fail(message)
-                                    raise Exception(message)
+                                    raise LoggedError(message)
                                 else:
                                     logger.warning(message)
                             else:
@@ -116,23 +123,17 @@ def test_blockchain_via_engine(
                                         f'expected: "{payload.validation_error}"'
                                     )
                                     if strict_exception_matching:
-                                        logger.fail(message)
-                                        raise Exception(message)
+                                        raise LoggedError(message)
                                     else:
                                         logger.warning(message)
 
                     except JSONRPCError as e:
                         logger.info(f"JSONRPC error encountered: {e.code} - {e.message}")
                         if payload.error_code is None:
-                            logger.fail(f"Unexpected error: {e.code} - {e.message}")
-                            raise Exception(f"unexpected error: {e.code} - {e.message}") from e
+                            raise LoggedError(f"Unexpected error: {e.code} - {e.message}") from e
                         if e.code != payload.error_code:
-                            expected_code = payload.error_code
-                            logger.fail(
-                                f"Unexpected error code: {e.code}, expected: {expected_code}"
-                            )
-                            raise Exception(
-                                f"unexpected error code: {e.code}, expected: {payload.error_code}"
+                            raise LoggedError(
+                                f"Unexpected error code: {e.code}, expected: {payload.error_code}"
                             ) from e
 
                 if payload.valid():
@@ -151,7 +152,9 @@ def test_blockchain_via_engine(
                         )
                         status = forkchoice_response.payload_status.status
                         logger.info(f"Forkchoice update response: {status}")
-                        assert (
-                            forkchoice_response.payload_status.status == PayloadStatusEnum.VALID
-                        ), f"unexpected status: {forkchoice_response}"
+                        if forkchoice_response.payload_status.status != PayloadStatusEnum.VALID:
+                            raise LoggedError(
+                                f"unexpected status: want {PayloadStatusEnum.VALID},"
+                                f" got {forkchoice_response.payload_status.status}"
+                            )
         logger.info("All payloads processed successfully.")

--- a/src/pytest_plugins/consume/hive_simulators/engine/test_via_engine.py
+++ b/src/pytest_plugins/consume/hive_simulators/engine/test_via_engine.py
@@ -23,6 +23,7 @@ def test_blockchain_via_engine(
     engine_rpc: EngineRPC,
     fixture: BlockchainEngineFixture,
     client_strict_exception_matching: bool,
+    fork_strict_exception_matching: bool,
 ):
     """
     1. Check the client genesis block hash matches `fixture.genesis.block_hash`.
@@ -115,11 +116,15 @@ def test_blockchain_via_engine(
                                         f'got: "{payload_response.validation_error}" '
                                         f'expected: "{payload.validation_error}"'
                                     )
-                                    if client_strict_exception_matching:
+                                    if (
+                                        not client_strict_exception_matching
+                                        or not fork_strict_exception_matching
+                                    ):
+                                        logger.warning(message)
+                                    else:
                                         logger.fail(message)
                                         raise Exception(message)
-                                    else:
-                                        logger.warning(message)
+
                     except JSONRPCError as e:
                         logger.info(f"JSONRPC error encountered: {e.code} - {e.message}")
                         if payload.error_code is None:

--- a/src/pytest_plugins/consume/hive_simulators/engine/test_via_engine.py
+++ b/src/pytest_plugins/consume/hive_simulators/engine/test_via_engine.py
@@ -94,10 +94,10 @@ def test_blockchain_via_engine(
                                 )
                             if isinstance(payload_response.validation_error, UndefinedException):
                                 logger.warning(
-                                    "Undefined exception message:\n"
-                                    f"expected exception: {payload.validation_error}:\n"
-                                    f"returned exception: {payload_response.validation_error}\n"
-                                    f"mapper: {payload_response.validation_error.mapper_name}"
+                                    "Undefined exception message: "
+                                    f"expected exception: {payload.validation_error}: "
+                                    f"returned exception: {payload_response.validation_error} "
+                                    f"(mapper: {payload_response.validation_error.mapper_name})"
                                 )
                             else:
                                 if (

--- a/src/pytest_plugins/consume/hive_simulators/engine/test_via_engine.py
+++ b/src/pytest_plugins/consume/hive_simulators/engine/test_via_engine.py
@@ -95,13 +95,13 @@ def test_blockchain_via_engine(
                             if isinstance(payload_response.validation_error, UndefinedException):
                                 logger.warning(
                                     "Undefined exception message: "
-                                    f"expected exception: {payload.validation_error}: "
-                                    f"returned exception: {payload_response.validation_error} "
-                                    f"(mapper: {payload_response.validation_error.mapper_name})"
+                                    f'expected exception: "{payload.validation_error}", '
+                                    f'returned exception: "{payload_response.validation_error}" '
+                                    f'(mapper: "{payload_response.validation_error.mapper_name}")'
                                 )
                             else:
                                 if (
-                                    payload_response.validation_error.exception
+                                    payload_response.validation_error
                                     not in payload.validation_error  # type: ignore
                                 ):
                                     logger.fail(

--- a/src/pytest_plugins/consume/hive_simulators/engine/test_via_engine.py
+++ b/src/pytest_plugins/consume/hive_simulators/engine/test_via_engine.py
@@ -22,8 +22,7 @@ def test_blockchain_via_engine(
     eth_rpc: EthRPC,
     engine_rpc: EngineRPC,
     fixture: BlockchainEngineFixture,
-    client_strict_exception_matching: bool,
-    fork_strict_exception_matching: bool,
+    strict_exception_matching: bool,
 ):
     """
     1. Check the client genesis block hash matches `fixture.genesis.block_hash`.
@@ -101,7 +100,7 @@ def test_blockchain_via_engine(
                                     f'returned exception: "{payload_response.validation_error}" '
                                     f'(mapper: "{payload_response.validation_error.mapper_name}")'
                                 )
-                                if client_strict_exception_matching:
+                                if strict_exception_matching:
                                     logger.fail(message)
                                     raise Exception(message)
                                 else:
@@ -116,14 +115,11 @@ def test_blockchain_via_engine(
                                         f'got: "{payload_response.validation_error}" '
                                         f'expected: "{payload.validation_error}"'
                                     )
-                                    if (
-                                        not client_strict_exception_matching
-                                        or not fork_strict_exception_matching
-                                    ):
-                                        logger.warning(message)
-                                    else:
+                                    if strict_exception_matching:
                                         logger.fail(message)
                                         raise Exception(message)
+                                    else:
+                                        logger.warning(message)
 
                     except JSONRPCError as e:
                         logger.info(f"JSONRPC error encountered: {e.code} - {e.message}")

--- a/src/pytest_plugins/consume/hive_simulators/exceptions.py
+++ b/src/pytest_plugins/consume/hive_simulators/exceptions.py
@@ -215,6 +215,8 @@ class RethMapper(ExceptionMapper):
         TransactionException.TYPE_4_EMPTY_AUTHORIZATION_LIST: "empty authorization list",
         TransactionException.TYPE_4_TX_CONTRACT_CREATION: "unexpected length",
         BlockException.INVALID_REQUESTS: "mismatched block requests hash",
+        BlockException.INVALID_RECEIPTS_ROOT: "receipt root mismatch",
+        BlockException.INVALID_STATE_ROOT: "mismatched block state root",
         BlockException.INVALID_BLOCK_HASH: "block hash mismatch",
         BlockException.INVALID_GAS_USED: "block gas used mismatch",
     }

--- a/src/pytest_plugins/consume/hive_simulators/exceptions.py
+++ b/src/pytest_plugins/consume/hive_simulators/exceptions.py
@@ -3,6 +3,7 @@
 import pprint
 from typing import Dict, List, Tuple
 
+from ethereum_clis.clis.ethereumjs import EthereumJSExceptionMapper
 from ethereum_clis.clis.geth import GethExceptionMapper
 from ethereum_test_exceptions import ExceptionMapper
 from ethereum_test_fixtures.blockchain import FixtureHeader
@@ -56,6 +57,47 @@ class GenesisBlockMismatchExceptionError(Exception):
         return differences, unexpected_fields
 
 
+class NethermindMapper(ExceptionMapper):
+    """Nethermind exception mapper."""
+
+    mapping_substring = {}
+    mapping_regex = {}
+
+
+class ErigonMapper(ExceptionMapper):
+    """Erigon exception mapper."""
+
+    mapping_substring = {}
+    mapping_regex = {}
+
+
+class BesuMapper(ExceptionMapper):
+    """Besu exception mapper."""
+
+    mapping_substring = {}
+    mapping_regex = {}
+
+
+class RethMapper(ExceptionMapper):
+    """Reth exception mapper."""
+
+    mapping_substring = {}
+    mapping_regex = {}
+
+
+class NimbusMapper(ExceptionMapper):
+    """Nimbus exception mapper."""
+
+    mapping_substring = {}
+    mapping_regex = {}
+
+
 EXCEPTION_MAPPERS: Dict[str, ExceptionMapper] = {
     "go-ethereum": GethExceptionMapper(),
+    "nethermind": NethermindMapper(),
+    "erigon": ErigonMapper(),
+    "besu": BesuMapper(),
+    "reth": RethMapper(),
+    "nimbus": NimbusMapper(),
+    "ethereumjs": EthereumJSExceptionMapper(),
 }

--- a/src/pytest_plugins/consume/hive_simulators/exceptions.py
+++ b/src/pytest_plugins/consume/hive_simulators/exceptions.py
@@ -3,6 +3,8 @@
 import pprint
 from typing import Dict, List, Tuple
 
+from ethereum_clis.clis.geth import GethExceptionMapper
+from ethereum_test_exceptions import ExceptionMapper
 from ethereum_test_fixtures.blockchain import FixtureHeader
 
 
@@ -52,3 +54,8 @@ class GenesisBlockMismatchExceptionError(Exception):
             if got_value is None:
                 unexpected_fields.append(got_name)
         return differences, unexpected_fields
+
+
+EXCEPTION_MAPPERS: Dict[str, ExceptionMapper] = {
+    "go-ethereum": GethExceptionMapper(),
+}

--- a/src/pytest_plugins/consume/hive_simulators/exceptions.py
+++ b/src/pytest_plugins/consume/hive_simulators/exceptions.py
@@ -60,8 +60,53 @@ class GenesisBlockMismatchExceptionError(Exception):
 class NethermindMapper(ExceptionMapper):
     """Nethermind exception mapper."""
 
-    mapping_substring = {}
-    mapping_regex = {}
+    mapping_substring = {
+        TransactionException.SENDER_NOT_EOA: "sender has deployed code",
+        TransactionException.INSUFFICIENT_ACCOUNT_FUNDS: "insufficient sender balance",
+        TransactionException.INTRINSIC_GAS_TOO_LOW: "intrinsic gas too low",
+        TransactionException.INSUFFICIENT_MAX_FEE_PER_GAS: "miner premium is negative",
+        TransactionException.PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS: (
+            "InvalidMaxPriorityFeePerGas: Cannot be higher than maxFeePerGas"
+        ),
+        TransactionException.INITCODE_SIZE_EXCEEDED: "max initcode size exceeded",
+        TransactionException.NONCE_MISMATCH_TOO_LOW: "wrong transaction nonce",
+        TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS: (
+            "InsufficientMaxFeePerBlobGas: Not enough to cover blob gas fee"
+        ),
+        TransactionException.TYPE_3_TX_ZERO_BLOBS: "blob transaction missing blob hashes",
+        TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH: (
+            "InvalidBlobVersionedHashVersion: Blob version not supported"
+        ),
+        TransactionException.TYPE_3_TX_CONTRACT_CREATION: "blob transaction of type create",
+        TransactionException.TYPE_4_EMPTY_AUTHORIZATION_LIST: (
+            "MissingAuthorizationList: Must be set"
+        ),
+        TransactionException.TYPE_4_TX_CONTRACT_CREATION: (
+            "NotAllowedCreateTransaction: To must be set"
+        ),
+        BlockException.INCORRECT_BLOB_GAS_USED: (
+            "HeaderBlobGasMismatch: Blob gas in header does not match calculated"
+        ),
+        BlockException.INVALID_REQUESTS: "InvalidRequestsHash: Requests hash mismatch in block",
+    }
+    mapping_regex = {
+        TransactionException.TYPE_3_TX_WITH_FULL_BLOBS: r"Transaction \d+ is not valid",
+        TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED: (
+            r"BlobTxGasLimitExceeded: Transaction's totalDataGas=\d+ "
+            r"exceeded MaxBlobGas per transaction=\d+"
+        ),
+        TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED: (
+            r"BlockBlobGasExceeded: A block cannot have more than \d+ blob gas, blobs count \d+, "
+            r"blobs gas used: \d+"
+        ),
+        BlockException.INCORRECT_EXCESS_BLOB_GAS: (
+            r"HeaderExcessBlobGasMismatch: Excess blob gas in header does not match calculated"
+            r"|Overflow in excess blob gas"
+        ),
+        BlockException.INVALID_BLOCK_HASH: (
+            r"Invalid block hash 0x[0-9a-f]+ does not match calculated hash 0x[0-9a-f]+"
+        ),
+    }
 
 
 class ErigonMapper(ExceptionMapper):

--- a/src/pytest_plugins/consume/hive_simulators/exceptions.py
+++ b/src/pytest_plugins/consume/hive_simulators/exceptions.py
@@ -195,8 +195,42 @@ class BesuMapper(ExceptionMapper):
 class RethMapper(ExceptionMapper):
     """Reth exception mapper."""
 
-    mapping_substring = {}
-    mapping_regex = {}
+    mapping_substring = {
+        TransactionException.SENDER_NOT_EOA: (
+            "reject transactions from senders with deployed code"
+        ),
+        TransactionException.INSUFFICIENT_ACCOUNT_FUNDS: "lack of funds",
+        TransactionException.INITCODE_SIZE_EXCEEDED: "create initcode size limit",
+        TransactionException.INSUFFICIENT_MAX_FEE_PER_GAS: "gas price is less than basefee",
+        TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS: (
+            "blob gas price is greater than max fee per blob gas"
+        ),
+        TransactionException.PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS: (
+            "priority fee is greater than max fee"
+        ),
+        TransactionException.TYPE_3_TX_CONTRACT_CREATION: "unexpected length",
+        TransactionException.TYPE_3_TX_WITH_FULL_BLOBS: "unexpected list",
+        TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH: "blob version not supported",
+        TransactionException.TYPE_3_TX_ZERO_BLOBS: "empty blobs",
+        TransactionException.TYPE_4_EMPTY_AUTHORIZATION_LIST: "empty authorization list",
+        TransactionException.TYPE_4_TX_CONTRACT_CREATION: "unexpected length",
+        BlockException.INVALID_REQUESTS: "mismatched block requests hash",
+        BlockException.INVALID_BLOCK_HASH: "block hash mismatch",
+        BlockException.INVALID_GAS_USED: "block gas used mismatch",
+    }
+    mapping_regex = {
+        TransactionException.NONCE_MISMATCH_TOO_LOW: r"nonce \d+ too low, expected \d+",
+        TransactionException.INTRINSIC_GAS_TOO_LOW: (
+            r"(call gas cost|gas floor) \(\d+\) exceeds the gas limit \(\d+\)"
+        ),
+        TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED: r"too many blobs, have \d+, max \d+",
+        BlockException.INCORRECT_BLOB_GAS_USED: (
+            r"blob gas used mismatch|blob gas used \d+ is not a multiple of blob gas per blob"
+        ),
+        BlockException.INCORRECT_EXCESS_BLOB_GAS: (
+            r"excess blob gas \d+ is not a multiple of blob gas per blob|invalid excess blob gas"
+        ),
+    }
 
 
 class NimbusMapper(ExceptionMapper):

--- a/src/pytest_plugins/consume/hive_simulators/exceptions.py
+++ b/src/pytest_plugins/consume/hive_simulators/exceptions.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Tuple
 
 from ethereum_clis.clis.ethereumjs import EthereumJSExceptionMapper
 from ethereum_clis.clis.geth import GethExceptionMapper
-from ethereum_test_exceptions import ExceptionMapper
+from ethereum_test_exceptions import BlockException, ExceptionMapper, TransactionException
 from ethereum_test_fixtures.blockchain import FixtureHeader
 
 
@@ -74,8 +74,77 @@ class ErigonMapper(ExceptionMapper):
 class BesuMapper(ExceptionMapper):
     """Besu exception mapper."""
 
-    mapping_substring = {}
-    mapping_regex = {}
+    mapping_substring = {
+        BlockException.INCORRECT_BLOB_GAS_USED: (
+            "Payload BlobGasUsed does not match calculated BlobGasUsed"
+        ),
+        BlockException.INCORRECT_EXCESS_BLOB_GAS: (
+            "Payload excessBlobGas does not match calculated excessBlobGas"
+        ),
+        TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH: "Invalid versionedHash",
+        TransactionException.TYPE_3_TX_CONTRACT_CREATION: (
+            "transaction invalid transaction blob transactions must have a to address"
+        ),
+        BlockException.RLP_STRUCTURES_ENCODING: (
+            "Failed to decode transactions from block parameter"
+        ),
+        TransactionException.TYPE_3_TX_WITH_FULL_BLOBS: (
+            "Failed to decode transactions from block parameter"
+        ),
+        TransactionException.TYPE_3_TX_ZERO_BLOBS: (
+            "Failed to decode transactions from block parameter"
+        ),
+        TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS: (
+            "transaction invalid tx max fee per blob gas less than block blob gas fee"
+        ),
+        TransactionException.INSUFFICIENT_MAX_FEE_PER_GAS: (
+            "transaction invalid gasPrice is less than the current BaseFee"
+        ),
+        TransactionException.PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS: (
+            "transaction invalid max priority fee per gas cannot be greater than max fee per gas"
+        ),
+        TransactionException.TYPE_4_EMPTY_AUTHORIZATION_LIST: (
+            "transaction invalid transaction code delegation transactions must have a "
+            "non-empty code delegation list"
+        ),
+        TransactionException.TYPE_4_TX_CONTRACT_CREATION: (
+            "transaction invalid transaction code delegation transactions must have a to address"
+        ),
+        TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED: "Invalid Blob Count",
+        TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED: "Invalid Blob Count",
+        BlockException.BLOB_GAS_USED_ABOVE_LIMIT: (
+            "Payload BlobGasUsed does not match calculated BlobGasUsed"
+        ),
+        BlockException.INCORRECT_BLOB_GAS_USED: (
+            "Payload BlobGasUsed does not match calculated BlobGasUsed"
+        ),
+    }
+    mapping_regex = {
+        BlockException.INVALID_REQUESTS: (
+            r"Invalid execution requests|Requests hash mismatch, calculated: 0x[0-9a-f]+ header: "
+            r"0x[0-9a-f]+"
+        ),
+        BlockException.INVALID_BLOCK_HASH: (
+            r"Computed block hash 0x[0-9a-f]+ does not match block hash parameter 0x[0-9a-f]+"
+        ),
+        TransactionException.INITCODE_SIZE_EXCEEDED: (
+            r"transaction invalid Initcode size of \d+ exceeds maximum size of \d+"
+        ),
+        TransactionException.INSUFFICIENT_ACCOUNT_FUNDS: (
+            r"transaction invalid transaction up-front cost 0x[0-9a-f]+ exceeds transaction "
+            r"sender account balance 0x[0-9a-f]+"
+        ),
+        TransactionException.INTRINSIC_GAS_TOO_LOW: (
+            r"transaction invalid intrinsic gas cost \d+ exceeds gas limit \d+"
+        ),
+        TransactionException.SENDER_NOT_EOA: (
+            r"transaction invalid Sender 0x[0-9a-f]+ has deployed code and so is not authorized "
+            r"to send transactions"
+        ),
+        TransactionException.NONCE_MISMATCH_TOO_LOW: (
+            r"transaction invalid transaction nonce \d+ below sender account nonce \d+"
+        ),
+    }
 
 
 class RethMapper(ExceptionMapper):

--- a/tests/cancun/eip4844_blobs/test_blob_txs.py
+++ b/tests/cancun/eip4844_blobs/test_blob_txs.py
@@ -1347,6 +1347,7 @@ def test_blob_tx_attribute_gasprice_opcode(
         "parent_excess_blobs",
         "tx_max_fee_per_blob_gas",
         "tx_error",
+        "block_error",
     ],
     [
         (
@@ -1354,8 +1355,15 @@ def test_blob_tx_attribute_gasprice_opcode(
             None,
             1,
             [TransactionException.TYPE_3_TX_PRE_FORK, TransactionException.TYPE_3_TX_ZERO_BLOBS],
+            [TransactionException.TYPE_3_TX_PRE_FORK, TransactionException.TYPE_3_TX_ZERO_BLOBS],
         ),
-        ([1], None, 1, TransactionException.TYPE_3_TX_PRE_FORK),
+        (
+            [1],
+            None,
+            1,
+            TransactionException.TYPE_3_TX_PRE_FORK,
+            [TransactionException.TYPE_3_TX_PRE_FORK, BlockException.INVALID_VERSIONED_HASHES],
+        ),
     ],
     ids=["no_blob_tx", "one_blob_tx"],
 )
@@ -1365,6 +1373,7 @@ def test_blob_type_tx_pre_fork(
     state_test: StateTestFiller,
     pre: Alloc,
     txs: List[Transaction],
+    block_error: Optional[TransactionException | BlockException],
 ):
     """
     Reject blocks with blob type transactions before Cancun fork.
@@ -1378,4 +1387,5 @@ def test_blob_type_tx_pre_fork(
         post={},
         tx=txs[0],
         env=Environment(),  # `env` fixture has blob fields
+        block_exception=block_error,
     )

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -155,6 +155,7 @@ esbenp
 eest
 EEST
 EEST's
+ERC
 eth
 ethash
 ethereum


### PR DESCRIPTION
## 🗒️ Description

Adds support of the exception mapper to consume-engine:

`consume engine` now checks exceptions returned by the execution clients in their Engine API responses, specifically in the `validationError`field of the `engine_newPayloadVX` method.

Exception mappers of all current mainnet clients have been added to the `ethereum_clis` library.

The feature can be disabled by using `--disable-strict-exception-matching` for specific clients or forks.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist

- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
