### PR TITLE
chore(tests): add zkevm marker for bls g1 add tests

### DIFF
--- a/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1add.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1add.py
@@ -5,8 +5,9 @@ abstract: Tests BLS12_G1ADD precompile of [EIP-2537: Precompile for BLS12-381 cu
 
 import pytest
 
-from ethereum_test_tools import Alloc, Environment, StateTestFiller, Transaction
+from ethereum_test_tools import Alloc, Environment
 from ethereum_test_tools import Opcodes as Op
+from ethereum_test_tools import StateTestFiller, Transaction
 
 from .conftest import G1_POINTS_NOT_IN_SUBGROUP, G1_POINTS_NOT_ON_CURVE
 from .helpers import add_points_g1, vectors_from_file
@@ -18,6 +19,7 @@ REFERENCE_SPEC_VERSION = ref_spec_2537.version
 pytestmark = [
     pytest.mark.valid_from("Prague"),
     pytest.mark.parametrize("precompile_address", [Spec.G1ADD], ids=[""]),
+    pytest.mark.zkevm
 ]
 
 

--- a/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1add.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1add.py
@@ -18,7 +18,7 @@ REFERENCE_SPEC_VERSION = ref_spec_2537.version
 pytestmark = [
     pytest.mark.valid_from("Prague"),
     pytest.mark.parametrize("precompile_address", [Spec.G1ADD], ids=[""]),
-    pytest.mark.zkevm
+    pytest.mark.zkevm,
 ]
 
 

--- a/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1add.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1add.py
@@ -5,9 +5,8 @@ abstract: Tests BLS12_G1ADD precompile of [EIP-2537: Precompile for BLS12-381 cu
 
 import pytest
 
-from ethereum_test_tools import Alloc, Environment
+from ethereum_test_tools import Alloc, Environment, StateTestFiller, Transaction
 from ethereum_test_tools import Opcodes as Op
-from ethereum_test_tools import StateTestFiller, Transaction
 
 from .conftest import G1_POINTS_NOT_IN_SUBGROUP, G1_POINTS_NOT_ON_CURVE
 from .helpers import add_points_g1, vectors_from_file


### PR DESCRIPTION
## 🗒️ Description
Adds the zkevm marker for bls g1 add tests.

Required to test an initial zkevm fixtures release.

## 🔗 Related Issues
N/A

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] ~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~
- [x] ~All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.~
