### PR TITLE
feat(fw): add max_stack_increase to EOF Section.Code

### DIFF
--- a/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_eof_example.py
+++ b/tests/osaka/eip7692_eof_v1/eip3540_eof_v1/test_eof_example.py
@@ -25,7 +25,7 @@ def test_eof_example(eof_test: EOFTestFiller):
             Section.Code(
                 code=Op.CALLF[1](Op.PUSH0) + Op.STOP,  # bytecode to be deployed in the body
                 # Code: call section 1 with a single zero as input, then stop.
-                max_stack_height=1,  # define code header (in body) stack size
+                max_stack_increase=1,  # define code header (in body) stack size
             ),
             # There can be multiple code sections
             Section.Code(
@@ -33,20 +33,20 @@ def test_eof_example(eof_test: EOFTestFiller):
                 code=Op.POP + Op.CALLF[2]() + Op.POP + Op.RETF,
                 code_inputs=1,
                 code_outputs=0,
-                max_stack_height=1,
+                max_stack_increase=0,
             ),
             Section.Code(
                 # Call section 3 with two inputs (address twice), return
                 code=Op.CALLF[3](Op.DUP1, Op.ADDRESS) + Op.POP + Op.POP + Op.RETF,
                 code_outputs=1,
-                max_stack_height=3,
+                max_stack_increase=3,
             ),
             Section.Code(
                 # Duplicate one input and return
                 code=Op.DUP1 + Op.RETF,
                 code_inputs=2,
                 code_outputs=3,
-                max_stack_height=3,
+                max_stack_increase=1,
             ),
             # DATA section
             Section.Data("0xef"),

--- a/tests/osaka/eip7692_eof_v1/eip4750_functions/test_code_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip4750_functions/test_code_validation.py
@@ -787,6 +787,7 @@ def test_callf_stack_overflow_variable_stack_3(eof_test: EOFTestFiller, stack_he
             ),
         ],
     )
+    assert container.sections[0].max_stack_height is not None
     stack_overflow = (
         container.sections[0].max_stack_height + stack_height > MAX_RUNTIME_OPERAND_STACK_HEIGHT
     )
@@ -925,6 +926,7 @@ def test_callf_with_inputs_stack_overflow(
             code_section,
         ],
     )
+    assert code_section.max_stack_height is not None
     exception = None
     if (
         push_stack + code_section.max_stack_height - code_section.code_inputs
@@ -1055,6 +1057,7 @@ def test_callf_with_inputs_stack_overflow_variable_stack(
         ],
     )
     initial_stack = 3  # Initial items in the scak
+    assert code_section.max_stack_height is not None
     exception = None
     if (
         push_stack + initial_stack + code_section.max_stack_height - code_section.code_inputs


### PR DESCRIPTION
## 🗒️ Description
The `max_stack_increase` is complementary but preferred to `max_stack_height`. Both cannot be set at the same time.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
