### PR TITLE
fix(tests): EIP-7620 - make CREATE/CREATE2 restrictions specific

### DIFF
--- a/tests/osaka/eip7692_eof_v1/eip7620_eof_create/helpers.py
+++ b/tests/osaka/eip7692_eof_v1/eip7620_eof_create/helpers.py
@@ -19,6 +19,7 @@ slot_max_depth = next(_slot)
 slot_call_or_create = next(_slot)
 slot_counter = next(_slot)
 slot_data_load = next(_slot)
+slot_all_subcall_gas_gone = next(_slot)
 
 slot_last_slot = next(_slot)
 

--- a/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_legacy_eof_creates.py
+++ b/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_legacy_eof_creates.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from ethereum_test_base_types.base_types import Bytes
+from ethereum_test_base_types.base_types import Address, Bytes
 from ethereum_test_tools import (
     Account,
     Alloc,
@@ -15,6 +15,7 @@ from ethereum_test_tools.vm.opcode import Opcodes
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 from ethereum_test_types.eof.v1 import Container
 from ethereum_test_types.helpers import compute_create_address
+from tests.prague.eip7702_set_code_tx.spec import Spec
 
 from .. import EOF_FORK_NAME
 from .helpers import (
@@ -114,7 +115,7 @@ def test_cross_version_creates_fail_light(
         Bytes("0xEF"),
         Bytes("0xEF01"),
         Bytes("0xEF0101"),
-        Bytes("0xEF01" + "".join("ab")),
+        Spec.delegation_designation(Address(0xAA)),
         Bytes("0xEF02"),
     ],
 )


### PR DESCRIPTION
## 🗒️ Description

I've noticed that the assertions in one of the tests were quite loose, so I made them more specific

## 🔗 Related Issues

NA

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
