### PR TITLE
refactor(tests): change CALLF tests to max_stack_increase

### DIFF
--- a/tests/osaka/eip7692_eof_v1/eip4750_functions/test_callf_execution.py
+++ b/tests/osaka/eip7692_eof_v1/eip4750_functions/test_callf_execution.py
@@ -39,8 +39,7 @@ def test_callf_factorial(eof_state_test: EOFStateTestFiller, n, result):
         container=Container(
             sections=[
                 Section.Code(
-                    Op.CALLDATALOAD(0) + Op.SSTORE(0, Op.CALLF[1]) + Op.STOP,
-                    max_stack_height=2,
+                    Op.SSTORE(0, Op.CALLF[1](Op.CALLDATALOAD(0))) + Op.STOP,
                 ),
                 Section.Code(
                     Op.PUSH1[1]
@@ -61,7 +60,6 @@ def test_callf_factorial(eof_state_test: EOFStateTestFiller, n, result):
                     + Op.RETF,
                     code_inputs=1,
                     code_outputs=1,
-                    max_stack_height=3,
                 ),
             ]
         ),
@@ -80,8 +78,7 @@ def test_callf_fibonacci(eof_state_test: EOFStateTestFiller, n, result):
         container=Container(
             sections=[
                 Section.Code(
-                    Op.CALLDATALOAD(0) + Op.SSTORE(0, Op.CALLF[1]) + Op.STOP,
-                    max_stack_height=2,
+                    Op.SSTORE(0, Op.CALLF[1](Op.CALLDATALOAD(0))) + Op.STOP,
                 ),
                 Section.Code(
                     Op.PUSH1[2]
@@ -105,7 +102,6 @@ def test_callf_fibonacci(eof_state_test: EOFStateTestFiller, n, result):
                     + Op.RETF,
                     code_inputs=1,
                     code_outputs=1,
-                    max_stack_height=4,
                 ),
             ]
         ),
@@ -124,16 +120,15 @@ def test_callf_fibonacci(eof_state_test: EOFStateTestFiller, n, result):
                 Section.Code(
                     Op.SSTORE(
                         slot_code_worked,
-                        Op.PUSH1[1] + Op.PUSH2[value_code_worked + 1] + Op.CALLF[1],
+                        Op.CALLF[1](value_code_worked + 1, 1),
                     )
                     + Op.STOP,
-                    max_stack_height=2,
+                    max_stack_increase=2,
                 ),
                 Section.Code(
                     Op.SUB + Op.RETF,
                     code_inputs=2,
                     code_outputs=1,
-                    max_stack_height=2,
                 ),
             ],
         ),
@@ -142,24 +137,20 @@ def test_callf_fibonacci(eof_state_test: EOFStateTestFiller, n, result):
             sections=[
                 Section.Code(
                     Op.CALLF[1] + Op.SSTORE + Op.STOP,
-                    max_stack_height=2,
                 )
             ]
             + [
                 Section.Code(
                     Op.CALLF[i] + Op.RETF,
-                    code_inputs=0,
                     code_outputs=2,
-                    max_stack_height=2,
+                    max_stack_increase=2,
                 )
                 for i in range(2, 1024)
             ]
             + [
                 Section.Code(
                     Op.PUSH2[value_code_worked] + Op.PUSH1[slot_code_worked] + Op.RETF,
-                    code_inputs=0,
                     code_outputs=2,
-                    max_stack_height=2,
                 ),
             ],
         ),
@@ -174,25 +165,21 @@ def test_callf_fibonacci(eof_state_test: EOFStateTestFiller, n, result):
                     + Op.CALLF[3]
                     + Op.SSTORE
                     + Op.STOP,
-                    max_stack_height=4,
+                    max_stack_increase=4,
                 ),
                 Section.Code(
                     Op.POP + Op.RETF,
                     code_inputs=1,
                     code_outputs=0,
-                    max_stack_height=1,
                 ),
                 Section.Code(
                     Op.PUSH2[value_code_worked] + Op.RETF,
-                    code_inputs=0,
                     code_outputs=1,
-                    max_stack_height=1,
                 ),
                 Section.Code(
                     Op.DUP2 + Op.PUSH2[slot_code_worked] + Op.RETF,
                     code_inputs=2,
                     code_outputs=4,
-                    max_stack_height=4,
                 ),
             ],
         ),
@@ -219,13 +206,10 @@ def test_callf(eof_state_test: EOFStateTestFiller, container: Container):
                     + Op.POP * 1023
                     + Op.SSTORE(slot_code_worked, value_code_worked)
                     + Op.RETURN(0, 0),
-                    max_stack_height=1023,
                 ),
                 Section.Code(
                     Op.PUSH0 + Op.POP + Op.RETF,
-                    code_inputs=0,
                     code_outputs=0,
-                    max_stack_height=1,
                 ),
             ],
         ),
@@ -238,13 +222,12 @@ def test_callf(eof_state_test: EOFStateTestFiller, container: Container):
                     + Op.POP * 1023
                     + Op.SSTORE(slot_code_worked, value_code_worked)
                     + Op.RETURN(0, 0),
-                    max_stack_height=1023,
                 ),
                 Section.Code(
                     Op.PUSH0 + Op.POP + Op.RETF,
                     code_inputs=3,
                     code_outputs=3,
-                    max_stack_height=4,
+                    max_stack_increase=1,
                 ),
             ],
         ),
@@ -257,7 +240,6 @@ def test_callf(eof_state_test: EOFStateTestFiller, container: Container):
                     + Op.POP * 1023
                     + Op.SSTORE(slot_code_worked, value_code_worked)
                     + Op.RETURN(0, 0),
-                    max_stack_height=1023,
                 ),
                 Section.Code(
                     Op.CALLF[2]
@@ -265,15 +247,11 @@ def test_callf(eof_state_test: EOFStateTestFiller, container: Container):
                     # stack has 1024 items
                     Op.POP
                     + Op.RETF,
-                    code_inputs=0,
                     code_outputs=0,
-                    max_stack_height=1,
                 ),
                 Section.Code(
                     Op.PUSH0 + Op.RETF,  # stack has 1024 items
-                    code_inputs=0,
                     code_outputs=1,
-                    max_stack_height=1,
                 ),
             ],
         ),
@@ -286,7 +264,6 @@ def test_callf(eof_state_test: EOFStateTestFiller, container: Container):
                     + Op.POP * 1022
                     + Op.SSTORE(slot_code_worked, value_code_worked)
                     + Op.RETURN(0, 0),
-                    max_stack_height=1022,
                 ),
                 Section.Code(
                     Op.PUSH0
@@ -295,9 +272,7 @@ def test_callf(eof_state_test: EOFStateTestFiller, container: Container):
                     Op.CALLF[2]
                     + Op.POP
                     + Op.RETF,
-                    code_inputs=0,
                     code_outputs=0,
-                    max_stack_height=1,
                 ),
                 Section.Code(
                     Op.PUSH0
@@ -305,9 +280,7 @@ def test_callf(eof_state_test: EOFStateTestFiller, container: Container):
                     # stack has 1024 items
                     Op.POP
                     + Op.RETF,
-                    code_inputs=0,
                     code_outputs=0,
-                    max_stack_height=1,
                 ),
             ],
         ),
@@ -320,7 +293,6 @@ def test_callf(eof_state_test: EOFStateTestFiller, container: Container):
                     + Op.POP * 1022
                     + Op.SSTORE(slot_code_worked, value_code_worked)
                     + Op.RETURN(0, 0),
-                    max_stack_height=1022,
                 ),
                 Section.Code(
                     Op.PUSH0
@@ -331,7 +303,7 @@ def test_callf(eof_state_test: EOFStateTestFiller, container: Container):
                     + Op.RETF,
                     code_inputs=3,
                     code_outputs=3,
-                    max_stack_height=4,
+                    max_stack_increase=1,
                 ),
                 Section.Code(
                     Op.PUSH0
@@ -341,7 +313,7 @@ def test_callf(eof_state_test: EOFStateTestFiller, container: Container):
                     + Op.RETF,
                     code_inputs=3,
                     code_outputs=3,
-                    max_stack_height=4,
+                    max_stack_increase=1,
                 ),
             ],
         ),
@@ -355,7 +327,7 @@ def test_callf(eof_state_test: EOFStateTestFiller, container: Container):
                     + Op.PUSH1[slot_code_worked]
                     + Op.SSTORE
                     + Op.STOP,
-                    max_stack_height=2,
+                    max_stack_increase=2,
                 ),
                 Section.Code(
                     Op.POP  # clear input
@@ -364,7 +336,6 @@ def test_callf(eof_state_test: EOFStateTestFiller, container: Container):
                     + Op.RETF,  # return nothing
                     code_inputs=1,
                     code_outputs=0,
-                    max_stack_height=1023,
                 ),
             ],
         ),
@@ -377,7 +348,7 @@ def test_callf(eof_state_test: EOFStateTestFiller, container: Container):
                     + Op.CALLF[1]
                     + Op.SSTORE(slot_code_worked, value_code_worked)
                     + Op.STOP,
-                    max_stack_height=2,
+                    max_stack_increase=2,
                 ),
                 Section.Code(
                     Op.POP  # clear input[0]
@@ -387,7 +358,6 @@ def test_callf(eof_state_test: EOFStateTestFiller, container: Container):
                     + Op.RETF,  # return nothing
                     code_inputs=2,
                     code_outputs=0,
-                    max_stack_height=1023,
                 ),
             ],
         ),
@@ -414,28 +384,19 @@ def test_callf_operand_stack_size_max(eof_state_test: EOFStateTestFiller, contai
                     + Op.POP * 1023
                     + Op.SSTORE(slot_code_worked, value_code_worked)
                     + Op.RETURN(0, 0),
-                    max_stack_height=1023,
                 ),
                 Section.Code(
-                    Op.PUSH0
-                    +
-                    # Stack has 1024 items
-                    Op.CALLF[2]
+                    Op.PUSH0  # Stack has 1024 items
+                    + Op.CALLF[2]
                     + Op.POP
                     + Op.RETF,
-                    code_inputs=0,
                     code_outputs=0,
-                    max_stack_height=1,
                 ),
                 Section.Code(
-                    Op.PUSH0
-                    +
-                    # Runtime stack overflow
-                    Op.POP
+                    Op.PUSH0  # Runtime stack overflow
+                    + Op.POP
                     + Op.RETF,
-                    code_inputs=0,
                     code_outputs=0,
-                    max_stack_height=1,
                 ),
             ],
         ),
@@ -448,28 +409,23 @@ def test_callf_operand_stack_size_max(eof_state_test: EOFStateTestFiller, contai
                     + Op.POP * 1023
                     + Op.SSTORE(slot_code_worked, value_code_worked)
                     + Op.RETURN(0, 0),
-                    max_stack_height=1023,
                 ),
                 Section.Code(
-                    Op.PUSH0
-                    +
-                    # Stack has 1024 items
-                    Op.CALLF[2]
+                    Op.PUSH0  # Stack has 1024 items
+                    + Op.CALLF[2]
                     + Op.POP
                     + Op.RETF,
                     code_inputs=3,
                     code_outputs=3,
-                    max_stack_height=4,
+                    max_stack_increase=1,
                 ),
                 Section.Code(
-                    Op.PUSH0
-                    +
-                    # Runtime stackoverflow
-                    Op.POP
+                    Op.PUSH0  # Runtime stackoverflow
+                    + Op.POP
                     + Op.RETF,
                     code_inputs=3,
                     code_outputs=3,
-                    max_stack_height=4,
+                    max_stack_increase=1,
                 ),
             ],
         ),
@@ -520,13 +476,13 @@ def test_callf_sneaky_stack_overflow(
                     + Op.POP * stack_height
                     + Op.SSTORE(slot_code_worked, value_code_worked)
                     + Op.RETURN(0, 0),
-                    max_stack_height=stack_height + outputs - inputs,
+                    max_stack_increase=stack_height + outputs - inputs,
                 ),
                 Section.Code(
                     Op.CALLF[2] + Op.POP + Op.RETF,
                     code_inputs=inputs,
                     code_outputs=outputs,
-                    max_stack_height=outputs + 1,
+                    max_stack_increase=outputs - inputs + 1,
                 ),
                 Section.Code(
                     Op.RJUMPI[4]
@@ -537,7 +493,7 @@ def test_callf_sneaky_stack_overflow(
                     + Op.RETF,
                     code_inputs=inputs,
                     code_outputs=outputs + 1,
-                    max_stack_height=outputs + 2,
+                    max_stack_increase=outputs - inputs + 2,
                 ),
                 Section.Code(
                     Op.POP * inputs
@@ -546,7 +502,7 @@ def test_callf_sneaky_stack_overflow(
                     + Op.RETF,
                     code_inputs=inputs,
                     code_outputs=outputs + 1,
-                    max_stack_height=outputs + 1,
+                    max_stack_increase=outputs - inputs + 1,
                 ),
             ],
         ),
@@ -619,7 +575,6 @@ def test_callf_max_stack(
                     + Op.CALLF[1]
                     + Op.SSTORE(slot_code_worked, value_code_worked)
                     + Op.RETURN(0, 0),
-                    max_stack_height=7,
                 ),
                 Section.Code(
                     Op.PUSH1(1)  # arg, 1
@@ -635,13 +590,10 @@ def test_callf_max_stack(
                     + Op.RETF,
                     code_inputs=1,
                     code_outputs=1,
-                    max_stack_height=2,
                 ),
                 Section.Code(
                     Op.RETF,
-                    code_inputs=0,
                     code_outputs=0,
-                    max_stack_height=0,
                 ),
             ],
         ),


### PR DESCRIPTION
## 🗒️ Description
This updates EIP-4750 CALLF tests to use `max_stack_increase` instead of `max_stack_height`.
In many places the value is correctly auto-computed so for these cases the explicit value is omitted.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
