### PR TITLE
fix(tests): Update legacy creation tx rules

### DIFF
--- a/src/ethereum_clis/clis/evmone.py
+++ b/src/ethereum_clis/clis/evmone.py
@@ -80,7 +80,6 @@ class EvmoneExceptionMapper(ExceptionMapper):
         ),
         TransactionException.NONCE_MISMATCH_TOO_LOW: "nonce too low",
         TransactionException.NONCE_MISMATCH_TOO_HIGH: "nonce too high",
-        TransactionException.EOF_CREATION_TRANSACTION: "EOF initcode in creation transaction",
         # TODO EVMONE needs to differentiate when the section is missing in the header or body
         EOFException.MISSING_STOP_OPCODE: "err: no_terminating_instruction",
         EOFException.MISSING_CODE_HEADER: "err: code_section_missing",

--- a/src/ethereum_test_exceptions/exceptions.py
+++ b/src/ethereum_test_exceptions/exceptions.py
@@ -327,10 +327,6 @@ class TransactionException(ExceptionBase):
     """
     Transaction's initcode for a contract-creating transaction is too large.
     """
-    EOF_CREATION_TRANSACTION = auto()
-    """
-    Creation transaction (to: nil) contains EOF initcode
-    """
     TYPE_3_TX_PRE_FORK = auto()
     """
     Transaction type 3 included before activation fork.

--- a/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_legacy_eof_creates.py
+++ b/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_legacy_eof_creates.py
@@ -29,9 +29,77 @@ from .helpers import (
 from .spec import EOFCREATE_FAILURE
 
 REFERENCE_SPEC_GIT_PATH = "EIPS/eip-7620.md"
-REFERENCE_SPEC_VERSION = "todo"
+REFERENCE_SPEC_VERSION = "52ddbcdddcf72dd72427c319f2beddeb468e1737"
 
 pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
+
+
+@pytest.mark.parametrize(
+    "legacy_create_opcode",
+    [
+        pytest.param(Op.CREATE, id="CREATE"),
+        pytest.param(Op.CREATE2, id="CREATE2"),
+    ],
+)
+@pytest.mark.parametrize(
+    "initcode",
+    [
+        Bytes("0xEF00"),
+        Bytes("0xEF0001"),
+        pytest.param(smallest_initcode_subcontainer, id="deploy_eof_initcontainer"),
+        pytest.param(smallest_runtime_subcontainer, id="deploy_eof_container"),
+    ],
+)
+def test_cross_version_creates_fail_light(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    legacy_create_opcode: Opcodes,
+    initcode: Bytes | Container,
+):
+    """Verifies that CREATE and CREATE2 cannot run EOF initcodes and fail early on attempt."""
+    env = Environment()
+
+    sender = pre.fund_eoa()
+
+    tx_gas_limit = 10_000_000
+
+    contract_address = pre.deploy_contract(
+        code=Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE)
+        + Op.SSTORE(slot_create_address, legacy_create_opcode(size=Op.CALLDATASIZE))
+        # Aproximates whether code until here consumed the 63/64th gas given to subcall
+        + Op.SSTORE(slot_all_subcall_gas_gone, Op.LT(Op.GAS, tx_gas_limit // 64))
+        + Op.SSTORE(slot_code_worked, value_code_worked)
+        + Op.STOP
+    )
+
+    post = {
+        contract_address: Account(
+            storage={
+                slot_create_address: EOFCREATE_FAILURE,
+                slot_code_worked: value_code_worked,
+                slot_all_subcall_gas_gone: 0,
+            },
+            nonce=1,
+        ),
+        # Double check no accounts were created
+        compute_create_address(address=contract_address, nonce=1): Account.NONEXISTENT,
+        compute_create_address(
+            address=contract_address, initcode=initcode, salt=0, opcode=Op.CREATE2
+        ): Account.NONEXISTENT,
+    }
+    tx = Transaction(
+        to=contract_address,
+        gas_limit=tx_gas_limit,
+        sender=sender,
+        data=initcode,
+    )
+
+    state_test(
+        env=env,
+        pre=pre,
+        post=post,
+        tx=tx,
+    )
 
 
 @pytest.mark.parametrize(
@@ -49,10 +117,6 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
         Bytes("0xEF0101"),
         Spec.delegation_designation(Address(0xAA)),
         Bytes("0xEF02"),
-        Bytes("0xEF00"),
-        Bytes("0xEF0001"),
-        pytest.param(smallest_initcode_subcontainer, id="deploy_eof_initcontainer"),
-        pytest.param(smallest_runtime_subcontainer, id="deploy_eof_container"),
     ],
 )
 def test_cross_version_creates_fail_hard(
@@ -61,7 +125,10 @@ def test_cross_version_creates_fail_hard(
     legacy_create_opcode: Opcodes,
     initcode: Bytes,
 ):
-    """Verifies that CREATE and CREATE2 fail hard on attempt to run initcode starting with `EF`."""
+    """
+    Verifies that CREATE and CREATE2 fail hard on attempt to run initcode starting with `EF` but
+    not `EF00`.
+    """
     env = Environment()
 
     sender = pre.fund_eoa()

--- a/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_legacy_eof_creates.py
+++ b/tests/osaka/eip7692_eof_v1/eip7620_eof_create/test_legacy_eof_creates.py
@@ -29,77 +29,9 @@ from .helpers import (
 from .spec import EOFCREATE_FAILURE
 
 REFERENCE_SPEC_GIT_PATH = "EIPS/eip-7620.md"
-REFERENCE_SPEC_VERSION = "52ddbcdddcf72dd72427c319f2beddeb468e1737"
+REFERENCE_SPEC_VERSION = "todo"
 
 pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
-
-
-@pytest.mark.parametrize(
-    "legacy_create_opcode",
-    [
-        pytest.param(Op.CREATE, id="CREATE"),
-        pytest.param(Op.CREATE2, id="CREATE2"),
-    ],
-)
-@pytest.mark.parametrize(
-    "initcode",
-    [
-        Bytes("0xEF00"),
-        Bytes("0xEF0001"),
-        pytest.param(smallest_initcode_subcontainer, id="deploy_eof_initcontainer"),
-        pytest.param(smallest_runtime_subcontainer, id="deploy_eof_container"),
-    ],
-)
-def test_cross_version_creates_fail_light(
-    state_test: StateTestFiller,
-    pre: Alloc,
-    legacy_create_opcode: Opcodes,
-    initcode: Bytes | Container,
-):
-    """Verifies that CREATE and CREATE2 cannot run EOF initcodes and fail early on attempt."""
-    env = Environment()
-
-    sender = pre.fund_eoa()
-
-    tx_gas_limit = 10_000_000
-
-    contract_address = pre.deploy_contract(
-        code=Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE)
-        + Op.SSTORE(slot_create_address, legacy_create_opcode(size=Op.CALLDATASIZE))
-        # Aproximates whether code until here consumed the 63/64th gas given to subcall
-        + Op.SSTORE(slot_all_subcall_gas_gone, Op.LT(Op.GAS, tx_gas_limit // 64))
-        + Op.SSTORE(slot_code_worked, value_code_worked)
-        + Op.STOP
-    )
-
-    post = {
-        contract_address: Account(
-            storage={
-                slot_create_address: EOFCREATE_FAILURE,
-                slot_code_worked: value_code_worked,
-                slot_all_subcall_gas_gone: 0,
-            },
-            nonce=1,
-        ),
-        # Double check no accounts were created
-        compute_create_address(address=contract_address, nonce=1): Account.NONEXISTENT,
-        compute_create_address(
-            address=contract_address, initcode=initcode, salt=0, opcode=Op.CREATE2
-        ): Account.NONEXISTENT,
-    }
-    tx = Transaction(
-        to=contract_address,
-        gas_limit=tx_gas_limit,
-        sender=sender,
-        data=initcode,
-    )
-
-    state_test(
-        env=env,
-        pre=pre,
-        post=post,
-        tx=tx,
-    )
 
 
 @pytest.mark.parametrize(
@@ -117,6 +49,10 @@ def test_cross_version_creates_fail_light(
         Bytes("0xEF0101"),
         Spec.delegation_designation(Address(0xAA)),
         Bytes("0xEF02"),
+        Bytes("0xEF00"),
+        Bytes("0xEF0001"),
+        pytest.param(smallest_initcode_subcontainer, id="deploy_eof_initcontainer"),
+        pytest.param(smallest_runtime_subcontainer, id="deploy_eof_container"),
     ],
 )
 def test_cross_version_creates_fail_hard(
@@ -125,10 +61,7 @@ def test_cross_version_creates_fail_hard(
     legacy_create_opcode: Opcodes,
     initcode: Bytes,
 ):
-    """
-    Verifies that CREATE and CREATE2 fail hard on attempt to run initcode starting with `EF` but
-    not `EF00`.
-    """
+    """Verifies that CREATE and CREATE2 fail hard on attempt to run initcode starting with `EF`."""
     env = Environment()
 
     sender = pre.fund_eoa()

--- a/tests/osaka/eip7692_eof_v1/eip7873_tx_create/test_creation_tx.py
+++ b/tests/osaka/eip7692_eof_v1/eip7873_tx_create/test_creation_tx.py
@@ -22,7 +22,7 @@ from ..eip7620_eof_create.helpers import (
 )
 
 REFERENCE_SPEC_GIT_PATH = "EIPS/eip-7873.md"
-REFERENCE_SPEC_VERSION = "todo"
+REFERENCE_SPEC_VERSION = "23d96ceff8f0690432ab91089ae257f08f32340f"
 
 pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
 

--- a/tests/osaka/eip7692_eof_v1/eip7873_tx_create/test_creation_tx.py
+++ b/tests/osaka/eip7692_eof_v1/eip7873_tx_create/test_creation_tx.py
@@ -3,7 +3,6 @@
 import pytest
 
 from ethereum_test_base_types.base_types import Address, Bytes
-from ethereum_test_exceptions.exceptions import TransactionException
 from ethereum_test_tools import (
     Account,
     Alloc,
@@ -13,6 +12,7 @@ from ethereum_test_tools import (
 )
 from ethereum_test_tools.code.generators import Initcode as LegacyInitcode
 from ethereum_test_types.eof.v1 import Container
+from ethereum_test_types.types import TransactionReceipt
 from tests.prague.eip7702_set_code_tx.spec import Spec
 
 from .. import EOF_FORK_NAME
@@ -22,7 +22,7 @@ from ..eip7620_eof_create.helpers import (
 )
 
 REFERENCE_SPEC_GIT_PATH = "EIPS/eip-7873.md"
-REFERENCE_SPEC_VERSION = "1115fe6110fcc0efc823fb7f8f5cd86c42173efe"
+REFERENCE_SPEC_VERSION = "todo"
 
 pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
 
@@ -81,58 +81,15 @@ def test_legacy_create_tx_legacy_initcode_eof_bytecode(
 @pytest.mark.parametrize(
     "initcode",
     [
-        Bytes("0xEF00"),
-        Bytes("0xEF0001"),
-        smallest_runtime_subcontainer,
-        smallest_initcode_subcontainer,
-    ],
-)
-@pytest.mark.exception_test
-def test_legacy_create_tx_eof_initcode(
-    state_test: StateTestFiller,
-    pre: Alloc,
-    tx_type: int,
-    initcode: Bytes | Container,
-):
-    """
-    Test that a legacy contract creation tx with EOF initcode (or anything starting with
-    `0xEF00` in data) is invalid.
-    """
-    env = Environment()
-    sender = pre.fund_eoa()
-
-    tx = Transaction(
-        ty=tx_type,
-        sender=sender,
-        to=None,
-        gas_limit=100_000,
-        data=initcode,
-        error=TransactionException.EOF_CREATION_TRANSACTION,
-    )
-
-    destination_contract_address = tx.created_contract
-
-    post = {
-        destination_contract_address: Account.NONEXISTENT,
-    }
-
-    state_test(
-        env=env,
-        pre=pre,
-        post=post,
-        tx=tx,
-    )
-
-
-@pytest.mark.with_all_contract_creating_tx_types(selector=lambda tx_type: tx_type != 6)
-@pytest.mark.parametrize(
-    "initcode",
-    [
         Bytes("0xEF"),
         Bytes("0xEF01"),
         Bytes("0xEF0101"),
         Spec.delegation_designation(Address(0xAA)),
         Bytes("0xEF02"),
+        Bytes("0xEF00"),
+        Bytes("0xEF0001"),
+        smallest_runtime_subcontainer,
+        smallest_initcode_subcontainer,
     ],
 )
 def test_legacy_create_tx_prefix_initcode(
@@ -143,25 +100,25 @@ def test_legacy_create_tx_prefix_initcode(
 ):
     """
     Test that a legacy contract creation tx behaves as it did before EIP-7873 for
-    initcode stating with `EF`, but not falling into the special case of `EF00`.
+    initcode stating with `EF`.
     The transaction should be valid but fail on executing of the first byte `EF`.
     """
     env = Environment()
     sender = pre.fund_eoa()
+    gas_limit = 100_000
 
     tx = Transaction(
         ty=tx_type,
         sender=sender,
         to=None,
-        gas_limit=100_000,
+        gas_limit=gas_limit,
         data=initcode,
+        expected_receipt=TransactionReceipt(gas_used=gas_limit),
     )
 
     destination_contract_address = tx.created_contract
 
-    post = {
-        destination_contract_address: Account.NONEXISTENT,
-    }
+    post = {destination_contract_address: Account.NONEXISTENT, sender: Account(nonce=1)}
 
     state_test(
         env=env,


### PR DESCRIPTION
## 🗒️ Description

Updates according to:
- https://github.com/ethereum/EIPs/pull/9669
- ~~https://github.com/ethereum/EIPs/pull/9688~~ EDIT: dropped, keeping CREATE/CREATE2 failures light

Requires https://github.com/ethereum/evmone/pull/1205 to fill using `evmone`.

## 🔗 Related Issues

NA

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
