### PR TITLE
zkEVM: add modexp attack

### DIFF
--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -10,7 +10,8 @@ import math
 import pytest
 
 from ethereum_test_forks import Fork
-from ethereum_test_tools import Alloc, Block, BlockchainTestFiller, Environment, Transaction
+from ethereum_test_tools import (Alloc, Block, BlockchainTestFiller,
+                                 Environment, Transaction)
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 REFERENCE_SPEC_GIT_PATH = "TODO"
@@ -126,7 +127,7 @@ def test_worst_modexp(
     exp_length = 32
 
     base = 2 ** (8 * base_mod_length) - 1
-    mod = 2 ** (8 * base_mod_length) - 2  # Prevnts base == mod
+    mod = 2 ** (8 * base_mod_length) - 2  # Prevents base == mod
     exp = 2 ** (8 * exp_length) - 1
 
     # MODEXP calldata

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -114,33 +114,25 @@ def test_worst_keccak(
         36_000_000,
     ],
 )
-@pytest.mark.parametrize(
-    "base_mod_length, exp_length",
-    [
-        (32, 32),
-    ],
-)
 def test_worst_modexp(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
     fork: Fork,
     gas_limit: int,
-    base_mod_length: int,
-    exp_length: int,
+    
 ):
     """Test running a block with as many MODEXP calls as possible."""
     env = Environment(gas_limit=gas_limit)
 
+    base_mod_length = 32
+    exp_length = 32
+
     base = 2 ** (8 * base_mod_length) - 1
-    mod = 2 ** (8 * base_mod_length) - 1
+    mod = 2 ** (8 * base_mod_length) - 2 # Prevnts base == mod
     exp = 2 ** (8 * exp_length) - 1
 
-    # EIP-7883 (TODO: generalize)
-    mul_complexity = math.ceil(base_mod_length / 8) ** 2
-    iter_complexity = exp.bit_length() - 1
-    gas_cost = math.floor((mul_complexity * iter_complexity) / 3)
-
-    mem_prep = (
+    # MODEXP calldata
+    calldata = (
         Op.MSTORE(0 * 32, 32)
         + Op.MSTORE(1 * 32, 32)
         + Op.MSTORE(2 * 32, 32)
@@ -149,14 +141,19 @@ def test_worst_modexp(
         + Op.MSTORE(5 * 32, mod)
     )
 
+    # EIP-2565
+    mul_complexity = math.ceil(base_mod_length / 8) ** 2
+    iter_complexity = exp.bit_length() - 1
+    gas_cost = math.floor((mul_complexity * iter_complexity) / 3)
     attack_block = Op.STATICCALL(gas_cost, 0x5, 0, 32 * 6, 0, 0) + Op.POP
 
+    # The attack contract is: JUMPDEST + [attack_block]* + PUSH0 + JUMP
     jumpdest = Op.JUMPDEST
-    jump_back = Op.JUMP(len(mem_prep))
-    max_iters_loop = (MAX_CODE_SIZE - len(mem_prep) - len(jumpdest) - len(jump_back)) // len(
+    jump_back = Op.JUMP(len(calldata))
+    max_iters_loop = (MAX_CODE_SIZE - len(calldata) - len(jumpdest) - len(jump_back)) // len(
         attack_block
     )
-    code = mem_prep + jumpdest + sum([attack_block] * max_iters_loop) + jump_back
+    code = calldata + jumpdest + sum([attack_block] * max_iters_loop) + jump_back
     if len(code) > MAX_CODE_SIZE:
         # Must never happen, but keep it as a sanity check.
         raise ValueError(f"Code size {len(code)} exceeds maximum code size {MAX_CODE_SIZE}")

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -143,7 +143,7 @@ def test_worst_modexp(
     mul_complexity = math.ceil(base_mod_length / 8) ** 2
     iter_complexity = exp.bit_length() - 1
     gas_cost = math.floor((mul_complexity * iter_complexity) / 3)
-    attack_block = Op.STATICCALL(gas_cost, 0x5, 0, 32 * 6, 0, 0) + Op.POP
+    attack_block = Op.POP(Op.STATICCALL(gas_cost, 0x5, 0, 32 * 6, 0, 0))
 
     # The attack contract is: JUMPDEST + [attack_block]* + PUSH0 + JUMP
     jumpdest = Op.JUMPDEST

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -161,10 +161,7 @@ def test_worst_modexp(
     tx = Transaction(
         to=code_address,
         gas_limit=gas_limit,
-        gas_price=10,
         sender=pre.fund_eoa(),
-        data=[],
-        value=0,
     )
 
     blockchain_test(

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -10,7 +10,8 @@ import math
 import pytest
 
 from ethereum_test_forks import Fork
-from ethereum_test_tools import Alloc, Block, BlockchainTestFiller, Environment, Transaction
+from ethereum_test_tools import (Alloc, Block, BlockchainTestFiller,
+                                 Environment, Transaction)
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 REFERENCE_SPEC_GIT_PATH = "TODO"
@@ -111,9 +112,6 @@ def test_worst_keccak(
     "gas_limit",
     [
         36_000_000,
-        60_000_000,
-        100_000_000,
-        300_000_000,
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -110,7 +110,7 @@ def test_worst_keccak(
 @pytest.mark.parametrize(
     "gas_limit",
     [
-        36_000_000,
+        Environment().gas_limit,
     ],
 )
 def test_worst_modexp(
@@ -156,7 +156,7 @@ def test_worst_modexp(
         # Must never happen, but keep it as a sanity check.
         raise ValueError(f"Code size {len(code)} exceeds maximum code size {MAX_CODE_SIZE}")
 
-    code_address = pre.deploy_contract(code=bytes(code))
+    code_address = pre.deploy_contract(code=code)
 
     tx = Transaction(
         to=code_address,

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -10,8 +10,7 @@ import math
 import pytest
 
 from ethereum_test_forks import Fork
-from ethereum_test_tools import (Alloc, Block, BlockchainTestFiller,
-                                 Environment, Transaction)
+from ethereum_test_tools import Alloc, Block, BlockchainTestFiller, Environment, Transaction
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 REFERENCE_SPEC_GIT_PATH = "TODO"

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -131,9 +131,9 @@ def test_worst_modexp(
 
     # MODEXP calldata
     calldata = (
-        Op.MSTORE(0 * 32, 32)
-        + Op.MSTORE(1 * 32, 32)
-        + Op.MSTORE(2 * 32, 32)
+        Op.MSTORE(0 * 32, base_mod_length)
+        + Op.MSTORE(1 * 32, exp_length)
+        + Op.MSTORE(2 * 32, base_mod_length)
         + Op.MSTORE(3 * 32, base)
         + Op.MSTORE(4 * 32, exp)
         + Op.MSTORE(5 * 32, mod)

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -10,8 +10,7 @@ import math
 import pytest
 
 from ethereum_test_forks import Fork
-from ethereum_test_tools import (Alloc, Block, BlockchainTestFiller,
-                                 Environment, Transaction)
+from ethereum_test_tools import Alloc, Block, BlockchainTestFiller, Environment, Transaction
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 REFERENCE_SPEC_GIT_PATH = "TODO"
@@ -119,7 +118,6 @@ def test_worst_modexp(
     pre: Alloc,
     fork: Fork,
     gas_limit: int,
-    
 ):
     """Test running a block with as many MODEXP calls as possible."""
     env = Environment(gas_limit=gas_limit)
@@ -128,7 +126,7 @@ def test_worst_modexp(
     exp_length = 32
 
     base = 2 ** (8 * base_mod_length) - 1
-    mod = 2 ** (8 * base_mod_length) - 2 # Prevnts base == mod
+    mod = 2 ** (8 * base_mod_length) - 2  # Prevnts base == mod
     exp = 2 ** (8 * exp_length) - 1
 
     # MODEXP calldata


### PR DESCRIPTION
This PR introduces an attack vector for the MODEXP precompile.

We assume 32-byte operands for the base, modulus, and exponent, anticipating the activation of EIP-7883 on mainnet in the near future (TM). Beyond the 32-byte boundary, the cost per unit of work rises, so it is valuable to model that limit from the outset.

The test suite is already parameterised for multiple gas limits (and can easily be extended to cover base/modulo/exp sizes), but for now we target 36M gas-limit since it is the relevant case for zkVMs today.

SP1 cycles: 36M gas limit -> ~27 billion cycles.

cc @kevaundray 
