### PR TITLE
fix(consume): Fix consume input parsing on arbitrary URLs

### DIFF
--- a/src/pytest_plugins/consume/consume.py
+++ b/src/pytest_plugins/consume/consume.py
@@ -20,7 +20,7 @@ from ethereum_test_fixtures.consume import IndexFile, TestCases
 from ethereum_test_forks import get_forks, get_relative_fork_markers, get_transition_forks
 from ethereum_test_tools.utility.versioning import get_current_commit_hash_or_tag
 
-from .releases import ReleaseTag, get_release_page_url, get_release_url
+from .releases import ReleaseTag, get_release_page_url, get_release_url, is_url
 
 CACHED_DOWNLOADS_DIRECTORY = (
     Path(platformdirs.user_cache_dir("ethereum-execution-spec-tests")) / "cached_downloads"
@@ -157,12 +157,6 @@ class FixturesSource:
         if not any(path.glob("**/*.json")):
             pytest.exit(f"Specified fixture directory '{path}' does not contain any JSON files.")
         return FixturesSource(input_option=str(path), path=path)
-
-
-def is_url(string: str) -> bool:
-    """Check if a string is a remote URL."""
-    result = urlparse(string)
-    return all([result.scheme, result.netloc])
 
 
 class SimLimitBehavior:

--- a/src/pytest_plugins/consume/releases.py
+++ b/src/pytest_plugins/consume/releases.py
@@ -216,7 +216,7 @@ def get_release_page_url(release_string: str) -> str:
             for asset in release.assets.root:
                 if asset.url == release_string:
                     return release.url  # The HTML page for this release
-        raise NoSuchReleaseError(f"No release found for asset URL: {release_string}")
+        return ""
 
     # Case 2: Otherwise, treat it as a release descriptor (e.g., "eip7692@latest")
     release_descriptor = ReleaseTag.from_string(release_string)
@@ -224,8 +224,8 @@ def get_release_page_url(release_string: str) -> str:
         if release_descriptor in release:
             return release.url
 
-    # If nothing matched, raise
-    raise NoSuchReleaseError(release_string)
+    # If nothing matched, return empty string
+    return ""
 
 
 def get_release_information() -> List[ReleaseInformation]:


### PR DESCRIPTION
## 🗒️ Description
Fixes raising on arbitrary urls.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist

- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
