### PR TITLE
fix(clis/reth,evmone): Exception mapper fixes

### DIFF
--- a/src/ethereum_clis/clis/evmone.py
+++ b/src/ethereum_clis/clis/evmone.py
@@ -71,6 +71,7 @@ class EvmoneExceptionMapper(ExceptionMapper):
         TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS: (
             "max blob fee per gas less than block base fee"
         ),
+        TransactionException.TYPE_4_TX_PRE_FORK: "transaction type not supported",
         TransactionException.TYPE_3_TX_PRE_FORK: "transaction type not supported",
         TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH: "invalid blob hash version",
         TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED: "blob gas limit exceeded",

--- a/src/ethereum_clis/clis/reth.py
+++ b/src/ethereum_clis/clis/reth.py
@@ -23,6 +23,7 @@ class RethExceptionMapper(ExceptionMapper):
         TransactionException.TYPE_3_TX_CONTRACT_CREATION: "unexpected length",
         TransactionException.TYPE_3_TX_WITH_FULL_BLOBS: "unexpected list",
         TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH: "blob version not supported",
+        TransactionException.TYPE_3_TX_ZERO_BLOBS: "empty blobs",
         TransactionException.TYPE_4_EMPTY_AUTHORIZATION_LIST: "empty authorization list",
         TransactionException.TYPE_4_TX_CONTRACT_CREATION: "unexpected length",
         TransactionException.TYPE_4_TX_PRE_FORK: (
@@ -45,7 +46,7 @@ class RethExceptionMapper(ExceptionMapper):
         TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED: (
             r"blob gas used \d+ exceeds maximum allowance \d+"
         ),
-        TransactionException.TYPE_3_TX_ZERO_BLOBS: (
+        TransactionException.TYPE_3_TX_PRE_FORK: (
             r"blob transactions present in pre-cancun payload|empty blobs"
         ),
         TransactionException.GAS_ALLOWANCE_EXCEEDED: (


### PR DESCRIPTION
## 🗒️ Description
Fixes the following exceptions in the clients
- Reth: TYPE_3_TX_ZERO_BLOBS, TYPE_3_TX_ZERO_BLOBS
- evmone: TYPE_4_TX_PRE_FORK

## 🔗 Related Issues
None

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] ~~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.