### PR TITLE
feat(specs,tests): `exception_test` marker

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 - 🐞 Fix `DeprecationWarning: Pickle, copy, and deepcopy support will be removed from itertools in Python 3.14.` by avoiding use `itertools` object in the spec `BaseTest` pydantic model ([#1414](https://github.com/ethereum/execution-spec-tests/pull/1414)).
 - ✨ The `static_filler` plug-in now has support for static state tests (from [GeneralStateTests](https://github.com/ethereum/tests/tree/develop/src/GeneralStateTestsFiller)) ([#1362](https://github.com/ethereum/execution-spec-tests/pull/1362)).
+- ✨ Introduce `pytest.mark.negative` to mark tests that contain an invalid transaction or block ([#1436](https://github.com/ethereum/execution-spec-tests/pull/1436)).
 
 ### 📋 Misc
 

--- a/src/cli/eofwrap.py
+++ b/src/cli/eofwrap.py
@@ -308,7 +308,6 @@ class EofWrapper:
                 raise TypeError("not a FixtureBlock")
 
         result = test.generate(
-            request=None,  # type: ignore
             t8n=t8n,
             fork=Osaka,
             fixture_format=BlockchainFixture,

--- a/src/ethereum_clis/tests/test_transition_tools_support.py
+++ b/src/ethereum_clis/tests/test_transition_tools_support.py
@@ -236,7 +236,6 @@ def test_t8n_support(fork: Fork, installed_t8n: TransitionTool):
         blocks=[block_1, block_2],
     )
     test.generate(
-        request=None,  # type: ignore
         t8n=installed_t8n,
         fork=fork,
         fixture_format=BlockchainFixture,

--- a/src/ethereum_test_specs/base.py
+++ b/src/ethereum_test_specs/base.py
@@ -145,7 +145,7 @@ class BaseTest(BaseModel):
             return self._request.node.get_closest_marker("slow") is not None
         return False
 
-    def is_negative_test(self) -> bool | None:
+    def is_exception_test(self) -> bool | None:
         """
         Check if the test is an exception test (invalid block, invalid transaction).
 
@@ -162,13 +162,13 @@ class BaseTest(BaseModel):
             return self._request.node.nodeid
         return ""
 
-    def check_negative_test(
+    def check_exception_test(
         self,
         *,
         exception: bool,
     ):
         """Compare the test marker against the outcome of the test."""
-        negative_test_marker = self.is_negative_test()
+        negative_test_marker = self.is_exception_test()
         if negative_test_marker is None:
             return
         if negative_test_marker != exception:

--- a/src/ethereum_test_specs/base.py
+++ b/src/ethereum_test_specs/base.py
@@ -4,10 +4,10 @@ from abc import abstractmethod
 from functools import reduce
 from os import path
 from pathlib import Path
-from typing import Callable, ClassVar, Dict, Generator, List, Optional, Sequence
+from typing import Callable, ClassVar, Dict, Generator, List, Optional, Sequence, Type, TypeVar
 
 import pytest
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, PrivateAttr
 
 from ethereum_clis import Result, TransitionTool
 from ethereum_test_base_types import to_hex
@@ -41,10 +41,15 @@ def verify_result(result: Result, env: Environment):
         assert result.withdrawals_root == to_hex(Withdrawal.list_root(env.withdrawals))
 
 
+T = TypeVar("T", bound="BaseTest")
+
+
 class BaseTest(BaseModel):
     """Represents a base Ethereum test which must return a single test fixture."""
 
     tag: str = ""
+
+    _request: pytest.FixtureRequest | None = PrivateAttr(None)
 
     # Transition tool specific fields
     t8n_dump_dir: Path | None = Field(None, exclude=True)
@@ -66,6 +71,22 @@ class BaseTest(BaseModel):
         return False
 
     @classmethod
+    def from_test(
+        cls: Type[T],
+        *,
+        base_test: "BaseTest",
+        **kwargs,
+    ) -> T:
+        """Create a test in a different format from a base test."""
+        new_instance = cls(
+            tag=base_test.tag,
+            t8n_dump_dir=base_test.t8n_dump_dir,
+            **kwargs,
+        )
+        new_instance._request = base_test._request
+        return new_instance
+
+    @classmethod
     def discard_execute_format_by_marks(
         cls,
         execute_format: ExecuteFormat,
@@ -79,7 +100,6 @@ class BaseTest(BaseModel):
     def generate(
         self,
         *,
-        request: pytest.FixtureRequest,
         t8n: TransitionTool,
         fork: Fork,
         fixture_format: FixtureFormat,
@@ -118,6 +138,52 @@ class BaseTest(BaseModel):
             self.t8n_dump_dir,
             str(current_value),
         )
+
+    def is_slow_test(self) -> bool:
+        """Check if the test is slow."""
+        if self._request is not None and hasattr(self._request, "node"):
+            return self._request.node.get_closest_marker("slow") is not None
+        return False
+
+    def is_negative_test(self) -> bool | None:
+        """
+        Check if the test is an exception test (invalid block, invalid transaction).
+
+        `None` is returned if it's not possible to determine if the test is negative or not.
+        This is the case when the test is not run in pytest.
+        """
+        if self._request is not None and hasattr(self._request, "node"):
+            return self._request.node.get_closest_marker("exception_test") is not None
+        return None
+
+    def node_id(self) -> str:
+        """Return the node ID of the test."""
+        if self._request is not None and hasattr(self._request, "node"):
+            return self._request.node.nodeid
+        return ""
+
+    def check_negative_test(
+        self,
+        *,
+        exception: bool,
+    ):
+        """Compare the test marker against the outcome of the test."""
+        negative_test_marker = self.is_negative_test()
+        if negative_test_marker is None:
+            return
+        if negative_test_marker != exception:
+            if exception:
+                raise Exception(
+                    "Test produced an invalid block or transaction but was not marked with the "
+                    "`exception_test` marker. Add the `@pytest.mark.exception_test` decorator "
+                    "to the test."
+                )
+            else:
+                raise Exception(
+                    "Test didn't produce an invalid block or transaction but was marked with the "
+                    "`exception_test` marker. Remove the `@pytest.mark.exception_test` decorator "
+                    "from the test."
+                )
 
 
 TestSpec = Callable[[Fork], Generator[BaseTest, None, None]]

--- a/src/ethereum_test_specs/blockchain.py
+++ b/src/ethereum_test_specs/blockchain.py
@@ -607,8 +607,8 @@ class BlockchainTest(BaseTest):
                     head = header.block_hash
                 else:
                     assert negative_test, (
-                        "unmarked negative test: the test case produces an invalid block but "
-                        + "does not specify the `pytest.mark.negative` marker"
+                        "unmarked exception test: the test case produces an invalid block but "
+                        + "does not specify the `pytest.mark.exception_test` marker"
                     )
                     fixture_blocks.append(
                         InvalidFixtureBlock(
@@ -628,8 +628,8 @@ class BlockchainTest(BaseTest):
                     + "the block is expected to produce an exception"
                 )
                 assert negative_test, (
-                    "unmarked negative test: the test case produces an invalid block but "
-                    + "does not specify the `pytest.mark.negative` marker"
+                    "unmarked exception test: the test case produces an invalid block but "
+                    + "does not specify the `pytest.mark.exception_test` marker"
                 )
                 fixture_blocks.append(
                     InvalidFixtureBlock(
@@ -646,7 +646,7 @@ class BlockchainTest(BaseTest):
 
         if invalid_blocks == 0 and negative_test:
             raise Exception(
-                "test correctness: the test case is marked as negative but "
+                "test correctness: the test case is marked as an exception test but "
                 + "no invalid blocks were found"
             )
 
@@ -711,8 +711,8 @@ class BlockchainTest(BaseTest):
                     head_hash = header.block_hash
                 else:
                     assert negative_test, (
-                        "unmarked negative test: the test case produces an invalid block but "
-                        + "does not specify the `pytest.mark.negative` marker"
+                        "unmarked exception test: the test case produces an invalid block but "
+                        + "does not specify the `pytest.mark.exception_test` marker"
                     )
 
             if block.expected_post_state:

--- a/src/ethereum_test_specs/blockchain.py
+++ b/src/ethereum_test_specs/blockchain.py
@@ -633,7 +633,7 @@ class BlockchainTest(BaseTest):
                 self.verify_post_state(
                     t8n, t8n_state=alloc, expected_state=block.expected_post_state
                 )
-        self.check_negative_test(exception=invalid_blocks > 0)
+        self.check_exception_test(exception=invalid_blocks > 0)
         self.verify_post_state(t8n, t8n_state=alloc)
         network_info = BlockchainTest.network_info(fork, eips)
         return BlockchainFixture(
@@ -698,7 +698,7 @@ class BlockchainTest(BaseTest):
                 self.verify_post_state(
                     t8n, t8n_state=alloc, expected_state=block.expected_post_state
                 )
-        self.check_negative_test(exception=invalid_blocks > 0)
+        self.check_exception_test(exception=invalid_blocks > 0)
         fcu_version = fork.engine_forkchoice_updated_version(header.number, header.timestamp)
         assert fcu_version is not None, (
             "A hive fixture was requested but no forkchoice update is defined."

--- a/src/ethereum_test_specs/helpers.py
+++ b/src/ethereum_test_specs/helpers.py
@@ -316,7 +316,7 @@ def is_slow_test(request: pytest.FixtureRequest) -> bool:
 
 
 def is_negative_test(request: pytest.FixtureRequest) -> bool:
-    """Check if the test is negative (invalid block, invalid transaction)."""
+    """Check if the test is an exception test (invalid block, invalid transaction)."""
     if hasattr(request, "node"):
-        return request.node.get_closest_marker("negative") is not None
+        return request.node.get_closest_marker("exception_test") is not None
     return False

--- a/src/ethereum_test_specs/helpers.py
+++ b/src/ethereum_test_specs/helpers.py
@@ -4,8 +4,6 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, List
 
-import pytest
-
 from ethereum_clis import Result
 from ethereum_test_exceptions import (
     BlockException,
@@ -306,17 +304,3 @@ def verify_block(
         got_exception=result.block_exception,
     )
     info.verify(strict_match=transition_tool_exceptions_reliable)
-
-
-def is_slow_test(request: pytest.FixtureRequest) -> bool:
-    """Check if the test is slow."""
-    if hasattr(request, "node"):
-        return request.node.get_closest_marker("slow") is not None
-    return False
-
-
-def is_negative_test(request: pytest.FixtureRequest) -> bool:
-    """Check if the test is an exception test (invalid block, invalid transaction)."""
-    if hasattr(request, "node"):
-        return request.node.get_closest_marker("exception_test") is not None
-    return False

--- a/src/ethereum_test_specs/helpers.py
+++ b/src/ethereum_test_specs/helpers.py
@@ -313,3 +313,10 @@ def is_slow_test(request: pytest.FixtureRequest) -> bool:
     if hasattr(request, "node"):
         return request.node.get_closest_marker("slow") is not None
     return False
+
+
+def is_negative_test(request: pytest.FixtureRequest) -> bool:
+    """Check if the test is negative (invalid block, invalid transaction)."""
+    if hasattr(request, "node"):
+        return request.node.get_closest_marker("negative") is not None
+    return False

--- a/src/ethereum_test_specs/state.py
+++ b/src/ethereum_test_specs/state.py
@@ -231,7 +231,7 @@ class StateTest(BaseTest):
         eips: Optional[List[int]] = None,
     ) -> BaseFixture:
         """Generate the BlockchainTest fixture."""
-        self.check_negative_test(exception=self.tx.error is not None)
+        self.check_exception_test(exception=self.tx.error is not None)
         if fixture_format in BlockchainTest.supported_fixture_formats:
             return self.generate_blockchain_test(fork=fork).generate(
                 t8n=t8n, fork=fork, fixture_format=fixture_format, eips=eips

--- a/src/ethereum_test_specs/state.py
+++ b/src/ethereum_test_specs/state.py
@@ -34,7 +34,7 @@ from ethereum_test_types import Alloc, Environment, Transaction
 from .base import BaseTest
 from .blockchain import Block, BlockchainTest, Header
 from .debugging import print_traces
-from .helpers import is_slow_test, verify_transactions
+from .helpers import is_negative_test, is_slow_test, verify_transactions
 
 
 class StateTest(BaseTest):
@@ -233,6 +233,16 @@ class StateTest(BaseTest):
         eips: Optional[List[int]] = None,
     ) -> BaseFixture:
         """Generate the BlockchainTest fixture."""
+        if self.tx.error is not None and not is_negative_test(request):
+            raise Exception(
+                "State tests with an error code should be marked with the "
+                "`pytest.mark.negative` test marker"
+            )
+        elif self.tx.error is None and is_negative_test(request):
+            raise Exception(
+                "State tests without an error code should not be marked with the "
+                "`pytest.mark.negative` test marker"
+            )
         if fixture_format in BlockchainTest.supported_fixture_formats:
             return self.generate_blockchain_test(fork=fork).generate(
                 request=request, t8n=t8n, fork=fork, fixture_format=fixture_format, eips=eips

--- a/src/ethereum_test_specs/state.py
+++ b/src/ethereum_test_specs/state.py
@@ -236,12 +236,12 @@ class StateTest(BaseTest):
         if self.tx.error is not None and not is_negative_test(request):
             raise Exception(
                 "State tests with an error code should be marked with the "
-                "`pytest.mark.negative` test marker"
+                "`pytest.mark.exception_test` test marker"
             )
         elif self.tx.error is None and is_negative_test(request):
             raise Exception(
                 "State tests without an error code should not be marked with the "
-                "`pytest.mark.negative` test marker"
+                "`pytest.mark.exception_test` test marker"
             )
         if fixture_format in BlockchainTest.supported_fixture_formats:
             return self.generate_blockchain_test(fork=fork).generate(

--- a/src/ethereum_test_specs/state.py
+++ b/src/ethereum_test_specs/state.py
@@ -34,7 +34,7 @@ from ethereum_test_types import Alloc, Environment, Transaction
 from .base import BaseTest
 from .blockchain import Block, BlockchainTest, Header
 from .debugging import print_traces
-from .helpers import is_negative_test, is_slow_test, verify_transactions
+from .helpers import verify_transactions
 
 
 class StateTest(BaseTest):
@@ -142,12 +142,12 @@ class StateTest(BaseTest):
 
     def generate_blockchain_test(self, *, fork: Fork) -> BlockchainTest:
         """Generate a BlockchainTest fixture from this StateTest fixture."""
-        return BlockchainTest(
+        return BlockchainTest.from_test(
+            base_test=self,
             genesis_environment=self._generate_blockchain_genesis_environment(fork=fork),
             pre=self.pre,
             post=self.post,
             blocks=self._generate_blockchain_blocks(fork=fork),
-            t8n_dump_dir=self.t8n_dump_dir,
         )
 
     def make_state_test_fixture(
@@ -155,7 +155,6 @@ class StateTest(BaseTest):
         t8n: TransitionTool,
         fork: Fork,
         eips: Optional[List[int]] = None,
-        slow: bool = False,
     ) -> StateFixture:
         """Create a fixture from the state test definition."""
         # We can't generate a state test fixture that names a transition fork,
@@ -182,7 +181,7 @@ class StateTest(BaseTest):
             eips=eips,
             debug_output_path=self.get_next_transition_tool_output_path(),
             state_test=True,
-            slow_request=slow,
+            slow_request=self.is_slow_test(),
         )
 
         try:
@@ -226,29 +225,19 @@ class StateTest(BaseTest):
 
     def generate(
         self,
-        request: pytest.FixtureRequest,
         t8n: TransitionTool,
         fork: Fork,
         fixture_format: FixtureFormat,
         eips: Optional[List[int]] = None,
     ) -> BaseFixture:
         """Generate the BlockchainTest fixture."""
-        if self.tx.error is not None and not is_negative_test(request):
-            raise Exception(
-                "State tests with an error code should be marked with the "
-                "`pytest.mark.exception_test` test marker"
-            )
-        elif self.tx.error is None and is_negative_test(request):
-            raise Exception(
-                "State tests without an error code should not be marked with the "
-                "`pytest.mark.exception_test` test marker"
-            )
+        self.check_negative_test(exception=self.tx.error is not None)
         if fixture_format in BlockchainTest.supported_fixture_formats:
             return self.generate_blockchain_test(fork=fork).generate(
-                request=request, t8n=t8n, fork=fork, fixture_format=fixture_format, eips=eips
+                t8n=t8n, fork=fork, fixture_format=fixture_format, eips=eips
             )
         elif fixture_format == StateFixture:
-            return self.make_state_test_fixture(t8n, fork, eips, slow=is_slow_test(request))
+            return self.make_state_test_fixture(t8n, fork, eips)
 
         raise Exception(f"Unknown fixture format: {fixture_format}")
 

--- a/src/ethereum_test_specs/tests/test_expect.py
+++ b/src/ethereum_test_specs/tests/test_expect.py
@@ -120,7 +120,7 @@ def state_test(  # noqa: D103
 def test_post_storage_value_mismatch(expected_exception, state_test, default_t8n, fork):
     """Test post state `Account.storage` exceptions during state test fixture generation."""
     with pytest.raises(Storage.KeyValueMismatchError) as e_info:
-        state_test.generate(request=None, t8n=default_t8n, fork=fork, fixture_format=StateFixture)
+        state_test.generate(t8n=default_t8n, fork=fork, fixture_format=StateFixture)
     assert e_info.value == expected_exception
 
 
@@ -146,10 +146,10 @@ def test_post_nonce_value_mismatch(pre: Alloc, post: Alloc, state_test, default_
     pre_nonce = pre_account.nonce
     post_nonce = post_account.nonce
     if "nonce" not in post_account.model_fields_set:  # no exception
-        state_test.generate(request=None, t8n=default_t8n, fork=fork, fixture_format=StateFixture)
+        state_test.generate(t8n=default_t8n, fork=fork, fixture_format=StateFixture)
         return
     with pytest.raises(Account.NonceMismatchError) as e_info:
-        state_test.generate(request=None, t8n=default_t8n, fork=fork, fixture_format=StateFixture)
+        state_test.generate(t8n=default_t8n, fork=fork, fixture_format=StateFixture)
     assert e_info.value == Account.NonceMismatchError(
         address=ADDRESS_UNDER_TEST, want=post_nonce, got=pre_nonce
     )
@@ -177,10 +177,10 @@ def test_post_code_value_mismatch(pre: Alloc, post: Alloc, state_test, default_t
     pre_code = pre_account.code
     post_code = post_account.code
     if "code" not in post_account.model_fields_set:  # no exception
-        state_test.generate(request=None, t8n=default_t8n, fork=fork, fixture_format=StateFixture)
+        state_test.generate(t8n=default_t8n, fork=fork, fixture_format=StateFixture)
         return
     with pytest.raises(Account.CodeMismatchError) as e_info:
-        state_test.generate(request=None, t8n=default_t8n, fork=fork, fixture_format=StateFixture)
+        state_test.generate(t8n=default_t8n, fork=fork, fixture_format=StateFixture)
     assert e_info.value == Account.CodeMismatchError(
         address=ADDRESS_UNDER_TEST, want=post_code, got=pre_code
     )
@@ -208,10 +208,10 @@ def test_post_balance_value_mismatch(pre: Alloc, post: Alloc, state_test, defaul
     pre_balance = pre_account.balance
     post_balance = post_account.balance
     if "balance" not in post_account.model_fields_set:  # no exception
-        state_test.generate(request=None, t8n=default_t8n, fork=fork, fixture_format=StateFixture)
+        state_test.generate(t8n=default_t8n, fork=fork, fixture_format=StateFixture)
         return
     with pytest.raises(Account.BalanceMismatchError) as e_info:
-        state_test.generate(request=None, t8n=default_t8n, fork=fork, fixture_format=StateFixture)
+        state_test.generate(t8n=default_t8n, fork=fork, fixture_format=StateFixture)
     assert e_info.value == Account.BalanceMismatchError(
         address=ADDRESS_UNDER_TEST, want=post_balance, got=pre_balance
     )
@@ -252,10 +252,10 @@ def test_post_account_mismatch(
     fixture generation.
     """
     if exception_type is None:
-        state_test.generate(request=None, t8n=default_t8n, fork=fork, fixture_format=StateFixture)
+        state_test.generate(t8n=default_t8n, fork=fork, fixture_format=StateFixture)
         return
     with pytest.raises(exception_type) as _:
-        state_test.generate(request=None, t8n=default_t8n, fork=fork, fixture_format=StateFixture)
+        state_test.generate(t8n=default_t8n, fork=fork, fixture_format=StateFixture)
 
 
 # Transaction result mismatch tests
@@ -344,14 +344,10 @@ def test_transaction_expectation(
             f"({default_t8n.__class__.__name__})."
         )
     if exception_type is None:
-        state_test.generate(
-            request=None, t8n=default_t8n, fork=fork, fixture_format=fixture_format
-        )
+        state_test.generate(t8n=default_t8n, fork=fork, fixture_format=fixture_format)
     else:
         with pytest.raises(exception_type) as _:
-            state_test.generate(
-                request=None, t8n=default_t8n, fork=fork, fixture_format=fixture_format
-            )
+            state_test.generate(t8n=default_t8n, fork=fork, fixture_format=fixture_format)
 
 
 @pytest.mark.parametrize(
@@ -428,7 +424,7 @@ def test_block_intermediate_state(
                 post=block_3.expected_post_state,
                 blocks=[block_1, block_2, block_3],
             ).generate(
-                request=None,  # type: ignore
+                # type: ignore
                 t8n=default_t8n,
                 fork=fork,
                 fixture_format=fixture_format,
@@ -443,7 +439,7 @@ def test_block_intermediate_state(
             post=block_3.expected_post_state,
             blocks=[block_1, block_2, block_3],
         ).generate(
-            request=None,  # type: ignore
+            # type: ignore
             t8n=default_t8n,
             fork=fork,
             fixture_format=fixture_format,

--- a/src/ethereum_test_specs/tests/test_expect.py
+++ b/src/ethereum_test_specs/tests/test_expect.py
@@ -423,12 +423,7 @@ def test_block_intermediate_state(
                 pre=pre,
                 post=block_3.expected_post_state,
                 blocks=[block_1, block_2, block_3],
-            ).generate(
-                # type: ignore
-                t8n=default_t8n,
-                fork=fork,
-                fixture_format=fixture_format,
-            )
+            ).generate(t8n=default_t8n, fork=fork, fixture_format=fixture_format)
         return
     else:
         BlockchainTest(
@@ -438,9 +433,4 @@ def test_block_intermediate_state(
             pre=pre,
             post=block_3.expected_post_state,
             blocks=[block_1, block_2, block_3],
-        ).generate(
-            # type: ignore
-            t8n=default_t8n,
-            fork=fork,
-            fixture_format=fixture_format,
-        )
+        ).generate(t8n=default_t8n, fork=fork, fixture_format=fixture_format)

--- a/src/ethereum_test_specs/tests/test_fixtures.py
+++ b/src/ethereum_test_specs/tests/test_fixtures.py
@@ -87,12 +87,7 @@ def test_make_genesis(fork: Fork, fixture_hash: bytes, default_t8n: TransitionTo
         post={},
         blocks=[],
         tag="some_state_test",
-    ).generate(
-        request=None,  # type: ignore
-        t8n=default_t8n,
-        fork=fork,
-        fixture_format=BlockchainFixture,
-    )
+    ).generate(t8n=default_t8n, fork=fork, fixture_format=BlockchainFixture)
     assert isinstance(fixture, BlockchainFixture)
     assert fixture.genesis is not None
 
@@ -182,12 +177,7 @@ def test_fill_state_test(
         post=post,
         tx=tx,
         tag="my_chain_id_test",
-    ).generate(
-        request=None,  # type: ignore
-        t8n=default_t8n,
-        fork=fork,
-        fixture_format=fixture_format,
-    )
+    ).generate(t8n=default_t8n, fork=fork, fixture_format=fixture_format)
     assert generated_fixture.__class__ == fixture_format
     fixture = {
         f"000/my_chain_id_test/{fork}/tx_type_{tx_type}": generated_fixture.json_dict_with_info(
@@ -515,12 +505,7 @@ class TestFillBlockchainValidTxs:
             blocks=blocks,
             genesis_environment=genesis_environment,
             tag="my_blockchain_test_valid_txs",
-        ).generate(
-            request=None,  # type: ignore
-            t8n=default_t8n,
-            fork=fork,
-            fixture_format=fixture_format,
-        )
+        ).generate(t8n=default_t8n, fork=fork, fixture_format=fixture_format)
 
     @pytest.mark.parametrize("fork", [London, Shanghai], indirect=True)
     def test_fill_blockchain_valid_txs(  # noqa: D102
@@ -896,12 +881,7 @@ def test_fill_blockchain_invalid_txs(
         post=post,
         blocks=blocks,
         genesis_environment=genesis_environment,
-    ).generate(
-        request=None,  # type: ignore
-        t8n=default_t8n,
-        fork=fork,
-        fixture_format=fixture_format,
-    )
+    ).generate(t8n=default_t8n, fork=fork, fixture_format=fixture_format)
     assert generated_fixture.__class__ == fixture_format
     assert isinstance(generated_fixture, BlockchainFixtureCommon)
 

--- a/src/ethereum_test_specs/tests/test_transaction.py
+++ b/src/ethereum_test_specs/tests/test_transaction.py
@@ -22,7 +22,6 @@ from .helpers import remove_info_metadata
 def test_transaction_test_filling(name: str, tx: Transaction, fork: Fork):
     """Test the transaction test filling."""
     generated_fixture = TransactionTest(tx=tx.with_signature_and_sender()).generate(
-        request=None,  # type: ignore
         t8n=None,  # type: ignore
         fork=fork,
         fixture_format=TransactionFixture,

--- a/src/ethereum_test_specs/transaction.py
+++ b/src/ethereum_test_specs/transaction.py
@@ -89,12 +89,12 @@ class TransactionTest(BaseTest):
         if self.tx.error is not None and not is_negative_test(request):
             raise Exception(
                 "Transaction tests with an error code should be marked with the "
-                "`pytest.mark.negative` test marker."
+                "`pytest.mark.exception_test` test marker."
             )
         elif self.tx.error is None and is_negative_test(request):
             raise Exception(
                 "Transaction tests without an error code should not be marked with "
-                "`pytest.mark.negative` test marker."
+                "`pytest.mark.exception_test` test marker."
             )
         if fixture_format == TransactionFixture:
             return self.make_transaction_test_fixture(fork, eips)

--- a/src/ethereum_test_specs/transaction.py
+++ b/src/ethereum_test_specs/transaction.py
@@ -22,6 +22,7 @@ from ethereum_test_forks import Fork
 from ethereum_test_types import Alloc, Transaction
 
 from .base import BaseTest
+from .helpers import is_negative_test
 
 
 class TransactionTest(BaseTest):
@@ -85,6 +86,16 @@ class TransactionTest(BaseTest):
         eips: Optional[List[int]] = None,
     ) -> BaseFixture:
         """Generate the TransactionTest fixture."""
+        if self.tx.error is not None and not is_negative_test(request):
+            raise Exception(
+                "Transaction tests with an error code should be marked with the "
+                "`pytest.mark.negative` test marker."
+            )
+        elif self.tx.error is None and is_negative_test(request):
+            raise Exception(
+                "Transaction tests without an error code should not be marked with "
+                "`pytest.mark.negative` test marker."
+            )
         if fixture_format == TransactionFixture:
             return self.make_transaction_test_fixture(fork, eips)
 

--- a/src/ethereum_test_specs/transaction.py
+++ b/src/ethereum_test_specs/transaction.py
@@ -82,7 +82,7 @@ class TransactionTest(BaseTest):
         eips: Optional[List[int]] = None,
     ) -> BaseFixture:
         """Generate the TransactionTest fixture."""
-        self.check_negative_test(exception=self.tx.error is not None)
+        self.check_exception_test(exception=self.tx.error is not None)
         if fixture_format == TransactionFixture:
             return self.make_transaction_test_fixture(fork, eips)
 

--- a/src/ethereum_test_specs/transaction.py
+++ b/src/ethereum_test_specs/transaction.py
@@ -2,8 +2,6 @@
 
 from typing import Callable, ClassVar, Generator, List, Optional, Sequence, Type
 
-import pytest
-
 from ethereum_clis import TransitionTool
 from ethereum_test_execution import (
     BaseExecute,
@@ -22,7 +20,6 @@ from ethereum_test_forks import Fork
 from ethereum_test_types import Alloc, Transaction
 
 from .base import BaseTest
-from .helpers import is_negative_test
 
 
 class TransactionTest(BaseTest):
@@ -79,23 +76,13 @@ class TransactionTest(BaseTest):
 
     def generate(
         self,
-        request: pytest.FixtureRequest,
         t8n: TransitionTool,
         fork: Fork,
         fixture_format: FixtureFormat,
         eips: Optional[List[int]] = None,
     ) -> BaseFixture:
         """Generate the TransactionTest fixture."""
-        if self.tx.error is not None and not is_negative_test(request):
-            raise Exception(
-                "Transaction tests with an error code should be marked with the "
-                "`pytest.mark.exception_test` test marker."
-            )
-        elif self.tx.error is None and is_negative_test(request):
-            raise Exception(
-                "Transaction tests without an error code should not be marked with "
-                "`pytest.mark.exception_test` test marker."
-            )
+        self.check_negative_test(exception=self.tx.error is not None)
         if fixture_format == TransactionFixture:
             return self.make_transaction_test_fixture(fork, eips)
 

--- a/src/ethereum_test_tools/tests/test_code.py
+++ b/src/ethereum_test_tools/tests/test_code.py
@@ -630,7 +630,6 @@ def test_switch(
         post=post,
     )
     state_test.generate(
-        request=None,  # type: ignore
         t8n=default_t8n,
         fork=Cancun,
         fixture_format=BlockchainFixture,

--- a/src/pytest_plugins/execute/execute.py
+++ b/src/pytest_plugins/execute/execute.py
@@ -268,6 +268,7 @@ def base_test_parametrizer(cls: Type[BaseTest]):
                 request.node.config.sender_address = str(pre._sender)
 
                 super(BaseTestWrapper, self).__init__(*args, **kwargs)
+                self._request = request
 
                 # wait for pre-requisite transactions to be included in blocks
                 pre.wait_for_transactions()

--- a/src/pytest_plugins/filler/filler.py
+++ b/src/pytest_plugins/filler/filler.py
@@ -717,8 +717,8 @@ def base_test_parametrizer(cls: Type[BaseTest]):
                 if "pre" not in kwargs:
                     kwargs["pre"] = pre
                 super(BaseTestWrapper, self).__init__(*args, **kwargs)
+                self._request = request
                 fixture = self.generate(
-                    request=request,
                     t8n=t8n,
                     fork=fork,
                     fixture_format=fixture_format,

--- a/src/pytest_plugins/shared/execute_fill.py
+++ b/src/pytest_plugins/shared/execute_fill.py
@@ -87,7 +87,7 @@ def pytest_configure(config: pytest.Config):
     )
     config.addinivalue_line(
         "markers",
-        "negative: Negative tests that include an invalid block or transaction.",
+        "exception_test: Negative tests that include an invalid block or transaction.",
     )
 
 

--- a/src/pytest_plugins/shared/execute_fill.py
+++ b/src/pytest_plugins/shared/execute_fill.py
@@ -85,6 +85,10 @@ def pytest_configure(config: pytest.Config):
         "markers",
         "zkevm: Tests that are relevant to zkEVM.",
     )
+    config.addinivalue_line(
+        "markers",
+        "negative: Negative tests that include an invalid block or transaction.",
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/cancun/eip4844_blobs/test_blob_txs.py
+++ b/tests/cancun/eip4844_blobs/test_blob_txs.py
@@ -424,7 +424,7 @@ def generate_invalid_tx_max_fee_per_blob_gas_tests(
             min_base_fee_per_blob_gas,  # tx max_blob_gas_cost is the minimum
             TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS,
             id="insufficient_max_fee_per_blob_gas",
-            marks=pytest.mark.negative,
+            marks=pytest.mark.exception_test,
         )
     )
     if (next_base_fee_per_blob_gas - min_base_fee_per_blob_gas) > 1:
@@ -437,7 +437,7 @@ def generate_invalid_tx_max_fee_per_blob_gas_tests(
                 - 1,  # tx max_blob_gas_cost is one less than the minimum
                 TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS,
                 id="insufficient_max_fee_per_blob_gas_one_less_than_next",
-                marks=pytest.mark.negative,
+                marks=pytest.mark.exception_test,
             )
         )
     if min_base_fee_per_blob_gas > 1:
@@ -448,7 +448,7 @@ def generate_invalid_tx_max_fee_per_blob_gas_tests(
                 min_base_fee_per_blob_gas - 1,  # tx max_blob_gas_cost is one less than the minimum
                 TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS,
                 id="insufficient_max_fee_per_blob_gas_one_less_than_min",
-                marks=pytest.mark.negative,
+                marks=pytest.mark.exception_test,
             )
         )
 
@@ -459,7 +459,7 @@ def generate_invalid_tx_max_fee_per_blob_gas_tests(
             0,  # tx max_blob_gas_cost is 0
             TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS,
             id="invalid_max_fee_per_blob_gas",
-            marks=pytest.mark.negative,
+            marks=pytest.mark.exception_test,
         )
     )
     return tests
@@ -537,7 +537,7 @@ def test_invalid_tx_max_fee_per_blob_gas_state(
     ],
     ids=["insufficient_max_fee_per_gas"],
 )
-@pytest.mark.negative
+@pytest.mark.exception_test
 @pytest.mark.valid_from("Cancun")
 def test_invalid_normal_gas(
     state_test: StateTestFiller,
@@ -577,7 +577,7 @@ def test_invalid_normal_gas(
     ],
     ids=[""],
 )
-@pytest.mark.negative
+@pytest.mark.exception_test
 @pytest.mark.valid_from("Cancun")
 def test_invalid_block_blob_count(
     blockchain_test: BlockchainTestFiller,
@@ -617,7 +617,7 @@ def test_invalid_block_blob_count(
 @pytest.mark.parametrize("tx_max_fee_per_blob_gas_multiplier", [1, 100, 10000])
 @pytest.mark.parametrize("account_balance_modifier", [-1], ids=["exact_balance_minus_1"])
 @pytest.mark.parametrize("tx_error", [TransactionException.INSUFFICIENT_ACCOUNT_FUNDS], ids=[""])
-@pytest.mark.negative
+@pytest.mark.exception_test
 @pytest.mark.valid_from("Cancun")
 def test_insufficient_balance_blob_tx(
     state_test: StateTestFiller,
@@ -838,7 +838,7 @@ def test_blob_gas_subtraction_tx(
 )
 @pytest.mark.parametrize("account_balance_modifier", [-1], ids=["exact_balance_minus_1"])
 @pytest.mark.parametrize("tx_error", [TransactionException.INSUFFICIENT_ACCOUNT_FUNDS], ids=[""])
-@pytest.mark.negative
+@pytest.mark.exception_test
 @pytest.mark.valid_from("Cancun")
 def test_insufficient_balance_blob_tx_combinations(
     blockchain_test: BlockchainTestFiller,
@@ -885,7 +885,7 @@ def generate_invalid_tx_blob_count_tests(
     "blobs_per_tx,tx_error",
     generate_invalid_tx_blob_count_tests,
 )
-@pytest.mark.negative
+@pytest.mark.exception_test
 @pytest.mark.valid_from("Cancun")
 def test_invalid_tx_blob_count(
     state_test: StateTestFiller,
@@ -930,7 +930,7 @@ def test_invalid_tx_blob_count(
 @pytest.mark.parametrize(
     "tx_error", [TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH], ids=[""]
 )
-@pytest.mark.negative
+@pytest.mark.exception_test
 @pytest.mark.valid_from("Cancun")
 def test_invalid_blob_hash_versioning_single_tx(
     state_test: StateTestFiller,
@@ -989,7 +989,7 @@ def test_invalid_blob_hash_versioning_single_tx(
 @pytest.mark.parametrize(
     "tx_error", [TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH], ids=[""]
 )
-@pytest.mark.negative
+@pytest.mark.exception_test
 @pytest.mark.valid_from("Cancun")
 def test_invalid_blob_hash_versioning_multiple_txs(
     blockchain_test: BlockchainTestFiller,
@@ -1016,7 +1016,7 @@ def test_invalid_blob_hash_versioning_multiple_txs(
 @pytest.mark.parametrize(
     "tx_gas", [500_000], ids=[""]
 )  # Increase gas to account for contract creation
-@pytest.mark.negative
+@pytest.mark.exception_test
 @pytest.mark.valid_from("Cancun")
 def test_invalid_blob_tx_contract_creation(
     blockchain_test: BlockchainTestFiller,
@@ -1359,7 +1359,7 @@ def test_blob_tx_attribute_gasprice_opcode(
     ],
     ids=["no_blob_tx", "one_blob_tx"],
 )
-@pytest.mark.negative
+@pytest.mark.exception_test
 @pytest.mark.valid_at_transition_to("Cancun")
 def test_blob_type_tx_pre_fork(
     state_test: StateTestFiller,

--- a/tests/cancun/eip4844_blobs/test_blob_txs.py
+++ b/tests/cancun/eip4844_blobs/test_blob_txs.py
@@ -424,6 +424,7 @@ def generate_invalid_tx_max_fee_per_blob_gas_tests(
             min_base_fee_per_blob_gas,  # tx max_blob_gas_cost is the minimum
             TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS,
             id="insufficient_max_fee_per_blob_gas",
+            marks=pytest.mark.negative,
         )
     )
     if (next_base_fee_per_blob_gas - min_base_fee_per_blob_gas) > 1:
@@ -436,6 +437,7 @@ def generate_invalid_tx_max_fee_per_blob_gas_tests(
                 - 1,  # tx max_blob_gas_cost is one less than the minimum
                 TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS,
                 id="insufficient_max_fee_per_blob_gas_one_less_than_next",
+                marks=pytest.mark.negative,
             )
         )
     if min_base_fee_per_blob_gas > 1:
@@ -446,6 +448,7 @@ def generate_invalid_tx_max_fee_per_blob_gas_tests(
                 min_base_fee_per_blob_gas - 1,  # tx max_blob_gas_cost is one less than the minimum
                 TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS,
                 id="insufficient_max_fee_per_blob_gas_one_less_than_min",
+                marks=pytest.mark.negative,
             )
         )
 
@@ -456,6 +459,7 @@ def generate_invalid_tx_max_fee_per_blob_gas_tests(
             0,  # tx max_blob_gas_cost is 0
             TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS,
             id="invalid_max_fee_per_blob_gas",
+            marks=pytest.mark.negative,
         )
     )
     return tests
@@ -533,6 +537,7 @@ def test_invalid_tx_max_fee_per_blob_gas_state(
     ],
     ids=["insufficient_max_fee_per_gas"],
 )
+@pytest.mark.negative
 @pytest.mark.valid_from("Cancun")
 def test_invalid_normal_gas(
     state_test: StateTestFiller,
@@ -572,6 +577,7 @@ def test_invalid_normal_gas(
     ],
     ids=[""],
 )
+@pytest.mark.negative
 @pytest.mark.valid_from("Cancun")
 def test_invalid_block_blob_count(
     blockchain_test: BlockchainTestFiller,
@@ -611,6 +617,7 @@ def test_invalid_block_blob_count(
 @pytest.mark.parametrize("tx_max_fee_per_blob_gas_multiplier", [1, 100, 10000])
 @pytest.mark.parametrize("account_balance_modifier", [-1], ids=["exact_balance_minus_1"])
 @pytest.mark.parametrize("tx_error", [TransactionException.INSUFFICIENT_ACCOUNT_FUNDS], ids=[""])
+@pytest.mark.negative
 @pytest.mark.valid_from("Cancun")
 def test_insufficient_balance_blob_tx(
     state_test: StateTestFiller,
@@ -831,6 +838,7 @@ def test_blob_gas_subtraction_tx(
 )
 @pytest.mark.parametrize("account_balance_modifier", [-1], ids=["exact_balance_minus_1"])
 @pytest.mark.parametrize("tx_error", [TransactionException.INSUFFICIENT_ACCOUNT_FUNDS], ids=[""])
+@pytest.mark.negative
 @pytest.mark.valid_from("Cancun")
 def test_insufficient_balance_blob_tx_combinations(
     blockchain_test: BlockchainTestFiller,
@@ -877,6 +885,7 @@ def generate_invalid_tx_blob_count_tests(
     "blobs_per_tx,tx_error",
     generate_invalid_tx_blob_count_tests,
 )
+@pytest.mark.negative
 @pytest.mark.valid_from("Cancun")
 def test_invalid_tx_blob_count(
     state_test: StateTestFiller,
@@ -921,6 +930,7 @@ def test_invalid_tx_blob_count(
 @pytest.mark.parametrize(
     "tx_error", [TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH], ids=[""]
 )
+@pytest.mark.negative
 @pytest.mark.valid_from("Cancun")
 def test_invalid_blob_hash_versioning_single_tx(
     state_test: StateTestFiller,
@@ -979,6 +989,7 @@ def test_invalid_blob_hash_versioning_single_tx(
 @pytest.mark.parametrize(
     "tx_error", [TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH], ids=[""]
 )
+@pytest.mark.negative
 @pytest.mark.valid_from("Cancun")
 def test_invalid_blob_hash_versioning_multiple_txs(
     blockchain_test: BlockchainTestFiller,
@@ -1005,6 +1016,7 @@ def test_invalid_blob_hash_versioning_multiple_txs(
 @pytest.mark.parametrize(
     "tx_gas", [500_000], ids=[""]
 )  # Increase gas to account for contract creation
+@pytest.mark.negative
 @pytest.mark.valid_from("Cancun")
 def test_invalid_blob_tx_contract_creation(
     blockchain_test: BlockchainTestFiller,
@@ -1347,6 +1359,7 @@ def test_blob_tx_attribute_gasprice_opcode(
     ],
     ids=["no_blob_tx", "one_blob_tx"],
 )
+@pytest.mark.negative
 @pytest.mark.valid_at_transition_to("Cancun")
 def test_blob_type_tx_pre_fork(
     state_test: StateTestFiller,

--- a/tests/cancun/eip4844_blobs/test_blob_txs_full.py
+++ b/tests/cancun/eip4844_blobs/test_blob_txs_full.py
@@ -293,7 +293,7 @@ def generate_full_blob_tests(
     "txs_blobs,txs_wrapped_blobs",
     generate_full_blob_tests,
 )
-@pytest.mark.negative
+@pytest.mark.exception_test
 @pytest.mark.valid_from("Cancun")
 def test_reject_valid_full_blob_in_block_rlp(
     blockchain_test: BlockchainTestFiller,

--- a/tests/cancun/eip4844_blobs/test_blob_txs_full.py
+++ b/tests/cancun/eip4844_blobs/test_blob_txs_full.py
@@ -293,6 +293,7 @@ def generate_full_blob_tests(
     "txs_blobs,txs_wrapped_blobs",
     generate_full_blob_tests,
 )
+@pytest.mark.negative
 @pytest.mark.valid_from("Cancun")
 def test_reject_valid_full_blob_in_block_rlp(
     blockchain_test: BlockchainTestFiller,

--- a/tests/cancun/eip4844_blobs/test_excess_blob_gas.py
+++ b/tests/cancun/eip4844_blobs/test_excess_blob_gas.py
@@ -387,6 +387,7 @@ def test_correct_decreasing_blob_gas_costs(
     "parent_blobs",
     lambda fork: range(0, fork.max_blobs_per_block() + 1),
 )
+@pytest.mark.negative
 def test_invalid_zero_excess_blob_gas_in_header(
     blockchain_test: BlockchainTestFiller,
     env: Environment,
@@ -435,6 +436,7 @@ def all_invalid_blob_gas_used_combinations(fork: Fork) -> Iterator[Tuple[int, in
     all_invalid_blob_gas_used_combinations,
 )
 @pytest.mark.parametrize("parent_blobs", [0])
+@pytest.mark.negative
 def test_invalid_blob_gas_used_in_header(
     blockchain_test: BlockchainTestFiller,
     env: Environment,
@@ -479,6 +481,7 @@ def generate_invalid_excess_blob_gas_above_target_change_tests(fork: Fork) -> Li
     generate_invalid_excess_blob_gas_above_target_change_tests,
 )
 @pytest.mark.parametrize("new_blobs", [1])
+@pytest.mark.negative
 def test_invalid_excess_blob_gas_above_target_change(
     blockchain_test: BlockchainTestFiller,
     env: Environment,
@@ -523,6 +526,7 @@ def test_invalid_excess_blob_gas_above_target_change(
     "parent_excess_blobs", lambda fork: [1, fork.target_blobs_per_block()]
 )
 @pytest.mark.parametrize("new_blobs", [1])
+@pytest.mark.negative
 def test_invalid_static_excess_blob_gas(
     blockchain_test: BlockchainTestFiller,
     env: Environment,
@@ -564,6 +568,7 @@ def test_invalid_static_excess_blob_gas(
 )
 @pytest.mark.parametrize("parent_excess_blobs", [0])  # Start at 0
 @pytest.mark.parametrize("new_blobs", [1])
+@pytest.mark.negative
 def test_invalid_excess_blob_gas_target_blobs_increase_from_zero(
     blockchain_test: BlockchainTestFiller,
     env: Environment,
@@ -605,6 +610,7 @@ def test_invalid_excess_blob_gas_target_blobs_increase_from_zero(
 )
 @pytest.mark.parametrize("parent_excess_blobs", [0])  # Start at 0
 @pytest.mark.parametrize("new_blobs", [1])
+@pytest.mark.negative
 def test_invalid_static_excess_blob_gas_from_zero_on_blobs_above_target(
     blockchain_test: BlockchainTestFiller,
     env: Environment,
@@ -653,6 +659,7 @@ def test_invalid_static_excess_blob_gas_from_zero_on_blobs_above_target(
     ),
 )
 @pytest.mark.parametrize("new_blobs", [1])
+@pytest.mark.negative
 def test_invalid_excess_blob_gas_change(
     blockchain_test: BlockchainTestFiller,
     env: Environment,
@@ -704,6 +711,7 @@ def test_invalid_excess_blob_gas_change(
     "parent_excess_blobs",
     lambda fork: range(fork.target_blobs_per_block()),
 )
+@pytest.mark.negative
 def test_invalid_negative_excess_blob_gas(
     blockchain_test: BlockchainTestFiller,
     env: Environment,
@@ -753,6 +761,7 @@ def test_invalid_negative_excess_blob_gas(
     "parent_excess_blobs",
     lambda fork: [fork.target_blobs_per_block() + 1],
 )
+@pytest.mark.negative
 def test_invalid_non_multiple_excess_blob_gas(
     blockchain_test: BlockchainTestFiller,
     env: Environment,

--- a/tests/cancun/eip4844_blobs/test_excess_blob_gas.py
+++ b/tests/cancun/eip4844_blobs/test_excess_blob_gas.py
@@ -387,7 +387,7 @@ def test_correct_decreasing_blob_gas_costs(
     "parent_blobs",
     lambda fork: range(0, fork.max_blobs_per_block() + 1),
 )
-@pytest.mark.negative
+@pytest.mark.exception_test
 def test_invalid_zero_excess_blob_gas_in_header(
     blockchain_test: BlockchainTestFiller,
     env: Environment,
@@ -436,7 +436,7 @@ def all_invalid_blob_gas_used_combinations(fork: Fork) -> Iterator[Tuple[int, in
     all_invalid_blob_gas_used_combinations,
 )
 @pytest.mark.parametrize("parent_blobs", [0])
-@pytest.mark.negative
+@pytest.mark.exception_test
 def test_invalid_blob_gas_used_in_header(
     blockchain_test: BlockchainTestFiller,
     env: Environment,
@@ -481,7 +481,7 @@ def generate_invalid_excess_blob_gas_above_target_change_tests(fork: Fork) -> Li
     generate_invalid_excess_blob_gas_above_target_change_tests,
 )
 @pytest.mark.parametrize("new_blobs", [1])
-@pytest.mark.negative
+@pytest.mark.exception_test
 def test_invalid_excess_blob_gas_above_target_change(
     blockchain_test: BlockchainTestFiller,
     env: Environment,
@@ -526,7 +526,7 @@ def test_invalid_excess_blob_gas_above_target_change(
     "parent_excess_blobs", lambda fork: [1, fork.target_blobs_per_block()]
 )
 @pytest.mark.parametrize("new_blobs", [1])
-@pytest.mark.negative
+@pytest.mark.exception_test
 def test_invalid_static_excess_blob_gas(
     blockchain_test: BlockchainTestFiller,
     env: Environment,
@@ -568,7 +568,7 @@ def test_invalid_static_excess_blob_gas(
 )
 @pytest.mark.parametrize("parent_excess_blobs", [0])  # Start at 0
 @pytest.mark.parametrize("new_blobs", [1])
-@pytest.mark.negative
+@pytest.mark.exception_test
 def test_invalid_excess_blob_gas_target_blobs_increase_from_zero(
     blockchain_test: BlockchainTestFiller,
     env: Environment,
@@ -610,7 +610,7 @@ def test_invalid_excess_blob_gas_target_blobs_increase_from_zero(
 )
 @pytest.mark.parametrize("parent_excess_blobs", [0])  # Start at 0
 @pytest.mark.parametrize("new_blobs", [1])
-@pytest.mark.negative
+@pytest.mark.exception_test
 def test_invalid_static_excess_blob_gas_from_zero_on_blobs_above_target(
     blockchain_test: BlockchainTestFiller,
     env: Environment,
@@ -659,7 +659,7 @@ def test_invalid_static_excess_blob_gas_from_zero_on_blobs_above_target(
     ),
 )
 @pytest.mark.parametrize("new_blobs", [1])
-@pytest.mark.negative
+@pytest.mark.exception_test
 def test_invalid_excess_blob_gas_change(
     blockchain_test: BlockchainTestFiller,
     env: Environment,
@@ -711,7 +711,7 @@ def test_invalid_excess_blob_gas_change(
     "parent_excess_blobs",
     lambda fork: range(fork.target_blobs_per_block()),
 )
-@pytest.mark.negative
+@pytest.mark.exception_test
 def test_invalid_negative_excess_blob_gas(
     blockchain_test: BlockchainTestFiller,
     env: Environment,
@@ -761,7 +761,7 @@ def test_invalid_negative_excess_blob_gas(
     "parent_excess_blobs",
     lambda fork: [fork.target_blobs_per_block() + 1],
 )
-@pytest.mark.negative
+@pytest.mark.exception_test
 def test_invalid_non_multiple_excess_blob_gas(
     blockchain_test: BlockchainTestFiller,
     env: Environment,

--- a/tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py
+++ b/tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py
@@ -213,6 +213,7 @@ def post(  # noqa: D103
         (True, True),
     ],
 )
+@pytest.mark.negative
 def test_invalid_pre_fork_block_with_blob_fields(
     blockchain_test: BlockchainTestFiller,
     env: Environment,
@@ -257,6 +258,7 @@ def test_invalid_pre_fork_block_with_blob_fields(
         (True, True),
     ],
 )
+@pytest.mark.negative
 def test_invalid_post_fork_block_without_blob_fields(
     blockchain_test: BlockchainTestFiller,
     env: Environment,

--- a/tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py
+++ b/tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py
@@ -213,7 +213,7 @@ def post(  # noqa: D103
         (True, True),
     ],
 )
-@pytest.mark.negative
+@pytest.mark.exception_test
 def test_invalid_pre_fork_block_with_blob_fields(
     blockchain_test: BlockchainTestFiller,
     env: Environment,
@@ -258,7 +258,7 @@ def test_invalid_pre_fork_block_with_blob_fields(
         (True, True),
     ],
 )
-@pytest.mark.negative
+@pytest.mark.exception_test
 def test_invalid_post_fork_block_without_blob_fields(
     blockchain_test: BlockchainTestFiller,
     env: Environment,

--- a/tests/prague/eip6110_deposits/test_deposits.py
+++ b/tests/prague/eip6110_deposits/test_deposits.py
@@ -951,7 +951,7 @@ def test_deposit(
         ),
     ],
 )
-@pytest.mark.negative
+@pytest.mark.exception_test
 def test_deposit_negative(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,

--- a/tests/prague/eip6110_deposits/test_deposits.py
+++ b/tests/prague/eip6110_deposits/test_deposits.py
@@ -951,6 +951,7 @@ def test_deposit(
         ),
     ],
 )
+@pytest.mark.negative
 def test_deposit_negative(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,

--- a/tests/prague/eip7002_el_triggerable_withdrawals/test_withdrawal_requests.py
+++ b/tests/prague/eip7002_el_triggerable_withdrawals/test_withdrawal_requests.py
@@ -679,7 +679,7 @@ def test_withdrawal_requests(
         ),
     ],
 )
-@pytest.mark.negative
+@pytest.mark.exception_test
 def test_withdrawal_requests_negative(
     pre: Alloc,
     fork: Fork,

--- a/tests/prague/eip7002_el_triggerable_withdrawals/test_withdrawal_requests.py
+++ b/tests/prague/eip7002_el_triggerable_withdrawals/test_withdrawal_requests.py
@@ -679,6 +679,7 @@ def test_withdrawal_requests(
         ),
     ],
 )
+@pytest.mark.negative
 def test_withdrawal_requests_negative(
     pre: Alloc,
     fork: Fork,

--- a/tests/prague/eip7251_consolidations/test_consolidations.py
+++ b/tests/prague/eip7251_consolidations/test_consolidations.py
@@ -730,6 +730,7 @@ def test_consolidation_requests(
         ),
     ],
 )
+@pytest.mark.negative
 def test_consolidation_requests_negative(
     pre: Alloc,
     fork: Fork,

--- a/tests/prague/eip7251_consolidations/test_consolidations.py
+++ b/tests/prague/eip7251_consolidations/test_consolidations.py
@@ -730,7 +730,7 @@ def test_consolidation_requests(
         ),
     ],
 )
-@pytest.mark.negative
+@pytest.mark.exception_test
 def test_consolidation_requests_negative(
     pre: Alloc,
     fork: Fork,

--- a/tests/prague/eip7623_increase_calldata_cost/test_transaction_validity.py
+++ b/tests/prague/eip7623_increase_calldata_cost/test_transaction_validity.py
@@ -37,7 +37,7 @@ pytestmark += [
             # the data floor does not consume more gas than it should.
             pytest.param(1, id="extra_gas"),
             pytest.param(0, id="exact_gas"),
-            pytest.param(-1, id="insufficient_gas"),
+            pytest.param(-1, id="insufficient_gas", marks=pytest.mark.negative),
         ],
     ),
     pytest.mark.parametrize(

--- a/tests/prague/eip7623_increase_calldata_cost/test_transaction_validity.py
+++ b/tests/prague/eip7623_increase_calldata_cost/test_transaction_validity.py
@@ -37,7 +37,7 @@ pytestmark += [
             # the data floor does not consume more gas than it should.
             pytest.param(1, id="extra_gas"),
             pytest.param(0, id="exact_gas"),
-            pytest.param(-1, id="insufficient_gas", marks=pytest.mark.negative),
+            pytest.param(-1, id="insufficient_gas", marks=pytest.mark.exception_test),
         ],
     ),
     pytest.mark.parametrize(

--- a/tests/prague/eip7685_general_purpose_el_requests/test_multi_type_requests.py
+++ b/tests/prague/eip7685_general_purpose_el_requests/test_multi_type_requests.py
@@ -604,7 +604,7 @@ def invalid_requests_block_combinations(fork: Fork) -> List[ParameterSet]:
     "requests,block_body_override_requests,exception",
     invalid_requests_block_combinations,
 )
-@pytest.mark.negative
+@pytest.mark.exception_test
 def test_invalid_deposit_withdrawal_consolidation_requests(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
@@ -632,7 +632,7 @@ def test_invalid_deposit_withdrawal_consolidation_requests(
 )
 @pytest.mark.parametrize("correct_requests_hash_in_header", [True])
 @pytest.mark.blockchain_test_engine_only
-@pytest.mark.negative
+@pytest.mark.exception_test
 def test_invalid_deposit_withdrawal_consolidation_requests_engine(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,

--- a/tests/prague/eip7685_general_purpose_el_requests/test_multi_type_requests.py
+++ b/tests/prague/eip7685_general_purpose_el_requests/test_multi_type_requests.py
@@ -604,6 +604,7 @@ def invalid_requests_block_combinations(fork: Fork) -> List[ParameterSet]:
     "requests,block_body_override_requests,exception",
     invalid_requests_block_combinations,
 )
+@pytest.mark.negative
 def test_invalid_deposit_withdrawal_consolidation_requests(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
@@ -631,6 +632,7 @@ def test_invalid_deposit_withdrawal_consolidation_requests(
 )
 @pytest.mark.parametrize("correct_requests_hash_in_header", [True])
 @pytest.mark.blockchain_test_engine_only
+@pytest.mark.negative
 def test_invalid_deposit_withdrawal_consolidation_requests_engine(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,

--- a/tests/prague/eip7702_set_code_tx/test_gas.py
+++ b/tests/prague/eip7702_set_code_tx/test_gas.py
@@ -894,7 +894,7 @@ def test_account_warming(
 @pytest.mark.parametrize(**gas_test_parameter_args(include_pre_authorized=False))
 @pytest.mark.parametrize(
     "valid",
-    [True, pytest.param(False, marks=pytest.mark.negative)],
+    [True, pytest.param(False, marks=pytest.mark.exception_test)],
 )
 def test_intrinsic_gas_cost(
     state_test: StateTestFiller,

--- a/tests/prague/eip7702_set_code_tx/test_gas.py
+++ b/tests/prague/eip7702_set_code_tx/test_gas.py
@@ -894,7 +894,7 @@ def test_account_warming(
 @pytest.mark.parametrize(**gas_test_parameter_args(include_pre_authorized=False))
 @pytest.mark.parametrize(
     "valid",
-    [True, False],
+    [True, pytest.param(False, marks=pytest.mark.negative)],
 )
 def test_intrinsic_gas_cost(
     state_test: StateTestFiller,

--- a/tests/prague/eip7702_set_code_tx/test_invalid_tx.py
+++ b/tests/prague/eip7702_set_code_tx/test_invalid_tx.py
@@ -23,7 +23,7 @@ from .spec import Spec, ref_spec_7702
 REFERENCE_SPEC_GIT_PATH = ref_spec_7702.git_path
 REFERENCE_SPEC_VERSION = ref_spec_7702.version
 
-pytestmark = pytest.mark.valid_from("Prague")
+pytestmark = [pytest.mark.valid_from("Prague"), pytest.mark.negative]
 
 auth_account_start_balance = 0
 

--- a/tests/prague/eip7702_set_code_tx/test_invalid_tx.py
+++ b/tests/prague/eip7702_set_code_tx/test_invalid_tx.py
@@ -23,7 +23,7 @@ from .spec import Spec, ref_spec_7702
 REFERENCE_SPEC_GIT_PATH = ref_spec_7702.git_path
 REFERENCE_SPEC_VERSION = ref_spec_7702.version
 
-pytestmark = [pytest.mark.valid_from("Prague"), pytest.mark.negative]
+pytestmark = [pytest.mark.valid_from("Prague"), pytest.mark.exception_test]
 
 auth_account_start_balance = 0
 

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -2973,6 +2973,7 @@ def test_reset_code(
     )
 
 
+@pytest.mark.negative
 def test_contract_create(
     state_test: StateTestFiller,
     pre: Alloc,
@@ -3000,6 +3001,7 @@ def test_contract_create(
     )
 
 
+@pytest.mark.negative
 def test_empty_authorization_list(
     state_test: StateTestFiller,
     pre: Alloc,
@@ -3488,6 +3490,7 @@ def test_many_delegations(
     )
 
 
+@pytest.mark.negative
 def test_invalid_transaction_after_authorization(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
@@ -3589,6 +3592,7 @@ def test_authorization_reusing_nonce(
     "self_sponsored",
     [True, False],
 )
+@pytest.mark.negative
 @pytest.mark.execute(pytest.mark.skip(reason="Requires contract-eoa address collision"))
 def test_set_code_from_account_with_non_delegating_code(
     state_test: StateTestFiller,
@@ -3669,6 +3673,7 @@ def test_set_code_from_account_with_non_delegating_code(
         "priority_greater_than_max_fee_per_gas",
     ],
 )
+@pytest.mark.negative
 def test_set_code_transaction_fee_validations(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -2973,7 +2973,7 @@ def test_reset_code(
     )
 
 
-@pytest.mark.negative
+@pytest.mark.exception_test
 def test_contract_create(
     state_test: StateTestFiller,
     pre: Alloc,
@@ -3001,7 +3001,7 @@ def test_contract_create(
     )
 
 
-@pytest.mark.negative
+@pytest.mark.exception_test
 def test_empty_authorization_list(
     state_test: StateTestFiller,
     pre: Alloc,
@@ -3490,7 +3490,7 @@ def test_many_delegations(
     )
 
 
-@pytest.mark.negative
+@pytest.mark.exception_test
 def test_invalid_transaction_after_authorization(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
@@ -3592,7 +3592,7 @@ def test_authorization_reusing_nonce(
     "self_sponsored",
     [True, False],
 )
-@pytest.mark.negative
+@pytest.mark.exception_test
 @pytest.mark.execute(pytest.mark.skip(reason="Requires contract-eoa address collision"))
 def test_set_code_from_account_with_non_delegating_code(
     state_test: StateTestFiller,
@@ -3673,7 +3673,7 @@ def test_set_code_from_account_with_non_delegating_code(
         "priority_greater_than_max_fee_per_gas",
     ],
 )
-@pytest.mark.negative
+@pytest.mark.exception_test
 def test_set_code_transaction_fee_validations(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/shanghai/eip3860_initcode/test_initcode.py
+++ b/tests/shanghai/eip3860_initcode/test_initcode.py
@@ -122,8 +122,8 @@ Test cases using a contract creating transaction
     [
         INITCODE_ZEROS_MAX_LIMIT,
         INITCODE_ONES_MAX_LIMIT,
-        INITCODE_ZEROS_OVER_LIMIT,
-        INITCODE_ONES_OVER_LIMIT,
+        pytest.param(INITCODE_ZEROS_OVER_LIMIT, marks=pytest.mark.negative),
+        pytest.param(INITCODE_ONES_OVER_LIMIT, marks=pytest.mark.negative),
     ],
     ids=get_initcode_name,
 )
@@ -181,7 +181,11 @@ def valid_gas_test_case(initcode: Initcode, gas_test_case: str) -> bool:
 @pytest.mark.parametrize(
     "initcode,gas_test_case",
     [
-        (i, g)
+        pytest.param(
+            i,
+            g,
+            marks=([pytest.mark.negative] if g == "too_little_intrinsic_gas" else []),
+        )
         for i in [
             INITCODE_ZEROS_MAX_LIMIT,
             INITCODE_ONES_MAX_LIMIT,

--- a/tests/shanghai/eip3860_initcode/test_initcode.py
+++ b/tests/shanghai/eip3860_initcode/test_initcode.py
@@ -122,8 +122,8 @@ Test cases using a contract creating transaction
     [
         INITCODE_ZEROS_MAX_LIMIT,
         INITCODE_ONES_MAX_LIMIT,
-        pytest.param(INITCODE_ZEROS_OVER_LIMIT, marks=pytest.mark.negative),
-        pytest.param(INITCODE_ONES_OVER_LIMIT, marks=pytest.mark.negative),
+        pytest.param(INITCODE_ZEROS_OVER_LIMIT, marks=pytest.mark.exception_test),
+        pytest.param(INITCODE_ONES_OVER_LIMIT, marks=pytest.mark.exception_test),
     ],
     ids=get_initcode_name,
 )
@@ -184,7 +184,7 @@ def valid_gas_test_case(initcode: Initcode, gas_test_case: str) -> bool:
         pytest.param(
             i,
             g,
-            marks=([pytest.mark.negative] if g == "too_little_intrinsic_gas" else []),
+            marks=([pytest.mark.exception_test] if g == "too_little_intrinsic_gas" else []),
         )
         for i in [
             INITCODE_ZEROS_MAX_LIMIT,

--- a/tests/shanghai/eip4895_withdrawals/test_withdrawals.py
+++ b/tests/shanghai/eip4895_withdrawals/test_withdrawals.py
@@ -39,7 +39,9 @@ ONE_GWEI = 10**9
     "test_case",
     [
         pytest.param(
-            "tx_in_withdrawals_block", id="tx_in_withdrawals_block", marks=pytest.mark.negative
+            "tx_in_withdrawals_block",
+            id="tx_in_withdrawals_block",
+            marks=pytest.mark.exception_test,
         ),
         pytest.param("tx_after_withdrawals_block", id="tx_after_withdrawals_block"),
     ],

--- a/tests/shanghai/eip4895_withdrawals/test_withdrawals.py
+++ b/tests/shanghai/eip4895_withdrawals/test_withdrawals.py
@@ -37,8 +37,12 @@ ONE_GWEI = 10**9
 
 @pytest.mark.parametrize(
     "test_case",
-    ["tx_in_withdrawals_block", "tx_after_withdrawals_block"],
-    ids=lambda x: x,
+    [
+        pytest.param(
+            "tx_in_withdrawals_block", id="tx_in_withdrawals_block", marks=pytest.mark.negative
+        ),
+        pytest.param("tx_after_withdrawals_block", id="tx_after_withdrawals_block"),
+    ],
 )
 class TestUseValueInTx:
     """


### PR DESCRIPTION
## 🗒️ Description

### `exception_test` marker
Introduce a new marker to mark tests that produce an invalid transaction or block.

```python
@pytest.mark.exception_test
```

Test filling now fails if this marker is not applied and the test contains either an invalid transaction or an invalid block.

This PR also marks all existing negative tests.

### Make `request` a `PrivateAttr` in `BaseTest`

The pytest fixture request is now a private attribute of `BaseTest` and a new class method `from_test` is introduced as a generic to automatically generate a test type from an instance of another test type, which `BaseTest` attributes automatically.

Also request has no longer to be passed to `generate` method, so it has been removed from all unit tests.

## 🔗 Related Issues
None

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.