### PR TITLE
chore: update besu exception mapper deposits

### DIFF
--- a/src/ethereum_clis/clis/besu.py
+++ b/src/ethereum_clis/clis/besu.py
@@ -338,8 +338,8 @@ class BesuExceptionMapper(ExceptionMapper):
             r"transaction invalid transaction nonce \d+ below sender account nonce \d+"
         ),
         TransactionException.INVALID_DEPOSIT_EVENT_LAYOUT: (
-            r"Invalid (amount|index|pubKey|signature|withdrawalCred|deposit log length)"
-            r"(offset|size): "
-            r"expected (\d+), but got (-?\d+)"
+            r"Invalid (amount|index|pubKey|signature|withdrawalCred) (offset|size): "
+            r"expected (\d+), but got (-?\d+)|"
+            r"Invalid deposit log length\. Must be \d+ bytes, but is \d+ bytes"
         ),
     }

--- a/src/ethereum_clis/clis/besu.py
+++ b/src/ethereum_clis/clis/besu.py
@@ -318,8 +318,7 @@ class BesuExceptionMapper(ExceptionMapper):
             r"System call halted|System call did not execute to completion"
         ),
         BlockException.SYSTEM_CONTRACT_EMPTY: (
-            r"(Invalid system call, no code at address)|"
-            r"(Invalid system call address:)"
+            r"(Invalid system call, no code at address)|" r"(Invalid system call address:)"
         ),
         TransactionException.INITCODE_SIZE_EXCEEDED: (
             r"transaction invalid Initcode size of \d+ exceeds maximum size of \d+"
@@ -339,7 +338,8 @@ class BesuExceptionMapper(ExceptionMapper):
             r"transaction invalid transaction nonce \d+ below sender account nonce \d+"
         ),
         TransactionException.INVALID_DEPOSIT_EVENT_LAYOUT: (
-            r"Invalid (amount|index|pubKey|signature|withdrawalCred) (offset|size): "
+            r"Invalid (amount|index|pubKey|signature|withdrawalCred|deposit log length)"
+            r"(offset|size): "
             r"expected (\d+), but got (-?\d+)"
         ),
     }


### PR DESCRIPTION
## 🗒️ Description

Final Besu mapper tweaks for deposits.

####  `TransactionException.INVALID_DEPOSIT_EVENT_LAYOUT`

Here are the exceptions from `tests/prague/eip6110_deposits/test_modified_contract.py::test_invalid_log_length[fork_Prague-blockchain_test_engine-*]`:
```
slice_bytes_False                 Invalid deposit log length. Must be 576 bytes, but is 575 bytes
slice_bytes_True	          Invalid deposit log length. Must be 576 bytes, but is 577 bytes
```

## 🔗 Related Issues
#1487

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] ~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~
- [x] ~All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.~

