### PR TITLE
fix(solc): don't install `solc` via `solc-select` on ARM; add version sanity check

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,8 +24,9 @@ A new fork `EOFv1` has additionally been created to fill and consume EOF related
 
 - ✨ Engine API updates for Osaka, add `get_blobs` rpc method ([#1510](https://github.com/ethereum/execution-spec-tests/pull/1510)).
 - ✨ The EIP Version checker has been moved from `fill` and `execute` to it's own command-line tool `check_eip_versions` that gets ran daily as a Github Action ([#1537](https://github.com/ethereum/execution-spec-tests/pull/1537)).
-🔀 Add new `tests/unscheduled` folder, move EOF from Osaka to unscheduled, add `EOFv1` fork name for EOF tests ([#1507](https://github.com/ethereum/execution-spec-tests/pull/1507)).
+- 🔀 Add new `tests/unscheduled` folder, move EOF from Osaka to unscheduled, add `EOFv1` fork name for EOF tests ([#1507](https://github.com/ethereum/execution-spec-tests/pull/1507)).
 - ✨ CI features now contain an optional field to skip them from EEST full releases, `zkevm` and EOF features are now feature only ([#1596](https://github.com/ethereum/execution-spec-tests/pull/1596)).
+- 🐞 Don't attempt to install `solc` via `solc-select` on ARM (official Linux ARM builds of `solc` are not available at the time of writing, cf [ethereum/solidity#11351](https://github.com/ethereum/solidity/issues/11351)) and add a version sanity check ([#1556](https://github.com/ethereum/execution-spec-tests/pull/1556)).
 
 ### 🧪 Test Cases
 

--- a/src/pytest_plugins/solc/solc.py
+++ b/src/pytest_plugins/solc/solc.py
@@ -1,5 +1,7 @@
 """Pytest plugin for configuring and installing the solc compiler."""
 
+import platform
+import subprocess
 from argparse import ArgumentTypeError
 from shutil import which
 
@@ -63,6 +65,12 @@ def pytest_configure(config: pytest.Config):
         except ArgumentTypeError:
             version = None
         if version != solc_version:
+            # solc-select current does not support ARM linux
+            if platform.system().lower() == "linux" and platform.machine().lower() == "aarch64":
+                error_message = f"Version {version} does not match solc_version {solc_version}\
+ and since solc-select currently does not support ARM linux we can not recover from this problem."
+                pytest.exit(error_message, returncode=pytest.ExitCode.USAGE_ERROR)
+
             if config.getoption("verbose") > 0:
                 print(f"Setting solc version {solc_version} via solc-select...")
             try:
@@ -89,6 +97,27 @@ def pytest_configure(config: pytest.Config):
             returncode=pytest.ExitCode.USAGE_ERROR,
         )
     config.solc_version = solc_version_semver  # type: ignore
+
+    # test whether solc_version matches actual one
+    # using subprocess because that's how yul is compiled in
+    # ./src/ethereum_test_specs/static_state/common/compile_yul.py
+    expected_solc_version_string: str = str(solc_version_semver)
+    actual_solc_version = subprocess.run(
+        ["solc", "--version"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=True,
+    )
+    actual_solc_version_string = actual_solc_version.stdout
+    # use only look at first 10 chars to pass e.g.
+    # actual: 0.8.25+commit.b61c2a91.Linux.g++ should pass with expected: "0.8.25+commit.b61c2a91
+    if (
+        expected_solc_version_string[:10] not in actual_solc_version_string
+    ) or expected_solc_version_string == "":
+        error_message = f"Expected solc version {solc_version_semver} but detected a\
+ different solc version:\n{actual_solc_version_string}\nCritical error, aborting.."
+        pytest.exit(error_message, returncode=pytest.ExitCode.USAGE_ERROR)
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/src/pytest_plugins/solc/solc.py
+++ b/src/pytest_plugins/solc/solc.py
@@ -67,8 +67,14 @@ def pytest_configure(config: pytest.Config):
         if version != solc_version:
             # solc-select current does not support ARM linux
             if platform.system().lower() == "linux" and platform.machine().lower() == "aarch64":
-                error_message = f"Version {version} does not match solc_version {solc_version}\
- and since solc-select currently does not support ARM linux we can not recover from this problem."
+                error_message = (
+                    f"Version {version} does not match solc_version {solc_version} "
+                    "and since solc-select currently does not support ARM linux you must "
+                    "manually do the following: "
+                    "Build solc from source, and manually move the binary to "
+                    ".venv/.solc-select/artifacts/solc-x.y.z/solc-x.y.z, then run "
+                    "'uv run solc-select use <x.y.z>'"
+                )
                 pytest.exit(error_message, returncode=pytest.ExitCode.USAGE_ERROR)
 
             if config.getoption("verbose") > 0:


### PR DESCRIPTION
## 🗒️ Description
Read the [issue](https://github.com/ethereum/execution-spec-tests/issues/1512) for more context

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
