### PR TITLE
fix(tests): Create transaction sarting with `0xef` is a valid tx, but should fail execution

### DIFF
--- a/tests/osaka/eip7692_eof_v1/eip7873_tx_create/test_creation_tx.py
+++ b/tests/osaka/eip7692_eof_v1/eip7873_tx_create/test_creation_tx.py
@@ -60,7 +60,6 @@ def test_legacy_create_tx_legacy_initcode_eof_bytecode(
 
 @pytest.mark.with_all_contract_creating_tx_types(selector=lambda tx_type: tx_type != 6)
 @pytest.mark.xfail(reason="evmone incorrectly deploys the contract")
-@pytest.mark.exception_test
 def test_legacy_create_tx_eof_initcode(
     state_test: StateTestFiller,
     pre: Alloc,
@@ -76,7 +75,6 @@ def test_legacy_create_tx_eof_initcode(
         to=None,
         gas_limit=100_000,
         data=smallest_initcode_subcontainer,
-        error=TransactionException.EOF_CREATION_TRANSACTION,
     )
 
     destination_contract_address = tx.created_contract

--- a/tests/osaka/eip7692_eof_v1/eip7873_tx_create/test_creation_tx.py
+++ b/tests/osaka/eip7692_eof_v1/eip7873_tx_create/test_creation_tx.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-from ethereum_test_exceptions.exceptions import TransactionException
 from ethereum_test_tools import (
     Account,
     Alloc,


### PR DESCRIPTION

## 🗒️ Description
The EIP-3541 handling of EOF code was to execute it as uncontained code, executing the first 0xef byte and reverting.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist

- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
