### PR TITLE
new(tests): EIP-7620/7873 - ensure no account gets created on failure

### DIFF
--- a/tests/osaka/eip7692_eof_v1/eip7873_tx_create/test_txcreate.py
+++ b/tests/osaka/eip7692_eof_v1/eip7873_tx_create/test_txcreate.py
@@ -57,8 +57,6 @@ def test_simple_txcreate(state_test: StateTestFiller, pre: Alloc, tx_initcode_co
     tx = Transaction(
         to=contract_address,
         gas_limit=10_000_000,
-        max_priority_fee_per_gas=10,
-        max_fee_per_gas=10,
         sender=sender,
         initcodes=[smallest_initcode_subcontainer] * tx_initcode_count,
     )
@@ -104,8 +102,6 @@ def test_txcreate_then_dataload(
     tx = Transaction(
         to=contract_address,
         gas_limit=10_000_000,
-        max_priority_fee_per_gas=10,
-        max_fee_per_gas=10,
         sender=sender,
         initcodes=[small_auxdata_container],
     )
@@ -156,8 +152,6 @@ def test_txcreate_then_call(state_test: StateTestFiller, pre: Alloc, evm_code_ty
     tx = Transaction(
         to=contract_address,
         gas_limit=10_000_000,
-        max_priority_fee_per_gas=10,
-        max_fee_per_gas=10,
         sender=sender,
         initcodes=[callable_contract_initcode],
     )
@@ -224,8 +218,6 @@ def test_auxdata_variations(state_test: StateTestFiller, pre: Alloc, auxdata_byt
     tx = Transaction(
         to=contract_address,
         gas_limit=10_000_000,
-        max_priority_fee_per_gas=10,
-        max_fee_per_gas=10,
         sender=sender,
         initcodes=[initcode_subcontainer],
     )
@@ -282,8 +274,6 @@ def test_calldata(state_test: StateTestFiller, pre: Alloc):
     tx = Transaction(
         to=contract_address,
         gas_limit=10_000_000,
-        max_priority_fee_per_gas=10,
-        max_fee_per_gas=10,
         sender=sender,
         initcodes=[initcode_subcontainer],
     )
@@ -382,8 +372,6 @@ def test_txcreate_in_initcode(
     tx = Transaction(
         to=contract_address,
         gas_limit=10_000_000,
-        max_priority_fee_per_gas=10,
-        max_fee_per_gas=10,
         sender=sender,
         initcodes=[nested_initcode_subcontainer, smallest_initcode_subcontainer],
     )
@@ -445,8 +433,6 @@ def test_return_data_cleared(
     tx = Transaction(
         to=contract_address,
         gas_limit=10_000_000,
-        max_priority_fee_per_gas=10,
-        max_fee_per_gas=10,
         sender=sender,
         initcodes=[smallest_initcode_subcontainer],
     )
@@ -495,8 +481,6 @@ def test_address_collision(
     tx = Transaction(
         to=contract_address,
         gas_limit=300_000_000_000,
-        max_priority_fee_per_gas=10,
-        max_fee_per_gas=10,
         sender=sender,
         initcodes=[smallest_initcode_subcontainer],
     )
@@ -546,8 +530,6 @@ def test_txcreate_revert_eof_returndata(
     tx = Transaction(
         to=contract_address,
         gas_limit=1_000_000,
-        max_priority_fee_per_gas=10,
-        max_fee_per_gas=10,
         sender=sender,
         initcodes=[code_reverts_with_calldata],
         # Simplest possible valid EOF container, which is going to be
@@ -603,8 +585,6 @@ def test_txcreate_context(
         to=factory_address,
         gas_limit=200_000,
         value=value,
-        max_priority_fee_per_gas=10,
-        max_fee_per_gas=10,
         initcodes=[initcode],
     )
 
@@ -688,8 +668,6 @@ def test_txcreate_memory_context(
         to=contract_address,
         gas_limit=200_000,
         sender=pre.fund_eoa(),
-        max_priority_fee_per_gas=10,
-        max_fee_per_gas=10,
         initcodes=[initcontainer],
     )
     state_test(env=env, pre=pre, post=post, tx=tx)

--- a/tests/osaka/eip7692_eof_v1/eip7873_tx_create/test_txcreate_failures.py
+++ b/tests/osaka/eip7692_eof_v1/eip7873_tx_create/test_txcreate_failures.py
@@ -92,8 +92,6 @@ def test_initcode_revert(state_test: StateTestFiller, pre: Alloc, revert: bytes)
     tx = Transaction(
         to=contract_address,
         gas_limit=10_000_000,
-        max_priority_fee_per_gas=10,
-        max_fee_per_gas=10,
         sender=sender,
         initcodes=[initcode_subcontainer],
     )
@@ -128,8 +126,6 @@ def test_txcreate_invalid_hash(
     tx = Transaction(
         to=contract_address,
         gas_limit=10_000_000,
-        max_priority_fee_per_gas=10,
-        max_fee_per_gas=10,
         sender=sender,
         initcodes=[smallest_initcode_subcontainer] * tx_initcode_count,
     )
@@ -163,8 +159,6 @@ def test_initcode_aborts(
     tx = Transaction(
         to=contract_address,
         gas_limit=10_000_000,
-        max_priority_fee_per_gas=10,
-        max_fee_per_gas=10,
         sender=sender,
         initcodes=[aborting_container],
     )
@@ -253,8 +247,6 @@ def test_txcreate_deploy_sizes(
     tx = Transaction(
         to=contract_address,
         gas_limit=20_000_000,
-        max_priority_fee_per_gas=10,
-        max_fee_per_gas=10,
         sender=sender,
         initcodes=[initcode_subcontainer],
     )
@@ -323,8 +315,6 @@ def test_auxdata_size_failures(state_test: StateTestFiller, pre: Alloc, auxdata_
     tx = Transaction(
         to=contract_address,
         gas_limit=20_000_000,
-        max_priority_fee_per_gas=10,
-        max_fee_per_gas=10,
         sender=sender,
         initcodes=[initcode_subcontainer],
         data=auxdata_bytes,
@@ -376,8 +366,6 @@ def test_txcreate_insufficient_stipend(
     tx = Transaction(
         to=contract_address,
         gas_limit=20_000_000,
-        max_priority_fee_per_gas=10,
-        max_fee_per_gas=10,
         sender=sender,
         initcodes=[smallest_initcode_subcontainer],
     )
@@ -429,8 +417,6 @@ def test_insufficient_initcode_gas(state_test: StateTestFiller, pre: Alloc, fork
     tx = Transaction(
         to=contract_address,
         gas_limit=gas_limit,
-        max_priority_fee_per_gas=10,
-        max_fee_per_gas=10,
         sender=sender,
         initcodes=[initcode_container],
     )
@@ -484,8 +470,6 @@ def test_insufficient_gas_memory_expansion(
     tx = Transaction(
         to=contract_address,
         gas_limit=gas_limit,
-        max_priority_fee_per_gas=10,
-        max_fee_per_gas=10,
         sender=sender,
         initcodes=[smallest_initcode_subcontainer],
     )
@@ -546,8 +530,6 @@ def test_insufficient_returncode_auxdata_gas(
     tx = Transaction(
         to=contract_address,
         gas_limit=gas_limit,
-        max_priority_fee_per_gas=10,
-        max_fee_per_gas=10,
         sender=sender,
         initcodes=[initcode_container],
     )
@@ -608,8 +590,6 @@ def test_static_flag_txcreate(
     tx = Transaction(
         to=calling_address,
         gas_limit=10_000_000,
-        max_priority_fee_per_gas=10,
-        max_fee_per_gas=10,
         sender=sender,
         initcodes=[initcode],
     )
@@ -713,8 +693,6 @@ def test_eof_txcreate_msg_depth(
     )
 
     tx = Transaction(
-        max_priority_fee_per_gas=10,
-        max_fee_per_gas=10,
         sender=sender,
         initcodes=[initcode],
         to=calling_contract_address if who_fails == magic_value_call else passthrough_address,
@@ -797,8 +775,6 @@ def test_reentrant_txcreate(
     tx = Transaction(
         to=contract_address,
         gas_limit=500_000,
-        max_priority_fee_per_gas=10,
-        max_fee_per_gas=10,
         initcodes=[initcontainer],
         sender=pre.fund_eoa(),
     )

--- a/tests/osaka/eip7692_eof_v1/eip7873_tx_create/test_txcreate_failures.py
+++ b/tests/osaka/eip7692_eof_v1/eip7873_tx_create/test_txcreate_failures.py
@@ -86,7 +86,8 @@ def test_initcode_revert(state_test: StateTestFiller, pre: Alloc, revert: bytes)
                 slot_returndata: revert,
                 slot_code_worked: value_code_worked,
             }
-        )
+        ),
+        compute_eofcreate_address(contract_address, 0): Account.NONEXISTENT,
     }
     tx = Transaction(
         to=contract_address,
@@ -121,7 +122,8 @@ def test_txcreate_invalid_hash(
                 slot_create_address: TXCREATE_FAILURE,
                 slot_code_worked: value_code_worked,
             }
-        )
+        ),
+        compute_eofcreate_address(contract_address, 0): Account.NONEXISTENT,
     }
     tx = Transaction(
         to=contract_address,
@@ -155,7 +157,8 @@ def test_initcode_aborts(
                 slot_create_address: TXCREATE_FAILURE,
                 slot_code_worked: value_code_worked,
             }
-        )
+        ),
+        compute_eofcreate_address(contract_address, 0): Account.NONEXISTENT,
     }
     tx = Transaction(
         to=contract_address,
@@ -233,15 +236,19 @@ def test_txcreate_deploy_sizes(
     # Storage in 0 should have the address,
     # Storage 1 is a canary of 1 to make sure it tried to execute, which also covers cases of
     #   data+code being greater than initcode_size_max, which is allowed.
+    success = target_deploy_size <= MAX_BYTECODE_SIZE
     post = {
         contract_address: Account(
             storage={
                 slot_create_address: compute_eofcreate_address(contract_address, 0)
-                if target_deploy_size <= MAX_BYTECODE_SIZE
+                if success
                 else TXCREATE_FAILURE,
                 slot_code_worked: value_code_worked,
             }
-        )
+        ),
+        compute_eofcreate_address(contract_address, 0): Account()
+        if success
+        else Account.NONEXISTENT,
     }
     tx = Transaction(
         to=contract_address,
@@ -298,6 +305,7 @@ def test_auxdata_size_failures(state_test: StateTestFiller, pre: Alloc, auxdata_
 
     # Storage in 0 will have address in first test, 0 in all other cases indicating failure
     # Storage 1 in 1 is a canary to see if TXCREATE opcode halted
+    success = deployed_container_size <= MAX_BYTECODE_SIZE
     post = {
         contract_address: Account(
             storage={
@@ -306,7 +314,10 @@ def test_auxdata_size_failures(state_test: StateTestFiller, pre: Alloc, auxdata_
                 else 0,
                 slot_code_worked: value_code_worked,
             }
-        )
+        ),
+        compute_eofcreate_address(contract_address, 0): Account()
+        if success
+        else Account.NONEXISTENT,
     }
 
     tx = Transaction(
@@ -591,7 +602,8 @@ def test_static_flag_txcreate(
                 else LEGACY_CALL_FAILURE,
                 slot_code_worked: value_code_worked,
             }
-        )
+        ),
+        compute_eofcreate_address(contract_address, 0): Account.NONEXISTENT,
     }
     tx = Transaction(
         to=calling_address,
@@ -777,7 +789,10 @@ def test_reentrant_txcreate(
                 0: compute_eofcreate_address(contract_address, 0),
                 1: 0,
             }
-        )
+        ),
+        compute_eofcreate_address(contract_address, 0): Account(
+            nonce=1, code=smallest_runtime_subcontainer
+        ),
     }
     tx = Transaction(
         to=contract_address,


### PR DESCRIPTION
## 🗒️ Description

Introduces more detailed assertions on the post state of failure of TX/EOFCREATE

## 🔗 Related Issues

NA

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
