### PR TITLE
fix(consume): fix the test re-run hive commands displayed in hive ui

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,8 @@ Users can expect that all tests currently living in [ethereum/tests](https://git
 
 #### `consume`
 
+- 🐞 Fix the Hive commands used to reproduce test executions that are displayed in test descriptions in the Hive UI ([#1494](https://github.com/ethereum/execution-spec-tests/pull/1494)).
+
 ### 📋 Misc
 
 ### 🧪 Test Cases

--- a/src/pytest_plugins/consume/hive_simulators/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/conftest.py
@@ -138,6 +138,12 @@ def filtered_hive_options(hive_info: HiveInfo) -> List[str]:
 
 
 @pytest.fixture(scope="function")
+def hive_client_config_file_parameter(hive_clients_yaml_target_filename: str) -> str:
+    """Return the hive client config file parameter."""
+    return f"--client-file {hive_clients_yaml_target_filename}"
+
+
+@pytest.fixture(scope="function")
 def hive_consume_command(
     test_case: TestCaseIndexFile | TestCaseStream,
     filtered_hive_options: List[str],
@@ -145,16 +151,11 @@ def hive_consume_command(
 ) -> str:
     """Command to run the test within hive."""
     command_parts = filtered_hive_options.copy()
+    command_parts.append(f"{hive_client_config_file_parameter}")
     command_parts.append(f"--client={client_type.name}")
     command_parts.append(f'--sim.limit="id:{test_case.id}"')
 
     return " ".join(command_parts)
-
-
-@pytest.fixture(scope="function")
-def hive_client_config_file_parameter(hive_clients_yaml_target_filename: str) -> str:
-    """Return the hive client config file parameter."""
-    return f"--client-file {hive_clients_yaml_target_filename}"
 
 
 @pytest.fixture(scope="function")

--- a/src/pytest_plugins/consume/hive_simulators/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/conftest.py
@@ -146,6 +146,7 @@ def hive_client_config_file_parameter(hive_clients_yaml_target_filename: str) ->
 @pytest.fixture(scope="function")
 def hive_consume_command(
     test_case: TestCaseIndexFile | TestCaseStream,
+    hive_client_config_file_parameter: str,
     filtered_hive_options: List[str],
     client_type: ClientType,
 ) -> str:

--- a/src/pytest_plugins/consume/hive_simulators/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/conftest.py
@@ -219,7 +219,6 @@ def test_case_description(
 
     description = description.strip()
     description = description.replace("\n", "<br/>")
-    logger.info(f"Test case description:\n{description}")
     return description
 
 

--- a/src/pytest_plugins/consume/hive_simulators/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/conftest.py
@@ -114,6 +114,7 @@ def filtered_hive_options(hive_info: HiveInfo) -> List[str]:
     logger.info("Hive info: %s", hive_info.command)
 
     unwanted_options = [
+        "--client",  # we specify a single client
         "--client-file",  # we'll write our own client file
         "--results-root",  # use default value instead (or you have to pass to ./hiveview)
         "--sim.limit",  # we specify this ourselves to only run the current test case id
@@ -143,10 +144,12 @@ def filtered_hive_options(hive_info: HiveInfo) -> List[str]:
 def hive_consume_command(
     test_case: TestCaseIndexFile | TestCaseStream,
     filtered_hive_options: List[str],
+    client_type: ClientType,
 ) -> str:
     """Command to run the test within hive."""
     command_parts = filtered_hive_options.copy()
-    command_parts.append(f'--sim.limit "id:{test_case.id}"')
+    command_parts.append(f"--client={client_type.name}")
+    command_parts.append(f'--sim.limit="id:{test_case.id}"')
 
     return " ".join(command_parts)
 

--- a/src/pytest_plugins/pytest_hive/hive_info.py
+++ b/src/pytest_plugins/pytest_hive/hive_info.py
@@ -1,25 +1,54 @@
 """Hive instance information structures."""
 
-from typing import List
+from typing import Dict, List, Optional
 
-from pydantic import BaseModel, Field
+import yaml
+from pydantic import BaseModel, Field, RootModel
 
 from ethereum_test_base_types import CamelModel
 
 
-class ClientInfo(BaseModel):
-    """Client information."""
+class YAMLModel(BaseModel):
+    """A helper class for YAML serialization of pydantic models."""
+
+    def yaml(self, **kwargs):
+        """Return the YAML representation of the model."""
+        return yaml.dump(self.model_dump(), **kwargs)
+
+    @classmethod
+    def parse_yaml(cls, yaml_string):
+        """Parse a YAML string into a model instance."""
+        data = yaml.safe_load(yaml_string)
+        return cls(**data)
+
+
+class ClientConfig(YAMLModel):
+    """
+    Client configuration for YAML serialization.
+
+    Represents a single client entry in the clients.yaml file.
+    """
 
     client: str
-    nametag: str | None = None
-    dockerfile: str | None = None
-    build_args: dict[str, str] | None = None
+    nametag: Optional[str] = None
+    dockerfile: Optional[str] = None
+    build_args: Optional[Dict[str, str]] = Field(default_factory=lambda: {})
+
+
+class ClientFile(RootModel, YAMLModel):
+    """
+    Represents the entire clients.yaml file structure.
+
+    The clients.yaml file is a list of client configurations.
+    """
+
+    root: List[ClientConfig]
 
 
 class HiveInfo(CamelModel):
     """Hive instance information."""
 
     command: List[str]
-    client_file: List[ClientInfo] = Field(default_factory=list)
+    client_file: ClientFile = Field(default_factory=lambda: ClientFile(root=[]))
     commit: str
     date: str

--- a/src/pytest_plugins/pytest_hive/pytest_hive.py
+++ b/src/pytest_plugins/pytest_hive/pytest_hive.py
@@ -34,7 +34,6 @@ import os
 import warnings
 from dataclasses import asdict
 from pathlib import Path
-from typing import List
 
 import pytest
 from filelock import FileLock
@@ -43,7 +42,7 @@ from hive.simulation import Simulation
 from hive.testing import HiveTest, HiveTestResult, HiveTestSuite
 
 from ..logging import get_logger
-from .hive_info import ClientInfo, HiveInfo
+from .hive_info import ClientFile, HiveInfo
 
 logger = get_logger(__name__)
 
@@ -122,7 +121,7 @@ def pytest_report_header(config, start_path):
             f"hive commit: {hive_info.commit}",
             f"hive date: {hive_info.date}",
         ]
-        for client in hive_info.client_file:
+        for client in hive_info.client_file.root:
             header_lines += [
                 f"hive client ({client.client}): {client.model_dump_json(exclude_none=True)}",
             ]
@@ -160,10 +159,10 @@ def hive_info(simulator: Simulation):
 
 
 @pytest.fixture(scope="session")
-def client_file(hive_info: HiveInfo | None) -> List[ClientInfo]:
+def client_file(hive_info: HiveInfo | None) -> ClientFile:
     """Return the client file used when launching hive."""
     if hive_info is None:
-        return []
+        return ClientFile(root=[])
     return hive_info.client_file
 
 

--- a/src/pytest_plugins/shared/execute_fill.py
+++ b/src/pytest_plugins/shared/execute_fill.py
@@ -158,11 +158,7 @@ def test_case_description(request: pytest.FixtureRequest) -> str:
     if hasattr(request.node, "cls"):
         test_class_doc = f"Test class documentation:\n{request.cls.__doc__}" if request.cls else ""
     if hasattr(request.node, "function"):
-        test_function_doc = (
-            f"Test function documentation:\n{request.function.__doc__}"
-            if request.function.__doc__
-            else ""
-        )
+        test_function_doc = f"{request.function.__doc__}" if request.function.__doc__ else ""
     if not test_class_doc and not test_function_doc:
         return description_unavailable
     combined_docstring = f"{test_class_doc}\n\n{test_function_doc}".strip()

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -883,3 +883,4 @@ coeffs
 uncomp
 isogeny
 codomain
+nametag


### PR DESCRIPTION
## 🗒️ Description
Fixes the commands in the test description that is shown in the Hive UI to help client devs reproduce fails:
- Adds a separate command to write the client yaml file.
- Newly uses the `HiveInfo` instance obtained from the `/hive` endpoint to get the exact hive command used, cf:
  - https://github.com/ethereum/hive/pull/1198 
  - https://github.com/marioevz/hive.py/pull/8

#### Before
bc8713ee14
![image](https://github.com/user-attachments/assets/12d26a82-7518-41da-b0cc-0411b3d28ace)
#### After
![image](https://github.com/user-attachments/assets/7f8d2f71-04c4-4270-a72c-3ed150545437)

##### Commands from screenshot:
```
echo "\
- build_args:
    GOPROXY: https://goproxy.primary.production.platform.ethpandaops.io
    github: ethereum/go-ethereum
    tag: master
  client: go-ethereum
  dockerfile: git
  nametag: default
" > clients_eest.yaml
./hive --sim ethereum/eest/consume-engine --client.checktimelimit=180s --docker.buildoutput --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/v4.3.0/fixtures_develop.tar.gz --sim.buildarg branch=fix/consume-reproduce-command --sim.loglevel=3 --docker.nocache consume --client-file clients_eest.yaml --client=go-ethereum_default --sim.limit="id:tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Shanghai-blockchain_test_engine_from_state_test]"
```
and
```
./hive --dev --client-file clients.yaml --client go-ethereum_default
uv run consume engine --input https://github.com/ethereum/execution-spec-tests/releases/download/v4.3.0/fixtures_develop.tar.gz --sim.limit="id:tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Cancun-blockchain_test_engine_from_state_test]" -v -s
```

## 🔗 Related Issues
Follow-up to:
- https://github.com/ethereum/execution-spec-tests/pull/1044

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).

