### PR TITLE
feat(forks): Implement `transition_time` method 

### DIFF
--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -833,6 +833,11 @@ class Paris(
         """From Paris, payloads can be sent through the engine API."""
         return 1
 
+    @classmethod
+    def transition_time(cls) -> int:
+        """Return the fork transition timestamp for Paris."""
+        return 15_000
+
 
 class Shanghai(Paris):
     """Shanghai fork."""


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
• Added `transition_time()` in the `Paris class` to return the transition timestamp `15_000`.
• Currently, it is only implemented in the `Paris class`, and I’d like to know if it should be moved to `BaseFork` or stay specific to `Paris class`. Seeking feedback on where to add this method in [BaseFork](https://github.com/ethereum/execution-spec-tests/blob/main/src/ethereum_test_forks/base_fork.py#L146) for global usage across forks.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->
#1472 

## ✅ Checklist

- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.