### PR TITLE
fix(tests): assign ids to parametrized EOF code sections

### DIFF
--- a/tests/osaka/eip7692_eof_v1/eip4750_functions/test_code_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip4750_functions/test_code_validation.py
@@ -871,7 +871,7 @@ def test_callf_validate_outputs(eof_test: EOFTestFiller, stack_height: int):
                 code_outputs=3,
                 max_stack_height=4,
             ),
-            id="pop",
+            id="push_pop",
         ),
         pytest.param(
             Section.Code(

--- a/tests/osaka/eip7692_eof_v1/eip4750_functions/test_code_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip4750_functions/test_code_validation.py
@@ -855,41 +855,59 @@ def test_callf_validate_outputs(eof_test: EOFTestFiller, stack_height: int):
 @pytest.mark.parametrize(
     "code_section",
     [
-        Section.Code(
-            code=Op.POP * 2 + Op.RETF,
-            code_inputs=2,
-            code_outputs=0,
-            max_stack_height=2,
+        pytest.param(
+            Section.Code(
+                code=Op.POP * 2 + Op.RETF,
+                code_inputs=2,
+                code_outputs=0,
+                max_stack_height=2,
+            ),
+            id="pop2",
         ),
-        Section.Code(
-            code=Op.PUSH1[1] + Op.POP + Op.RETF,
-            code_inputs=3,
-            code_outputs=3,
-            max_stack_height=4,
+        pytest.param(
+            Section.Code(
+                code=Op.PUSH1[1] + Op.POP + Op.RETF,
+                code_inputs=3,
+                code_outputs=3,
+                max_stack_height=4,
+            ),
+            id="pop",
         ),
-        Section.Code(
-            code=Op.PUSH0 * 2 + Op.RETF,
-            code_inputs=3,
-            code_outputs=5,
-            max_stack_height=5,
+        pytest.param(
+            Section.Code(
+                code=Op.PUSH0 * 2 + Op.RETF,
+                code_inputs=3,
+                code_outputs=5,
+                max_stack_height=5,
+            ),
+            id="push2",
         ),
-        Section.Code(
-            code=Op.PUSH0 * 2 + Op.POP * 2 + Op.RETF,
-            code_inputs=3,
-            code_outputs=3,
-            max_stack_height=5,
+        pytest.param(
+            Section.Code(
+                code=Op.PUSH0 * 2 + Op.POP * 2 + Op.RETF,
+                code_inputs=3,
+                code_outputs=3,
+                max_stack_height=5,
+            ),
+            id="push2_pop2",
         ),
-        Section.Code(
-            code=Op.PUSH0 + Op.POP * 3 + Op.RETF,
-            code_inputs=2,
-            code_outputs=0,
-            max_stack_height=3,
+        pytest.param(
+            Section.Code(
+                code=Op.PUSH0 + Op.POP * 3 + Op.RETF,
+                code_inputs=2,
+                code_outputs=0,
+                max_stack_height=3,
+            ),
+            id="push_pop3",
         ),
-        Section.Code(
-            code=Op.PUSH0 * 2 + Op.POP * 4 + Op.RETF,
-            code_inputs=2,
-            code_outputs=0,
-            max_stack_height=4,
+        pytest.param(
+            Section.Code(
+                code=Op.PUSH0 * 2 + Op.POP * 4 + Op.RETF,
+                code_inputs=2,
+                code_outputs=0,
+                max_stack_height=4,
+            ),
+            id="push2_pop4",
         ),
     ],
 )
@@ -924,65 +942,95 @@ def test_callf_with_inputs_stack_overflow(
 @pytest.mark.parametrize(
     "code_section",
     [
-        Section.Code(
-            code=Op.POP * 2 + Op.RETF,
-            code_inputs=2,
-            code_outputs=0,
-            max_stack_height=2,
+        pytest.param(
+            Section.Code(
+                code=Op.POP * 2 + Op.RETF,
+                code_inputs=2,
+                code_outputs=0,
+                max_stack_height=2,
+            ),
+            id="pop2",
         ),
-        Section.Code(
-            code=Op.PUSH1[1] + Op.POP + Op.RETF,
-            code_inputs=3,
-            code_outputs=3,
-            max_stack_height=4,
+        pytest.param(
+            Section.Code(
+                code=Op.PUSH1[1] + Op.POP + Op.RETF,
+                code_inputs=3,
+                code_outputs=3,
+                max_stack_height=4,
+            ),
+            id="push_pop",
         ),
-        Section.Code(
-            code=Op.PUSH0 * 4 + Op.RETF,
-            code_inputs=3,
-            code_outputs=7,
-            max_stack_height=7,
+        pytest.param(
+            Section.Code(
+                code=Op.PUSH0 * 4 + Op.RETF,
+                code_inputs=3,
+                code_outputs=7,
+                max_stack_height=7,
+            ),
+            id="push4",
         ),
-        Section.Code(
-            code=Op.PUSH0 * 2 + Op.RETF,
-            code_inputs=3,
-            code_outputs=5,
-            max_stack_height=5,
+        pytest.param(
+            Section.Code(
+                code=Op.PUSH0 * 2 + Op.RETF,
+                code_inputs=3,
+                code_outputs=5,
+                max_stack_height=5,
+            ),
+            id="push2",
         ),
-        Section.Code(
-            code=Op.PUSH0 * 4 + Op.POP * 2 + Op.RETF,
-            code_inputs=3,
-            code_outputs=3,
-            max_stack_height=7,
+        pytest.param(
+            Section.Code(
+                code=Op.PUSH0 * 4 + Op.POP * 2 + Op.RETF,
+                code_inputs=3,
+                code_outputs=3,
+                max_stack_height=7,
+            ),
+            id="push4_pop2",
         ),
-        Section.Code(
-            code=Op.PUSH0 * 2 + Op.POP * 2 + Op.RETF,
-            code_inputs=3,
-            code_outputs=3,
-            max_stack_height=5,
+        pytest.param(
+            Section.Code(
+                code=Op.PUSH0 * 2 + Op.POP * 2 + Op.RETF,
+                code_inputs=3,
+                code_outputs=3,
+                max_stack_height=5,
+            ),
+            id="push2_pop2",
         ),
-        Section.Code(
-            code=Op.PUSH0 * 3 + Op.POP * 5 + Op.RETF,
-            code_inputs=2,
-            code_outputs=0,
-            max_stack_height=5,
+        pytest.param(
+            Section.Code(
+                code=Op.PUSH0 * 3 + Op.POP * 5 + Op.RETF,
+                code_inputs=2,
+                code_outputs=0,
+                max_stack_height=5,
+            ),
+            id="push3_pop5",
         ),
-        Section.Code(
-            code=Op.PUSH0 + Op.POP * 3 + Op.RETF,
-            code_inputs=2,
-            code_outputs=0,
-            max_stack_height=3,
+        pytest.param(
+            Section.Code(
+                code=Op.PUSH0 + Op.POP * 3 + Op.RETF,
+                code_inputs=2,
+                code_outputs=0,
+                max_stack_height=3,
+            ),
+            id="push_pop3",
         ),
-        Section.Code(
-            code=Op.PUSH0 * 4 + Op.POP * 6 + Op.RETF,
-            code_inputs=2,
-            code_outputs=0,
-            max_stack_height=6,
+        pytest.param(
+            Section.Code(
+                code=Op.PUSH0 * 4 + Op.POP * 6 + Op.RETF,
+                code_inputs=2,
+                code_outputs=0,
+                max_stack_height=6,
+            ),
+            id="push4_pop6",
         ),
-        Section.Code(
-            code=Op.PUSH0 * 2 + Op.POP * 4 + Op.RETF,
-            code_inputs=2,
-            code_outputs=0,
-            max_stack_height=4,
+        pytest.param(
+            Section.Code(
+                code=Op.PUSH0 * 2 + Op.POP * 4 + Op.RETF,
+                code_inputs=2,
+                code_outputs=0,
+                max_stack_height=4,
+            ),
+            id="push2_pop4",
         ),
     ],
 )


### PR DESCRIPTION
## 🗒️ Description
Otherwise, the generated test names are too long and filling fails.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist

- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
