### PR TITLE
fix(cli/eest): allow user to cancel via ctrl+C in interactive test creator

### DIFF
--- a/src/cli/eest/make/commands/test.py
+++ b/src/cli/eest/make/commands/test.py
@@ -23,6 +23,12 @@ template_env = jinja2.Environment(
 )
 
 
+def exit_now():
+    """Helper function to allow user to interrupt execution instantly via ctrl+C."""
+    print("Ctrl+C detected, exiting..")
+    exit(0)
+
+
 @click.command(
     short_help="Generate a new test file for an EIP.",
     epilog=f"Further help: {DocsConfig().DOCS_URL__WRITING_TESTS}",
@@ -53,9 +59,13 @@ def test():
     test_type = input_select(
         "Choose the type of test to generate", choices=["State", "Blockchain"]
     )
+    if test_type is None:
+        exit_now()
 
     fork_choices = [str(fork) for fork in get_forks()]
     fork = input_select("Select the fork", choices=fork_choices)
+    if fork is None:
+        exit_now()
 
     base_path = Path("tests") / fork.lower()
     base_path.mkdir(parents=True, exist_ok=True)
@@ -70,6 +80,8 @@ def test():
             {"name": "** Create new sub-directory **", "value": "new"},
         ],
     )
+    if location_choice is None:
+        exit_now()
 
     if location_choice == "new":
         eip_number = input_text("Enter the EIP number (int)").strip()

--- a/src/cli/eest/make/commands/test.py
+++ b/src/cli/eest/make/commands/test.py
@@ -24,7 +24,7 @@ template_env = jinja2.Environment(
 
 
 def exit_now():
-    """Helper function to allow user to interrupt execution instantly via ctrl+C."""
+    """Interrupt execution instantly via ctrl+C."""
     print("Ctrl+C detected, exiting..")
     exit(0)
 


### PR DESCRIPTION
## 🗒️ Description
When using `uv run eest make test` it is quite annoying to cancel, even after pressing ctrl+C it will keep asking you questions and eventually fail due to never handling receiving None. This commit allows the user to cancel via ctrl+C at any time.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist

- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
