### PR TITLE
zkevm: add ECRECOVER, SHA2-256, IDENTITY and RIPEMD precompiles

### DIFF
--- a/tests/zkevm/test_worst_bytecode.py
+++ b/tests/zkevm/test_worst_bytecode.py
@@ -10,17 +10,9 @@ import math
 import pytest
 
 from ethereum_test_forks import Fork
-from ethereum_test_tools import (
-    Account,
-    Alloc,
-    Block,
-    BlockchainTestFiller,
-    Environment,
-    Hash,
-    Transaction,
-    While,
-    compute_create2_address,
-)
+from ethereum_test_tools import (Account, Alloc, Block, BlockchainTestFiller,
+                                 Environment, Hash, Transaction, While,
+                                 compute_create2_address)
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 REFERENCE_SPEC_GIT_PATH = "TODO"

--- a/tests/zkevm/test_worst_bytecode.py
+++ b/tests/zkevm/test_worst_bytecode.py
@@ -10,9 +10,17 @@ import math
 import pytest
 
 from ethereum_test_forks import Fork
-from ethereum_test_tools import (Account, Alloc, Block, BlockchainTestFiller,
-                                 Environment, Hash, Transaction, While,
-                                 compute_create2_address)
+from ethereum_test_tools import (
+    Account,
+    Alloc,
+    Block,
+    BlockchainTestFiller,
+    Environment,
+    Hash,
+    Transaction,
+    While,
+    compute_create2_address,
+)
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 REFERENCE_SPEC_GIT_PATH = "TODO"

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -11,6 +11,7 @@ import pytest
 
 from ethereum_test_forks import Fork
 from ethereum_test_tools import (
+    Address,
     Alloc,
     Block,
     BlockchainTestFiller,
@@ -103,6 +104,94 @@ def test_worst_keccak(
         sender=pre.fund_eoa(),
         data=[],
         value=0,
+    )
+
+    blockchain_test(
+        env=env,
+        pre=pre,
+        post={},
+        blocks=[Block(txs=[tx])],
+    )
+
+
+@pytest.mark.zkevm
+@pytest.mark.valid_from("Cancun")
+@pytest.mark.parametrize(
+    "gas_limit",
+    [
+        Environment().gas_limit,
+    ],
+)
+@pytest.mark.parametrize(
+    "address,static_cost,per_word_dynamic_cost,bytes_per_unit_of_work",
+    [
+        pytest.param(0x02, 60, 12, 64, id="SHA2-256"),
+        pytest.param(0x03, 600, 120, 64, id="RIPEMD-160"),
+        pytest.param(0x04, 15, 3, 1, id="IDENTITY"),
+    ],
+)
+def test_worst_precompile_only_data_input(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    gas_limit: int,
+    address: Address,
+    static_cost: int,
+    per_word_dynamic_cost: int,
+    bytes_per_unit_of_work: int,
+):
+    """Test running a block with as many precompile calls which have a single `data` input."""
+    env = Environment(gas_limit=gas_limit)
+
+    # Intrinsic gas cost is paid once.
+    intrinsic_gas_calculator = fork.transaction_intrinsic_cost_calculator()
+    available_gas = gas_limit - intrinsic_gas_calculator()
+
+    gsc = fork.gas_costs()
+    mem_exp_gas_calculator = fork.memory_expansion_gas_calculator()
+
+    # Discover the optimal input size to maximize precompile calls, not precompile permutations.
+    max_work = 0
+    optimal_input_length = 0
+    for input_length in range(1, 1_000_000, 32):
+        staticcall_parameters_gas = (
+            gsc.G_BASE  # PUSH0 = arg offset
+            + gsc.G_BASE  # PUSH0 = arg size
+            + gsc.G_BASE  # PUSH0 = arg size
+            + gsc.G_VERY_LOW  # PUSH0 = arg offset
+            + gsc.G_VERY_LOW  # PUSHN = address
+            + gsc.G_BASE  # GAS
+        )
+        iteration_gas_cost = (
+            staticcall_parameters_gas
+            + +static_cost  # Precompile static cost
+            + math.ceil(input_length / 32) * per_word_dynamic_cost  # Precompile dynamic cost
+            + gsc.G_BASE  # POP
+        )
+        # From the available gas, we substract the mem expansion costs considering we know the
+        # current input size length.
+        available_gas_after_expansion = max(
+            0, available_gas - mem_exp_gas_calculator(new_bytes=input_length)
+        )
+        # Calculate how many calls we can do.
+        num_calls = available_gas_after_expansion // iteration_gas_cost
+        total_work = num_calls * math.ceil(input_length / bytes_per_unit_of_work)
+
+        # If we found an input size that is better (reg permutations/gas), then save it.
+        if total_work > max_work:
+            max_work = total_work
+            optimal_input_length = input_length
+
+    calldata = Op.CODECOPY(0, 0, optimal_input_length)
+    attack_block = Op.POP(Op.STATICCALL(Op.GAS, address, 0, optimal_input_length, 0, 0))
+    code = code_loop_precompile_call(calldata, attack_block)
+
+    code_address = pre.deploy_contract(code=code)
+
+    tx = Transaction(
+        to=code_address,
+        gas_limit=gas_limit,
+        sender=pre.fund_eoa(),
     )
 
     blockchain_test(

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -139,7 +139,7 @@ def test_worst_precompile_only_data_input(
     max_work = 0
     optimal_input_length = 0
     for input_length in range(1, 1_000_000, 32):
-        staticcall_parameters_gas = (
+        parameters_gas = (
             gsc.G_BASE  # PUSH0 = arg offset
             + gsc.G_BASE  # PUSH0 = arg size
             + gsc.G_BASE  # PUSH0 = arg size
@@ -148,7 +148,7 @@ def test_worst_precompile_only_data_input(
             + gsc.G_BASE  # GAS
         )
         iteration_gas_cost = (
-            staticcall_parameters_gas
+            parameters_gas
             + +static_cost  # Precompile static cost
             + math.ceil(input_length / 32) * per_word_dynamic_cost  # Precompile dynamic cost
             + gsc.G_BASE  # POP

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -30,24 +30,17 @@ ECRECOVER_GAS_COST = 3_000
 
 
 @pytest.mark.valid_from("Cancun")
-@pytest.mark.parametrize(
-    "gas_limit",
-    [
-        Environment().gas_limit,
-    ],
-)
 def test_worst_keccak(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
     fork: Fork,
-    gas_limit: int,
 ):
     """Test running a block with as many KECCAK256 permutations as possible."""
-    env = Environment(gas_limit=gas_limit)
+    env = Environment()
 
     # Intrinsic gas cost is paid once.
     intrinsic_gas_calculator = fork.transaction_intrinsic_cost_calculator()
-    available_gas = gas_limit - intrinsic_gas_calculator()
+    available_gas = env.gas_limit - intrinsic_gas_calculator()
 
     gsc = fork.gas_costs()
     mem_exp_gas_calculator = fork.memory_expansion_gas_calculator()
@@ -99,7 +92,7 @@ def test_worst_keccak(
 
     tx = Transaction(
         to=code_address,
-        gas_limit=gas_limit,
+        gas_limit=env.gas_limit,
         gas_price=10,
         sender=pre.fund_eoa(),
         data=[],
@@ -116,12 +109,6 @@ def test_worst_keccak(
 
 @pytest.mark.valid_from("Cancun")
 @pytest.mark.parametrize(
-    "gas_limit",
-    [
-        Environment().gas_limit,
-    ],
-)
-@pytest.mark.parametrize(
     "address,static_cost,per_word_dynamic_cost,bytes_per_unit_of_work",
     [
         pytest.param(0x02, 60, 12, 64, id="SHA2-256"),
@@ -133,18 +120,17 @@ def test_worst_precompile_only_data_input(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
     fork: Fork,
-    gas_limit: int,
     address: Address,
     static_cost: int,
     per_word_dynamic_cost: int,
     bytes_per_unit_of_work: int,
 ):
     """Test running a block with as many precompile calls which have a single `data` input."""
-    env = Environment(gas_limit=gas_limit)
+    env = Environment()
 
     # Intrinsic gas cost is paid once.
     intrinsic_gas_calculator = fork.transaction_intrinsic_cost_calculator()
-    available_gas = gas_limit - intrinsic_gas_calculator()
+    available_gas = env.gas_limit - intrinsic_gas_calculator()
 
     gsc = fork.gas_costs()
     mem_exp_gas_calculator = fork.memory_expansion_gas_calculator()
@@ -189,7 +175,7 @@ def test_worst_precompile_only_data_input(
 
     tx = Transaction(
         to=code_address,
-        gas_limit=gas_limit,
+        gas_limit=env.gas_limit,
         sender=pre.fund_eoa(),
     )
 
@@ -202,20 +188,13 @@ def test_worst_precompile_only_data_input(
 
 
 @pytest.mark.valid_from("Cancun")
-@pytest.mark.parametrize(
-    "gas_limit",
-    [
-        Environment().gas_limit,
-    ],
-)
 def test_worst_modexp(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
     fork: Fork,
-    gas_limit: int,
 ):
     """Test running a block with as many MODEXP calls as possible."""
-    env = Environment(gas_limit=gas_limit)
+    env = Environment()
 
     base_mod_length = 32
     exp_length = 32
@@ -245,7 +224,7 @@ def test_worst_modexp(
 
     tx = Transaction(
         to=code_address,
-        gas_limit=gas_limit,
+        gas_limit=env.gas_limit,
         sender=pre.fund_eoa(),
     )
 
@@ -258,20 +237,13 @@ def test_worst_modexp(
 
 
 @pytest.mark.valid_from("Cancun")
-@pytest.mark.parametrize(
-    "gas_limit",
-    [
-        Environment().gas_limit,
-    ],
-)
 def test_worst_ecrecover(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
     fork: Fork,
-    gas_limit: int,
 ):
     """Test running a block with as many ECRECOVER calls as possible."""
-    env = Environment(gas_limit=gas_limit)
+    env = Environment()
 
     # Calldata
     calldata = (
@@ -287,7 +259,7 @@ def test_worst_ecrecover(
 
     tx = Transaction(
         to=code_address,
-        gas_limit=gas_limit,
+        gas_limit=env.gas_limit,
         gas_price=10,
         sender=pre.fund_eoa(),
         data=[],

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -10,15 +10,8 @@ import math
 import pytest
 
 from ethereum_test_forks import Fork
-from ethereum_test_tools import (
-    Address,
-    Alloc,
-    Block,
-    BlockchainTestFiller,
-    Bytecode,
-    Environment,
-    Transaction,
-)
+from ethereum_test_tools import (Address, Alloc, Block, BlockchainTestFiller,
+                                 Bytecode, Environment, Transaction)
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 REFERENCE_SPEC_GIT_PATH = "TODO"
@@ -114,7 +107,6 @@ def test_worst_keccak(
     )
 
 
-@pytest.mark.zkevm
 @pytest.mark.valid_from("Cancun")
 @pytest.mark.parametrize(
     "gas_limit",
@@ -202,7 +194,6 @@ def test_worst_precompile_only_data_input(
     )
 
 
-@pytest.mark.zkevm
 @pytest.mark.valid_from("Cancun")
 @pytest.mark.parametrize(
     "gas_limit",
@@ -259,7 +250,6 @@ def test_worst_modexp(
     )
 
 
-@pytest.mark.zkevm
 @pytest.mark.valid_from("Cancun")
 @pytest.mark.parametrize(
     "gas_limit",

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -10,8 +10,14 @@ import math
 import pytest
 
 from ethereum_test_forks import Fork
-from ethereum_test_tools import (Alloc, Block, BlockchainTestFiller, Bytecode,
-                                 Environment, Transaction)
+from ethereum_test_tools import (
+    Alloc,
+    Block,
+    BlockchainTestFiller,
+    Bytecode,
+    Environment,
+    Transaction,
+)
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 REFERENCE_SPEC_GIT_PATH = "TODO"

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -93,10 +93,7 @@ def test_worst_keccak(
     tx = Transaction(
         to=code_address,
         gas_limit=env.gas_limit,
-        gas_price=10,
         sender=pre.fund_eoa(),
-        data=[],
-        value=0,
     )
 
     blockchain_test(
@@ -260,10 +257,7 @@ def test_worst_ecrecover(
     tx = Transaction(
         to=code_address,
         gas_limit=env.gas_limit,
-        gas_price=10,
         sender=pre.fund_eoa(),
-        data=[],
-        value=0,
     )
 
     blockchain_test(

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -10,8 +10,15 @@ import math
 import pytest
 
 from ethereum_test_forks import Fork
-from ethereum_test_tools import (Address, Alloc, Block, BlockchainTestFiller,
-                                 Bytecode, Environment, Transaction)
+from ethereum_test_tools import (
+    Address,
+    Alloc,
+    Block,
+    BlockchainTestFiller,
+    Bytecode,
+    Environment,
+    Transaction,
+)
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 REFERENCE_SPEC_GIT_PATH = "TODO"

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -195,7 +195,7 @@ def test_worst_ecrecover(
         + Op.MSTORE(3 * 32, 0x789D1DD423D25F0772D2748D60F7E4B81BB14D086EBA8E8E8EFB6DCFF8A4AE02)
     )
 
-    attack_block = Op.STATICCALL(ECRECOVER_GAS_COST, 0x1, 0, 32 * 4, 0, 0) + Op.POP
+    attack_block = Op.POP(Op.STATICCALL(ECRECOVER_GAS_COST, 0x1, 0, 32 * 4, 0, 0))
     code = code_loop_precompile_call(calldata, attack_block)
     code_address = pre.deploy_contract(code=bytes(code))
 
@@ -218,7 +218,7 @@ def test_worst_ecrecover(
 
 def code_loop_precompile_call(calldata: Bytecode, attack_block: Bytecode):
     """Create a code loop that calls a precompile with the given calldata."""
-    # The attack contract is: JUMPDEST + [attack_block]* + PUSH0 + JUMP
+    # The attack contract is: CALLDATA_PREP + #JUMPDEST + [attack_block]* + JUMP(#)
     jumpdest = Op.JUMPDEST
     jump_back = Op.JUMP(len(calldata))
     max_iters_loop = (MAX_CODE_SIZE - len(calldata) - len(jumpdest) - len(jump_back)) // len(

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -10,15 +10,8 @@ import math
 import pytest
 
 from ethereum_test_forks import Fork
-from ethereum_test_tools import (
-    Address,
-    Alloc,
-    Block,
-    BlockchainTestFiller,
-    Bytecode,
-    Environment,
-    Transaction,
-)
+from ethereum_test_tools import (Address, Alloc, Block, BlockchainTestFiller,
+                                 Bytecode, Environment, Transaction)
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 REFERENCE_SPEC_GIT_PATH = "TODO"
@@ -135,7 +128,7 @@ def test_worst_precompile_only_data_input(
     gsc = fork.gas_costs()
     mem_exp_gas_calculator = fork.memory_expansion_gas_calculator()
 
-    # Discover the optimal input size to maximize precompile calls, not precompile permutations.
+    # Discover the optimal input size to maximize precompile work, not precompile calls.
     max_work = 0
     optimal_input_length = 0
     for input_length in range(1, 1_000_000, 32):


### PR DESCRIPTION
This PR:
- Adds tests four new precompiles: ECRECOVER, SHA2-256, IDENTITY, and RIPEMD.
- Removes `zkevm` pytest markers since the testing framework now automatically does this.
- Uses `Environment()` configured gas limits, which are expected to be correctly set via the new `--block-gas-limit` filling flag.
- I updated the CI pipeline to use 36M gas limit for filling.

Cycle counts in the new precompiles:
- ECRECOVER: 682 million cycles
- SHA2-256: 5.8 billion cycles
- IDENTITY: 305 million cycles
- RIPEMD: 360 million cycles

The last three are all part of a generic test since these precompiles have the same input parameter structure (i.e., `data`). The generic test automatically discovers the optimal input length for each case to amortize the static cost as much as possible against the quadratic cost of memory expansions. ECRECOVER is a separate test since the parameter input structure is particular.
