### PR TITLE
fix(clis): update besu's exception mapper (`SYSTEM_CONTRACT_EMPTY`, `INVALID_DEPOSIT_EVENT_LAYOUT`)

### DIFF
--- a/src/ethereum_clis/clis/besu.py
+++ b/src/ethereum_clis/clis/besu.py
@@ -259,7 +259,6 @@ class BesuExceptionMapper(ExceptionMapper):
         BlockException.INCORRECT_BLOB_GAS_USED: (
             "Payload BlobGasUsed does not match calculated BlobGasUsed"
         ),
-        BlockException.SYSTEM_CONTRACT_EMPTY: "Invalid system call, no code at address",
         # TODO EVMONE needs to differentiate when the section is missing in the header or body
         EOFException.MISSING_STOP_OPCODE: "err: no_terminating_instruction",
         EOFException.MISSING_CODE_HEADER: "err: code_section_missing",
@@ -311,6 +310,10 @@ class BesuExceptionMapper(ExceptionMapper):
         ),
         BlockException.SYSTEM_CONTRACT_CALL_FAILED: (
             r"System call halted|System call did not execute to completion"
+        ),
+        BlockException.SYSTEM_CONTRACT_EMPTY: (
+            r"(Invalid system call, no code at address)|"
+            r"(Invalid system call address:)"
         ),
         TransactionException.INITCODE_SIZE_EXCEEDED: (
             r"transaction invalid Initcode size of \d+ exceeds maximum size of \d+"

--- a/src/ethereum_clis/clis/besu.py
+++ b/src/ethereum_clis/clis/besu.py
@@ -260,9 +260,7 @@ class BesuExceptionMapper(ExceptionMapper):
         BlockException.INCORRECT_BLOB_GAS_USED: (
             "Payload BlobGasUsed does not match calculated BlobGasUsed"
         ),
-        BlockException.SYSTEM_CONTRACT_EMPTY: (
-            "Invalid system call, no code at address"
-        ),
+        BlockException.SYSTEM_CONTRACT_EMPTY: "Invalid system call, no code at address",
         # TODO EVMONE needs to differentiate when the section is missing in the header or body
         EOFException.MISSING_STOP_OPCODE: "err: no_terminating_instruction",
         EOFException.MISSING_CODE_HEADER: "err: code_section_missing",

--- a/src/ethereum_clis/clis/besu.py
+++ b/src/ethereum_clis/clis/besu.py
@@ -247,7 +247,6 @@ class BesuExceptionMapper(ExceptionMapper):
         TransactionException.TYPE_4_TX_PRE_FORK: (
             "transaction invalid Transaction type DELEGATE_CODE is invalid"
         ),
-        TransactionException.INVALID_DEPOSIT_EVENT_LAYOUT: "Invalid deposit log",
         BlockException.RLP_STRUCTURES_ENCODING: (
             "Failed to decode transactions from block parameter"
         ),
@@ -329,5 +328,9 @@ class BesuExceptionMapper(ExceptionMapper):
         ),
         TransactionException.NONCE_MISMATCH_TOO_LOW: (
             r"transaction invalid transaction nonce \d+ below sender account nonce \d+"
+        ),
+        TransactionException.INVALID_DEPOSIT_EVENT_LAYOUT: (
+            r"Invalid (amount|index|pubKey|signature|withdrawalCred) (offset|size): "
+            r"expected (\d+), but got (-?\d+)"
         ),
     }

--- a/src/ethereum_clis/clis/besu.py
+++ b/src/ethereum_clis/clis/besu.py
@@ -260,6 +260,9 @@ class BesuExceptionMapper(ExceptionMapper):
         BlockException.INCORRECT_BLOB_GAS_USED: (
             "Payload BlobGasUsed does not match calculated BlobGasUsed"
         ),
+        BlockException.SYSTEM_CONTRACT_EMPTY: (
+            "Invalid system call, no code at address"
+        ),
         # TODO EVMONE needs to differentiate when the section is missing in the header or body
         EOFException.MISSING_STOP_OPCODE: "err: no_terminating_instruction",
         EOFException.MISSING_CODE_HEADER: "err: code_section_missing",


### PR DESCRIPTION
## 🗒️ Description
Adds exceptions to Besu's exception mapper:
-  `BlockException.SYSTEM_CONTRACT_EMPTY` 
-  `TransactionException.INVALID_DEPOSIT_EVENT_LAYOUT`

####  `TransactionException.INVALID_DEPOSIT_EVENT_LAYOUT`

Here are the exceptions from `tests/prague/eip6110_deposits/test_modified_contract.py::test_invalid_layout[fork_Prague-blockchain_test_engine-log_argument_*]`:
```
amount_offset-value_max_uint256	                 Invalid amount offset: expected 320, but got -1
amount_offset-value_zero	                     Invalid amount offset: expected 320, but got 0
amount_size-value_max_uint256	                 Invalid amount size: expected 8, but got -1
amount_size-value_zero                           Invalid amount size: expected 8, but got 0
index_offset-value_max_uint256	                 Invalid index offset: expected 512, but got -1
index_offset-value_zero	                         Invalid index offset: expected 512, but got 0
index_size-value_max_uint256	                 Invalid index size: expected 8, but got -1
index_size-value_zero	                         Invalid index size: expected 8, but got 0
pubkey_offset-value_max_uint256	                 Invalid pubKey offset: expected 160, but got -1
pubkey_offset-value_zero	                     Invalid pubKey offset: expected 160, but got 0
pubkey_size-value_max_uint256	                 Invalid pubKey size: expected 48, but got -1
pubkey_size-value_zero	                         Invalid pubKey size: expected 48, but got 0
signature_offset-value_max_uint256               Invalid signature offset: expected 384, but got -1
signature_offset-value_zero	                     Invalid signature offset: expected 384, but got 0
signature_size-value_max_uint256                 Invalid signature size: expected 96, but got -1
signature_size-value_zero	                     Invalid signature size: expected 96, but got 0
withdrawal_credentials_offset-value_max_uint256	 Invalid withdrawalCred offset: expected 256, but got -1
withdrawal_credentials_offset-value_zero	     Invalid withdrawalCred offset: expected 256, but got 0
withdrawal_credentials_size-value_max_uint256	 Invalid withdrawalCred size: expected 32, but got -1
withdrawal_credentials_size-value_zero	         Invalid withdrawalCred size: expected 32, but got 0
```
## 🔗 Related Issues
- https://github.com/hyperledger/besu/pull/8574

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] ~~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.