### PR TITLE
chore(docs): add non forks to test case reference

### DIFF
--- a/src/pytest_plugins/filler/gen_test_doc/gen_test_doc.py
+++ b/src/pytest_plugins/filler/gen_test_doc/gen_test_doc.py
@@ -566,6 +566,8 @@ class TestDocsGenerator:
             length = len(x.path.parts)
             if length > 1:
                 fork = str(x.path.parts[1]).lower()  # the fork folder from the relative path
+                if fork not in fork_order:  # speculative features added to the end
+                    return (999, str(x.path))
             if length == 1:
                 return (0,)
             elif length == 2:


### PR DESCRIPTION
## 🗒️ Description
Fixes the docs building issue, for cases where the dir `tests/<dir>` is not labelled a valid fork.

## 🔗 Related Issues
#1499 

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] ~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
