### PR TITLE
chore(docs): bump the changelog after `v4.3.0`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,20 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 ### 💥 Breaking Change
 
+### 🛠️ Framework
+
+#### `fill`
+
+#### `consume`
+
+### 📋 Misc
+
+### 🧪 Test Cases
+
+## [v4.3.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v4.3.0) - 2025-04-18
+
+### 💥 Breaking Change
+
 #### Consume engine strict exception checking
 
 `consume engine` now checks exceptions returned by the execution clients in their Engine API responses, specifically in the `validationError`field of the `engine_newPayloadVX` method.

--- a/docs/changelog_section_template.md
+++ b/docs/changelog_section_template.md
@@ -8,6 +8,10 @@ The following can be copy-pasted into the `CHANGELOG.md` file for a new release.
 
 ### 🛠️ Framework
 
+#### `fill`
+
+#### `consume`
+
 ### 📋 Misc
 
 ### 🧪 Test Cases


### PR DESCRIPTION
## 🗒️ Description
Bumps the changelog following the v4.3.0 release.

## 🔗 Related Issues
N/A

## ✅ Checklist

- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
