### PR TITLE
fix(github): Remove `vars` usage in build-fixtures

### DIFF
--- a/.github/actions/build-fixtures/action.yaml
+++ b/.github/actions/build-fixtures/action.yaml
@@ -3,15 +3,21 @@ inputs:
   release_name:
     description: "Name of the fixture release"
     required: true
+  uv_version:
+    description: "Version of UV to install"
+    required: true
+  python_version:
+    description: "Version of Python to install"
+    required: true
 runs:
   using: "composite"
   steps:
-    - name: Install uv ${{ vars.UV_VERSION }} and python ${{ vars.DEFAULT_PYTHON_VERSION }}
+    - name: Install uv ${{ inputs.uv_version }} and python ${{ inputs.python_version }}
       uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182
       with:
         enable-cache: false
-        version: ${{ vars.UV_VERSION }}
-        python-version: ${{ vars.DEFAULT_PYTHON_VERSION }}
+        version: ${{ inputs.uv_version }}
+        python-version: ${{ inputs.python_version }}
     - name: Install EEST
       shell: bash
       run: uv sync --no-progress

--- a/.github/workflows/fixtures.yaml
+++ b/.github/workflows/fixtures.yaml
@@ -31,6 +31,8 @@ jobs:
       - uses: ./.github/actions/build-fixtures
         with:
           release_name: ${{ matrix.name }}
+          uv_version: ${{ vars.UV_VERSION }}
+          python_version: ${{ vars.DEFAULT_PYTHON_VERSION }}
   release:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/fixtures_feature.yaml
+++ b/.github/workflows/fixtures_feature.yaml
@@ -35,6 +35,8 @@ jobs:
       - uses: ./.github/actions/build-fixtures
         with:
           release_name: ${{ matrix.feature }}
+          uv_version: ${{ vars.UV_VERSION }}
+          python_version: ${{ vars.DEFAULT_PYTHON_VERSION }}
   release:
     runs-on: ubuntu-latest
     needs: build


### PR DESCRIPTION
## 🗒️ Description
Fixture building is currently failing due to the use of `vars`, which is not allowed in that context.

Solution is to accept all required vars as input and then populate the input in the caller workflows.

## 🔗 Related Issues
None

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
