### PR TITLE
refactor(tests): change RJUMP validation tests to max_stack_increase

### DIFF
--- a/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjump.py
+++ b/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjump.py
@@ -275,7 +275,7 @@ def test_rjump_into_self_pre_code(
             sections=[
                 Section.Code(
                     code=Op.RJUMP[0] + Op.STOP,
-                    max_stack_height=0,
+                    max_stack_increase=0,
                 ),
             ],
             expected_bytecode="ef00010100040200010004ff00000000800000e0000000",
@@ -285,7 +285,7 @@ def test_rjump_into_self_pre_code(
             sections=[
                 Section.Code(
                     code=Op.PUSH0 + Op.PUSH1[0] + Op.RJUMPI[3] + Op.RJUMP[1] + Op.NOT + Op.STOP,
-                    max_stack_height=2,
+                    max_stack_increase=2,
                 ),
             ],
             expected_bytecode="ef0001010004020001000bff000000008000025f6000e10003e000011900",
@@ -303,7 +303,7 @@ def test_rjump_into_self_pre_code(
                     + Op.RJUMP[1]
                     + Op.NOT
                     + Op.STOP,
-                    max_stack_height=2,
+                    max_stack_increase=2,
                 ),
             ],
             expected_bytecode="ef00010100040200010013ff000000008000025f6000e100086000e10006e00004e000011900",
@@ -313,7 +313,7 @@ def test_rjump_into_self_pre_code(
             sections=[
                 Section.Code(
                     code=Op.PUSH0 + Op.PUSH1[0] + Op.RJUMPI[3] + Op.RJUMP[1] + Op.PUSH0 + Op.STOP,
-                    max_stack_height=2,
+                    max_stack_increase=2,
                 ),
             ],
             expected_bytecode="ef0001010004020001000bff000000008000025f6000e10003e000015f00",
@@ -332,7 +332,7 @@ def test_rjump_into_self_pre_code(
                     + Op.RJUMP[1]
                     + Op.NOT
                     + Op.STOP,
-                    max_stack_height=2,
+                    max_stack_increase=2,
                 ),
             ],
             expected_bytecode="ef00010100040200010014ff000000008000025f6000e100086000e10007e000055fe000011900",
@@ -348,7 +348,7 @@ def test_rjump_into_self_pre_code(
                     + Op.PUSH0
                     + Op.RJUMP[0]
                     + Op.STOP,
-                    max_stack_height=3,
+                    max_stack_increase=3,
                 ),
             ],
             expected_bytecode="ef0001010004020001000cff000000008000035f6000e100025f5fe0000000",
@@ -368,7 +368,7 @@ def test_rjump_into_self_pre_code(
                     + Op.RJUMP[1]
                     + Op.NOT
                     + Op.STOP,
-                    max_stack_height=5,
+                    max_stack_increase=5,
                 ),
             ],
             expected_bytecode="ef00010100040200010013ff000000008000055f6000e100025f5f5f6000e10003e000011900",
@@ -391,7 +391,7 @@ def test_rjump_into_self_pre_code(
                     + Op.RJUMP[1]
                     + Op.NOT
                     + Op.STOP,
-                    max_stack_height=5,
+                    max_stack_increase=5,
                 ),
             ],
             expected_bytecode="ef0001010004020001001bff000000008000055f6000e100025f5f5f6000e100086000e10006e00004e000011900",
@@ -411,7 +411,7 @@ def test_rjump_into_self_pre_code(
                     + Op.RJUMP[1]
                     + Op.PUSH0
                     + Op.STOP,
-                    max_stack_height=5,
+                    max_stack_increase=5,
                 ),
             ],
             expected_bytecode="ef00010100040200010013ff000000008000055f6000e100025f5f5f6000e10003e000015f00",
@@ -434,7 +434,7 @@ def test_rjump_into_self_pre_code(
                     + Op.RJUMP[1]
                     + Op.NOT
                     + Op.STOP,
-                    max_stack_height=4,
+                    max_stack_increase=4,
                 ),
             ],
             expected_bytecode="ef0001010004020001001bff000000008000045f6000e100025f5f6000e100086000e10007e000055fe000011900",
@@ -461,7 +461,7 @@ def test_rjump_valid_forward(
             sections=[
                 Section.Code(
                     code=Op.PUSH0 + Op.POP + Op.RJUMP[-5],
-                    max_stack_height=1,
+                    max_stack_increase=1,
                 ),
             ],
             expected_bytecode="ef00010100040200010005ff000000008000015f50e0fffb",
@@ -476,7 +476,7 @@ def test_rjump_valid_forward(
                     + Op.RJUMPI[3]
                     + Op.RJUMP[-8]
                     + Op.RJUMP[-11],
-                    max_stack_height=1,
+                    max_stack_increase=1,
                 ),
             ],
             expected_bytecode="ef0001010004020001000dff000000008000015f506001e10003e0fff8e0fff5",
@@ -491,7 +491,7 @@ def test_rjump_valid_forward(
                     + Op.PUSH0
                     + Op.PUSH0
                     + Op.RJUMP[-3],
-                    max_stack_height=3,
+                    max_stack_increase=3,
                 ),
             ],
             expected_bytecode="ef0001010004020001000bff000000008000035f6000e100025f5fe0fffd",
@@ -508,7 +508,7 @@ def test_rjump_valid_forward(
                     + Op.PUSH0
                     + Op.POP
                     + Op.RJUMP[-5],
-                    max_stack_height=4,
+                    max_stack_increase=4,
                 ),
             ],
             expected_bytecode="ef0001010004020001000dff000000008000045f6000e100025f5f5f50e0fffb",
@@ -530,7 +530,7 @@ def test_rjump_valid_forward(
                         + Op.RJUMP[-8]
                         + Op.RJUMP[-11]
                     ),
-                    max_stack_height=4,
+                    max_stack_increase=4,
                 ),
             ],
             expected_bytecode="ef00010100040200010015ff000000008000045f6000e100025f5f5f506001e10003e0fff8e0fff5",
@@ -585,7 +585,7 @@ def test_rjump_into_stack_height_diff_2(
                     + Op.RJUMP[-8]
                     + Op.PUSH0
                     + Op.RJUMP[-12],
-                    max_stack_height=1,
+                    max_stack_increase=1,
                 ),
             ],
             expected_bytecode="ef0001010004020001000eff000000008000015f506001e10003e0fff85fe0fff4",
@@ -595,7 +595,7 @@ def test_rjump_into_stack_height_diff_2(
             sections=[
                 Section.Code(
                     code=Op.PUSH0 + Op.RJUMP[-4],
-                    max_stack_height=1,
+                    max_stack_increase=1,
                 ),
             ],
             expected_bytecode="ef00010100040200010004ff000000008000015fe0fffc",
@@ -605,7 +605,7 @@ def test_rjump_into_stack_height_diff_2(
             sections=[
                 Section.Code(
                     code=Op.PUSH0 + Op.POP + Op.RJUMP[-4],
-                    max_stack_height=1,
+                    max_stack_increase=1,
                 ),
             ],
             expected_bytecode="ef00010100040200010005ff000000008000015f50e0fffc",
@@ -620,7 +620,7 @@ def test_rjump_into_stack_height_diff_2(
                     + Op.RJUMPI[-7]
                     + Op.PUSH0
                     + Op.RJUMP[-11],
-                    max_stack_height=1,
+                    max_stack_increase=1,
                 ),
             ],
             expected_bytecode="ef0001010004020001000bff000000008000015f506000e1fff95fe0fff5",
@@ -643,7 +643,7 @@ def test_rjump_into_stack_height_diff_2(
                         + Op.PUSH0
                         + Op.RJUMP[-12]
                     ),
-                    max_stack_height=4,
+                    max_stack_increase=4,
                 ),
             ],
             expected_bytecode="ef00010100040200010016ff000000008000045f6000e100025f5f5f506001e10003e0fff85fe0fff4",
@@ -663,7 +663,7 @@ def test_rjump_into_stack_height_diff_2(
                         + Op.PUSH0
                         + Op.RJUMP[-7]
                     ),
-                    max_stack_height=4,
+                    max_stack_increase=4,
                 ),
             ],
             expected_bytecode="ef00010100040200010011ff000000008000045f6000e100025f5f6000e100015fe0fff9",
@@ -683,7 +683,7 @@ def test_rjump_into_stack_height_diff_2(
                         + Op.POP
                         + Op.RJUMP[-7]
                     ),
-                    max_stack_height=4,
+                    max_stack_increase=4,
                 ),
             ],
             expected_bytecode="ef00010100040200010011ff000000008000045f6000e100025f5f6000e1000150e0fff9",
@@ -699,7 +699,7 @@ def test_rjump_into_stack_height_diff_2(
                     + Op.PUSH0
                     + Op.PUSH0
                     + Op.RJUMP[-4],
-                    max_stack_height=4,
+                    max_stack_increase=4,
                 ),
             ],
             expected_bytecode="ef0001010004020001000cff000000008000045f6000e100025f5f5fe0fffc",
@@ -716,7 +716,7 @@ def test_rjump_into_stack_height_diff_2(
                     + Op.PUSH0
                     + Op.POP
                     + Op.RJUMP[-4],
-                    max_stack_height=3,
+                    max_stack_increase=3,
                 ),
             ],
             expected_bytecode="ef0001010004020001000dff000000008000035f6000e100025f5f5f50e0fffc",
@@ -736,7 +736,7 @@ def test_rjump_into_stack_height_diff_2(
                     + Op.RJUMPI[-7]
                     + Op.PUSH0
                     + Op.RJUMP[-11],
-                    max_stack_height=4,
+                    max_stack_increase=4,
                 ),
             ],
             expected_bytecode="ef00010100040200010013ff000000008000045f6000e100025f5f5f506000e1fff95fe0fff5",
@@ -1067,7 +1067,7 @@ def test_rjump_backwards_illegal_stack_height(
                 + Op.PUSH3[0x015500]
                 + Op.RJUMP[-10]
             ),
-            max_stack_height=0x24,
+            max_stack_increase=0x24,
         ),
         expect_exception=EOFException.STACK_HEIGHT_MISMATCH,
     )

--- a/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpi.py
+++ b/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpi.py
@@ -270,7 +270,7 @@ def test_rjumpi_max_backward(
             sections=[
                 Section.Code(
                     code=Op.PUSH1[1] + Op.RJUMPI[0] + Op.STOP,
-                    max_stack_height=1,
+                    max_stack_increase=1,
                 ),
             ],
             expected_bytecode="ef00010100040200010006ff000000008000016001e1000000",
@@ -280,7 +280,7 @@ def test_rjumpi_max_backward(
             sections=[
                 Section.Code(
                     code=Op.PUSH0 + Op.PUSH1[0] + Op.RJUMPI[1] + Op.NOT + Op.STOP,
-                    max_stack_height=2,
+                    max_stack_increase=2,
                 ),
             ],
             expected_bytecode="ef00010100040200010008ff000000008000025f6000e100011900",
@@ -296,7 +296,7 @@ def test_rjumpi_max_backward(
                     + Op.RJUMP[1]
                     + Op.NOT
                     + Op.STOP,
-                    max_stack_height=2,
+                    max_stack_increase=2,
                 ),
             ],
             expected_bytecode="ef0001010004020001000cff000000008000025f6000e1000450e000011900",
@@ -306,7 +306,7 @@ def test_rjumpi_max_backward(
             sections=[
                 Section.Code(
                     code=Op.PUSH0 + Op.PUSH1[0] + Op.RJUMPI[3] + Op.RJUMP[0] + Op.STOP,
-                    max_stack_height=2,
+                    max_stack_increase=2,
                 ),
             ],
             expected_bytecode="ef0001010004020001000aff000000008000025f6000e10003e0000000",
@@ -316,7 +316,7 @@ def test_rjumpi_max_backward(
             sections=[
                 Section.Code(
                     code=Op.PUSH0 + Op.PUSH1[0] + Op.RJUMPI[4] + Op.PUSH0 + Op.RJUMP[0] + Op.STOP,
-                    max_stack_height=2,
+                    max_stack_increase=2,
                 ),
             ],
             expected_bytecode="ef0001010004020001000bff000000008000025f6000e100045fe0000000",
@@ -332,7 +332,7 @@ def test_rjumpi_max_backward(
                     + Op.RJUMPI[1]
                     + Op.NOT
                     + Op.STOP,
-                    max_stack_height=2,
+                    max_stack_increase=2,
                 ),
             ],
             expected_bytecode="ef0001010004020001000dff000000008000025f6000e100066000e100011900",
@@ -342,7 +342,7 @@ def test_rjumpi_max_backward(
             sections=[
                 Section.Code(
                     code=Op.PUSH0 + Op.PUSH1[0] + Op.RJUMPI[1] + Op.PUSH0 + Op.STOP,
-                    max_stack_height=2,
+                    max_stack_increase=2,
                 ),
             ],
             expected_bytecode="ef00010100040200010008ff000000008000025f6000e100015f00",
@@ -359,7 +359,7 @@ def test_rjumpi_max_backward(
                     + Op.RJUMPI[1]
                     + Op.NOT
                     + Op.STOP,
-                    max_stack_height=3,
+                    max_stack_increase=3,
                 ),
             ],
             expected_bytecode="ef0001010004020001000eff000000008000035f6000e100075f6000e100011900",
@@ -378,7 +378,7 @@ def test_rjumpi_max_backward(
                     + Op.DUP1
                     + Op.RJUMPI[-14]
                     + Op.STOP,
-                    max_stack_height=3,
+                    max_stack_increase=3,
                 ),
             ],
             expected_bytecode="ef00010100040200010010ff000000008000035f60010180600a11e1000480e1fff200",
@@ -398,7 +398,7 @@ def test_rjumpi_max_backward(
                     + Op.DUP1
                     + Op.RJUMPI[-13]
                     + Op.STOP,
-                    max_stack_height=3,
+                    max_stack_increase=3,
                 ),
             ],
             expected_bytecode="ef00010100040200010011ff000000008000035f60010180600a11e100055f80e1fff300",
@@ -414,7 +414,7 @@ def test_rjumpi_max_backward(
                     + Op.RJUMP[1]
                     + Op.PUSH0
                     + Op.STOP,
-                    max_stack_height=2,
+                    max_stack_increase=2,
                 ),
             ],
             expected_bytecode="ef0001010004020001000cff000000008000025f6000e100045fe000015f00",
@@ -430,7 +430,7 @@ def test_rjumpi_max_backward(
                     + Op.RJUMP[1]
                     + Op.NOT
                     + Op.STOP,
-                    max_stack_height=2,
+                    max_stack_increase=2,
                 ),
             ],
             expected_bytecode="ef0001010004020001000cff000000008000025f6000e100045fe000011900",
@@ -446,7 +446,7 @@ def test_rjumpi_max_backward(
                     + Op.RJUMP[1]
                     + Op.POP
                     + Op.STOP,
-                    max_stack_height=2,
+                    max_stack_increase=2,
                 ),
             ],
             expected_bytecode="ef0001010004020001000cff000000008000025f6000e1000450e000015000",
@@ -463,7 +463,7 @@ def test_rjumpi_max_backward(
                     + Op.PUSH1[1]
                     + Op.RJUMPI[0]
                     + Op.STOP,
-                    max_stack_height=4,
+                    max_stack_increase=4,
                 ),
             ],
             expected_bytecode="ef0001010004020001000eff000000008000045f6000e100025f5f6001e1000000",
@@ -482,7 +482,7 @@ def test_rjumpi_max_backward(
                     + Op.RJUMPI[1]
                     + Op.NOT
                     + Op.STOP,
-                    max_stack_height=5,
+                    max_stack_increase=5,
                 ),
             ],
             expected_bytecode="ef00010100040200010010ff000000008000055f6000e100025f5f5f6000e100011900",
@@ -503,7 +503,7 @@ def test_rjumpi_max_backward(
                     + Op.RJUMP[1]
                     + Op.NOT
                     + Op.STOP,
-                    max_stack_height=5,
+                    max_stack_increase=5,
                 ),
             ],
             expected_bytecode="ef00010100040200010014ff000000008000055f6000e100025f5f5f6000e1000450e000011900",
@@ -522,7 +522,7 @@ def test_rjumpi_max_backward(
                     + Op.RJUMPI[3]
                     + Op.RJUMP[0]
                     + Op.STOP,
-                    max_stack_height=5,
+                    max_stack_increase=5,
                 ),
             ],
             expected_bytecode="ef00010100040200010012ff000000008000055f6000e100025f5f5f6000e10003e0000000",
@@ -542,7 +542,7 @@ def test_rjumpi_max_backward(
                     + Op.PUSH0
                     + Op.RJUMP[0]
                     + Op.STOP,
-                    max_stack_height=5,
+                    max_stack_increase=5,
                 ),
             ],
             expected_bytecode="ef00010100040200010013ff000000008000055f6000e100025f5f5f6000e100045fe0000000",
@@ -563,7 +563,7 @@ def test_rjumpi_max_backward(
                     + Op.RJUMPI[1]
                     + Op.NOT
                     + Op.STOP,
-                    max_stack_height=5,
+                    max_stack_increase=5,
                 ),
             ],
             expected_bytecode="ef00010100040200010015ff000000008000055f6000e100025f5f5f6000e100066000e100011900",
@@ -582,7 +582,7 @@ def test_rjumpi_max_backward(
                     + Op.RJUMPI[1]
                     + Op.PUSH0
                     + Op.STOP,
-                    max_stack_height=5,
+                    max_stack_increase=5,
                 ),
             ],
             expected_bytecode="ef00010100040200010010ff000000008000055f6000e100025f5f5f6000e100015f00",
@@ -604,7 +604,7 @@ def test_rjumpi_max_backward(
                     + Op.RJUMPI[1]
                     + Op.NOT
                     + Op.STOP,
-                    max_stack_height=6,
+                    max_stack_increase=6,
                 ),
             ],
             expected_bytecode="ef00010100040200010016ff000000008000065f6000e100025f5f5f6000e100075f6000e100011900",
@@ -628,7 +628,7 @@ def test_rjumpi_max_backward(
                     + Op.DUP1
                     + Op.RJUMPI[-14]
                     + Op.STOP,
-                    max_stack_height=6,
+                    max_stack_increase=6,
                 ),
             ],
             expected_bytecode="ef00010100040200010018ff000000008000065f6000e100025f5f5f60010180600a11e1000480e1fff200",
@@ -653,7 +653,7 @@ def test_rjumpi_max_backward(
                     + Op.DUP1
                     + Op.RJUMPI[-13]
                     + Op.STOP,
-                    max_stack_height=6,
+                    max_stack_increase=6,
                 ),
             ],
             expected_bytecode="ef00010100040200010019ff000000008000065f6000e100025f5f5f60010180600a11e100055f80e1fff300",
@@ -674,7 +674,7 @@ def test_rjumpi_max_backward(
                     + Op.RJUMP[1]
                     + Op.PUSH0
                     + Op.STOP,
-                    max_stack_height=5,
+                    max_stack_increase=5,
                 ),
             ],
             expected_bytecode="ef00010100040200010014ff000000008000055f6000e100025f5f5f6000e100045fe000015f00",
@@ -695,7 +695,7 @@ def test_rjumpi_max_backward(
                     + Op.RJUMP[1]
                     + Op.NOT
                     + Op.STOP,
-                    max_stack_height=5,
+                    max_stack_increase=5,
                 ),
             ],
             expected_bytecode="ef00010100040200010014ff000000008000055f6000e100025f5f5f6000e100045fe000011900",
@@ -716,7 +716,7 @@ def test_rjumpi_max_backward(
                     + Op.RJUMP[1]
                     + Op.POP
                     + Op.STOP,
-                    max_stack_height=5,
+                    max_stack_increase=5,
                 ),
             ],
             expected_bytecode="ef00010100040200010014ff000000008000055f6000e100025f5f5f6000e1000450e000015000",
@@ -743,7 +743,7 @@ def test_rjumpi_valid_forward(
             sections=[
                 Section.Code(
                     code=Op.PUSH1[0] + Op.RJUMPI[-5] + Op.STOP,
-                    max_stack_height=1,
+                    max_stack_increase=1,
                 ),
             ],
             expected_bytecode="ef00010100040200010006ff000000008000016000e1fffb00",
@@ -753,7 +753,7 @@ def test_rjumpi_valid_forward(
             sections=[
                 Section.Code(
                     code=Op.PUSH0 + Op.POP + Op.PUSH1[0] + Op.RJUMPI[-7] + Op.STOP,
-                    max_stack_height=1,
+                    max_stack_increase=1,
                 ),
             ],
             expected_bytecode="ef00010100040200010008ff000000008000015f506000e1fff900",
@@ -769,7 +769,7 @@ def test_rjumpi_valid_forward(
                     + Op.PUSH1[0]
                     + Op.RJUMPI[-12]
                     + Op.STOP,
-                    max_stack_height=1,
+                    max_stack_increase=1,
                 ),
             ],
             expected_bytecode="ef0001010004020001000dff000000008000015f506000e1fff96000e1fff400",
@@ -779,7 +779,7 @@ def test_rjumpi_valid_forward(
             sections=[
                 Section.Code(
                     code=Op.PUSH0 + Op.PUSH1[1] + Op.ADD + Op.DUP1 + Op.RJUMPI[-7] + Op.STOP,
-                    max_stack_height=2,
+                    max_stack_increase=2,
                 ),
             ],
             expected_bytecode="ef00010100040200010009ff00000000800002 5f60010180e1fff900",
@@ -789,7 +789,7 @@ def test_rjumpi_valid_forward(
             sections=[
                 Section.Code(
                     code=Op.PUSH0 + Op.POP + Op.PUSH1[0] + Op.RJUMPI[-7] + Op.RJUMP[-10],
-                    max_stack_height=1,
+                    max_stack_increase=1,
                 ),
             ],
             expected_bytecode="ef0001010004020001000aff000000008000015f506000e1fff9e0fff6",
@@ -806,7 +806,7 @@ def test_rjumpi_valid_forward(
                     + Op.PUSH1[0]
                     + Op.RJUMPI[-5]
                     + Op.STOP,
-                    max_stack_height=4,
+                    max_stack_increase=4,
                 ),
             ],
             expected_bytecode="ef0001010004020001000eff000000008000045f6000e100025f5f6000e1fffb00",
@@ -825,7 +825,7 @@ def test_rjumpi_valid_forward(
                     + Op.PUSH1[0]
                     + Op.RJUMPI[-7]
                     + Op.STOP,
-                    max_stack_height=4,
+                    max_stack_increase=4,
                 ),
             ],
             expected_bytecode="ef00010100040200010010ff000000008000045f6000e100025f5f5f506000e1fff900",
@@ -846,7 +846,7 @@ def test_rjumpi_valid_forward(
                     + Op.PUSH1[0]
                     + Op.RJUMPI[-12]
                     + Op.STOP,
-                    max_stack_height=4,
+                    max_stack_increase=4,
                 ),
             ],
             expected_bytecode="ef00010100040200010015ff000000008000045f6000e100025f5f5f506000e1fff96000e1fff400",
@@ -866,7 +866,7 @@ def test_rjumpi_valid_forward(
                     + Op.DUP1
                     + Op.RJUMPI[-7]
                     + Op.STOP,
-                    max_stack_height=5,
+                    max_stack_increase=5,
                 ),
             ],
             expected_bytecode="ef00010100040200010011ff000000008000055f6000e100025f5f5f60010180e1fff900",
@@ -885,7 +885,7 @@ def test_rjumpi_valid_forward(
                     + Op.PUSH1[0]
                     + Op.RJUMPI[-7]
                     + Op.RJUMP[-10],
-                    max_stack_height=4,
+                    max_stack_increase=4,
                 ),
             ],
             expected_bytecode="ef00010100040200010012ff000000008000045f6000e100025f5f5f506000e1fff9e0fff6",
@@ -1523,7 +1523,7 @@ def test_rjumpi_backwards_onto_dup(
     """Backwards jumpi onto a dup."""
     container = Container.Code(
         code=(Op.PUSH0 + Op.DUP1 + Op.RJUMPI[-4] + Op.STOP),
-        max_stack_height=2,
+        max_stack_increase=2,
     )
     eof_test(
         container=container,
@@ -1544,7 +1544,7 @@ def test_rjumpi_backwards_min_stack_wrong(
             + Op.RJUMPI[-9]  # (2, 3) To first RJUMPI with (1, 2)
             + Op.STOP  # (1, 2)
         ),
-        max_stack_height=3,
+        max_stack_increase=3,
     )
     eof_test(
         container=container,
@@ -1566,7 +1566,7 @@ def test_rjumpi_rjumpv_backwards_min_stack_wrong(
             + Op.RJUMPV[-10]  # (2, 3) To first RJUMPI with (1, 2)
             + Op.STOP  # (1, 2)
         ),
-        max_stack_height=3,
+        max_stack_increase=3,
     )
     eof_test(
         container=container,
@@ -1588,7 +1588,7 @@ def test_double_rjumpi_stack_underflow(
             + Op.RJUMPI[0]  # (3, 3)
             + Op.RETURN  # (1, 2) Underflow
         ),
-        max_stack_height=3,
+        max_stack_increase=3,
     )
     eof_test(
         container=container,
@@ -1612,7 +1612,7 @@ def test_double_rjumpi_stack_height_mismatch(
                     + Op.RJUMPI[3]  # (2, 2) to LAST
                     + Op.RJUMPI[0]  # (1, 1) to LAST
                     + Op.RJUMP[-11],  # LAST: (0, 1) to BEGIN; stack height mismatch
-                    max_stack_height=2,
+                    max_stack_increase=2,
                 ),
             ],
         ),
@@ -1638,7 +1638,7 @@ def test_double_rjumpi_invalid_max_stack_height(
                     + Op.PUSH0  # EXIT: (0, 1)
                     + Op.PUSH0  # (1, 2)
                     + Op.INVALID,  # (2, 3)
-                    max_stack_height=2,  # should be 3
+                    max_stack_increase=2,  # should be 3
                 ),
             ],
         ),
@@ -1660,7 +1660,7 @@ def test_double_rjumpi_invalid_max_stack_height(
                     + Op.PUSH1[0]
                     + Op.RJUMPI[-11]
                     + Op.STOP,
-                    max_stack_height=3,
+                    max_stack_increase=3,
                 ),
             ],
             expected_bytecode="ef0001010004020001000eff0000000080000360be6000e10001506000e1fff500",
@@ -1677,7 +1677,7 @@ def test_double_rjumpi_invalid_max_stack_height(
                     + Op.PUSH1[0]
                     + Op.RJUMPI[-13]
                     + Op.STOP,
-                    max_stack_height=2,
+                    max_stack_increase=2,
                 ),
             ],
             expected_bytecode="ef0001010004020001000eff000000008000025f506000e1fff95f6000e1fff300",
@@ -1693,7 +1693,7 @@ def test_double_rjumpi_invalid_max_stack_height(
                     + Op.DUP1
                     + Op.RJUMPI[-8]
                     + Op.STOP,
-                    max_stack_height=2,
+                    max_stack_increase=2,
                 ),
             ],
             expected_bytecode="ef0001010004020001000aff000000008000025f6001018080e1fff800",
@@ -1708,7 +1708,7 @@ def test_double_rjumpi_invalid_max_stack_height(
                     + Op.RJUMPI[-6]
                     + Op.PUSH0
                     + Op.RJUMP[-10],
-                    max_stack_height=1,
+                    max_stack_increase=1,
                 ),
             ],
         ),
@@ -1723,7 +1723,7 @@ def test_double_rjumpi_invalid_max_stack_height(
                     + Op.PUSH1[0]
                     + Op.RJUMPI[-11]
                     + Op.STOP,
-                    max_stack_height=3,
+                    max_stack_increase=3,
                 ),
             ],
             expected_bytecode="ef0001010004020001000dff000000008000035f6000e100015f6000e1fff500",
@@ -1745,7 +1745,7 @@ def test_double_rjumpi_invalid_max_stack_height(
                     + Op.PUSH1[0]
                     + Op.RJUMPI[-13]
                     + Op.STOP,
-                    max_stack_height=5,
+                    max_stack_increase=5,
                 ),
             ],
             expected_bytecode="ef00010100040200010016ff000000008000055f6000e100025f5f5f506000e1fff95f6000e1fff300",
@@ -1766,7 +1766,7 @@ def test_double_rjumpi_invalid_max_stack_height(
                     + Op.DUP1
                     + Op.RJUMPI[-8]
                     + Op.STOP,
-                    max_stack_height=5,
+                    max_stack_increase=5,
                 ),
             ],
             expected_bytecode="ef00010100040200010012ff000000008000055f6000e100025f5f5f6001018080e1fff800",
@@ -1786,7 +1786,7 @@ def test_double_rjumpi_invalid_max_stack_height(
                     + Op.POP
                     + Op.RJUMPI[-4]
                     + Op.STOP,
-                    max_stack_height=5,
+                    max_stack_increase=5,
                 ),
             ],
             expected_bytecode="ef00010100040200010010ff000000008000055f6000e100025f5f5f5f5f50e1fffc00",
@@ -1806,7 +1806,7 @@ def test_double_rjumpi_invalid_max_stack_height(
                     + Op.PUSH0
                     + Op.RJUMPI[-5]
                     + Op.STOP,
-                    max_stack_height=5,
+                    max_stack_increase=5,
                 ),
             ],
         ),
@@ -1825,7 +1825,7 @@ def test_double_rjumpi_invalid_max_stack_height(
                     + Op.RJUMPI[-8]
                     + Op.PUSH0
                     + Op.RJUMP[-10],
-                    max_stack_height=4,
+                    max_stack_increase=4,
                 ),
             ],
         ),

--- a/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py
+++ b/tests/osaka/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py
@@ -126,7 +126,7 @@ def test_rjumpv_backwards_onto_dup(
     """Backwards jumpv vector onto a dup."""
     container = Container.Code(
         code=(Op.PUSH0 + Op.DUP1 + Op.RJUMPV[-5] + Op.STOP),
-        max_stack_height=2,
+        max_stack_increase=2,
     )
     eof_test(
         container=container,
@@ -143,7 +143,7 @@ def test_rjumpv_backwards_large_table(
     jump_table += [length * -2 - 6]
     container = Container.Code(
         code=(Op.RJUMPV[jump_table](length) + Op.STOP),
-        max_stack_height=1,
+        max_stack_increase=1,
     )
     eof_test(
         container=container,
@@ -1120,7 +1120,7 @@ def test_rjumpv_backwards_min_stack_wrong(
             + Op.RJUMPV[-11]  # (2, 3) To first RJUMPV with (1, 2)
             + Op.STOP  # (1, 2)
         ),
-        max_stack_height=3,
+        max_stack_increase=3,
     )
     eof_test(
         container=container,
@@ -1142,7 +1142,7 @@ def test_rjumpv_rjumpi_backwards_min_stack_wrong(
             + Op.RJUMPI[-10]  # (2, 3) To first RJUMPV with (1, 2)
             + Op.STOP  # (1, 2)
         ),
-        max_stack_height=3,
+        max_stack_increase=3,
     )
     eof_test(
         container=container,
@@ -1156,7 +1156,7 @@ def test_double_rjumpv(
     """Two RJUMPVs, causing the min stack to underflow."""
     container = Container.Code(
         code=(Op.PUSH0 + Op.PUSH0 + Op.RJUMPV[6] + Op.PUSH0 + Op.PUSH0 + Op.RJUMPV[0] + Op.RETURN),
-        max_stack_height=3,
+        max_stack_increase=3,
     )
     eof_test(
         container=container,
@@ -1172,7 +1172,7 @@ def test_double_rjumpv(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1) + Op.RJUMPV[0] + Op.STOP,
-                    max_stack_height=1,
+                    max_stack_increase=1,
                 ),
             ],
             expected_bytecode="ef00010100040200010007ff000000008000016001e200000000",
@@ -1182,7 +1182,7 @@ def test_double_rjumpv(
             sections=[
                 Section.Code(
                     code=Op.PUSH0 + Op.PUSH1(0) + Op.RJUMPV[1] + Op.NOT + Op.STOP,
-                    max_stack_height=2,
+                    max_stack_increase=2,
                 ),
             ],
             expected_bytecode="ef00010100040200010009ff000000008000025f6000e20000011900",
@@ -1198,7 +1198,7 @@ def test_double_rjumpv(
                     + Op.POP
                     + Op.NOT
                     + Op.STOP,
-                    max_stack_height=2,
+                    max_stack_increase=2,
                 ),
             ],
             expected_bytecode="ef0001010004020001000dff000000008000025f6000e201000200035f501900",
@@ -1208,7 +1208,7 @@ def test_double_rjumpv(
             sections=[
                 Section.Code(
                     code=Op.PUSH0 + Op.PUSH1[0] + Op.RJUMPV[1] + Op.PUSH0 + Op.STOP,
-                    max_stack_height=2,
+                    max_stack_increase=2,
                 ),
             ],
             expected_bytecode="ef00010100040200010009ff000000008000025f6000e20000015f00",
@@ -1224,7 +1224,7 @@ def test_double_rjumpv(
                     + Op.PUSH0
                     + Op.NOT
                     + Op.STOP,
-                    max_stack_height=3,
+                    max_stack_increase=3,
                 ),
             ],
             expected_bytecode="ef0001010004020001000dff000000008000035f6000e201000100025f5f1900",
@@ -1242,7 +1242,7 @@ def test_double_rjumpv(
                     + Op.RJUMP[2]
                     + Op.PUSH1(3)
                     + Op.STOP,
-                    max_stack_height=2,
+                    max_stack_increase=2,
                 ),
             ],
             expected_bytecode="ef00010100040200010016ff000000008000025f6000e2010005000a6001e000076002e00002600300",
@@ -1263,7 +1263,7 @@ def test_double_rjumpv(
                     + Op.PUSH0
                     + Op.PUSH0
                     + Op.STOP,
-                    max_stack_height=4,
+                    max_stack_increase=4,
                 ),
             ],
             expected_bytecode="ef00010100040200010016ff000000008000045f6000e201000400095fe000085f5fe000035f5f5f00",
@@ -1287,7 +1287,7 @@ def test_double_rjumpv(
                     + Op.POP
                     + Op.POP
                     + Op.STOP,
-                    max_stack_height=5,
+                    max_stack_increase=5,
                 ),
             ],
             expected_bytecode="ef00010100040200010019ff000000008000055f5f5f5f6000e2010004000950e000085050e0000350505000",
@@ -1297,7 +1297,7 @@ def test_double_rjumpv(
             sections=[
                 Section.Code(
                     code=Op.PUSH0 + Op.PUSH1[0] + Op.RJUMPV[3] + Op.RJUMP[0] + Op.STOP,
-                    max_stack_height=2,
+                    max_stack_increase=2,
                 ),
             ],
             expected_bytecode="ef0001010004020001000bff000000008000025f6000e2000003e0000000",
@@ -1307,7 +1307,7 @@ def test_double_rjumpv(
             sections=[
                 Section.Code(
                     code=Op.PUSH0 + Op.PUSH1[0] + Op.RJUMPV[4] + Op.PUSH0 + Op.RJUMP[0] + Op.STOP,
-                    max_stack_height=2,
+                    max_stack_increase=2,
                 ),
             ],
             expected_bytecode="ef0001010004020001000cff000000008000025f6000e20000045fe0000000",
@@ -1324,7 +1324,7 @@ def test_double_rjumpv(
                     + Op.PUSH1(1)
                     + Op.RJUMPV[0]
                     + Op.STOP,
-                    max_stack_height=4,
+                    max_stack_increase=4,
                 ),
             ],
             expected_bytecode="ef0001010004020001000fff000000008000045f6000e100025f5f6001e200000000",
@@ -1343,7 +1343,7 @@ def test_double_rjumpv(
                     + Op.RJUMPV[1]
                     + Op.NOT
                     + Op.STOP,
-                    max_stack_height=5,
+                    max_stack_increase=5,
                 ),
             ],
             expected_bytecode="ef00010100040200010011ff000000008000055f6000e100025f5f5f6000e20000011900",
@@ -1364,7 +1364,7 @@ def test_double_rjumpv(
                     + Op.POP
                     + Op.NOT
                     + Op.STOP,
-                    max_stack_height=5,
+                    max_stack_increase=5,
                 ),
             ],
             expected_bytecode="ef00010100040200010015ff000000008000055f6000e100025f5f5f6000e201000200035f501900",
@@ -1383,7 +1383,7 @@ def test_double_rjumpv(
                     + Op.RJUMPV[1]
                     + Op.PUSH0
                     + Op.STOP,
-                    max_stack_height=5,
+                    max_stack_increase=5,
                 ),
             ],
             expected_bytecode="ef00010100040200010011ff000000008000055f6000e100025f5f5f6000e20000015f00",
@@ -1404,7 +1404,7 @@ def test_double_rjumpv(
                     + Op.PUSH0
                     + Op.NOT
                     + Op.STOP,
-                    max_stack_height=6,
+                    max_stack_increase=6,
                 ),
             ],
             expected_bytecode="ef00010100040200010015ff000000008000065f6000e100025f5f5f6000e201000100025f5f1900",
@@ -1427,7 +1427,7 @@ def test_double_rjumpv(
                     + Op.RJUMP[2]
                     + Op.PUSH1(3)
                     + Op.STOP,
-                    max_stack_height=5,
+                    max_stack_increase=5,
                 ),
             ],
             expected_bytecode="ef0001010004020001001eff000000008000055f6000e100025f5f5f6000e2010005000a6001e000076002e00002600300",
@@ -1453,7 +1453,7 @@ def test_double_rjumpv(
                     + Op.PUSH0
                     + Op.PUSH0
                     + Op.STOP,
-                    max_stack_height=7,
+                    max_stack_increase=7,
                 ),
             ],
             expected_bytecode="ef0001010004020001001eff000000008000075f6000e100025f5f5f6000e201000400095fe000085f5fe000035f5f5f00",
@@ -1482,7 +1482,7 @@ def test_double_rjumpv(
                     + Op.POP
                     + Op.POP
                     + Op.STOP,
-                    max_stack_height=8,
+                    max_stack_increase=8,
                 ),
             ],
             expected_bytecode="ef00010100040200010021ff000000008000085f6000e100025f5f5f5f5f5f6000e2010004000950e000085050e0000350505000",
@@ -1501,7 +1501,7 @@ def test_double_rjumpv(
                     + Op.RJUMPV[3]
                     + Op.RJUMP[0]
                     + Op.STOP,
-                    max_stack_height=5,
+                    max_stack_increase=5,
                 ),
             ],
             expected_bytecode="ef00010100040200010013ff000000008000055f6000e100025f5f5f6000e2000003e0000000",
@@ -1521,7 +1521,7 @@ def test_double_rjumpv(
                     + Op.PUSH0
                     + Op.RJUMP[0]
                     + Op.STOP,
-                    max_stack_height=5,
+                    max_stack_increase=5,
                 ),
             ],
             expected_bytecode="ef00010100040200010014ff000000008000055f6000e100025f5f5f6000e20000045fe0000000",
@@ -1548,7 +1548,7 @@ def test_rjumpv_valid_forward(
             sections=[
                 Section.Code(
                     code=Op.PUSH1[0] + Op.RJUMPV[-6] + Op.STOP,
-                    max_stack_height=1,
+                    max_stack_increase=1,
                 ),
             ],
             expected_bytecode="ef00010100040200010007ff000000008000016000e200fffa00",
@@ -1558,7 +1558,7 @@ def test_rjumpv_valid_forward(
             sections=[
                 Section.Code(
                     code=Op.PUSH0 + Op.POP + Op.PUSH1[0] + Op.RJUMPV[-8] + Op.STOP,
-                    max_stack_height=1,
+                    max_stack_increase=1,
                 ),
             ],
             expected_bytecode="ef00010100040200010009ff000000008000015f506000e200fff800",
@@ -1574,7 +1574,7 @@ def test_rjumpv_valid_forward(
                     + Op.PUSH1[0]
                     + Op.RJUMPV[-14]
                     + Op.STOP,
-                    max_stack_height=1,
+                    max_stack_increase=1,
                 ),
             ],
             expected_bytecode="ef0001010004020001000fff000000008000015f506000e200fff86000e200fff200",
@@ -1584,7 +1584,7 @@ def test_rjumpv_valid_forward(
             sections=[
                 Section.Code(
                     code=Op.PUSH0 + Op.POP + Op.PUSH1[0] + Op.RJUMPV[-8] + Op.RJUMP[-11],
-                    max_stack_height=1,
+                    max_stack_increase=1,
                 ),
             ],
             expected_bytecode="ef0001010004020001000bff000000008000015f506000e200fff8e0fff5",
@@ -1601,7 +1601,7 @@ def test_rjumpv_valid_forward(
                     + Op.PUSH1[0]
                     + Op.RJUMPV[-6]
                     + Op.STOP,
-                    max_stack_height=4,
+                    max_stack_increase=4,
                 ),
             ],
             expected_bytecode="ef0001010004020001000fff000000008000045f6000e100025f5f6000e200fffa00",
@@ -1620,7 +1620,7 @@ def test_rjumpv_valid_forward(
                     + Op.PUSH1[0]
                     + Op.RJUMPV[-8]
                     + Op.STOP,
-                    max_stack_height=4,
+                    max_stack_increase=4,
                 ),
             ],
             expected_bytecode="ef00010100040200010011ff000000008000045f6000e100025f5f5f506000e200fff800",
@@ -1641,7 +1641,7 @@ def test_rjumpv_valid_forward(
                     + Op.PUSH1[0]
                     + Op.RJUMPV[-14]
                     + Op.STOP,
-                    max_stack_height=4,
+                    max_stack_increase=4,
                 ),
             ],
             expected_bytecode="ef00010100040200010017ff000000008000045f6000e100025f5f5f506000e200fff86000e200fff200",
@@ -1660,7 +1660,7 @@ def test_rjumpv_valid_forward(
                     + Op.PUSH1[0]
                     + Op.RJUMPV[-8]
                     + Op.RJUMP[-11],
-                    max_stack_height=4,
+                    max_stack_increase=4,
                 ),
             ],
             expected_bytecode="ef00010100040200010013ff000000008000045f6000e100025f5f5f506000e200fff8e0fff5",
@@ -1694,7 +1694,7 @@ def test_rjumpv_valid_backward(
                     + Op.PUSH1[0]
                     + Op.RJUMPV[-15]
                     + Op.STOP,
-                    max_stack_height=2,
+                    max_stack_increase=2,
                 ),
             ],
             expected_bytecode="ef00010100040200010010ff000000008000025f506000e200fff85f6000e200fff100",
@@ -1709,7 +1709,7 @@ def test_rjumpv_valid_backward(
                     + Op.RJUMPV[-7]
                     + Op.PUSH0
                     + Op.RJUMP[-11],
-                    max_stack_height=1,
+                    max_stack_increase=1,
                 ),
             ],
         ),
@@ -1724,7 +1724,7 @@ def test_rjumpv_valid_backward(
                     + Op.PUSH1[0]
                     + Op.RJUMPV[-12]
                     + Op.STOP,
-                    max_stack_height=3,
+                    max_stack_increase=3,
                 ),
             ],
             expected_bytecode="ef0001010004020001000eff000000008000035f6000e100015f6000e200fff400",
@@ -1740,7 +1740,7 @@ def test_rjumpv_valid_backward(
                     + Op.PUSH1[0]
                     + Op.RJUMPV[-12]
                     + Op.STOP,
-                    max_stack_height=3,
+                    max_stack_increase=3,
                 ),
             ],
             expected_bytecode="ef0001010004020001000fff0000000080000360be6000e10001506000e200fff400",
@@ -1762,7 +1762,7 @@ def test_rjumpv_valid_backward(
                     + Op.PUSH1[0]
                     + Op.RJUMPV[-15]
                     + Op.STOP,
-                    max_stack_height=5,
+                    max_stack_increase=5,
                 ),
             ],
             expected_bytecode="ef00010100040200010018ff000000008000055f6000e100025f5f5f506000e200fff85f6000e200fff100",
@@ -1782,7 +1782,7 @@ def test_rjumpv_valid_backward(
                     + Op.RJUMPV[-7]
                     + Op.PUSH0
                     + Op.RJUMP[-11],
-                    max_stack_height=4,
+                    max_stack_increase=4,
                 ),
             ],
         ),
@@ -1802,7 +1802,7 @@ def test_rjumpv_valid_backward(
                     + Op.PUSH1[0]
                     + Op.RJUMPV[-12]
                     + Op.STOP,
-                    max_stack_height=5,
+                    max_stack_increase=5,
                 ),
             ],
             expected_bytecode="ef00010100040200010016ff000000008000055f6000e100025f5f5f6000e100015f6000e200fff400",
@@ -1824,7 +1824,7 @@ def test_rjumpv_valid_backward(
                     + Op.PUSH1[0]
                     + Op.RJUMPV[-12]
                     + Op.STOP,
-                    max_stack_height=5,
+                    max_stack_increase=5,
                 ),
             ],
             expected_bytecode="ef00010100040200010017ff000000008000055f6000e100025f5f5f5f6000e10001506000e200fff400",


### PR DESCRIPTION
## 🗒️ Description
Convert all EOF validation tests for EIP-4200 (relative jumps) to use `max_stack_increase`. The conversion here is simple because all these tests use the code section 0 and therefore `max_stack_increase` is equivalent to `max_stack_height`.

## 🔗 Related Issues
https://github.com/ipsilon/eof/issues/134

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
