### PR TITLE
refactor(tests): update JUMPF EOF tests to max_stack_increase

### DIFF
--- a/tests/osaka/eip7692_eof_v1/eip6206_jumpf/test_jumpf_target.py
+++ b/tests/osaka/eip7692_eof_v1/eip6206_jumpf/test_jumpf_target.py
@@ -57,7 +57,7 @@ def test_jumpf_target_rules(
         + Op.JUMPF[target_section_index],
         code_inputs=0,
         code_outputs=source_outputs,
-        max_stack_height=source_height + max(1, source_extra_push),
+        max_stack_increase=source_height + max(1, source_extra_push),
     )
 
     # `delta` is how many stack items the target output is from the input height, and tracks the
@@ -69,7 +69,7 @@ def test_jumpf_target_rules(
         + (Op.STOP if target_non_returning else Op.RETF),
         code_inputs=source_height,
         code_outputs=target_outputs,
-        max_stack_height=max(source_height, source_height + delta),
+        max_stack_increase=max(0, delta),
     )
 
     base_code = (
@@ -87,7 +87,7 @@ def test_jumpf_target_rules(
         sections=[
             Section.Code(
                 code=base_code,
-                max_stack_height=base_height,
+                max_stack_increase=base_height,
             ),
             source_section,
             target_section,

--- a/tests/osaka/eip7692_eof_v1/eip6206_jumpf/test_nonreturning_validation.py
+++ b/tests/osaka/eip7692_eof_v1/eip6206_jumpf/test_nonreturning_validation.py
@@ -70,7 +70,7 @@ def test_first_section_with_inputs(
                     code,
                     code_inputs=inputs,
                     code_outputs=outputs,
-                    max_stack_height=max(inputs, outputs),
+                    max_stack_increase=max(0, outputs - inputs),
                 )
             ],
             validity_error=EOFException.INVALID_FIRST_SECTION_TYPE,
@@ -98,7 +98,7 @@ def test_returning_section_not_returning(eof_test: EOFTestFiller, code_section: 
     eof_test(
         container=Container(
             sections=[
-                Section.Code(Op.CALLF[1] + Op.STOP, max_stack_height=code_section.code_outputs),
+                Section.Code(Op.CALLF[1] + Op.STOP, max_stack_increase=code_section.code_outputs),
                 code_section,
             ],
             validity_error=EOFException.INVALID_NON_RETURNING_FLAG,
@@ -124,7 +124,9 @@ def test_returning_section_returncode(eof_test: EOFTestFiller, code_section: Sec
     eof_test(
         container=Container(
             sections=[
-                Section.Code(Op.CALLF[1] + Op.INVALID, max_stack_height=code_section.code_outputs),
+                Section.Code(
+                    Op.CALLF[1] + Op.INVALID, max_stack_increase=code_section.code_outputs
+                ),
                 code_section,
             ]
             + [Section.Container(Container.Code(Op.INVALID))],


### PR DESCRIPTION
## 🗒️ Description
This updates EIP-6206 (JUMPF) tests to use `max_stack_increase` instead of `max_stack_height`.
In many places the value is correctly auto-computed so for these cases the explicit value is omitted.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist

- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
