### PR TITLE
chore(tests): add conftests to zkevm & bls subdirs to apply zkevm marker

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,8 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 ### 🧪 Test Cases
 
+- 🔀 Automatically apply the `zkevm` marker to all tests under `./tests/zkevm/` and `./tests/prague/eip2537_bls_12_381_precompiles/` via conftest configuration ([#1534](https://github.com/ethereum/execution-spec-tests/pull/1534)).
+
 ## [v4.4.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v4.4.0) - 2025-04-29
 
 ### 💥 Breaking Change

--- a/tests/prague/eip2537_bls_12_381_precompiles/conftest.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/conftest.py
@@ -1,5 +1,6 @@
 """Shared pytest definitions local to EIP-2537 tests."""
 
+from pathlib import Path
 from typing import SupportsBytes
 
 import pytest
@@ -9,6 +10,13 @@ from ethereum_test_tools import Opcodes as Op
 
 from .helpers import BLSPointGenerator
 from .spec import GAS_CALCULATION_FUNCTION_MAP
+
+
+def pytest_collection_modifyitems(config, items):
+    """Add the `zkevm` marker to all tests in `./tests/prague/eip2537_bls_12_381_precompiles`."""
+    for item in items:
+        if Path(__file__).parent in Path(item.fspath).parents:
+            item.add_marker(pytest.mark.zkevm)
 
 
 @pytest.fixture

--- a/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1add.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1add.py
@@ -18,7 +18,6 @@ REFERENCE_SPEC_VERSION = ref_spec_2537.version
 pytestmark = [
     pytest.mark.valid_from("Prague"),
     pytest.mark.parametrize("precompile_address", [Spec.G1ADD], ids=[""]),
-    pytest.mark.zkevm,
 ]
 
 

--- a/tests/zkevm/conftest.py
+++ b/tests/zkevm/conftest.py
@@ -1,0 +1,12 @@
+"""Pytest configuration for zkEVM tests."""
+
+from pathlib import Path
+
+import pytest
+
+
+def pytest_collection_modifyitems(config, items):
+    """Add the `zkevm` marker to all tests under `./tests/zkevm`."""
+    for item in items:
+        if Path(__file__).parent in Path(item.fspath).parents:
+            item.add_marker(pytest.mark.zkevm)

--- a/tests/zkevm/test_worst_bytecode.py
+++ b/tests/zkevm/test_worst_bytecode.py
@@ -35,7 +35,6 @@ XOR_TABLE_SIZE = 256
 XOR_TABLE = [Hash(i).sha256() for i in range(XOR_TABLE_SIZE)]
 
 
-@pytest.mark.zkevm
 @pytest.mark.parametrize(
     "opcode",
     [

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -20,7 +20,6 @@ MAX_CODE_SIZE = 24 * 1024
 KECCAK_RATE = 136
 
 
-@pytest.mark.zkevm
 @pytest.mark.valid_from("Cancun")
 @pytest.mark.parametrize(
     "gas_limit",


### PR DESCRIPTION
## 🗒️ Description
Automatically apply the `zkevm` marker to all tests under `./tests/zkevm/` and `./tests/prague/eip2537_bls_12_381_precompiles/` via conftest configuration.

Test via:
```
fill -m zkevm --from Cancun --until Prague --collect-only -q > zkevm.txt
```
[zkevm.txt](https://github.com/user-attachments/files/20032705/zkevm.txt)

## 🔗 Related Issues
Fixes 
- #1527

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).

