### PR TITLE
new(tests): EOF validation non constant stack

### DIFF
--- a/converted-ethereum-tests.txt
+++ b/converted-ethereum-tests.txt
@@ -35,6 +35,7 @@ EOFTests/efStack/jumpf_to_returning_.json
 EOFTests/efStack/jumpf_to_returning_variable_stack_.json
 EOFTests/efStack/jumpf_with_inputs_stack_overflow_.json
 EOFTests/efStack/jumpf_with_inputs_stack_overflow_variable_stack_.json
+EOFTests/efStack/non_constant_stack_height_.json
 EOFTests/efStack/retf_stack_validation_.json
 EOFTests/efStack/retf_variable_stack_.json
 EOFTests/efStack/forwards_rjump_.json


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist

- [ ] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened. https://github.com/ethereum/tests/pull/1483
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
