### PR TITLE
chore(cli): consume direct geth blocktest fail fix

### DIFF
--- a/src/ethereum_clis/clis/geth.py
+++ b/src/ethereum_clis/clis/geth.py
@@ -267,6 +267,18 @@ class GethFixtureConsumer(
                 f"Unexpected exit code:\n{' '.join(command)}\n\n Error:\n{result.stderr}"
             )
 
+        result_json = json.loads(result.stdout)
+        if not isinstance(result_json, list):
+            raise Exception(f"Unexpected result from evm blocktest: {result_json}")
+
+        if any(not test_result["pass"] for test_result in result_json):
+            exception_text = "Blockchain test failed: \n" + "\n".join(
+                f"{test_result['name']}: " + test_result["error"]
+                for test_result in result_json
+                if not test_result["pass"]
+            )
+            raise Exception(exception_text)
+
     @cache  # noqa
     def consume_state_test_file(
         self,


### PR DESCRIPTION
## 🗒️ Description

The refactor from the issue below resulted in missing a check for the test failures when running `consume direct` for geth using blockchain test fixtures. This PR adds a fix such that fails are reported correctly and don't simply pass.

## 🔗 Related Issues
https://github.com/ethereum/execution-spec-tests/pull/935
https://github.com/ethereum/go-ethereum/pull/30854


## ✅ Checklist

- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
