### PR TITLE
fix(fill): insist `fill`'s output directory is empty or doesn't exist

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,13 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 ## 🔜 [Unreleased]
 
+### 💥 Important Change for `fill` Users
+
+The output behavior of `fill` has changed:
+
+- Before: `fill` wrote fixtures into the directory specified by the `--output` flag (default: `fixtures`). This could have many unintended consequences, including unexpected errors if old or invalid fixtures existed in the directory (for details see [#1030](https://github.com/ethereum/execution-spec-tests/issues/1030)).
+- Now: `fill` will exit without filling any tests if the specified directory exists and is not-empty. This may be overridden by adding the `--clean` flag, which will first remove the specified directory.
+
 ### 💥 Breaking Change
 
 ### 🛠️ Framework
@@ -16,6 +23,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Introduce `pytest.mark.exception_test` to mark tests that contain an invalid transaction or block ([#1436](https://github.com/ethereum/execution-spec-tests/pull/1436)).
 - 🐞 Fix `DeprecationWarning: Pickle, copy, and deepcopy support will be removed from itertools in Python 3.14.` by avoiding use `itertools` object in the spec `BaseTest` pydantic model ([#1414](https://github.com/ethereum/execution-spec-tests/pull/1414)).
 - 🔀 Refactor: Encapsulate `fill`'s fixture output options (`--output`, `--flat-output`, `--single-fixture-per-file`) into a `FixtureOutput` class ([#1471](https://github.com/ethereum/execution-spec-tests/pull/1471)).
+- 🐞 Do not write generated fixtures into an existing, non-empty output directory; it must now be empty or `--clean` must be used to delete it first ([#1473](https://github.com/ethereum/execution-spec-tests/pull/1473)).
 
 #### `consume`
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ The `static_filler` plug-in now has support for static state tests (from [GeneralStateTests](https://github.com/ethereum/tests/tree/develop/src/GeneralStateTestsFiller)) ([#1362](https://github.com/ethereum/execution-spec-tests/pull/1362)).
 - ✨ Introduce `pytest.mark.exception_test` to mark tests that contain an invalid transaction or block ([#1436](https://github.com/ethereum/execution-spec-tests/pull/1436)).
 - 🐞 Fix `DeprecationWarning: Pickle, copy, and deepcopy support will be removed from itertools in Python 3.14.` by avoiding use `itertools` object in the spec `BaseTest` pydantic model ([#1414](https://github.com/ethereum/execution-spec-tests/pull/1414)).
+- 🔀 Refactor: Encapsulate `fill`'s fixture output options (`--output`, `--flat-output`, `--single-fixture-per-file`) into a `FixtureOutput` class ([#1471](https://github.com/ethereum/execution-spec-tests/pull/1471)).
 
 #### `consume`
 

--- a/src/cli/gentest/tests/test_cli.py
+++ b/src/cli/gentest/tests/test_cli.py
@@ -1,5 +1,7 @@
 """Tests for the gentest CLI command."""
 
+from tempfile import TemporaryDirectory
+
 import pytest
 from click.testing import CliRunner
 
@@ -111,5 +113,13 @@ def test_tx_type(tmp_path, monkeypatch, tx_type, transaction_hash):
     assert gentest_result.exit_code == 0
 
     ## Fill ##
-    fill_result = runner.invoke(fill, ["-c", "pytest.ini", "--skip-evm-dump", output_file])
+    args = [
+        "-c",
+        "pytest.ini",
+        "--skip-evm-dump",
+        "--output",
+        TemporaryDirectory().name,
+        output_file,
+    ]
+    fill_result = runner.invoke(fill, args)
     assert fill_result.exit_code == 0, f"Fill command failed:\n{fill_result.output}"

--- a/src/pytest_plugins/filler/filler.py
+++ b/src/pytest_plugins/filler/filler.py
@@ -11,6 +11,7 @@ import datetime
 import os
 import tarfile
 import warnings
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Generator, List, Type
 
@@ -51,16 +52,72 @@ def default_html_report_file_path() -> str:
     return ".meta/report_fill.html"
 
 
-def strip_output_tarball_suffix(output: Path) -> Path:
-    """Strip the '.tar.gz' suffix from the output path."""
-    if str(output).endswith(".tar.gz"):
-        return output.with_suffix("").with_suffix("")
-    return output
+@dataclass
+class FixtureOutput:
+    """Represents the output destination for generated test fixtures."""
 
+    path: Path
+    flat_output: bool = False
+    single_fixture_per_file: bool = False
 
-def is_output_stdout(output: Path) -> bool:
-    """Return True if the fixture output is configured to be stdout."""
-    return strip_output_tarball_suffix(output).name == "stdout"
+    @property
+    def directory(self) -> Path:
+        """Return the actual directory path where fixtures will be written."""
+        return self.strip_tarball_suffix(self.path)
+
+    @property
+    def metadata_dir(self) -> Path:
+        """Return metadata directory to store fixture meta files."""
+        if self.is_stdout:
+            return self.directory
+        return self.directory / ".meta"
+
+    @property
+    def is_tarball(self) -> bool:
+        """Return True if the output should be packaged as a tarball."""
+        return self.path.suffix == ".gz" and self.path.with_suffix("").suffix == ".tar"
+
+    @property
+    def is_stdout(self) -> bool:
+        """Return True if the fixture output is configured to be stdout."""
+        return self.directory.name == "stdout"
+
+    @staticmethod
+    def strip_tarball_suffix(path: Path) -> Path:
+        """Strip the '.tar.gz' suffix from the output path."""
+        if str(path).endswith(".tar.gz"):
+            return path.with_suffix("").with_suffix("")
+        return path
+
+    def create_directories(self) -> None:
+        """Create output and metadata directories if needed."""
+        if self.is_stdout:
+            return
+
+        self.directory.mkdir(parents=True, exist_ok=True)
+        self.metadata_dir.mkdir(parents=True, exist_ok=True)
+
+    def create_tarball(self) -> None:
+        """Create tarball of the output directory if configured to do so."""
+        if not self.is_tarball:
+            return
+
+        with tarfile.open(self.path, "w:gz") as tar:
+            for file in self.directory.rglob("*"):
+                if file.suffix in {".json", ".ini"}:
+                    arcname = Path("fixtures") / file.relative_to(self.directory)
+                    tar.add(file, arcname=arcname)
+
+    @classmethod
+    def from_options(
+        cls, output_path: Path, flat_output: bool, single_fixture_per_file: bool
+    ) -> "FixtureOutput":
+        """Create a FixtureOutput instance from pytest options."""
+        return cls(
+            path=output_path,
+            flat_output=flat_output,
+            single_fixture_per_file=single_fixture_per_file,
+        )
 
 
 def pytest_addoption(parser: pytest.Parser):
@@ -213,12 +270,18 @@ def pytest_configure(config):
     """
     if config.option.collectonly:
         return
+
+    # Initialize fixture output configuration
+    config.fixture_output = FixtureOutput.from_options(
+        output_path=config.getoption("output"),
+        flat_output=config.getoption("flat_output"),
+        single_fixture_per_file=config.getoption("single_fixture_per_file"),
+    )
+
     if not config.getoption("disable_html") and config.getoption("htmlpath") is None:
         # generate an html report by default, unless explicitly disabled
-        config.option.htmlpath = (
-            strip_output_tarball_suffix(config.getoption("output"))
-            / default_html_report_file_path()
-        )
+        config.option.htmlpath = config.fixture_output.directory / default_html_report_file_path()
+
     # Instantiate the transition tool here to check that the binary path/trace option is valid.
     # This ensures we only raise an error once, if appropriate, instead of for every test.
     t8n = TransitionTool.from_binary_path(
@@ -272,7 +335,7 @@ def pytest_report_teststatus(report, config: pytest.Config):
     ...x...
     ```
     """
-    if is_output_stdout(config.getoption("output")):
+    if config.fixture_output.is_stdout:  # type: ignore[attr-defined]
         return report.outcome, "", report.outcome.upper()
 
 
@@ -287,12 +350,12 @@ def pytest_terminal_summary(
     actually run the tests.
     """
     yield
-    if is_output_stdout(config.getoption("output")):
+    if config.fixture_output.is_stdout:  # type: ignore[attr-defined]
         return
     stats = terminalreporter.stats
     if "passed" in stats and stats["passed"]:
         # append / to indicate this is a directory
-        output_dir = str(strip_output_tarball_suffix(config.getoption("output"))) + "/"
+        output_dir = str(config.fixture_output.directory) + "/"  # type: ignore[attr-defined]
         terminalreporter.write_sep(
             "=",
             (
@@ -489,45 +552,33 @@ def base_dump_dir(request: pytest.FixtureRequest) -> Path | None:
 
 
 @pytest.fixture(scope="session")
-def is_output_tarball(request: pytest.FixtureRequest) -> bool:
+def fixture_output(request: pytest.FixtureRequest) -> FixtureOutput:
+    """Return the fixture output configuration."""
+    return request.config.fixture_output  # type: ignore[attr-defined]
+
+
+@pytest.fixture(scope="session")
+def is_output_tarball(fixture_output: FixtureOutput) -> bool:
     """Return True if the output directory is a tarball."""
-    output: Path = request.config.getoption("output")
-    if output.suffix == ".gz" and output.with_suffix("").suffix == ".tar":
-        return True
-    return False
+    return fixture_output.is_tarball
 
 
 @pytest.fixture(scope="session")
-def output_dir(request: pytest.FixtureRequest, is_output_tarball: bool) -> Path:
+def output_dir(fixture_output: FixtureOutput) -> Path:
     """Return directory to store the generated test fixtures."""
-    output = request.config.getoption("output")
-    if is_output_tarball:
-        return strip_output_tarball_suffix(output)
-    return output
-
-
-@pytest.fixture(scope="session")
-def output_metadata_dir(output_dir: Path) -> Path:
-    """Return metadata directory to store fixture meta files."""
-    if is_output_stdout(output_dir):
-        return output_dir
-    return output_dir / ".meta"
+    return fixture_output.directory
 
 
 @pytest.fixture(scope="session", autouse=True)
-def create_properties_file(
-    request: pytest.FixtureRequest, output_dir: Path, output_metadata_dir: Path
-) -> None:
+def create_properties_file(request: pytest.FixtureRequest, fixture_output: FixtureOutput) -> None:
     """
     Create ini file with fixture build properties in the fixture output
     directory.
     """
-    if is_output_stdout(request.config.getoption("output")):
+    if fixture_output.is_stdout:
         return
-    if not output_dir.exists():
-        output_dir.mkdir(parents=True)
-    if not output_metadata_dir.exists():
-        output_metadata_dir.mkdir(parents=True)
+
+    fixture_output.create_directories()
 
     fixture_properties = {
         "timestamp": datetime.datetime.now().isoformat(),
@@ -558,7 +609,7 @@ def create_properties_file(
             )
     config["environment"] = environment_properties
 
-    ini_filename = output_metadata_dir / "fixtures.ini"
+    ini_filename = fixture_output.metadata_dir / "fixtures.ini"
     with open(ini_filename, "w") as f:
         f.write("; This file describes fixture build properties\n\n")
         config.write(f)
@@ -594,9 +645,9 @@ def get_fixture_collection_scope(fixture_name, config):
 
     See: https://docs.pytest.org/en/stable/how-to/fixtures.html#dynamic-scope
     """
-    if is_output_stdout(config.getoption("output")):
+    if config.fixture_output.is_stdout:
         return "session"
-    if config.getoption("single_fixture_per_file"):
+    if config.fixture_output.single_fixture_per_file:
         return "function"
     return "module"
 
@@ -608,16 +659,16 @@ def fixture_collector(
     evm_fixture_verification: FixtureConsumer,
     filler_path: Path,
     base_dump_dir: Path | None,
-    output_dir: Path,
+    fixture_output: FixtureOutput,
 ) -> Generator[FixtureCollector, None, None]:
     """
     Return configured fixture collector instance used for all tests
     in one test module.
     """
     fixture_collector = FixtureCollector(
-        output_dir=output_dir,
-        flat_output=request.config.getoption("flat_output"),
-        single_fixture_per_file=request.config.getoption("single_fixture_per_file"),
+        output_dir=fixture_output.directory,
+        flat_output=fixture_output.flat_output,
+        single_fixture_per_file=fixture_output.single_fixture_per_file,
         filler_path=filler_path,
         base_dump_dir=base_dump_dir,
     )
@@ -836,29 +887,20 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int):
     if xdist.is_xdist_worker(session):
         return
 
-    output: Path = session.config.getoption("output")
+    fixture_output = session.config.fixture_output  # type: ignore[attr-defined]
     # When using --collect-only it should not matter whether fixtures folder exists or not
-    if is_output_stdout(output) or session.config.option.collectonly:
+    if fixture_output.is_stdout or session.config.option.collectonly:
         return
 
-    output_dir = strip_output_tarball_suffix(output)
     # Remove any lock files that may have been created.
-    for file in output_dir.rglob("*.lock"):
+    for file in fixture_output.directory.rglob("*.lock"):
         file.unlink()
 
     # Generate index file for all produced fixtures.
     if session.config.getoption("generate_index"):
         generate_fixtures_index(
-            output_dir, quiet_mode=True, force_flag=False, disable_infer_format=False
+            fixture_output.directory, quiet_mode=True, force_flag=False, disable_infer_format=False
         )
 
     # Create tarball of the output directory if the output is a tarball.
-    is_output_tarball = output.suffix == ".gz" and output.with_suffix("").suffix == ".tar"
-    if is_output_tarball:
-        source_dir = output_dir
-        tarball_filename = output
-        with tarfile.open(tarball_filename, "w:gz") as tar:
-            for file in source_dir.rglob("*"):
-                if file.suffix in {".json", ".ini"}:
-                    arcname = Path("fixtures") / file.relative_to(source_dir)
-                    tar.add(file, arcname=arcname)
+    fixture_output.create_tarball()

--- a/src/pytest_plugins/filler/tests/test_filler.py
+++ b/src/pytest_plugins/filler/tests/test_filler.py
@@ -567,6 +567,7 @@ def test_fixture_output_based_on_command_line_args(
     expected_ini_file = "fixtures.ini"
     expected_index_file = "index.json"
     expected_resolver_file = None
+    resolver_file = None
     if TransitionTool.default_tool == ExecutionSpecsTransitionTool:
         expected_resolver_file = "eels_resolutions.json"
 

--- a/src/pytest_plugins/filler/tests/test_output_directory.py
+++ b/src/pytest_plugins/filler/tests/test_output_directory.py
@@ -1,0 +1,165 @@
+"""Test the filler plugin's output directory handling."""
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+from pytest import TempPathFactory
+
+from cli.pytest_commands.fill import fill
+
+
+@pytest.fixture(scope="module")
+def test_path() -> Path:
+    """Specify the test path to be filled."""
+    return Path("tests/istanbul/eip1344_chainid/test_chainid.py")
+
+
+@pytest.fixture(scope="module")
+def fill_fork_from() -> str:
+    """Specify the value for `fill`'s `--from` argument."""
+    return "Paris"
+
+
+@pytest.fixture(scope="module")
+def fill_fork_until() -> str:
+    """Specify the value for `fill`'s `--until` argument."""
+    return "Cancun"
+
+
+@pytest.fixture
+def run_fill(test_path: Path, fill_fork_from: str, fill_fork_until: str):
+    """Create a function to run the fill command with various output directory scenarios."""
+
+    def _run_fill(output_dir: Path, clean: bool = False, expect_failure: bool = False):
+        """Run the fill command with the specified output directory and clean flag."""
+        args = [
+            "-c",
+            "pytest.ini",
+            "--skip-evm-dump",
+            "-m",
+            "(not blockchain_test_engine) and (not eip_version_check)",
+            f"--from={fill_fork_from}",
+            f"--until={fill_fork_until}",
+            f"--output={str(output_dir)}",
+            str(test_path),
+        ]
+
+        if clean:
+            args.append("--clean")
+
+        result = CliRunner().invoke(fill, args)
+
+        if expect_failure:
+            assert result.exit_code != 0, "Fill command was expected to fail but succeeded"
+        else:
+            assert result.exit_code == 0, f"Fill command failed:\n{result.output}"
+
+        return result
+
+    return _run_fill
+
+
+def test_fill_to_empty_directory(tmp_path_factory: TempPathFactory, run_fill):
+    """Test filling to a new, empty directory."""
+    output_dir = tmp_path_factory.mktemp("empty_fixtures")
+
+    run_fill(output_dir)
+
+    assert any(output_dir.glob("state_tests/**/*.json")), "No fixture files were created"
+    assert (output_dir / ".meta").exists(), "Metadata directory was not created"
+
+
+def test_fill_to_nonexistent_directory(tmp_path_factory: TempPathFactory, run_fill):
+    """Test filling to a nonexistent directory."""
+    base_dir = tmp_path_factory.mktemp("base")
+    output_dir = base_dir / "nonexistent_fixtures"
+
+    run_fill(output_dir)
+
+    assert any(output_dir.glob("state_tests/**/*.json")), "No fixture files were created"
+    assert (output_dir / ".meta").exists(), "Metadata directory was not created"
+
+
+def test_fill_to_nonempty_directory_fails(tmp_path_factory: TempPathFactory, run_fill):
+    """Test filling to a non-empty directory fails without --clean."""
+    # Create a directory with a file
+    output_dir = tmp_path_factory.mktemp("nonempty_fixtures")
+    (output_dir / "existing_file.txt").write_text("This directory is not empty")
+
+    result = run_fill(output_dir, expect_failure=True)
+
+    assert "is not empty" in str(result.output), "Expected error about non-empty directory"
+    assert "Use --clean" in str(result.output), "Expected suggestion to use --clean flag"
+
+
+def test_fill_to_nonempty_directory_with_clean(tmp_path_factory: TempPathFactory, run_fill):
+    """Test filling to a non-empty directory succeeds with --clean."""
+    # Create a directory with a file
+    output_dir = tmp_path_factory.mktemp("nonempty_fixtures_clean")
+    (output_dir / "existing_file.txt").write_text("This directory will be cleaned")
+
+    run_fill(output_dir, clean=True)
+
+    # Verify the existing file was removed
+    assert not (output_dir / "existing_file.txt").exists(), "Existing file was not removed"
+
+    assert any(output_dir.glob("state_tests/**/*.json")), "No fixture files were created"
+
+
+def test_fill_to_directory_with_meta_fails(tmp_path_factory: TempPathFactory, run_fill):
+    """Test filling to a directory with .meta subdirectory fails without --clean."""
+    # Create a directory with .meta
+    output_dir = tmp_path_factory.mktemp("directory_with_meta")
+    meta_dir = output_dir / ".meta"
+    meta_dir.mkdir()
+    (meta_dir / "existing_meta_file.txt").write_text("This is metadata")
+
+    result = run_fill(output_dir, expect_failure=True)
+
+    assert "is not empty" in str(result.output), "Expected error about non-empty directory"
+
+
+def test_fill_to_directory_with_meta_with_clean(tmp_path_factory: TempPathFactory, run_fill):
+    """Test filling to a directory with .meta succeeds with --clean."""
+    # Create a directory with .meta
+    output_dir = tmp_path_factory.mktemp("directory_with_meta_clean")
+    meta_dir = output_dir / ".meta"
+    meta_dir.mkdir()
+    (meta_dir / "existing_meta_file.txt").write_text("This is metadata")
+
+    run_fill(output_dir, clean=True)
+
+    assert any(output_dir.glob("state_tests/**/*.json")), "No fixture files were created"
+    assert not (meta_dir / "existing_meta_file.txt").exists(), "Existing meta file was not removed"
+
+
+def test_fill_stdout_always_works(tmp_path_factory: TempPathFactory, run_fill):
+    """Test filling to stdout always works regardless of output state."""
+    stdout_path = Path("stdout")
+    # create a directory called "stdout" - it should not have any effect
+    output_dir = tmp_path_factory.mktemp(stdout_path.name)
+    meta_dir = output_dir / ".meta"
+    meta_dir.mkdir()
+    (meta_dir / "existing_meta_file.txt").write_text("This is metadata")
+
+    result = run_fill(stdout_path)
+
+    assert (
+        '"tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Cancun-state_test]": {'
+        in result.output
+    ), "Expected JSON output for state test"
+
+
+def test_fill_to_tarball_directory(tmp_path_factory: TempPathFactory, run_fill):
+    """Test filling to a tarball output."""
+    output_dir = tmp_path_factory.mktemp("tarball_fixtures")
+    tarball_path = output_dir / "fixtures.tar.gz"
+
+    run_fill(tarball_path)
+
+    assert tarball_path.exists(), "Tarball was not created"
+    extracted_dir = output_dir / "fixtures"
+    assert extracted_dir.exists(), "Extracted directory doesn't exist"
+
+    assert any(extracted_dir.glob("state_tests/**/*.json")), "No fixture files were created"

--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,7 @@ setenv =
     # Use custom EELS_RESOLUTIONS_FILE if it is set via the environment (eg, in CI)
     EELS_RESOLUTIONS_FILE = {env:EELS_RESOLUTIONS_FILE:}
 commands_pre = solc-select use {[testenv]solc_version} --always-install
-commands = pytest -n auto -k "not slow" --skip-evm-dump
+commands = pytest -n auto -k "not slow" --skip-evm-dump --output=/tmp/fixtures-tox --clean
 
 [testenv:tests-develop]
 description = Fill test cases in ./tests/ for deployed and development mainnet forks
@@ -81,7 +81,7 @@ setenv =
     # Use custom EELS_RESOLUTIONS_FILE if it is set via the environment (eg, in CI)
     EELS_RESOLUTIONS_FILE = {env:EELS_RESOLUTIONS_FILE:}
 commands_pre = solc-select use {[testenv]solc_version} --always-install
-commands = pytest -n auto --until={[forks]develop} -k "not slow" --skip-evm-dump
+commands = pytest -n auto --until={[forks]develop} -k "not slow" --skip-evm-dump --output=/tmp/fixtures-tox --clean
 
 [testenv:tests-eip7692]
 description = Fill test cases in ./tests/ for EIP-7692 (EOF) on Osaka
@@ -89,7 +89,7 @@ setenv =
     # Use custom EELS_RESOLUTIONS_FILE if it is set via the environment (eg, in CI)
     EELS_RESOLUTIONS_FILE = {env:EELS_RESOLUTIONS_FILE:}
 commands_pre = solc-select use {[testenv]solc_version} --always-install
-commands =  pytest -n auto --evm-bin=evmone-t8n --fork={[forks]eip7692} -k "not slow" ./tests/osaka --skip-evm-dump
+commands =  pytest -n auto --evm-bin=evmone-t8n --fork={[forks]eip7692} -k "not slow" ./tests/osaka --skip-evm-dump --output=/tmp/fixtures-tox --clean
 
 # ----------------------------------------------------------------------------------------------
 # ALIAS ENVIRONMENTS


### PR DESCRIPTION
## 🗒️ Description

Requires:
- #1471

Make `fill`'s output behavior more robust: Do not write generated fixtures into an existing, non-empty output directory; it must now be empty or `--clean` must be used to delete it first.

## Todo

- [ ] Make directory deletion/creation multip-thread/pytest-xdist friendly.

## 🔗 Related Issues
Fixes #1030:
- #1030 

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
