### PR TITLE
feat(ci): Add `static` feature to produce `fixtures_static`

### DIFF
--- a/.github/configs/evm.yaml
+++ b/.github/configs/evm.yaml
@@ -6,7 +6,7 @@ develop:
   impl: eels
   repo: null
   ref: null
-legacy:
+static:
   impl: evmone
   repo: ethereum/evmone
   ref: master

--- a/.github/configs/evm.yaml
+++ b/.github/configs/evm.yaml
@@ -6,6 +6,11 @@ develop:
   impl: eels
   repo: null
   ref: null
+legacy:
+  impl: evmone
+  repo: ethereum/evmone
+  ref: master
+  targets: ["evmone-t8n", "evmone-eofparse"]
 eip7692:
   impl: evmone
   repo: ethereum/evmone

--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -7,8 +7,8 @@ develop:
   evm-type: develop
   fill-params: --until=Prague
   solc: 0.8.21
-legacy:
-  evm-type: legacy
+static:
+  evm-type: static
   fill-params: --until=Prague --fill-static-tests ./tests/legacy
   solc: 0.8.21
 eip7692:

--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -9,7 +9,7 @@ develop:
   solc: 0.8.21
 static:
   evm-type: static
-  fill-params: --until=Prague --fill-static-tests ./tests/legacy
+  fill-params: --until=Prague --fill-static-tests ./tests/static
   solc: 0.8.21
 eip7692:
   evm-type: eip7692

--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -7,6 +7,10 @@ develop:
   evm-type: develop
   fill-params: --until=Prague
   solc: 0.8.21
+legacy:
+  evm-type: legacy
+  fill-params: --until=Prague --fill-static-tests ./tests/legacy
+  solc: 0.8.21
 eip7692:
   evm-type: eip7692
   fill-params: --fork=Osaka ./tests/osaka

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,7 +32,7 @@ Users can expect that all tests currently living in [ethereum/tests](https://git
 
 - ✨ [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702): Test that DELEGATECALL to a 7702 target works as intended ([#1485](https://github.com/ethereum/execution-spec-tests/pull/1485)).
 - ✨ [EIP-2573](https://eips.ethereum.org/EIPS/eip-2537): Includes a BLS12 point generator, alongside additional coverage many of the precompiles ([#1350](https://github.com/ethereum/execution-spec-tests/pull/1350)).
-- ✨ Add all [`GeneralStateTests` from `ethereum/tests`](https://github.com/ethereum/tests/tree/7dc757ec132e372b6178a016b91f4c639f366c02/src/GeneralStateTestsFiller) to `execution-spec-tests` located now at [tests/legacy/state_tests](https://github.com/ethereum/execution-spec-tests/tree/main/tests/legacy/state_tests) ([#1442](https://github.com/ethereum/execution-spec-tests/pull/1442)).
+- ✨ Add all [`GeneralStateTests` from `ethereum/tests`](https://github.com/ethereum/tests/tree/7dc757ec132e372b6178a016b91f4c639f366c02/src/GeneralStateTestsFiller) to `execution-spec-tests` located now at [tests/static/state_tests](https://github.com/ethereum/execution-spec-tests/tree/main/tests/static/state_tests) ([#1442](https://github.com/ethereum/execution-spec-tests/pull/1442)).
 
 ## [v4.3.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v4.3.0) - 2025-04-18
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,16 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 ### 💥 Breaking Change
 
+#### `fixtures_static`
+
+A new fixture tarball has been included in this release: `fixtures_static.tar.gz`.
+
+This tarball contains all tests inside of [`./tests/static`](https://github.com/ethereum/execution-spec-tests/tree/main/tests/static), which at this point only contains all tests copied from [`GeneralStateTests` in `ethereum/tests@7dc757ec132e372b6178a016b91f4c639f366c02`](https://github.com/ethereum/tests/tree/7dc757ec132e372b6178a016b91f4c639f366c02/src/GeneralStateTestsFiller).
+
+The tests have been filled using the new static test filler introduced in [#1336](https://github.com/ethereum/execution-spec-tests/pull/1336), and enhanced in [#1362](https://github.com/ethereum/execution-spec-tests/pull/1362) and [#1439](https://github.com/ethereum/execution-spec-tests/pull/1439).
+
+Users can expect that all tests currently living in [ethereum/tests](https://github.com/ethereum/tests/tree/develop/src) should eventually make its way into [`./tests/static`](https://github.com/ethereum/execution-spec-tests/tree/main/tests/static) and can rely that these tests, filled for new forks even, will be included in `fixtures_static.tar.gz`.
+
 ### 🛠️ Framework
 
 #### `fill`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ where = ["src"]
 exclude = ["*tests*"]
 
 [tool.pyright]
-exclude = ["**/legacy/**"]
+exclude = ["tests/static/**"]
 
 [tool.setuptools.package-data]
 ethereum_test_forks = ["forks/contracts/*.bin"]


### PR DESCRIPTION
## 🗒️ Description
Requires #1439 and #1442.

Adds the `legacy` feature to build `fixtures_legacy` on every release.

We are going to use evmone due to speed because of some of the lengthier tests in `stTimeConsuming` that take longer than 60 seconds to execute with EELS, but this could change in the future.

## 🔗 Related Issues
None

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.