### PR TITLE
chore(tests): remove pytest skips from eip7251/7685 cases

### DIFF
--- a/tests/prague/eip7251_consolidations/test_consolidations.py
+++ b/tests/prague/eip7251_consolidations/test_consolidations.py
@@ -204,9 +204,6 @@ pytestmark = pytest.mark.valid_from("Prague")
                     )
                 ],
             ],
-            marks=pytest.mark.skip(
-                reason="duplicate test due to MAX_CONSOLIDATION_REQUESTS_PER_BLOCK==1"
-            ),
             id="single_block_max_consolidation_requests_from_eoa",
         ),
         pytest.param(

--- a/tests/prague/eip7685_general_purpose_el_requests/test_multi_type_requests.py
+++ b/tests/prague/eip7685_general_purpose_el_requests/test_multi_type_requests.py
@@ -189,7 +189,6 @@ def get_contract_permutations(n: int = 3) -> Generator[ParameterSet, None, None]
                 single_deposit_from_eoa(0),
                 single_consolidation_from_contract(1),
             ],
-            marks=pytest.mark.skip("Only one consolidation request is allowed per block"),
             id="consolidation_from_eoa+deposit_from_eoa+consolidation_from_contract",
         ),
         pytest.param(
@@ -198,7 +197,6 @@ def get_contract_permutations(n: int = 3) -> Generator[ParameterSet, None, None]
                 single_withdrawal_from_eoa(0),
                 single_consolidation_from_contract(1),
             ],
-            marks=pytest.mark.skip("Only one consolidation request is allowed per block"),
             id="consolidation_from_eoa+withdrawal_from_eoa+consolidation_from_contract",
         ),
         pytest.param(


### PR DESCRIPTION
## 🗒️ Description
Removes the pytest skips within the EIP-7251 & EIP-7685 test cases.

These were valid points after the change from 1 to 2 for `Spec.MAX_CONSOLIDATION_PER_BLOCK`.

Additional cases validated on all clients using `consume engine`.

## 🔗 Related Issues
N/A.

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] ~~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
