### PR TITLE
✨ feat(tests): zkEVM - Add parametrized opcodes and gas limits 

### DIFF
--- a/tests/zkevm/__init__.py
+++ b/tests/zkevm/__init__.py
@@ -1,3 +1,1 @@
-"""
-abstract: Tests for zkVMs
-"""
+"""Tests for zkEVM."""

--- a/tests/zkevm/__init__.py
+++ b/tests/zkevm/__init__.py
@@ -1,0 +1,3 @@
+"""
+abstract: Tests for zkVMs
+"""

--- a/tests/zkevm/test_proof_size.py
+++ b/tests/zkevm/test_proof_size.py
@@ -1,15 +1,36 @@
+"""
+A series of stress tests that assess the ability of a specific
+opcode or precompile to process large proofs in a block.
+
+A large proof is created by deploying a contract with
+maximum allowed bytecode.
+
+This proof is then "ingested" by an opcode or precompile.
+
+These tests first compute the "ingestion cost" for the proof.
+Next, they attempt to perform the maximum number of possible
+ingestions in a block.
+"""
+
 import pytest
 
 from ethereum_test_forks import Fork
-from ethereum_test_tools import (Alloc, Block, BlockchainTestFiller,
-                                 Environment, Transaction)
+from ethereum_test_tools import Alloc, Block, BlockchainTestFiller, Environment, Transaction
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 REFERENCE_SPEC_GIT_PATH = "TODO"
 REFERENCE_SPEC_VERSION = "TODO"
 
-MAX_CONTRACT_SIZE = 24 * 1024
+
+##############################
+#                            #
+#          Config            #
+#                            #
+##############################
 GAS_LIMIT = 36_000_000
+
+KiB = 1024
+CONTRACT_BYTECODE_MAX_SIZE = 24 * KiB
 MAX_NUM_CONTRACT_CALLS = (GAS_LIMIT - 21_000) // (3 + 2600)
 
 
@@ -23,20 +44,18 @@ MAX_NUM_CONTRACT_CALLS = (GAS_LIMIT - 21_000) // (3 + 2600)
         # MAX_NUM_CONTRACT_CALLS
     ],
 )
-def test_worst_bytecode(
+def test_via_opcode(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
     fork: Fork,
-    num_called_contracts : int,
+    num_called_contracts: int,
 ):
-    """
-    Test a block execution calling contracts with the maximum size of bytecode.
-    """
+    """Test zkEVM proof size limits using a specific opcode."""
     env = Environment(gas_limit=GAS_LIMIT)
 
     contract_addrs = []
     for i in range(num_called_contracts):
-        code = Op.JUMPDEST * (MAX_CONTRACT_SIZE - 1 - 10) + Op.PUSH10(i)
+        code = Op.JUMPDEST * (CONTRACT_BYTECODE_MAX_SIZE - 1 - 10) + Op.PUSH10(i)
         contract_addrs.append(pre.deploy_contract(code=code))
 
     attack_code = sum([Op.EXTCODESIZE(contract_addrs[i]) for i in range(num_called_contracts)])

--- a/tests/zkevm/test_proof_size.py
+++ b/tests/zkevm/test_proof_size.py
@@ -2,20 +2,29 @@
 A series of stress tests that assess the ability of a specific
 opcode or precompile to process large proofs in a block.
 
-A large proof is created by deploying a contract with
+Large proofs are created by deploying contracts with
 maximum allowed bytecode.
 
-This proof is then "ingested" by an opcode or precompile.
+These proofs are then "ingested" by an opcode or precompile.
 
-These tests first compute the "ingestion cost" for the proof.
-Next, they attempt to perform the maximum number of possible
-ingestions in a block.
+First, the tests compute the "ingestion cost" for the proof.
+Next, they attempt to ingest the maximum possible number of
+proofs in a block with a given gas limit.
 """
+
+from typing import List
 
 import pytest
 
 from ethereum_test_forks import Fork
-from ethereum_test_tools import Alloc, Block, BlockchainTestFiller, Environment, Transaction
+from ethereum_test_tools import (
+    Address,
+    Alloc,
+    Block,
+    BlockchainTestFiller,
+    Environment,
+    Transaction,
+)
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 REFERENCE_SPEC_GIT_PATH = "TODO"
@@ -27,15 +36,38 @@ REFERENCE_SPEC_VERSION = "TODO"
 #          Config            #
 #                            #
 ##############################
-GAS_LIMIT = 36_000_000
-
+GAS_LIMITS = [
+    30_000_000,
+]
 KiB = 1024
 CONTRACT_BYTECODE_MAX_SIZE = 24 * KiB
-MAX_NUM_CONTRACT_CALLS = (GAS_LIMIT - 21_000) // (3 + 2600)
 
 
+##############################
+#                            #
+#       Test Helpers         #
+#                            #
+##############################
+def get_proofs(pre: Alloc, proof_count: int) -> List[Address]:
+    """
+    Generate a list of proof addresses by deploying contracts
+    with maximum allowed bytecode size.
+    """
+    proofs = []
+    for i in range(proof_count):
+        code = Op.JUMPDEST * (CONTRACT_BYTECODE_MAX_SIZE - 1 - 10) + Op.PUSH10(i)
+        proofs.append(pre.deploy_contract(code=code))
+    return proofs
+
+
+##############################
+#                            #
+#       Test Cases           #
+#                            #
+##############################
 @pytest.mark.zkevm
 @pytest.mark.valid_from("Cancun")
+@pytest.mark.parametrize("gas_limit", GAS_LIMITS)
 @pytest.mark.parametrize(
     "num_called_contracts",
     [
@@ -48,22 +80,22 @@ def test_via_opcode(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
     fork: Fork,
+    gas_limit: int,
     num_called_contracts: int,
 ):
     """Test zkEVM proof size limits using a specific opcode."""
-    env = Environment(gas_limit=GAS_LIMIT)
+    env = Environment(gas_limit=gas_limit)
 
-    contract_addrs = []
-    for i in range(num_called_contracts):
-        code = Op.JUMPDEST * (CONTRACT_BYTECODE_MAX_SIZE - 1 - 10) + Op.PUSH10(i)
-        contract_addrs.append(pre.deploy_contract(code=code))
+    # MAX_NUM_CONTRACT_CALLS = (gas_limit - 21_000) // (3 + 2600)
 
-    attack_code = sum([Op.EXTCODESIZE(contract_addrs[i]) for i in range(num_called_contracts)])
+    proof_addresses = get_proofs(pre, num_called_contracts)
+
+    attack_code = sum([Op.EXTCODESIZE(proof_addresses[i]) for i in range(num_called_contracts)])
     attack_contract = pre.deploy_contract(code=attack_code)
 
     tx = Transaction(
         to=attack_contract,
-        gas_limit=GAS_LIMIT,
+        gas_limit=gas_limit,
         gas_price=10,
         sender=pre.fund_eoa(),
         data=[],
@@ -76,3 +108,5 @@ def test_via_opcode(
         post={},
         blocks=[Block(txs=[tx])],
     )
+
+    # TODO: Assert that ingestion cost is computed correctly

--- a/tests/zkevm/test_proof_size.py
+++ b/tests/zkevm/test_proof_size.py
@@ -5,23 +5,21 @@ opcode or precompile to process large proofs in a block.
 Large proofs are created by deploying contracts with
 maximum allowed bytecode.
 
-These proofs are then "ingested" by an opcode or precompile.
-
-First, the tests compute the "ingestion cost" for the proof.
-Next, they attempt to ingest the maximum possible number of
-proofs in a block with a given gas limit.
+Then, a pacman contract (ᗧ•••) consumes the maximum possible number of
+proofs in a block with a given gas limit using an opcode or precompile.
 """
 
-from typing import List
+from dataclasses import dataclass
+from typing import Callable
 
 import pytest
 
-from ethereum_test_forks import Fork
 from ethereum_test_tools import (
     Address,
     Alloc,
     Block,
     BlockchainTestFiller,
+    Bytecode,
     Environment,
     Transaction,
 )
@@ -30,44 +28,70 @@ from ethereum_test_tools.vm.opcode import Opcodes as Op
 REFERENCE_SPEC_GIT_PATH = "TODO"
 REFERENCE_SPEC_VERSION = "TODO"
 
-
 ##############################
 #                            #
 #          Config            #
 #                            #
 ##############################
-GAS_LIMITS = [
-    30_000_000,
+MAX_CODE_SIZE = 24 * 1024  # 24 KiB
+GAS_LIMITS = [30_000_000, 60_000_000, 100_000_000, 300_000_000]
+
+
+@dataclass
+class Consumer:
+    """
+    Consumer configuration for eating proofs.
+    Each consumer has a specific gas appetite and bytecode.
+    """
+
+    opcode: Op
+    """The opcode this consumer uses to eat proofs."""
+    gas_cost: int
+    """The gas appetite for consuming a single proof."""
+    generate_bytecode: Callable[[Address], Bytecode]
+    """A lambda function that generates the bytecode for the eating proof."""
+
+    def __str__(self) -> str:
+        """Str repr."""
+        return f"{self.opcode}"
+
+    def create_pacman(self, pre: Alloc, gas_limit: int) -> Address:
+        """
+        Generate a pacman contract that ingests proofs using this opcode.
+        ᗧ•••  nom nom nom.
+        """
+        proof_count = (gas_limit - 21_000) // self.gas_cost
+        proof_count = 5  # TODO: REMOVE THIS LIMIT
+
+        # Generate proofs
+        proofs = [
+            pre.deploy_contract(code=Op.JUMPDEST * (MAX_CODE_SIZE - 11) + Op.PUSH10(i))
+            for i in range(proof_count)
+        ]
+
+        # Generate bytecode using the opcode's configuration
+        code = sum(self.generate_bytecode(proof) for proof in proofs)
+        if not code:
+            raise ValueError("Generated code is empty")
+
+        return pre.deploy_contract(code=code)
+
+
+CONSUMERS = [
+    Consumer(
+        opcode=Op.EXTCODEHASH,
+        gas_cost=2603,  # PUSH20[3] + EXTCODEHASH[2600]
+        generate_bytecode=lambda proof: Op.EXTCODEHASH(proof),
+    ),
+    Consumer(
+        opcode=Op.EXTCODESIZE,
+        gas_cost=2603,  # PUSH20[3] + EXTCODESIZE[2600]
+        generate_bytecode=lambda proof: Op.EXTCODESIZE(proof),
+    ),
 ]
-KiB = 1024
-CONTRACT_BYTECODE_MAX_SIZE = 24 * KiB
 
 
-##############################
-#                            #
-#       Test Helpers         #
-#                            #
-##############################
-def get_proofs(pre: Alloc, proof_count: int) -> List[Address]:
-    """
-    Generate a list of proof addresses by deploying contracts
-    with maximum allowed bytecode size.
-    """
-    proofs = []
-    for i in range(proof_count):
-        code = Op.JUMPDEST * (CONTRACT_BYTECODE_MAX_SIZE - 1 - 10) + Op.PUSH10(i)
-        proofs.append(pre.deploy_contract(code=code))
-    return proofs
-
-
-def get_proof_eater(pre: Alloc, proof_count: int) -> Address:
-    """Generate a proof eater contract that ingests a given proofs."""
-    proofs = get_proofs(pre, proof_count)
-    code = sum([Op.EXTCODESIZE(proofs[i]) for i in range(proof_count)])
-    return pre.deploy_contract(code=code)
-
-
-##############################
+#############################
 #                            #
 #       Test Cases           #
 #                            #
@@ -75,28 +99,16 @@ def get_proof_eater(pre: Alloc, proof_count: int) -> Address:
 @pytest.mark.zkevm
 @pytest.mark.valid_from("Cancun")
 @pytest.mark.parametrize("gas_limit", GAS_LIMITS)
-@pytest.mark.parametrize(
-    "num_called_contracts",
-    [
-        1,
-        # 10,
-        # MAX_NUM_CONTRACT_CALLS
-    ],
-)
+@pytest.mark.parametrize("consumer", CONSUMERS, ids=str)
 def test_via_opcode(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
-    fork: Fork,
     gas_limit: int,
-    num_called_contracts: int,
+    consumer: Consumer,
 ):
     """Test zkEVM proof size limits using a specific opcode."""
-    env = Environment(gas_limit=gas_limit)
-
-    # MAX_NUM_CONTRACT_CALLS = (gas_limit - 21_000) // (3 + 2600)
-
     tx = Transaction(
-        to=get_proof_eater(pre, num_called_contracts),
+        to=consumer.create_pacman(pre, gas_limit),
         gas_limit=gas_limit,
         gas_price=10,
         sender=pre.fund_eoa(),
@@ -105,7 +117,7 @@ def test_via_opcode(
     )
 
     blockchain_test(
-        env=env,
+        env=Environment(gas_limit=gas_limit),
         pre=pre,
         post={},
         blocks=[Block(txs=[tx])],

--- a/tests/zkevm/test_proof_size.py
+++ b/tests/zkevm/test_proof_size.py
@@ -60,6 +60,13 @@ def get_proofs(pre: Alloc, proof_count: int) -> List[Address]:
     return proofs
 
 
+def get_proof_eater(pre: Alloc, proof_count: int) -> Address:
+    """Generate a proof eater contract that ingests a given proofs."""
+    proofs = get_proofs(pre, proof_count)
+    code = sum([Op.EXTCODESIZE(proofs[i]) for i in range(proof_count)])
+    return pre.deploy_contract(code=code)
+
+
 ##############################
 #                            #
 #       Test Cases           #
@@ -88,13 +95,8 @@ def test_via_opcode(
 
     # MAX_NUM_CONTRACT_CALLS = (gas_limit - 21_000) // (3 + 2600)
 
-    proof_addresses = get_proofs(pre, num_called_contracts)
-
-    attack_code = sum([Op.EXTCODESIZE(proof_addresses[i]) for i in range(num_called_contracts)])
-    attack_contract = pre.deploy_contract(code=attack_code)
-
     tx = Transaction(
-        to=attack_contract,
+        to=get_proof_eater(pre, num_called_contracts),
         gas_limit=gas_limit,
         gas_price=10,
         sender=pre.fund_eoa(),

--- a/tests/zkevm/test_worst_bytecode.py
+++ b/tests/zkevm/test_worst_bytecode.py
@@ -1,0 +1,59 @@
+import pytest
+
+from ethereum_test_forks import Fork
+from ethereum_test_tools import (Alloc, Block, BlockchainTestFiller,
+                                 Environment, Transaction)
+from ethereum_test_tools.vm.opcode import Opcodes as Op
+
+REFERENCE_SPEC_GIT_PATH = "TODO"
+REFERENCE_SPEC_VERSION = "TODO"
+
+MAX_CONTRACT_SIZE = 24 * 1024
+GAS_LIMIT = 36_000_000
+MAX_NUM_CONTRACT_CALLS = (GAS_LIMIT - 21_000) // (3 + 2600)
+
+
+@pytest.mark.zkevm
+@pytest.mark.valid_from("Cancun")
+@pytest.mark.parametrize(
+    "num_called_contracts",
+    [
+        1,
+        # 10,
+        # MAX_NUM_CONTRACT_CALLS
+    ],
+)
+def test_worst_bytecode(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    num_called_contracts : int,
+):
+    """
+    Test a block execution calling contracts with the maximum size of bytecode.
+    """
+    env = Environment(gas_limit=GAS_LIMIT)
+
+    contract_addrs = []
+    for i in range(num_called_contracts):
+        code = Op.JUMPDEST * (MAX_CONTRACT_SIZE - 1 - 10) + Op.PUSH10(i)
+        contract_addrs.append(pre.deploy_contract(code=code))
+
+    attack_code = sum([Op.EXTCODESIZE(contract_addrs[i]) for i in range(num_called_contracts)])
+    attack_contract = pre.deploy_contract(code=attack_code)
+
+    tx = Transaction(
+        to=attack_contract,
+        gas_limit=GAS_LIMIT,
+        gas_price=10,
+        sender=pre.fund_eoa(),
+        data=[],
+        value=0,
+    )
+
+    blockchain_test(
+        env=env,
+        pre=pre,
+        post={},
+        blocks=[Block(txs=[tx])],
+    )


### PR DESCRIPTION
## 🗒️ Description
The PR extends #1456 to add dynamic gas_limits and opcodes.

## 🔗 Related Issues
#1453 

### How it works
https://github.com/ethereum/execution-spec-tests/blob/96685834898a03000f9c24f7f6198a4fb48feb38/tests/zkevm/test_proof_size.py#L2-L9

### Configuring gas limits
https://github.com/ethereum/execution-spec-tests/blob/858af44a631813e3c910a2ce32d63d8a707de82c/tests/zkevm/test_proof_size.py#L37

### Configuring opcodes
https://github.com/ethereum/execution-spec-tests/blob/96685834898a03000f9c24f7f6198a4fb48feb38/tests/zkevm/test_proof_size.py#L80-L91

## What's pending
As described in #1456, the pre state size is huge. To solve that, I experimented deploying contracts in the same block, it had the following issues:
1. The code for deploying large contracts gets messy quickly, and it consumes large amounts gas due to high memory usage.
2. I adjusted gas limit to offset the contract deployment costs, but I think it skews the benchmark a bit if we do it in the same block. 

I was wondering if there is a way to persist data between blocks in the test.

If this approach sounds okay, then I can extend this to include precompiles.

Even after deploying contracts in a separate blocks, communicating the deployed addresses to be consumed would need more work.

cc: @jsign

## Output
```bash
tests/zkevm/test_proof_size.py::test_via_opcode[fork_Cancun-blockchain_test-EXTCODEHASH-gas_limit_30000000] FILLED                                               [ 1/16]
tests/zkevm/test_proof_size.py::test_via_opcode[fork_Cancun-blockchain_test-EXTCODEHASH-gas_limit_60000000] FILLED                                               [ 2/16]
tests/zkevm/test_proof_size.py::test_via_opcode[fork_Cancun-blockchain_test-EXTCODEHASH-gas_limit_100000000] FILLED                                              [ 3/16]
tests/zkevm/test_proof_size.py::test_via_opcode[fork_Cancun-blockchain_test-EXTCODEHASH-gas_limit_300000000] FILLED                                              [ 4/16]
tests/zkevm/test_proof_size.py::test_via_opcode[fork_Cancun-blockchain_test-EXTCODESIZE-gas_limit_30000000] FILLED                                               [ 5/16]
tests/zkevm/test_proof_size.py::test_via_opcode[fork_Cancun-blockchain_test-EXTCODESIZE-gas_limit_60000000] FILLED                                               [ 6/16]
tests/zkevm/test_proof_size.py::test_via_opcode[fork_Cancun-blockchain_test-EXTCODESIZE-gas_limit_100000000] FILLED                                              [ 7/16]
tests/zkevm/test_proof_size.py::test_via_opcode[fork_Cancun-blockchain_test-EXTCODESIZE-gas_limit_300000000] FILLED                                              [ 8/16]
```
## ✅ Checklist

- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
