### PR TITLE
zkevm: keccak worst-case

### DIFF
--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -10,7 +10,8 @@ import math
 import pytest
 
 from ethereum_test_forks import Fork
-from ethereum_test_tools import Alloc, Block, BlockchainTestFiller, Environment, Transaction
+from ethereum_test_tools import (Alloc, Block, BlockchainTestFiller,
+                                 Environment, Transaction)
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 REFERENCE_SPEC_GIT_PATH = "TODO"
@@ -26,9 +27,6 @@ KECCAK_RATE = 136
     "gas_limit",
     [
         36_000_000,
-        60_000_000,
-        100_000_000,
-        300_000_000,
     ],
 )
 def test_worst_keccak(

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -55,7 +55,8 @@ def test_worst_keccak(
             + math.ceil(i / 32) * gsc.G_KECCAK_256_WORD  # KECCAK256 dynamic cost
             + gsc.G_BASE  # POP
         )
-        # From the available gas, we substract the mem expansion costs considering we know the current input size length i.
+        # From the available gas, we substract the mem expansion costs considering we know the
+        # current input size length i.
         available_gas_after_expansion = max(0, available_gas - mem_exp_gas_calculator(new_bytes=i))
         # Calculate how many calls we can do.
         num_keccak_calls = available_gas_after_expansion // iteration_gas_cost

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -74,8 +74,8 @@ def test_worst_keccak(
     # Now calculate available gas for [attack iteration]:
     #   Numerator = MAX_CODE_SIZE-3. The -3 is for the JUMPDEST, PUSH0 and JUMP.
     #   Denominator = (PUSHN + PUSH1 + KECCAK256 + POP) + PUSH1_DATA + PUSHN_DATA
-    # TODO: the testing framework uses PUSH1(0) instead of PUSH0 which is suboptimal for the attack,
-    # whenever this is fixed adjust accordingly.
+    # TODO: the testing framework uses PUSH1(0) instead of PUSH0 which is suboptimal for the
+    # attack, whenever this is fixed adjust accordingly.
     max_iters_loop = (MAX_CODE_SIZE - 3) // (4 + 1 + (optimal_input_length.bit_length() + 7) // 8)
     code = (
         Op.JUMPDEST

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -1,0 +1,106 @@
+"""
+abstract: Tests zkEVMs worst-case compute scenarios.
+    Tests zkEVMs worst-case compute scenarios.
+
+Tests running worst-case compute opcodes and precompile scenarios for zkEVMs.
+"""
+
+import math
+
+import pytest
+
+from ethereum_test_forks import Fork
+from ethereum_test_tools import Alloc, Block, BlockchainTestFiller, Environment, Transaction
+from ethereum_test_tools.vm.opcode import Opcodes as Op
+
+REFERENCE_SPEC_GIT_PATH = "TODO"
+REFERENCE_SPEC_VERSION = "TODO"
+
+MAX_CODE_SIZE = 24 * 1024
+KECCAK_RATE = 136
+
+
+@pytest.mark.zkevm
+@pytest.mark.valid_from("Cancun")
+@pytest.mark.parametrize(
+    "gas_limit",
+    [
+        36_000_000,
+        60_000_000,
+        100_000_000,
+        300_000_000,
+    ],
+)
+def test_worst_keccak(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    gas_limit: int,
+):
+    """Test running a block with as many KECCAK256 permutations as possible."""
+    env = Environment(gas_limit=gas_limit)
+
+    # Intrinsic gas cost is paid once.
+    intrinsic_gasc_calculator = fork.transaction_intrinsic_cost_calculator()
+    available_gas = gas_limit - intrinsic_gasc_calculator()
+
+    gsc = fork.gas_costs()
+    mem_exp_gas_calculator = fork.memory_expansion_gas_calculator()
+
+    # Discover the optimal input size to maximize keccak-permutations, not keccak calls.
+    # The complication of the discovery arises from the non-linear gas cost of memory expansion.
+    max_keccak_perm_per_block = 0
+    optimal_input_length = 0
+    for i in range(1, 1_000_000, 32):
+        iteration_gas_cost = (
+            2 * gsc.G_VERY_LOW  # PUSHN + PUSH1
+            + gsc.G_KECCAK_256  # KECCAK256 static cost
+            + math.ceil(i / 32) * gsc.G_KECCAK_256_WORD  # KECCAK256 dynamic cost
+            + gsc.G_BASE  # POP
+        )
+        available_gas_after_expansion = max(0, available_gas - mem_exp_gas_calculator(new_bytes=i))
+        num_keccak_calls = available_gas_after_expansion // iteration_gas_cost
+        num_keccak_permutations = num_keccak_calls * math.ceil(i / KECCAK_RATE)
+
+        if num_keccak_permutations > max_keccak_perm_per_block:
+            max_keccak_perm_per_block = num_keccak_permutations
+            optimal_input_length = i
+
+    # max_iters_loop contains how many keccak calls can be done per loop.
+    # The loop is as big as possible bounded by the maximum code size.
+    #
+    # The loop structure is: JUMPDEST + [attack iteration] + PUSH0 + JUMP
+    #
+    # Now calculate available gas for [attack iteration]:
+    #   Numerator = MAX_CODE_SIZE-3. The -3 is for the JUMPDEST, PUSH0 and JUMP.
+    #   Denominator = (PUSHN + PUSH1 + KECCAK256 + POP) + PUSH1_DATA + PUSHN_DATA
+    # TODO: the testing framework uses PUSH1(0) instead of PUSH0 which is suboptimal for the attack,
+    # whenever this is fixed adjust accordingly.
+    max_iters_loop = (MAX_CODE_SIZE - 3) // (4 + 1 + (optimal_input_length.bit_length() + 7) // 8)
+    code = (
+        Op.JUMPDEST
+        + sum([Op.SHA3(0, optimal_input_length) + Op.POP] * max_iters_loop)
+        + Op.PUSH0
+        + Op.JUMP
+    )
+    if len(code) > MAX_CODE_SIZE:
+        # Must never happen, but keep it as a sanity check.
+        raise ValueError(f"Code size {len(code)} exceeds maximum code size {MAX_CODE_SIZE}")
+
+    code_address = pre.deploy_contract(code=bytes(code))
+
+    tx = Transaction(
+        to=code_address,
+        gas_limit=gas_limit,
+        gas_price=10,
+        sender=pre.fund_eoa(),
+        data=[],
+        value=0,
+    )
+
+    blockchain_test(
+        env=env,
+        pre=pre,
+        post={},
+        blocks=[Block(txs=[tx])],
+    )

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -10,8 +10,7 @@ import math
 import pytest
 
 from ethereum_test_forks import Fork
-from ethereum_test_tools import (Alloc, Block, BlockchainTestFiller,
-                                 Environment, Transaction)
+from ethereum_test_tools import Alloc, Block, BlockchainTestFiller, Environment, Transaction
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 REFERENCE_SPEC_GIT_PATH = "TODO"

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -6,7 +6,6 @@ Tests running worst-case compute opcodes and precompile scenarios for zkEVMs.
 """
 
 import math
-import time
 
 import pytest
 
@@ -45,8 +44,6 @@ def test_worst_keccak(
     gsc = fork.gas_costs()
     mem_exp_gas_calculator = fork.memory_expansion_gas_calculator()
 
-    start = time.time()  # Start time in seconds (float)
-
     # Discover the optimal input size to maximize keccak-permutations, not keccak calls.
     # The complication of the discovery arises from the non-linear gas cost of memory expansion.
     max_keccak_perm_per_block = 0
@@ -70,11 +67,6 @@ def test_worst_keccak(
             max_keccak_perm_per_block = num_keccak_permutations
             optimal_input_length = i
 
-    end = time.time()  # End time
-
-    # Calculate duration in milliseconds
-    duration_ms = (end - start) * 1000
-    print(f"Execution time: {duration_ms:.2f} ms")
     # max_iters_loop contains how many keccak calls can be done per loop.
     # The loop is as big as possible bounded by the maximum code size.
     #
@@ -89,11 +81,7 @@ def test_worst_keccak(
     loop_code = Op.POP(Op.SHA3(Op.PUSH0, Op.DUP1))
     end_code = Op.POP + Op.JUMP(Op.PUSH0)
     max_iters_loop = (MAX_CODE_SIZE - (len(start_code) + len(end_code))) // len(loop_code)
-    code = (
-        start_code
-        + (loop_code * max_iters_loop)
-        + end_code
-    )
+    code = start_code + (loop_code * max_iters_loop) + end_code
     if len(code) > MAX_CODE_SIZE:
         # Must never happen, but keep it as a sanity check.
         raise ValueError(f"Code size {len(code)} exceeds maximum code size {MAX_CODE_SIZE}")


### PR DESCRIPTION
This PR adds a test that builds a block to maximize the number of keccak permutations for a given gas limit (considering the max contract size).  

There are two main aspects of the test design.

### Find the optimal input size
The metric we care about is gas per permutation, not simply max opcode calls. Although the dynamic cost of `KECCAK256` is linear in input length, memory expansion is quadratic, so there is a sweet spot for minimal cost per permutation.

Instead of baking magic numbers, the test does a scan for the optimal cost and then does the attack with it. This is much more transparent on how this optimal length is found, plus it sounds also more future-proof.

Another way of understanding the above is by looking at this chart I created from that same script, with a more detailed output:
![image](https://github.com/user-attachments/assets/4feb18aa-2d66-4cfb-9313-21ff7e1e032f)


### The “attack” loop  

Once the optimal length is known, I create a loop that drives as many permutations as the block gas limit allows. The loop shouldn't be a tight loop, but quite the opposite -- run as many calls as possible within the max contract size, so the "JUMP"-like gas overhead is amortized as much as possible.

The general structure is:
```text
JUMPDEST
 (PUSH+PUSH+KECCAK256+POP)
 ...
PUSH0
JUMP
```

Note that for 36M you can fit the `(....)` without a loop since the max you can add fits within 24KiB contract limit. But for bigger gas limits, you run short with 24KiB and need the loop!

---

zkVM cycles: 36m gas -> 632 million cycles
