### PR TITLE
chore(tooling): configure `markdownlint` ul indent to 4

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,7 +1,9 @@
 # All rules: https://github.com/DavidAnson/markdownlint#rules--aliases
-default: true  # Default state for all rules
-MD013: false  # line-length: We don't fill paragaraphs/limit line length
-MD034: false  # no-bare-urls - We use pymdownx.magiclink which allows bare urls
-MD046: false  # code-block-style - This doesn't play well with material's admonitions)
-MD024: false  # no-duplicate-heading - We use duplicate headings in the changelog.
-MD033: false  # no-inline-html - Too strict.
+default: true # Default state for all rules
+MD013: false # line-length: We don't fill paragaraphs/limit line length
+MD034: false # no-bare-urls - We use pymdownx.magiclink which allows bare urls
+MD046: false # code-block-style - This doesn't play well with material's admonitions)
+MD024: false # no-duplicate-heading - We use duplicate headings in the changelog.
+MD033: false # no-inline-html - Too strict.
+MD007:
+  indent: 4

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -404,8 +404,8 @@ The following changes may be potentially breaking (all clients were tested with 
 - 💥 "Merge" has been renamed to "Paris" in the "network" field of the Blockchain tests, and in the "post" field of the State tests ([#480](https://github.com/ethereum/execution-spec-tests/pull/480)).
 - ✨ Port entry point scripts to use [click](https://click.palletsprojects.com) and add tests ([#483](https://github.com/ethereum/execution-spec-tests/pull/483)).
 - 💥 As part of the pydantic conversion, the fixtures have the following (possibly breaking) changes ([#486](https://github.com/ethereum/execution-spec-tests/pull/486)):
-  - State test field `transaction` now uses the proper zero-padded hex number format for fields `maxPriorityFeePerGas`, `maxFeePerGas`, and `maxFeePerBlobGas`
-  - Fixtures' hashes (in the `_info` field) are now calculated by removing the "_info" field entirely instead of it being set to an empty dict.
+    - State test field `transaction` now uses the proper zero-padded hex number format for fields `maxPriorityFeePerGas`, `maxFeePerGas`, and `maxFeePerBlobGas`
+    - Fixtures' hashes (in the `_info` field) are now calculated by removing the "_info" field entirely instead of it being set to an empty dict.
 - 🐞 Relax minor and patch dependency requirements to avoid conflicting package dependencies ([#510](https://github.com/ethereum/execution-spec-tests/pull/510)).
 - 🔀 Update all CI actions to use their respective Node.js 20 versions, ahead of their Node.js 16 version deprecations ([#527](https://github.com/ethereum/execution-spec-tests/pull/527)).
 - ✨ Releases now contain a `fixtures_eip7692.tar.gz` which contains all EOF fixtures ([#573](https://github.com/ethereum/execution-spec-tests/pull/573)).

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,13 +20,15 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 - 🐞 Fix fixture tarball downloading with regular, non-Github release URLS and with numerical versions in regular release specs, e.g., `stable@v4.2.0` ([#1437](https://github.com/ethereum/execution-spec-tests/pull/1437)).
 
-### 📋 Misc
-
 ### 🧪 Test Cases
 
 - ✨ [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702): Test precompile case in same transaction as delegation without extra gas in case of precompile code execution; parametrize all call opcodes in existing precompile test ([#1431](https://github.com/ethereum/execution-spec-tests/pull/1431)).
 - ✨ [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702): Add invalid nonce authorizations tests for the case of multiple signers when the sender's nonce gets increased ([#1441](https://github.com/ethereum/execution-spec-tests/pull/1441)).
 - ✨ [EIP-7623](https://eips.ethereum.org/EIPS/eip-7623): Additionally parametrize transaction validity tests with the `to` set to an EOA account (previously only contracts) ([#1422](https://github.com/ethereum/execution-spec-tests/pull/1422)).
+
+### 📋 Misc
+
+- 🐞 Configure `markdownlint` to expect an indent of 4 with unordered lists (otherwise HTML documentation is rendered incorrectly, [#1460](https://github.com/ethereum/execution-spec-tests/pull/1460)).
 
 ## [v4.2.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v4.2.0) - 2025-04-08
 


### PR DESCRIPTION
## 🗒️ Description

Correctly configure `markdownlint` to expect an indentation of 4. An indent of 4 is required for HTML documentation to render correctly. For example, the 2 highlighted items are included incorrectly as top-level items, but should be a sub-list:
![image](https://github.com/user-attachments/assets/10df1a16-5bd8-4e4a-9275-6543fdc75a49)


## 🔗 Related Issues
None.

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).

