### PR TITLE
fix(geth): fixes geth error mappings

### DIFF
--- a/src/ethereum_clis/clis/geth.py
+++ b/src/ethereum_clis/clis/geth.py
@@ -70,6 +70,7 @@ class GethExceptionMapper(ExceptionMapper):
         BlockException.INVALID_VERSIONED_HASHES: "invalid number of versionedHashes",
         BlockException.INVALID_REQUESTS: "invalid requests hash",
         BlockException.INVALID_BLOCK_HASH: "blockhash mismatch",
+        BlockException.SYSTEM_CONTRACT_CALL_FAILED: "system call failed to execute: \s"
         # TODO EVMONE needs to differentiate when the section is missing in the header or body
         EOFException.MISSING_STOP_OPCODE: "err: no_terminating_instruction",
         EOFException.MISSING_CODE_HEADER: "err: code_section_missing",

--- a/src/ethereum_clis/clis/geth.py
+++ b/src/ethereum_clis/clis/geth.py
@@ -69,6 +69,7 @@ class GethExceptionMapper(ExceptionMapper):
         BlockException.INCORRECT_EXCESS_BLOB_GAS: "invalid excessBlobGas",
         BlockException.INVALID_VERSIONED_HASHES: "invalid number of versionedHashes",
         BlockException.INVALID_REQUESTS: "invalid requests hash",
+        BlockException.SYSTEM_CONTRACT_CALL_FAILED: "system call failed to execute:",
         BlockException.INVALID_BLOCK_HASH: "blockhash mismatch",
         # TODO EVMONE needs to differentiate when the section is missing in the header or body
         EOFException.MISSING_STOP_OPCODE: "err: no_terminating_instruction",
@@ -121,7 +122,6 @@ class GethExceptionMapper(ExceptionMapper):
         BlockException.BLOB_GAS_USED_ABOVE_LIMIT: (
             r"blob gas used \d+ exceeds maximum allowance \d+"
         ),
-        BlockException.SYSTEM_CONTRACT_CALL_FAILED: (r"system call failed to execute: *"),
     }
 
 

--- a/src/ethereum_clis/clis/geth.py
+++ b/src/ethereum_clis/clis/geth.py
@@ -121,9 +121,7 @@ class GethExceptionMapper(ExceptionMapper):
         BlockException.BLOB_GAS_USED_ABOVE_LIMIT: (
             r"blob gas used \d+ exceeds maximum allowance \d+"
         ),
-        BlockException.SYSTEM_CONTRACT_CALL_FAILED: (
-            r"system call failed to execute: *"
-        ),
+        BlockException.SYSTEM_CONTRACT_CALL_FAILED: (r"system call failed to execute: *"),
     }
 
 

--- a/src/ethereum_clis/clis/geth.py
+++ b/src/ethereum_clis/clis/geth.py
@@ -70,7 +70,6 @@ class GethExceptionMapper(ExceptionMapper):
         BlockException.INVALID_VERSIONED_HASHES: "invalid number of versionedHashes",
         BlockException.INVALID_REQUESTS: "invalid requests hash",
         BlockException.INVALID_BLOCK_HASH: "blockhash mismatch",
-        BlockException.SYSTEM_CONTRACT_CALL_FAILED: "system call failed to execute: \s+"
         # TODO EVMONE needs to differentiate when the section is missing in the header or body
         EOFException.MISSING_STOP_OPCODE: "err: no_terminating_instruction",
         EOFException.MISSING_CODE_HEADER: "err: code_section_missing",
@@ -121,6 +120,9 @@ class GethExceptionMapper(ExceptionMapper):
         ),
         BlockException.BLOB_GAS_USED_ABOVE_LIMIT: (
             r"blob gas used \d+ exceeds maximum allowance \d+"
+        ),
+        BlockException.SYSTEM_CONTRACT_CALL_FAILED: (
+            r"system call failed to execute: *"
         ),
     }
 

--- a/src/ethereum_clis/clis/geth.py
+++ b/src/ethereum_clis/clis/geth.py
@@ -70,7 +70,7 @@ class GethExceptionMapper(ExceptionMapper):
         BlockException.INVALID_VERSIONED_HASHES: "invalid number of versionedHashes",
         BlockException.INVALID_REQUESTS: "invalid requests hash",
         BlockException.INVALID_BLOCK_HASH: "blockhash mismatch",
-        BlockException.SYSTEM_CONTRACT_CALL_FAILED: "system call failed to execute: \s"
+        BlockException.SYSTEM_CONTRACT_CALL_FAILED: "system call failed to execute: \s+"
         # TODO EVMONE needs to differentiate when the section is missing in the header or body
         EOFException.MISSING_STOP_OPCODE: "err: no_terminating_instruction",
         EOFException.MISSING_CODE_HEADER: "err: code_section_missing",


### PR DESCRIPTION
## 🗒️ Description
Fixes issues where the error returned by geth does not match the expected ones for system contract failures.
The errors have different reasons (suberrors) that can not be checked. e.g.
`"system call failed to execute: execution reverted"`
`"system call failed to execute: invalid opcode: INVALID"`
So I tried to add a \s to indicate that there might be a string afterwards. Don't know if that works in python

## 🔗 Related Issues
Fixes these errors: https://hive.ethpandaops.io/pectra/suite.html?suiteid=1745760795-339cef2738231feaae6575b0136bc6b0.json#test-4783

## ✅ Checklist

- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
