### PR TITLE
 new(tests): EIP-7873 expand legacy creation tx tests 

### DIFF
--- a/tests/osaka/eip7692_eof_v1/eip7873_tx_create/test_creation_tx.py
+++ b/tests/osaka/eip7692_eof_v1/eip7873_tx_create/test_creation_tx.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from ethereum_test_exceptions.exceptions import TransactionException
 from ethereum_test_tools import (
     Account,
     Alloc,
@@ -58,7 +59,7 @@ def test_legacy_create_tx_legacy_initcode_eof_bytecode(
 
 
 @pytest.mark.with_all_contract_creating_tx_types(selector=lambda tx_type: tx_type != 6)
-@pytest.mark.xfail(reason="evmone incorrectly deploys the contract")
+@pytest.mark.exception_test
 def test_legacy_create_tx_eof_initcode(
     state_test: StateTestFiller,
     pre: Alloc,
@@ -74,6 +75,7 @@ def test_legacy_create_tx_eof_initcode(
         to=None,
         gas_limit=100_000,
         data=smallest_initcode_subcontainer,
+        error=TransactionException.EOF_CREATION_TRANSACTION,
     )
 
     destination_contract_address = tx.created_contract

--- a/tests/osaka/eip7692_eof_v1/eip7873_tx_create/test_creation_tx.py
+++ b/tests/osaka/eip7692_eof_v1/eip7873_tx_create/test_creation_tx.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from ethereum_test_base_types.base_types import Bytes
+from ethereum_test_base_types.base_types import Address, Bytes
 from ethereum_test_exceptions.exceptions import TransactionException
 from ethereum_test_tools import (
     Account,
@@ -13,6 +13,7 @@ from ethereum_test_tools import (
 )
 from ethereum_test_tools.code.generators import Initcode as LegacyInitcode
 from ethereum_test_types.eof.v1 import Container
+from tests.prague.eip7702_set_code_tx.spec import Spec
 
 from .. import EOF_FORK_NAME
 from ..eip7620_eof_create.helpers import (
@@ -130,7 +131,7 @@ def test_legacy_create_tx_eof_initcode(
         Bytes("0xEF"),
         Bytes("0xEF01"),
         Bytes("0xEF0101"),
-        Bytes("0xEF01" + "".join("ab")),
+        Spec.delegation_designation(Address(0xAA)),
         Bytes("0xEF02"),
     ],
 )

--- a/tests/osaka/eip7692_eof_v1/eip7873_tx_create/test_creation_tx.py
+++ b/tests/osaka/eip7692_eof_v1/eip7873_tx_create/test_creation_tx.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from ethereum_test_base_types.base_types import Bytes
 from ethereum_test_exceptions.exceptions import TransactionException
 from ethereum_test_tools import (
     Account,
@@ -11,6 +12,7 @@ from ethereum_test_tools import (
     Transaction,
 )
 from ethereum_test_tools.code.generators import Initcode as LegacyInitcode
+from ethereum_test_types.eof.v1 import Container
 
 from .. import EOF_FORK_NAME
 from ..eip7620_eof_create.helpers import (
@@ -25,16 +27,32 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
 
 
 @pytest.mark.with_all_contract_creating_tx_types(selector=lambda tx_type: tx_type != 6)
+@pytest.mark.parametrize(
+    "deploy_code",
+    [
+        Bytes("0xEF"),
+        Bytes("0xEF00"),
+        Bytes("0xEF0001"),
+        Bytes("0xEF01"),
+        smallest_runtime_subcontainer,
+        smallest_initcode_subcontainer,
+    ],
+)
 def test_legacy_create_tx_legacy_initcode_eof_bytecode(
     state_test: StateTestFiller,
     pre: Alloc,
     tx_type: int,
+    deploy_code: Bytes | Container,
 ):
-    """Test that a legacy contract creation tx cannot create EOF code."""
+    """
+    Test that a legacy contract creation tx cannot create EOF code.
+
+    This tests only ensures EIP-3541 behavior is kept, not altered by EIP-7873
+    """
     env = Environment()
     sender = pre.fund_eoa()
 
-    initcode = LegacyInitcode(deploy_code=smallest_runtime_subcontainer)
+    initcode = LegacyInitcode(deploy_code=deploy_code)
 
     tx = Transaction(
         ty=tx_type,
@@ -59,13 +77,26 @@ def test_legacy_create_tx_legacy_initcode_eof_bytecode(
 
 
 @pytest.mark.with_all_contract_creating_tx_types(selector=lambda tx_type: tx_type != 6)
+@pytest.mark.parametrize(
+    "initcode",
+    [
+        Bytes("0xEF00"),
+        Bytes("0xEF0001"),
+        smallest_runtime_subcontainer,
+        smallest_initcode_subcontainer,
+    ],
+)
 @pytest.mark.exception_test
 def test_legacy_create_tx_eof_initcode(
     state_test: StateTestFiller,
     pre: Alloc,
     tx_type: int,
+    initcode: Bytes | Container,
 ):
-    """Test that a legacy contract creation tx cannot use EOF initcode."""
+    """
+    Test that a legacy contract creation tx with EOF initcode (or anything starting with
+    `0xEF00` in data) is invalid.
+    """
     env = Environment()
     sender = pre.fund_eoa()
 
@@ -74,8 +105,55 @@ def test_legacy_create_tx_eof_initcode(
         sender=sender,
         to=None,
         gas_limit=100_000,
-        data=smallest_initcode_subcontainer,
+        data=initcode,
         error=TransactionException.EOF_CREATION_TRANSACTION,
+    )
+
+    destination_contract_address = tx.created_contract
+
+    post = {
+        destination_contract_address: Account.NONEXISTENT,
+    }
+
+    state_test(
+        env=env,
+        pre=pre,
+        post=post,
+        tx=tx,
+    )
+
+
+@pytest.mark.with_all_contract_creating_tx_types(selector=lambda tx_type: tx_type != 6)
+@pytest.mark.parametrize(
+    "initcode",
+    [
+        Bytes("0xEF"),
+        Bytes("0xEF01"),
+        Bytes("0xEF0101"),
+        Bytes("0xEF01" + "".join("ab")),
+        Bytes("0xEF02"),
+    ],
+)
+def test_legacy_create_tx_prefix_initcode(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    tx_type: int,
+    initcode: Bytes,
+):
+    """
+    Test that a legacy contract creation tx behaves as it did before EIP-7873 for
+    initcode stating with `EF`, but not falling into the special case of `EF00`.
+    The transaction should be valid but fail on executing of the first byte `EF`.
+    """
+    env = Environment()
+    sender = pre.fund_eoa()
+
+    tx = Transaction(
+        ty=tx_type,
+        sender=sender,
+        to=None,
+        gas_limit=100_000,
+        data=initcode,
     )
 
     destination_contract_address = tx.created_contract


### PR DESCRIPTION
## 🗒️ Description

(requires evmone with [this update](https://github.com/ethereum/evmone/pull/1190) to fill) EDIT: Merged

Also **NOTE** that, same as https://github.com/ethereum/execution-spec-tests/pull/1475 this PR adds tests and facilities for behavior of "legacy creation txs" (to: nil, EOF container in data), which is likely to change based on recently obtained feedback. 

I'd like to merge this as a baby step (and https://github.com/ethereum/execution-spec-tests/pull/1475) and then update the behavior in a proper PR

## 🔗 Related Issues

NA

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
