### PR TITLE
fix(tests): Fix precompile warmup tests on python 3.10

### DIFF
--- a/tests/berlin/eip2929_gas_cost_increases/test_precompile_warming.py
+++ b/tests/berlin/eip2929_gas_cost_increases/test_precompile_warming.py
@@ -43,7 +43,7 @@ def precompile_addresses_in_predecessor_successor(
     predecessor_precompiles = set(get_transition_fork_predecessor(fork).precompiles())
     successor_precompiles = set(get_transition_fork_successor(fork).precompiles())
     all_precompiles = successor_precompiles | predecessor_precompiles
-    highest_precompile = int.from_bytes(max(all_precompiles))
+    highest_precompile = int.from_bytes(max(all_precompiles), byteorder="big")
     extra_range = 32
     extra_precompiles = {
         Address(i) for i in range(highest_precompile + 1, highest_precompile + extra_range)


### PR DESCRIPTION
## 🗒️ Description
Fixes an issue introduced in #1495 when using `int.from_bytes` without the `byteorder` keyword argument on python 3.10.

## 🔗 Related Issues
None

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] ~~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.