### PR TITLE
fix(ci): fix bad indentation in link checker yml; update title

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,4 +1,4 @@
-name: Links
+name: Check Links
 
 on:
   repository_dispatch:
@@ -20,8 +20,15 @@ jobs:
         # We use --exclude '\.md(#.*)?$' to skip internal links in markdown like [See test](../tests/.../test_case.md)
         # otherwise we get false positives due to links pointing to content that gets generated during our mkdocs flow.
         # These links are checked during `mkdocs build --strict`
-        args: lychee README.md src/**/*.py src/**/*.md tests/**/*.py tests/**/*.md docs/**/*.md --exclude '\.md(#.*)?$'
         with:
+          args: >
+            README.md
+            src/**/*.py
+            src/**/*.md
+            tests/**/*.py
+            tests/**/*.md
+            docs/**/*.md
+            --exclude '\.md(#.*)?$'
           fail: false
 
       - name: Create Issue From File


### PR DESCRIPTION
## 🗒️ Description
Fixes indentation in the link checker github action and improves its title.

## 🔗 Related Issues
- #1375

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] ~~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~ skipped

