### PR TITLE
chore(deps,pytest): update pytest to v8

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,7 @@ The output behavior of `fill` has changed ([#1608](https://github.com/ethereum/e
 - ✨ Added [Post-Mortems of Missed Test Scenarios](https://eest.ethereum.org/main/writing_tests/post_mortems/) to the documentation that serves as a reference list of all cases that were missed during the test implementation phase of a new EIP, and includes the steps taken in order to prevent similar test cases to be missed in the future ([#1327](https://github.com/ethereum/execution-spec-tests/pull/1327)).
 - ✨ Added a new `eest` sub-command, `eest info`, to easily print a cloned EEST repository's version and the versions of relevant tools, e.g., `python`, `uv` ([#1621](https://github.com/ethereum/execution-spec-tests/pull/1621)).
 - ✨ Add `CONTRIBUTING.md` for execution-spec-tests and improve coding standards documentation ([#1604](https://github.com/ethereum/execution-spec-tests/pull/1604)).
+- 🔀 Updated from pytest 7 to [pytest 8](https://docs.pytest.org/en/stable/changelog.html#features-and-improvements), benefits include improved type hinting and hook typing, stricter mark handling, and clearer error messages for plugin and metadata development [#1433](https://github.com/ethereum/execution-spec-tests/pull/1433).
 
 ### 🧪 Test Cases
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "requests>=2.31.0,<3",
     "requests_unixsocket2>=0.4.0",
     "colorlog>=6.7.0,<7",
-    "pytest>7.3.2,<8",
+    "pytest>=8,<9",
     "pytest-custom-report>=1.0.1,<2",
     "pytest-html>=4.1.0,<5",
     "pytest-metadata>=3,<4",

--- a/src/pytest_plugins/consume/hive_simulators/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/conftest.py
@@ -235,7 +235,6 @@ def total_timing_data(request) -> Generator[TimingData, None, None]:
 
 
 @pytest.fixture(scope="function")
-@pytest.mark.usefixtures("total_timing_data")
 def client_genesis(fixture: BlockchainFixtureCommon) -> dict:
     """Convert the fixture genesis block header and pre-state to a client genesis state."""
     genesis = to_json(fixture.genesis)

--- a/tests/berlin/eip2930_access_list/test_tx_intrinsic_gas.py
+++ b/tests/berlin/eip2930_access_list/test_tx_intrinsic_gas.py
@@ -36,12 +36,12 @@ tx_intrinsic_gas_data_vectors = [
     pytest.param(Bytes(b"0xFE00"), id="data_1_zero_byte_1_non_zero_byte_reversed"),
     pytest.param(Bytes(b"0x0102030405060708090A0B0C0D0E0F10"), id="data_set_1"),
     pytest.param(
-        Bytes(b"0x0102030405060708090A0B0C0D0E0F101112131415161718191a1b1c1d1e1f20"),
-        id="data_set_1",
-    ),
-    pytest.param(
         Bytes(b"0x00010203040506000708090A0B0C0D0E0F10111200131415161718191a1b1c1d1e1f"),
         id="data_set_2",
+    ),
+    pytest.param(
+        Bytes(b"0x0102030405060708090A0B0C0D0E0F101112131415161718191a1b1c1d1e1f20"),
+        id="data_set_3",
     ),
     pytest.param(
         Bytes(b"0x01020304050607080910111213141516171819202122232425262728293031"),

--- a/uv.lock
+++ b/uv.lock
@@ -585,7 +585,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.10.0,<3" },
     { name = "pyjwt", specifier = ">=2.3.0,<3" },
     { name = "pyspelling", marker = "extra == 'docs'", specifier = ">=2.8.2,<3" },
-    { name = "pytest", specifier = ">7.3.2,<8" },
+    { name = "pytest", specifier = ">=8,<9" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.1.0,<5" },
     { name = "pytest-custom-report", specifier = ">=1.0.1,<2" },
     { name = "pytest-html", specifier = ">=4.1.0,<5" },
@@ -1497,7 +1497,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "7.4.4"
+version = "8.3.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1507,9 +1507,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/1f/9d8e98e4133ffb16c90f3b405c43e38d3abb715bb5d7a63a5a684f7e46a3/pytest-7.4.4.tar.gz", hash = "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280", size = 1357116, upload-time = "2023-12-31T12:00:18.035Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/ff/f6e8b8f39e08547faece4bd80f89d5a8de68a38b2d179cc1c4490ffa3286/pytest-7.4.4-py3-none-any.whl", hash = "sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8", size = 325287, upload-time = "2023-12-31T12:00:13.963Z" },
+    { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634 },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🗒️ Description

Updates to pytest 8.3.5 (from pytest 7.4.4).

#### TODO

Sanity checks:
- [x] fill
- [x] static fill
- [x] full fixture diff until Prague
- [x] consume direct
- [x] consume rlp
- [x] consume engine
- [x] execute hive
- [ ] execute remote
- [x] fix pytest session warning for consume hive: `src/pytest_plugins/consume/hive_simulators/conftest.py:152: PytestRemovedIn9Warning: Marks applied to fixtures have no effect`

## 🔗 Related Issues
None

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).

