### PR TITLE
fix(fill): fix reported fixture source urls for the case of auto-generated tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,8 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 #### `fill`
 
+- 🐞 Fix the reported fixture source URLs for the case of auto-generated tests ([#1488](https://github.com/ethereum/execution-spec-tests/pull/1488)).
+
 #### `consume`
 
 ### 📋 Misc

--- a/src/pytest_plugins/filler/filler.py
+++ b/src/pytest_plugins/filler/filler.py
@@ -658,12 +658,22 @@ def fixture_source_url(
     if hasattr(request.node, "github_url"):
         return request.node.github_url
     function_line_number = request.function.__code__.co_firstlineno
-    module_relative_path = os.path.relpath(request.module.__file__)
+    module_relative_path = os.path.relpath(request.function.__code__.co_filename)
+
     github_url = generate_github_url(
         module_relative_path,
         branch_or_commit_or_tag=commit_hash_or_tag,
         line_number=function_line_number,
     )
+    test_module_relative_path = os.path.relpath(request.module.__file__)
+    if module_relative_path != test_module_relative_path:
+        # This can be the case when the test function's body only contains pass and the entire
+        # test logic is implemented as a test generator from the framework.
+        test_module_github_url = generate_github_url(
+            test_module_relative_path,
+            branch_or_commit_or_tag=commit_hash_or_tag,
+        )
+        github_url += f" called via `{request.node.originalname}()` in {test_module_github_url}"
     return github_url
 
 


### PR DESCRIPTION
## 🗒️ Description
Fixes the `fixture_source_url` field in the fixture `_info` section for the case of a test function who's body is simply `pass`. Here's an example of such a test function, whose test logic is applied via a decorate from an EEST framework generator:
https://github.com/ethereum/execution-spec-tests/blob/f330aac4ae776ebbbca6005bcfdabbb6b04cf76b/tests/prague/eip7251_consolidations/test_modified_consolidation_contract.py#L137-L151

In v4.3.0, consume test reports report an invalid URL (with a non-existent line number), e.g. https://hive.ethpandaops.io/#/test/pectra/1745242958-27275e8c3ce031d481359ddd1eb46b12?page=1&testnumber=4776 

In these special cases, pytest reports the generator function as the test function, instead of the original test function. For this case, where the test module name doesn't match the module name reported by pytest, both files are written to the url string, e.g.,

```
https://github.com/ethereum/execution-spec-tests/blob/e7cc42c660c466fa955cd9983906c50a3e64aab3/src/ethereum_test_tools/utility/generators.py#L280 called via `test_system_contract_errors()` in https://github.com/ethereum/execution-spec-tests/blob/e7cc42c660c466fa955cd9983906c50a3e64aab3/tests/prague/eip7251_consolidations/test_modified_consolidation_contract.py
```
> https://github.com/ethereum/execution-spec-tests/blob/e7cc42c660c466fa955cd9983906c50a3e64aab3/src/ethereum_test_tools/utility/generators.py#L280 called via `test_system_contract_errors()` in https://github.com/ethereum/execution-spec-tests/blob/e7cc42c660c466fa955cd9983906c50a3e64aab3/tests/prague/eip7251_consolidations/test_modified_consolidation_contract.py

This isn't perfect, I didn't find an easy way to get the test function's line number in this case.

## 🔗 Related Issues
None

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
