### PR TITLE
Add errors for system contracts failures in Nethermind

### DIFF
--- a/src/ethereum_clis/clis/nethermind.py
+++ b/src/ethereum_clis/clis/nethermind.py
@@ -380,4 +380,10 @@ class NethermindExceptionMapper(ExceptionMapper):
         BlockException.INVALID_BLOCK_HASH: (
             r"Invalid block hash 0x[0-9a-f]+ does not match calculated hash 0x[0-9a-f]+"
         ),
+        BlockException.SYSTEM_CONTRACT_EMPTY: (
+            r"(Withdrawals|Consolidations)\: Contract is not deployed\."
+        ),
+        BlockException.SYSTEM_CONTRACT_CALL_FAILED: (
+            r"(Withdrawals|Consolidations)\: Contract execution failed\."
+        ),
     }


### PR DESCRIPTION
## 🗒️ Description

Adds more error messages from Nethermind client that cover withdrawals and consolidation system calls failures:
- out of gas
- no code

## 🔗 Related Issues
-

## ✅ Checklist

- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
