### PR TITLE
feat(github): Add zkevm feature

### DIFF
--- a/.github/configs/evm.yaml
+++ b/.github/configs/evm.yaml
@@ -11,6 +11,11 @@ static:
   repo: ethereum/evmone
   ref: master
   targets: ["evmone-t8n", "evmone-eofparse"]
+zkevm:
+  impl: evmone
+  repo: ethereum/evmone
+  ref: master
+  targets: ["evmone-t8n", "evmone-eofparse"]
 eip7692:
   impl: evmone
   repo: ethereum/evmone

--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -11,6 +11,10 @@ static:
   evm-type: static
   fill-params: --until=Prague --fill-static-tests ./tests/static
   solc: 0.8.21
+zkevm:
+  evm-type: zkevm
+  fill-params: --from=Cancun --until=Prague -m zkevm ./tests
+  solc: 0.8.21
 eip7692:
   evm-type: eip7692
   fill-params: --fork=Osaka ./tests/osaka

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,12 @@ The tests have been filled using the new static test filler introduced in [#1336
 
 Users can expect that all tests currently living in [ethereum/tests](https://github.com/ethereum/tests/tree/develop/src) should eventually make its way into [`./tests/static`](https://github.com/ethereum/execution-spec-tests/tree/main/tests/static) and can rely that these tests, filled for new forks even, will be included in `fixtures_static.tar.gz`.
 
+#### `fixtures_zkevm`
+
+Another new fixture tarball has been included in this release: `fixtures_zkevm.tar.gz`.
+
+Includes tests that are tailored specifically to test the execution layer proof generators.
+
 ### 🛠️ Framework
 
 #### `fill`


### PR DESCRIPTION
## 🗒️ Description
Adds the zkevm feature to generate a separate fixture tarball that contains all zkevm marked tests.

The command to generated the fixtures is `--from=Cancun --until=Prague -m zkevm`, so it will generate tests for two forks, Cancun and Prague, but let me know if this is ok.

cc. @kevaundray

## 🔗 Related Issues
None

## ✅ Checklist

- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
