### PR TITLE
zkEVM: fix max contract size limitation in bytecode attack

### DIFF
--- a/src/ethereum_test_tools/code/generators.py
+++ b/src/ethereum_test_tools/code/generators.py
@@ -242,7 +242,7 @@ class While(Bytecode):
         cls,
         *,
         body: Bytecode | Op,
-        condition: Bytecode | Op,
+        condition: Bytecode | Op | None = None,
         evm_code_type: EVMCodeType = EVMCodeType.LEGACY,
     ):
         """
@@ -254,9 +254,12 @@ class While(Bytecode):
         if evm_code_type == EVMCodeType.LEGACY:
             bytecode += Op.JUMPDEST
             bytecode += body
-            bytecode += Op.JUMPI(
-                Op.SUB(Op.PC, Op.PUSH4[len(body) + len(condition) + 6]), condition
-            )
+            if condition is not None:
+                bytecode += Op.JUMPI(
+                    Op.SUB(Op.PC, Op.PUSH4[len(body) + len(condition) + 6]), condition
+                )
+            else:
+                bytecode += Op.JUMP(Op.SUB(Op.PC, Op.PUSH4[len(body) + 6]))
         elif evm_code_type == EVMCodeType.EOF_V1:
             raise NotImplementedError("EOF while loops are not implemented")
         return super().__new__(cls, bytecode)

--- a/tests/zkevm/test_worst_bytecode.py
+++ b/tests/zkevm/test_worst_bytecode.py
@@ -172,8 +172,8 @@ def test_worst_bytecode_single_opcode(
         + Op.MSTORE(64, initcode.keccak256())
         # Main loop
         + While(
-            body=Op.EXTCODESIZE(Op.SHA3(32 - 20 - 1, 85)) + Op.MSTORE(32, Op.ADD(Op.MLOAD(32), 1)),
-            condition=Op.PUSH1(1),
+            body=Op.POP(Op.EXTCODESIZE(Op.SHA3(32 - 20 - 1, 85)))
+            + Op.MSTORE(32, Op.ADD(Op.MLOAD(32), 1)),
         )
     )
 

--- a/tests/zkevm/test_worst_bytecode.py
+++ b/tests/zkevm/test_worst_bytecode.py
@@ -10,9 +10,17 @@ import math
 import pytest
 
 from ethereum_test_forks import Fork
-from ethereum_test_tools import (Account, Alloc, Block, BlockchainTestFiller,
-                                 Environment, Hash, Transaction, While,
-                                 compute_create2_address)
+from ethereum_test_tools import (
+    Account,
+    Alloc,
+    Block,
+    BlockchainTestFiller,
+    Environment,
+    Hash,
+    Transaction,
+    While,
+    compute_create2_address,
+)
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 REFERENCE_SPEC_GIT_PATH = "TODO"
@@ -110,7 +118,7 @@ def test_worst_bytecode_single_opcode(
 
     gas_costs = fork.gas_costs()
     intrinsic_gas_cost_calc = fork.transaction_intrinsic_cost_calculator()
-    loop_cost = ( 
+    loop_cost = (
         gas_costs.G_KECCAK_256  # KECCAK static cost
         + math.ceil(85 / 32) * gas_costs.G_KECCAK_256_WORD  # KECCAK dynamic cost for CREATE2
         + gas_costs.G_VERY_LOW * 3  # ~MSTOREs+ADDs


### PR DESCRIPTION
The previous bytecode-attack test relied on a contiguous PUSH20 + EXTCODESIZE pattern that embedded each 20-byte target address directly in the bytecode. Embedding the addresses with PUSH20 is far cheaper than loading them from storage, so it lets us amplify the attack.

However, contract-size limits cap the number of iterations we can fit in 24 KiB (or even 256 KiB), so the approach runs out of space long before it bumps into the block gas limit. For example, for 36M gas limit, you're limited by the 24KiB max size limit.

This strategy removes that bottleneck:
- Target deployment via CREATE2: The factory now spawns target contracts with CREATE2, incrementing a seed to derive unique addresses.
- Cheap address recalculation: because a CREATE2 address is keccak256(0xff || sender || salt || init_code), the attack contract can recompute each address inside the EVM for only a few gas with the KECCAK256 opcode.
- The attack contract iterates through the seeds, recalculates every target address on the fly, and triggers the attack—all without storing addresses, decoding calldata, or using chained CALLs.

This CREATE2-based loop is both more gas-efficient and less complex than falling back to SLOAD, CALLDATA, or multi-hop calls.