### PR TITLE
chore(cli): update exception mapper for nimbus-el

### DIFF
--- a/src/ethereum_clis/clis/nimbus.py
+++ b/src/ethereum_clis/clis/nimbus.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import ClassVar, Dict, Optional
 
 from ethereum_test_exceptions import (
+    BlockException,
     EOFException,
     ExceptionBase,
     ExceptionMapper,
@@ -66,69 +67,59 @@ class NimbusExceptionMapper(ExceptionMapper):
     """Translate between EEST exceptions and error strings returned by Nimbus."""
 
     mapping_substring: ClassVar[Dict[ExceptionBase, str]] = {
-        TransactionException.TYPE_4_TX_CONTRACT_CREATION: (
-            "set code transaction must not be a create transaction"
+        # TODO: these need to be fixed / incorrectly mapped
+        TransactionException.INSUFFICIENT_MAX_FEE_PER_GAS: (
+            "zero gasUsed but transactions present"
         ),
-        TransactionException.INSUFFICIENT_ACCOUNT_FUNDS: "invalid tx: not enough cash to send",
         TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED: (
-            "would exceed maximum allowance"
+            "zero gasUsed but transactions present"
+        ),
+        TransactionException.TYPE_4_TX_CONTRACT_CREATION: (
+            "zero gasUsed but transactions present"
+        ),
+        TransactionException.TYPE_4_EMPTY_AUTHORIZATION_LIST: (
+            "zero gasUsed but transactions present"
         ),
         TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS: (
-            "max fee per blob gas less than block blob gas fee"
+            "zero gasUsed but transactions present"
         ),
-        TransactionException.INSUFFICIENT_MAX_FEE_PER_GAS: (
-            "max fee per gas less than block base fee"
+        TransactionException.PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS: (
+            "zero gasUsed but transactions present"
         ),
-        TransactionException.TYPE_3_TX_PRE_FORK: (
-            "blob tx used but field env.ExcessBlobGas missing"
+        TransactionException.SENDER_NOT_EOA: "zero gasUsed but transactions present",
+        TransactionException.INTRINSIC_GAS_TOO_LOW: "zero gasUsed but transactions present",
+        TransactionException.INITCODE_SIZE_EXCEEDED: "zero gasUsed but transactions present",
+        TransactionException.TYPE_3_TX_PRE_FORK: "zero gasUsed but transactions present",
+        TransactionException.TYPE_3_TX_ZERO_BLOBS: "zero gasUsed but transactions present",
+        TransactionException.INVALID_DEPOSIT_EVENT_LAYOUT: "stateRoot mismatch",  # Leave for last.
+        # Correctly mapped
+        TransactionException.TYPE_3_TX_CONTRACT_CREATION: (
+            "invalid tx: destination must be not empty"
+        ),
+        TransactionException.NONCE_MISMATCH_TOO_LOW: "account nonce mismatch",
+        BlockException.INCORRECT_BLOB_GAS_USED: "calculated blobGas not equal header.blobGasUsed",
+        BlockException.INCORRECT_EXCESS_BLOB_GAS: "calculated excessBlobGas not equal header.excessBlobGas",
+        BlockException.INVALID_BLOCK_HASH: "blockhash mismatch",
+    }
+    mapping_regex: ClassVar[Dict[ExceptionBase, str]] = {
+        TransactionException.INSUFFICIENT_ACCOUNT_FUNDS: (
+            r"(invalid tx: not enough cash to send)|"
+            r"(zero gasUsed but transactions present)"  # TODO: Needs fix.
         ),
         TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH: (
-            "invalid tx: one of blobVersionedHash has invalid version"
+            r"(one of blobVersionedHash has invalid version)|"
+            r"(zero gasUsed but transactions present)"  # TODO: Needs fix.
         ),
-        # This message is the same as TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED
-        TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED: "exceeds maximum allowance",
-        TransactionException.TYPE_3_TX_ZERO_BLOBS: "blob transaction missing blob hashes",
-        TransactionException.INTRINSIC_GAS_TOO_LOW: "intrinsic gas too low",
-        TransactionException.INITCODE_SIZE_EXCEEDED: "max initcode size exceeded",
-        # TODO EVMONE needs to differentiate when the section is missing in the header or body
-        EOFException.MISSING_STOP_OPCODE: "err: no_terminating_instruction",
-        EOFException.MISSING_CODE_HEADER: "err: code_section_missing",
-        EOFException.MISSING_TYPE_HEADER: "err: type_section_missing",
-        # TODO EVMONE these exceptions are too similar, this leeds to ambiguity
-        EOFException.MISSING_TERMINATOR: "err: header_terminator_missing",
-        EOFException.MISSING_HEADERS_TERMINATOR: "err: section_headers_not_terminated",
-        EOFException.INVALID_VERSION: "err: eof_version_unknown",
-        EOFException.INVALID_NON_RETURNING_FLAG: "err: invalid_non_returning_flag",
-        EOFException.INVALID_MAGIC: "err: invalid_prefix",
-        EOFException.INVALID_FIRST_SECTION_TYPE: "err: invalid_first_section_type",
-        EOFException.INVALID_SECTION_BODIES_SIZE: "err: invalid_section_bodies_size",
-        EOFException.INVALID_TYPE_SECTION_SIZE: "err: invalid_type_section_size",
-        EOFException.INCOMPLETE_SECTION_SIZE: "err: incomplete_section_size",
-        EOFException.INCOMPLETE_SECTION_NUMBER: "err: incomplete_section_number",
-        EOFException.TOO_MANY_CODE_SECTIONS: "err: too_many_code_sections",
-        EOFException.ZERO_SECTION_SIZE: "err: zero_section_size",
-        EOFException.MISSING_DATA_SECTION: "err: data_section_missing",
-        EOFException.UNDEFINED_INSTRUCTION: "err: undefined_instruction",
-        EOFException.INPUTS_OUTPUTS_NUM_ABOVE_LIMIT: "err: inputs_outputs_num_above_limit",
-        EOFException.UNREACHABLE_INSTRUCTIONS: "err: unreachable_instructions",
-        EOFException.INVALID_RJUMP_DESTINATION: "err: invalid_rjump_destination",
-        EOFException.UNREACHABLE_CODE_SECTIONS: "err: unreachable_code_sections",
-        EOFException.STACK_UNDERFLOW: "err: stack_underflow",
-        EOFException.MAX_STACK_INCREASE_ABOVE_LIMIT: "err: max_stack_increase_above_limit",
-        EOFException.STACK_HIGHER_THAN_OUTPUTS: "err: stack_higher_than_outputs_required",
-        EOFException.JUMPF_DESTINATION_INCOMPATIBLE_OUTPUTS: (
-            "err: jumpf_destination_incompatible_outputs"
+        TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED: (
+            r"blobGasUsed (\d+) exceeds maximum allowance (\d+)"
         ),
-        EOFException.INVALID_MAX_STACK_INCREASE: "err: invalid_max_stack_increase",
-        EOFException.INVALID_DATALOADN_INDEX: "err: invalid_dataloadn_index",
-        EOFException.TRUNCATED_INSTRUCTION: "err: truncated_instruction",
-        EOFException.TOPLEVEL_CONTAINER_TRUNCATED: "err: toplevel_container_truncated",
-        EOFException.ORPHAN_SUBCONTAINER: "err: unreferenced_subcontainer",
-        EOFException.CONTAINER_SIZE_ABOVE_LIMIT: "err: container_size_above_limit",
-        EOFException.INVALID_CONTAINER_SECTION_INDEX: "err: invalid_container_section_index",
-        EOFException.INCOMPATIBLE_CONTAINER_KIND: "err: incompatible_container_kind",
-        EOFException.STACK_HEIGHT_MISMATCH: "err: stack_height_mismatch",
-        EOFException.TOO_MANY_CONTAINERS: "err: too_many_container_sections",
-        EOFException.INVALID_CODE_SECTION_INDEX: "err: invalid_code_section_index",
+        BlockException.SYSTEM_CONTRACT_CALL_FAILED: (
+            r"(Opcode Dispatch Error: OutOfGas)|(Opcode Dispatch Error: InvalidInstruction)|"
+            r"(REVERT opcode executed)"
+        ),
+        BlockException.SYSTEM_CONTRACT_EMPTY: (
+            r"No code found for withdrawal or consolidation requests contract"
+        ),
+        BlockException.RLP_STRUCTURES_ENCODING: r"Failed to decode payload",
+        BlockException.INVALID_REQUESTS: r"(Invalid execution request|requestsHash mismatch)",
     }
-    mapping_regex: ClassVar[Dict[ExceptionBase, str]] = {}


### PR DESCRIPTION
## 🗒️ Description
Updates the exception mapper for nimbus-el.

WIP - still needs some fixes on the nimbus-el side, as a lot of the exceptions return the same "zero gasUsed but transactions present" string.

## 🔗 Related Issues
N/A

## ✅ Checklist

- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
