### PR TITLE
new(tests): EOF validation stack_range maximally broad

### DIFF
--- a/converted-ethereum-tests.txt
+++ b/converted-ethereum-tests.txt
@@ -38,6 +38,7 @@ EOFTests/efStack/jumpf_with_inputs_stack_overflow_variable_stack_.json
 EOFTests/efStack/non_constant_stack_height_.json
 EOFTests/efStack/retf_stack_validation_.json
 EOFTests/efStack/retf_variable_stack_.json
+EOFTests/efStack/stack_range_maximally_broad_.json
 EOFTests/efStack/forwards_rjump_.json
 EOFTests/efStack/forwards_rjump_variable_stack_.json
 EOFTests/efStack/forwards_rjumpi_.json

--- a/tests/osaka/eip7692_eof_v1/eip5450_stack/test_code_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip5450_stack/test_code_validation.py
@@ -626,3 +626,21 @@ def test_valid_non_constant_stack_examples(
         data=data,
         container_post=Account(storage=expected_storage),
     )
+
+
+@pytest.mark.parametrize("num_rjumpi", [MAX_STACK_INCREASE_LIMIT, MAX_STACK_INCREASE_LIMIT + 1])
+def test_stack_range_maximally_broad(eof_test, num_rjumpi: int):
+    """Test stack range 0-1023 at final instruction."""
+    code = Op.STOP()
+    for i in range(0, num_rjumpi):
+        offset = i * 5 + 1
+        code = Op.PUSH0 + Op.RJUMPI[offset] + Op.PUSH0 + code
+
+    container = Container.Code(code=code, max_stack_increase=MAX_STACK_INCREASE_LIMIT)
+
+    eof_test(
+        container=container,
+        expect_exception=None
+        if num_rjumpi <= MAX_STACK_INCREASE_LIMIT
+        else EOFException.INVALID_MAX_STACK_INCREASE,
+    )

--- a/tests/osaka/eip7692_eof_v1/eof_tracker.md
+++ b/tests/osaka/eip7692_eof_v1/eof_tracker.md
@@ -321,7 +321,7 @@
 - [ ] Wrong max_stack_height (ethereum/tests: ./src/EOFTestsFiller/efExample/validInvalidFiller.yml src/EOFTestsFiller/efValidation/max_stack_height_Copier.json)
 - [ ] All opcodes correctly account for stack inputs/outputs (ethereum/tests: src/EOFTestsFiller/EIP5450/validInvalidFiller.yml)
 - [ ] Code reachable only via backwards jump is invalid
-- [ ] Maximally broad [0, 1023] stack range (ethereum/tests: src/EOFTestsFiller/efStack/stack_range_maximally_broad_Copier.json)
+- [x] Maximally broad [0, 1023] stack range ([`tests/osaka/eip7692_eof_v1/eip_5450_stack/test_code_validation.py::test_stack_range_maximally_broad`](./eip5450_stack/test_code_validation/test_stack_range_maximally_broad.md))
 
 ### Execution
 


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened. https://github.com/ethereum/tests/pull/1484
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
