### PR TITLE
chore: add osaka engine updates

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,8 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 ### 📋 Misc
 
+- ✨ Engine API updates for Osaka, add `get_blobs` rpc method ([#1510](https://github.com/ethereum/execution-spec-tests/pull/1510)).
+
 ### 🧪 Test Cases
 
 ## [v4.4.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v4.4.0) - 2025-04-29

--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -1285,6 +1285,13 @@ class Osaka(Prague, solc_name="cancun"):
     """Osaka fork."""
 
     @classmethod
+    def engine_get_payload_version(
+        cls, block_number: int = 0, timestamp: int = 0
+    ) -> Optional[int]:
+        """From Osaka, get payload calls must use version 5."""
+        return 5
+
+    @classmethod
     def evm_code_types(cls, block_number: int = 0, timestamp: int = 0) -> List[EVMCodeType]:
         """EOF V1 is supported starting from Osaka."""
         return super(Osaka, cls).evm_code_types(

--- a/src/ethereum_test_rpc/rpc.py
+++ b/src/ethereum_test_rpc/rpc.py
@@ -15,6 +15,7 @@ from ethereum_test_types import Transaction
 from .types import (
     ForkchoiceState,
     ForkchoiceUpdateResponse,
+    GetBlobsResponse,
     GetPayloadResponse,
     JSONRPCError,
     PayloadAttributes,
@@ -341,6 +342,21 @@ class EngineRPC(BaseRPC):
             self.post_request(
                 f"getPayloadV{version}",
                 f"{payload_id}",
+            ),
+            context=self.response_validation_context,
+        )
+
+    def get_blobs(
+        self,
+        params: List[Hash],
+        *,
+        version: int,
+    ) -> GetBlobsResponse:
+        """`engine_getBlobsVX`: Retrieves blobs from an execution layers tx pool."""
+        return GetBlobsResponse.model_validate(
+            self.post_request(
+                f"getBlobsV{version}",
+                *[to_json(param) for param in params],
             ),
             context=self.response_validation_context,
         )

--- a/src/ethereum_test_rpc/types.py
+++ b/src/ethereum_test_rpc/types.py
@@ -154,4 +154,4 @@ class GetPayloadResponse(CamelModel):
 class GetBlobsResponse(CamelModel):
     """Represents the response of a get blobs request."""
 
-    result: List[BlobAndProof]
+    result: List[BlobAndProof | None]

--- a/src/ethereum_test_rpc/types.py
+++ b/src/ethereum_test_rpc/types.py
@@ -140,7 +140,8 @@ class BlobAndProof(CamelModel):
     """Represents a blob and proof structure."""
 
     blob: Bytes
-    proofs: List[Bytes]
+    proofs: List[Bytes] | None = None
+    proof: Bytes | None= None
 
 
 class GetPayloadResponse(CamelModel):

--- a/src/ethereum_test_rpc/types.py
+++ b/src/ethereum_test_rpc/types.py
@@ -140,8 +140,9 @@ class BlobAndProof(CamelModel):
     """Represents a blob and proof structure."""
 
     blob: Bytes
-    proofs: List[Bytes] | None = None
-    proof: Bytes | None= None
+    proofs: List[Bytes] | None = None  # >= Osaka (V2)
+
+    proof: Bytes | None = None  # <= Prague (V1)
 
 
 class GetPayloadResponse(CamelModel):

--- a/src/ethereum_test_rpc/types.py
+++ b/src/ethereum_test_rpc/types.py
@@ -136,9 +136,22 @@ class BlobsBundle(CamelModel):
         return [Hash(b"\1" + commitment[1:]) for commitment in self.commitments]
 
 
+class BlobAndProof(CamelModel):
+    """Represents a blob and proof structure."""
+
+    blob: Bytes
+    proofs: List[Bytes]
+
+
 class GetPayloadResponse(CamelModel):
     """Represents the response of a get payload request."""
 
     execution_payload: FixtureExecutionPayload
     blobs_bundle: BlobsBundle | None = None
     execution_requests: List[Bytes] | None = None
+
+
+class GetBlobsResponse(CamelModel):
+    """Represents the response of a get blobs request."""
+
+    result: List[BlobAndProof]


### PR DESCRIPTION
## 🗒️ Description
Following: https://github.com/ethereum/execution-apis/pull/630

I don't think we needed to change much on our end but please double check. I added the `get_blobs` engine rpc method here on the assumption that we can maybe create a test suite that sends blob txs to ELs, then we call `get_blobs` to validate the response. This feels suited towards an extension in `execute`.

## 🔗 Related Issues
N/A.

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.