### PR TITLE
fix(consume): fix fixture downloads for non-release urls and numerical release specs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,8 +12,12 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 #### `fill`
 
-- 🐞 Fix `DeprecationWarning: Pickle, copy, and deepcopy support will be removed from itertools in Python 3.14.` by avoiding use `itertools` object in the spec `BaseTest` pydantic model ([#1414](https://github.com/ethereum/execution-spec-tests/pull/1414)).
 - ✨ The `static_filler` plug-in now has support for static state tests (from [GeneralStateTests](https://github.com/ethereum/tests/tree/develop/src/GeneralStateTestsFiller)) ([#1362](https://github.com/ethereum/execution-spec-tests/pull/1362)).
+- 🐞 Fix `DeprecationWarning: Pickle, copy, and deepcopy support will be removed from itertools in Python 3.14.` by avoiding use `itertools` object in the spec `BaseTest` pydantic model ([#1414](https://github.com/ethereum/execution-spec-tests/pull/1414)).
+
+#### `consume`
+
+- 🐞 Fix fixture tarball downloading with regular, non-Github release URLS and with numerical versions in regular release specs, e.g., `stable@v4.2.0` ([#1437](https://github.com/ethereum/execution-spec-tests/pull/1437)).
 
 ### 📋 Misc
 

--- a/src/pytest_plugins/consume/consume.py
+++ b/src/pytest_plugins/consume/consume.py
@@ -20,7 +20,7 @@ from ethereum_test_fixtures.consume import IndexFile, TestCases
 from ethereum_test_forks import get_forks, get_relative_fork_markers, get_transition_forks
 from ethereum_test_tools.utility.versioning import get_current_commit_hash_or_tag
 
-from .releases import ReleaseTag, get_release_page_url, get_release_url
+from .releases import ReleaseTag, get_release_page_url, get_release_url, is_release_url, is_url
 
 CACHED_DOWNLOADS_DIRECTORY = (
     Path(platformdirs.user_cache_dir("ethereum-execution-spec-tests")) / "cached_downloads"
@@ -50,10 +50,16 @@ class FixtureDownloader:
         self.url = url
         self.base_directory = base_directory
         self.parsed_url = urlparse(url)
-        self.org_repo = self.extract_github_repo()
-        self.version = Path(self.parsed_url.path).parts[-2]
         self.archive_name = self.strip_archive_extension(Path(self.parsed_url.path).name)
-        self.extract_to = base_directory / self.org_repo / self.version / self.archive_name
+
+    @property
+    def extract_to(self) -> Path:
+        """Path to the directory where the archive will be extracted."""
+        if is_release_url(self.url):
+            version = Path(self.parsed_url.path).parts[-2]
+            self.org_repo = self.extract_github_repo()
+            return self.base_directory / self.org_repo / version / self.archive_name
+        return self.base_directory / "other" / self.archive_name
 
     def download_and_extract(self) -> Tuple[bool, Path]:
         """Download the URL and extract it locally if it hasn't already been downloaded."""
@@ -91,7 +97,7 @@ class FixtureDownloader:
         """
         Detect a single top-level dir within the extracted archive, otherwise return extract_to.
         """  # noqa: D200
-        extracted_dirs = [d for d in self.extract_to.iterdir() if d.is_dir()]
+        extracted_dirs = [d for d in self.extract_to.iterdir() if d.is_dir() and d.name != ".meta"]
         return extracted_dirs[0] if len(extracted_dirs) == 1 else self.extract_to
 
 
@@ -112,6 +118,8 @@ class FixturesSource:
         """Determine the fixture source type and return an instance."""
         if input_source == "stdin":
             return cls(input_option=input_source, path=Path(), is_local=False, is_stdin=True)
+        if is_release_url(input_source):
+            return cls.from_release_url(input_source)
         if is_url(input_source):
             return cls.from_url(input_source)
         if ReleaseTag.is_release_string(input_source):
@@ -119,8 +127,8 @@ class FixturesSource:
         return cls.validate_local_path(Path(input_source))
 
     @classmethod
-    def from_url(cls, url: str) -> "FixturesSource":
-        """Create a fixture source from a direct URL."""
+    def from_release_url(cls, url: str) -> "FixturesSource":
+        """Create a fixture source from a support github repo release URL."""
         release_page = get_release_page_url(url)
         downloader = FixtureDownloader(url, CACHED_DOWNLOADS_DIRECTORY)
         was_cached, path = downloader.download_and_extract()
@@ -129,6 +137,20 @@ class FixturesSource:
             path=path,
             url=url,
             release_page=release_page,
+            is_local=False,
+            was_cached=was_cached,
+        )
+
+    @classmethod
+    def from_url(cls, url: str) -> "FixturesSource":
+        """Create a fixture source from a direct URL."""
+        downloader = FixtureDownloader(url, CACHED_DOWNLOADS_DIRECTORY)
+        was_cached, path = downloader.download_and_extract()
+        return cls(
+            input_option=url,
+            path=path,
+            url=url,
+            release_page="",
             is_local=False,
             was_cached=was_cached,
         )
@@ -157,12 +179,6 @@ class FixturesSource:
         if not any(path.glob("**/*.json")):
             pytest.exit(f"Specified fixture directory '{path}' does not contain any JSON files.")
         return FixturesSource(input_option=str(path), path=path)
-
-
-def is_url(string: str) -> bool:
-    """Check if a string is a remote URL."""
-    result = urlparse(string)
-    return all([result.scheme, result.netloc])
 
 
 class SimLimitBehavior:

--- a/src/pytest_plugins/consume/releases.py
+++ b/src/pytest_plugins/consume/releases.py
@@ -73,7 +73,11 @@ class ReleaseTag:
         """
         assert isinstance(value, str), f"Expected a string, but got: {value}"
         if self.version is not None:
-            return value == f"{self.tag_name}@{self.version}"
+            # normal release, e.g., stable@v4.0.0
+            normal_release_match = value == self.version
+            # pre release, e.g., pectra-devnet-6@v1.0.0
+            pre_release_match = value == f"{self.tag_name}@{self.version}"
+            return normal_release_match or pre_release_match
         return value.startswith(self.tag_name)
 
     @property

--- a/src/pytest_plugins/consume/releases.py
+++ b/src/pytest_plugins/consume/releases.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import List
+from urllib.parse import urlparse
 
 import platformdirs
 import requests
@@ -138,6 +139,21 @@ class Releases(RootModel[List[ReleaseInformation]]):
 def is_docker_or_ci() -> bool:
     """Check if the code is running inside a Docker container or a CI environment."""
     return "GITHUB_ACTIONS" in os.environ or Path("/.dockerenv").exists()
+
+
+def is_url(string: str) -> bool:
+    """Check if a string is a remote URL."""
+    result = urlparse(string)
+    return all([result.scheme, result.netloc])
+
+
+def is_release_url(input_str: str) -> bool:
+    """Check if the release string is a URL."""
+    if not is_url(input_str):
+        return False
+    repo_pattern = "|".join(re.escape(repo) for repo in SUPPORTED_REPOS)
+    regex_pattern = rf"https://github\.com/({repo_pattern})/releases/download/"
+    return re.match(regex_pattern, input_str) is not None
 
 
 def parse_release_information(release_information: List) -> List[ReleaseInformation]:


### PR DESCRIPTION
## 🗒️ Description

1. Fixes the `consume` `--input` flag with non-release URLs:
    ```
    uv run consume direct --input "http://eest.fixtures/v0/fixtures_stable.tar.gz" --collect-only -q
    ```
2. Fixes `consume` `--input` flag with "regular" numerical release specs `<tag_name>@v1.2.3`, (normal release specs, i.e., `{stable,develop}@latest` and pre-release specs, e.g., `pectra-devnet-6@v1.0.0`  were working):
    ```
    uv run consume direct --input stable@v4.2.0 -k chainid --collect-only -q
    ```

## 🔗 Related Issues
None

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).

