### PR TITLE
feat(tests): eip7623 - parametrize `test_transaction_validity_type_*` with a tx to an eoa

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,7 +19,8 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 ### 🧪 Test Cases
 
-- ✨  Test 7702 precompile case in same transaction as delegation without extra gas in case of precompile code execution; parametrize all call opcodes in existing precompile test ([#1431](https://github.com/ethereum/execution-spec-tests/pull/1431)).
+- ✨ [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702): Test precompile case in same transaction as delegation without extra gas in case of precompile code execution; parametrize all call opcodes in existing precompile test ([#1431](https://github.com/ethereum/execution-spec-tests/pull/1431)).
+- ✨ [EIP-7623](https://eips.ethereum.org/EIPS/eip-7623): Additionally parametrize transaction validity tests with the `to` set to an EOA account (previously only contracts) ([#1422](https://github.com/ethereum/execution-spec-tests/pull/1422)).
 
 ## [v4.2.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v4.2.0) - 2025-04-08
 

--- a/tests/prague/eip7623_increase_calldata_cost/conftest.py
+++ b/tests/prague/eip7623_increase_calldata_cost/conftest.py
@@ -43,8 +43,8 @@ def to(
 
     if param is None:
         return None
-    if isinstance(param, Address):
-        return param
+    if isinstance(param, str) and param == "eoa":
+        return pre.fund_eoa(amount=0)
     if isinstance(param, Bytecode):
         return pre.deploy_contract(param)
 

--- a/tests/prague/eip7623_increase_calldata_cost/test_transaction_validity.py
+++ b/tests/prague/eip7623_increase_calldata_cost/test_transaction_validity.py
@@ -70,7 +70,7 @@ pytestmark += [
 @pytest.mark.parametrize(
     "to",
     [
-        pytest.param(Address(1), id="to_address"),
+        pytest.param("eoa", id="to_eoa"),
         pytest.param(None, id="contract_creating"),
         pytest.param(Op.STOP, id=""),
     ],
@@ -92,7 +92,7 @@ def test_transaction_validity_type_0(
 @pytest.mark.parametrize(
     "to",
     [
-        pytest.param(Address(1), id="to_address"),
+        pytest.param("eoa", id="to_eoa"),
         pytest.param(None, id="contract_creating"),
         pytest.param(Op.STOP, id=""),
     ],

--- a/tests/prague/eip7623_increase_calldata_cost/test_transaction_validity.py
+++ b/tests/prague/eip7623_increase_calldata_cost/test_transaction_validity.py
@@ -70,6 +70,7 @@ pytestmark += [
 @pytest.mark.parametrize(
     "to",
     [
+        pytest.param(Address(1), id="to_address"),
         pytest.param(None, id="contract_creating"),
         pytest.param(Op.STOP, id=""),
     ],
@@ -91,6 +92,7 @@ def test_transaction_validity_type_0(
 @pytest.mark.parametrize(
     "to",
     [
+        pytest.param(Address(1), id="to_address"),
         pytest.param(None, id="contract_creating"),
         pytest.param(Op.STOP, id=""),
     ],


### PR DESCRIPTION
## 🗒️ Description
Additionally parametrize the test functions:
1. https://github.com/ethereum/execution-spec-tests/blob/dcdbfb29bcf5635bc15a0d3fd32cc4fda52c7b1f/tests/prague/eip7623_increase_calldata_cost/test_transaction_validity.py#L79
2. https://github.com/ethereum/execution-spec-tests/blob/dcdbfb29bcf5635bc15a0d3fd32cc4fda52c7b1f/tests/prague/eip7623_increase_calldata_cost/test_transaction_validity.py#L141

with a "to" value that corresponds to an EOA. 

This adds an additional 96 test cases, due to the existing parametrization these tests. All mainnet clients were tested using consume-engine, no fails were found.

Coverage analysis of the tests themselves revealed that L47 in the `to` fixture was not hit:
https://github.com/ethereum/execution-spec-tests/blob/dcdbfb29bcf5635bc15a0d3fd32cc4fda52c7b1f/tests/prague/eip7623_increase_calldata_cost/conftest.py#L33-L51

Generate a coverage report locally with:
```
fill --until Prague tests/prague/eip7623_increase_calldata_cost/test_transaction_validity.py --cov tests --cov-report=html:7623-coverage
```

## 🔗 Related Issues
None

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).

