### PR TITLE
feat(tests): add eip-2929 precompile address warming tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,7 @@ Users can expect that all tests currently living in [ethereum/tests](https://git
 - ✨ [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702): Test that DELEGATECALL to a 7702 target works as intended ([#1485](https://github.com/ethereum/execution-spec-tests/pull/1485)).
 - ✨ [EIP-2573](https://eips.ethereum.org/EIPS/eip-2537): Includes a BLS12 point generator, alongside additional coverage many of the precompiles ([#1350](https://github.com/ethereum/execution-spec-tests/pull/1350)).
 - ✨ Add all [`GeneralStateTests` from `ethereum/tests`](https://github.com/ethereum/tests/tree/7dc757ec132e372b6178a016b91f4c639f366c02/src/GeneralStateTestsFiller) to `execution-spec-tests` located now at [tests/static/state_tests](https://github.com/ethereum/execution-spec-tests/tree/main/tests/static/state_tests) ([#1442](https://github.com/ethereum/execution-spec-tests/pull/1442)).
+- ✨ [EIP-2929](https://eips.ethereum.org/EIPS/eip-2929): Test that precompile addresses are cold/warm depending on the fork they are activated ([#1495](https://github.com/ethereum/execution-spec-tests/pull/1495)).
 
 ## [v4.3.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v4.3.0) - 2025-04-18
 

--- a/src/pytest_plugins/consume/hive_simulators/ruleset.py
+++ b/src/pytest_plugins/consume/hive_simulators/ruleset.py
@@ -302,7 +302,7 @@ ruleset = {
         "HIVE_TERMINAL_TOTAL_DIFFICULTY": 0,
         "HIVE_SHANGHAI_TIMESTAMP": 0,
     },
-    "MergeToShanghaiAtTime15k": {
+    "ParisToShanghaiAtTime15k": {
         "HIVE_FORK_HOMESTEAD": 0,
         "HIVE_FORK_TANGERINE": 0,
         "HIVE_FORK_SPURIOUS": 0,

--- a/tests/berlin/eip2929_gas_cost_increases/__init__.py
+++ b/tests/berlin/eip2929_gas_cost_increases/__init__.py
@@ -1,0 +1,4 @@
+"""
+abstract: Tests [EIP-2929: Gas cost increases for state access opcodes](https://eips.ethereum.org/EIPS/eip-2929)
+    Test cases for [EIP-2929: Gas cost increases for state access opcodes](https://eips.ethereum.org/EIPS/eip-2929).
+"""  # noqa: E501

--- a/tests/berlin/eip2929_gas_cost_increases/test_precompile_warming.py
+++ b/tests/berlin/eip2929_gas_cost_increases/test_precompile_warming.py
@@ -1,0 +1,147 @@
+"""
+abstract: Tests [EIP-2929: Gas cost increases for state access opcodes](https://eips.ethereum.org/EIPS/eip-2929)
+    Test cases for [EIP-2929: Gas cost increases for state access opcodes](https://eips.ethereum.org/EIPS/eip-2929).
+"""  # noqa: E501
+
+from typing import Iterator, Tuple
+
+import pytest
+
+from ethereum_test_forks import (
+    Fork,
+    get_transition_fork_predecessor,
+    get_transition_fork_successor,
+)
+from ethereum_test_tools import (
+    Account,
+    Address,
+    Alloc,
+    Block,
+    BlockchainTestFiller,
+    Transaction,
+)
+from ethereum_test_tools.vm.opcode import Opcodes as Op
+
+REFERENCE_SPEC_GIT_PATH = "EIPS/eip-2929.md"
+REFERENCE_SPEC_VERSION = "0e11417265a623adb680c527b15d0cb6701b870b"
+
+
+def precompile_addresses_in_predecessor_successor(
+    fork: Fork,
+) -> Iterator[Tuple[Address, bool, bool]]:
+    """
+    Yield the addresses of precompiled contracts and whether they existed in the parent fork.
+
+    Args:
+        fork (Fork): The transition fork instance containing precompiled contract information.
+
+    Yields:
+        Iterator[Tuple[str, bool]]: A tuple containing the address in hexadecimal format and a
+            boolean indicating whether the address has existed in the predecessor.
+
+    """
+    predecessor_precompiles = set(get_transition_fork_predecessor(fork).precompiles())
+    successor_precompiles = set(get_transition_fork_successor(fork).precompiles())
+    all_precompiles = successor_precompiles | predecessor_precompiles
+    highest_precompile = int.from_bytes(max(all_precompiles))
+    extra_range = 5
+    extra_precompiles = {
+        Address(i) for i in range(highest_precompile + 1, highest_precompile + extra_range)
+    }
+    all_precompiles = all_precompiles | extra_precompiles
+    for address in sorted(all_precompiles):
+        yield address, address in successor_precompiles, address in predecessor_precompiles
+
+
+@pytest.mark.valid_at_transition_to("Paris", subsequent_forks=True)
+@pytest.mark.parametrize_by_fork(
+    "address,precompile_in_successor,precompile_in_predecessor",
+    precompile_addresses_in_predecessor_successor,
+)
+def test_precompile_warming(
+    blockchain_test: BlockchainTestFiller,
+    fork: Fork,
+    address: Address,
+    precompile_in_successor: bool,
+    precompile_in_predecessor: bool,
+    pre: Alloc,
+):
+    """
+    Call BALANCE of a precompile addresses before and after a fork.
+
+    According to EIP-2929, when a transaction begins, accessed_addresses is initialized to include:
+    - tx.sender, tx.to
+    - and the set of all precompiles
+
+    This test verifies that:
+    1. Precompiles that exist in the predecessor fork are always "warm" (lower gas cost)
+    2. New precompiles added in a fork are "cold" before the fork and become "warm" after
+
+    """
+    sender = pre.fund_eoa()
+    call_cost_slot = 0
+
+    code = (
+        Op.GAS
+        + Op.BALANCE(address)
+        + Op.POP
+        + Op.SSTORE(call_cost_slot, Op.SUB(Op.SWAP1, Op.GAS))
+        + Op.STOP
+    )
+    before = pre.deploy_contract(code, storage={call_cost_slot: 0xDEADBEEF})
+    after = pre.deploy_contract(code, storage={call_cost_slot: 0xDEADBEEF})
+
+    # Block before fork
+    blocks = [
+        Block(
+            timestamp=10_000,
+            txs=[
+                Transaction(
+                    sender=sender,
+                    to=before,
+                    gas_limit=1_000_000,
+                )
+            ],
+        )
+    ]
+
+    # Block after fork
+    blocks += [
+        Block(
+            timestamp=20_000,
+            txs=[
+                Transaction(
+                    sender=sender,
+                    to=after,
+                    gas_limit=1_000_000,
+                )
+            ],
+        )
+    ]
+
+    predecessor = get_transition_fork_predecessor(fork)
+    successor = get_transition_fork_successor(fork)
+
+    def get_expected_gas(precompile_present: bool, fork: Fork) -> int:
+        gas_costs = fork.gas_costs()
+        warm_access_cost = gas_costs.G_WARM_ACCOUNT_ACCESS
+        cold_access_cost = gas_costs.G_COLD_ACCOUNT_ACCESS
+        extra_cost = gas_costs.G_BASE * 2 + gas_costs.G_VERY_LOW
+        if precompile_present:
+            return warm_access_cost + extra_cost
+        else:
+            return cold_access_cost + extra_cost
+
+    expected_gas_before = get_expected_gas(precompile_in_predecessor, predecessor)
+    expected_gas_after = get_expected_gas(precompile_in_successor, successor)
+
+    post = {
+        before: Account(storage={call_cost_slot: expected_gas_before}),
+        after: Account(storage={call_cost_slot: expected_gas_after}),
+    }
+
+    blockchain_test(
+        pre=pre,
+        post=post,
+        blocks=blocks,
+    )

--- a/tests/berlin/eip2929_gas_cost_increases/test_precompile_warming.py
+++ b/tests/berlin/eip2929_gas_cost_increases/test_precompile_warming.py
@@ -44,7 +44,7 @@ def precompile_addresses_in_predecessor_successor(
     successor_precompiles = set(get_transition_fork_successor(fork).precompiles())
     all_precompiles = successor_precompiles | predecessor_precompiles
     highest_precompile = int.from_bytes(max(all_precompiles))
-    extra_range = 5
+    extra_range = 32
     extra_precompiles = {
         Address(i) for i in range(highest_precompile + 1, highest_precompile + extra_range)
     }

--- a/tests/frontier/precompiles/test_precompiles.py
+++ b/tests/frontier/precompiles/test_precompiles.py
@@ -178,8 +178,8 @@ def test_precompile_warming(
         + Op.SSTORE(call_cost_slot, Op.SUB(Op.SWAP1, Op.GAS))
         + Op.STOP
     )
-    before = pre.deploy_contract(code, storage={0: 0xDEADBEEF})
-    after = pre.deploy_contract(code, storage={0: 0xDEADBEEF})
+    before = pre.deploy_contract(code, storage={call_cost_slot: 0xDEADBEEF})
+    after = pre.deploy_contract(code, storage={call_cost_slot: 0xDEADBEEF})
 
     # Block before fork
     blocks = [

--- a/tests/frontier/precompiles/test_precompiles.py
+++ b/tests/frontier/precompiles/test_precompiles.py
@@ -4,10 +4,16 @@ from typing import Iterator, Tuple
 
 import pytest
 
-from ethereum_test_forks import Fork
+from ethereum_test_forks import (
+    Fork,
+    get_transition_fork_predecessor,
+    get_transition_fork_successor,
+)
 from ethereum_test_tools import (
     Account,
     Alloc,
+    Block,
+    BlockchainTestFiller,
     Environment,
     StateTestFiller,
     Transaction,
@@ -109,3 +115,107 @@ def test_precompiles(
     post = {account: Account(storage={0: "0x00" if precompile_exists else "0x01"})}
 
     state_test(env=env, pre=pre, post=post, tx=tx)
+
+
+def precompile_addresses_in_successor(fork: Fork) -> Iterator[Tuple[str, bool]]:
+    """
+    Yield the addresses of precompiled contracts and whether they existed in the parent fork.
+
+    Args:
+        fork (Fork): The transition fork instance containing precompiled contract information.
+
+    Yields:
+        Iterator[Tuple[str, bool]]: A tuple containing the address in hexadecimal format and a
+            boolean indicating whether the address has existed in the predecessor.
+
+    """
+    predecessor_precompiles = [
+        hex(int.from_bytes(address, byteorder="big"))
+        for address in get_transition_fork_predecessor(fork).precompiles()
+    ]
+    successor_precompiles = [
+        hex(int.from_bytes(address, byteorder="big"))
+        for address in get_transition_fork_successor(fork).precompiles()
+    ]
+    for address in successor_precompiles:
+        if address in predecessor_precompiles:
+            yield address, True
+        else:
+            yield address, False
+
+
+@pytest.mark.valid_at_transition_to("Paris", subsequent_forks=True)
+@pytest.mark.parametrize_by_fork(
+    "address,exists_in_predecessor", precompile_addresses_in_successor
+)
+def test_precompile_warming(
+    blockchain_test: BlockchainTestFiller, address: str, exists_in_predecessor: bool, pre: Alloc
+):
+    """
+    Call BALANCE of a precompile addresses before and after a fork.
+
+    According to EIP-2929, when a transaction begins, accessed_addresses is initialized to include:
+    - tx.sender, tx.to
+    - and the set of all precompiles
+
+    This test verifies that:
+    1. Precompiles that exist in the predecessor fork are always "warm" (lower gas cost)
+    2. New precompiles added in a fork are "cold" before the fork and become "warm" after
+
+    """
+    sender = pre.fund_eoa()
+    call_cost_slot = 0
+
+    code = (
+        Op.GAS
+        + Op.BALANCE(address)
+        + Op.POP
+        + Op.SSTORE(call_cost_slot, Op.SUB(Op.SWAP1, Op.GAS))
+        + Op.STOP
+    )
+    before = pre.deploy_contract(code, storage={0: 0xDEADBEEF})
+    after = pre.deploy_contract(code, storage={0: 0xDEADBEEF})
+
+    # Block before fork
+    blocks = [
+        Block(
+            timestamp=10000,
+            txs=[
+                Transaction(
+                    sender=sender,
+                    to=before,
+                    gas_limit=1_000_000,
+                )
+            ],
+        )
+    ]
+
+    # Block after fork
+    blocks += [
+        Block(
+            timestamp=20000,
+            txs=[
+                Transaction(
+                    sender=sender,
+                    to=after,
+                    gas_limit=1_000_000,
+                )
+            ],
+        )
+    ]
+
+    if not exists_in_predecessor:
+        expected_gas_before = 2607
+    else:
+        expected_gas_before = 107
+
+    post = {
+        before: Account(storage={call_cost_slot: expected_gas_before}),
+        after: Account(storage={call_cost_slot: 107}),
+    }
+
+    blockchain_test(
+        pre=pre,
+        post=post,
+        blocks=blocks,
+    )

--- a/tests/frontier/precompiles/test_precompiles.py
+++ b/tests/frontier/precompiles/test_precompiles.py
@@ -4,9 +4,7 @@ from typing import Iterator, Tuple
 
 import pytest
 
-from ethereum_test_forks import (
-    Fork,
-)
+from ethereum_test_forks import Fork
 from ethereum_test_tools import (
     Account,
     Alloc,

--- a/tests/frontier/precompiles/test_precompiles.py
+++ b/tests/frontier/precompiles/test_precompiles.py
@@ -6,15 +6,10 @@ import pytest
 
 from ethereum_test_forks import (
     Fork,
-    get_transition_fork_predecessor,
-    get_transition_fork_successor,
 )
 from ethereum_test_tools import (
     Account,
-    Address,
     Alloc,
-    Block,
-    BlockchainTestFiller,
     Environment,
     StateTestFiller,
     Transaction,
@@ -116,122 +111,3 @@ def test_precompiles(
     post = {account: Account(storage={0: "0x00" if precompile_exists else "0x01"})}
 
     state_test(env=env, pre=pre, post=post, tx=tx)
-
-
-def precompile_addresses_in_predecessor_successor(fork: Fork) -> Iterator[Tuple[Address, bool]]:
-    """
-    Yield the addresses of precompiled contracts and whether they existed in the parent fork.
-
-    Args:
-        fork (Fork): The transition fork instance containing precompiled contract information.
-
-    Yields:
-        Iterator[Tuple[str, bool]]: A tuple containing the address in hexadecimal format and a
-            boolean indicating whether the address has existed in the predecessor.
-
-    """
-    predecessor_precompiles = set(get_transition_fork_predecessor(fork).precompiles())
-    successor_precompiles = set(get_transition_fork_successor(fork).precompiles())
-    all_precompiles = successor_precompiles | predecessor_precompiles
-    highest_precompile = int.from_bytes(max(all_precompiles))
-    extra_range = 5
-    extra_precompiles = {
-        Address(i) for i in range(highest_precompile + 1, highest_precompile + extra_range)
-    }
-    all_precompiles = all_precompiles | extra_precompiles
-    for address in sorted(all_precompiles):
-        yield address, address in successor_precompiles, address in predecessor_precompiles
-
-
-@pytest.mark.valid_at_transition_to("Paris", subsequent_forks=True)
-@pytest.mark.parametrize_by_fork(
-    "address,precompile_in_successor,precompile_in_predecessor",
-    precompile_addresses_in_predecessor_successor,
-)
-def test_precompile_warming(
-    blockchain_test: BlockchainTestFiller,
-    fork: Fork,
-    address: Address,
-    precompile_in_successor: bool,
-    precompile_in_predecessor: bool,
-    pre: Alloc,
-):
-    """
-    Call BALANCE of a precompile addresses before and after a fork.
-
-    According to EIP-2929, when a transaction begins, accessed_addresses is initialized to include:
-    - tx.sender, tx.to
-    - and the set of all precompiles
-
-    This test verifies that:
-    1. Precompiles that exist in the predecessor fork are always "warm" (lower gas cost)
-    2. New precompiles added in a fork are "cold" before the fork and become "warm" after
-
-    """
-    sender = pre.fund_eoa()
-    call_cost_slot = 0
-
-    code = (
-        Op.GAS
-        + Op.BALANCE(address)
-        + Op.POP
-        + Op.SSTORE(call_cost_slot, Op.SUB(Op.SWAP1, Op.GAS))
-        + Op.STOP
-    )
-    before = pre.deploy_contract(code, storage={call_cost_slot: 0xDEADBEEF})
-    after = pre.deploy_contract(code, storage={call_cost_slot: 0xDEADBEEF})
-
-    # Block before fork
-    blocks = [
-        Block(
-            timestamp=10_000,
-            txs=[
-                Transaction(
-                    sender=sender,
-                    to=before,
-                    gas_limit=1_000_000,
-                )
-            ],
-        )
-    ]
-
-    # Block after fork
-    blocks += [
-        Block(
-            timestamp=20_000,
-            txs=[
-                Transaction(
-                    sender=sender,
-                    to=after,
-                    gas_limit=1_000_000,
-                )
-            ],
-        )
-    ]
-
-    predecessor = get_transition_fork_predecessor(fork)
-    successor = get_transition_fork_successor(fork)
-
-    def get_expected_gas(precompile_present: bool, fork: Fork) -> int:
-        gas_costs = fork.gas_costs()
-        warm_access_cost = gas_costs.G_WARM_ACCOUNT_ACCESS
-        cold_access_cost = gas_costs.G_COLD_ACCOUNT_ACCESS
-        extra_cost = gas_costs.G_BASE * 2 + gas_costs.G_VERY_LOW
-        if precompile_present:
-            return warm_access_cost + extra_cost
-        else:
-            return cold_access_cost + extra_cost
-
-    expected_gas_before = get_expected_gas(precompile_in_predecessor, predecessor)
-    expected_gas_after = get_expected_gas(precompile_in_successor, successor)
-
-    post = {
-        before: Account(storage={call_cost_slot: expected_gas_before}),
-        after: Account(storage={call_cost_slot: expected_gas_after}),
-    }
-
-    blockchain_test(
-        pre=pre,
-        post=post,
-        blocks=blocks,
-    )


### PR DESCRIPTION
## 🗒️ Description

Idea from @jochem-brouwer - thanks! Please check whether this test is doing what you intended.

Call BALANCE of a precompile address before and after a fork.

According to EIP-2929, when a transaction begins, accessed_addresses is initialized to include:
- tx.sender, tx.to
- and the set of all precompiles

This test verifies that:
1. Precompiles that exist in the predecessor fork are always "warm" (lower gas cost)
2. New precompiles added in a fork are "cold" before the fork and become "warm" after

These would perhaps be better as state tests. Feel free to close and implement a better suggestion, but happy for any feedback if you have time!

Also, this test should live in tests/paris, not tests/frontier, as they're only valid for EIP-2929, but it seemed silly to separate them from the other precompile generator tests. 

The test uses a generator; it generates these tests:
```
fill --fork CancunToPragueAtTime15k tests/frontier/precompiles/test_precompiles.py -k test_precompile_warming --collect-only -q -m blockchain_test
 pytest-regex selected 37 tests to run for regex: .*
tests/frontier/precompiles/test_precompiles.py::test_precompile_warming[fork_CancunToPragueAtTime15k-address_0xb-exists_in_predecessor_False-blockchain_test]
tests/frontier/precompiles/test_precompiles.py::test_precompile_warming[fork_CancunToPragueAtTime15k-address_0xc-exists_in_predecessor_False-blockchain_test]
tests/frontier/precompiles/test_precompiles.py::test_precompile_warming[fork_CancunToPragueAtTime15k-address_0xd-exists_in_predecessor_False-blockchain_test]
tests/frontier/precompiles/test_precompiles.py::test_precompile_warming[fork_CancunToPragueAtTime15k-address_0xe-exists_in_predecessor_False-blockchain_test]
tests/frontier/precompiles/test_precompiles.py::test_precompile_warming[fork_CancunToPragueAtTime15k-address_0xf-exists_in_predecessor_False-blockchain_test]
tests/frontier/precompiles/test_precompiles.py::test_precompile_warming[fork_CancunToPragueAtTime15k-address_0x10-exists_in_predecessor_False-blockchain_test]
tests/frontier/precompiles/test_precompiles.py::test_precompile_warming[fork_CancunToPragueAtTime15k-address_0x11-exists_in_predecessor_False-blockchain_test]
tests/frontier/precompiles/test_precompiles.py::test_precompile_warming[fork_CancunToPragueAtTime15k-address_0xa-exists_in_predecessor_True-blockchain_test]
tests/frontier/precompiles/test_precompiles.py::test_precompile_warming[fork_CancunToPragueAtTime15k-address_0x9-exists_in_predecessor_True-blockchain_test]
tests/frontier/precompiles/test_precompiles.py::test_precompile_warming[fork_CancunToPragueAtTime15k-address_0x5-exists_in_predecessor_True-blockchain_test]
tests/frontier/precompiles/test_precompiles.py::test_precompile_warming[fork_CancunToPragueAtTime15k-address_0x6-exists_in_predecessor_True-blockchain_test]
tests/frontier/precompiles/test_precompiles.py::test_precompile_warming[fork_CancunToPragueAtTime15k-address_0x7-exists_in_predecessor_True-blockchain_test]
tests/frontier/precompiles/test_precompiles.py::test_precompile_warming[fork_CancunToPragueAtTime15k-address_0x8-exists_in_predecessor_True-blockchain_test]
tests/frontier/precompiles/test_precompiles.py::test_precompile_warming[fork_CancunToPragueAtTime15k-address_0x1-exists_in_predecessor_True-blockchain_test]
tests/frontier/precompiles/test_precompiles.py::test_precompile_warming[fork_CancunToPragueAtTime15k-address_0x2-exists_in_predecessor_True-blockchain_test]
tests/frontier/precompiles/test_precompiles.py::test_precompile_warming[fork_CancunToPragueAtTime15k-address_0x3-exists_in_predecessor_True-blockchain_test]
tests/frontier/precompiles/test_precompiles.py::test_precompile_warming[fork_CancunToPragueAtTime15k-address_0x4-exists_in_predecessor_True-blockchain_test]
```

## 🔗 Related Issues
None

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).

