### PR TITLE
chore(ci): remove pectra devnet 6 evm feature

### DIFF
--- a/.github/configs/evm.yaml
+++ b/.github/configs/evm.yaml
@@ -16,7 +16,3 @@ eip7692:
   repo: ethereum/evmone
   ref: master
   targets: ["evmone-t8n", "evmone-eofparse"]
-pectra-devnet-6:
-  impl: eels
-  repo: null
-  ref: null  


### PR DESCRIPTION
## 🗒️ Description
Remove Pectra devnet-6 evm feature from GitHub CI.

## 🔗 Related Issues
N/A

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] ~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
