### PR TITLE
tooling(ux): only allow running fill command from root folder of repo

### DIFF
--- a/src/cli/pytest_commands/consume.py
+++ b/src/cli/pytest_commands/consume.py
@@ -31,6 +31,13 @@ def handle_hive_env_flags(args: List[str]) -> List[str]:
 
 def handle_consume_command_flags(consume_args: List[str], is_hive: bool) -> List[str]:
     """Handle all consume CLI flag pre-processing."""
+    # Ensure the consume command was called in the root folder of execution-spec-tests repo
+    cwd = Path(os.getcwd())
+    cwd_as_list = list(cwd.parts)
+    if cwd_as_list[-1].lower() != "execution-spec-tests":
+        pytest.exit(
+            "Please run the consume command in the root folder of the execution-spec-tests repo!"
+        )
     args = list(handle_help_flags(consume_args, pytest_type="consume"))
     args += ["-c", "pytest-consume.ini"]
     if is_hive:

--- a/src/pytest_plugins/filler/filler.py
+++ b/src/pytest_plugins/filler/filler.py
@@ -223,6 +223,14 @@ def pytest_configure(config):
         called before the pytest-html plugin's pytest_configure to ensure that
         it uses the modified `htmlpath` option.
     """
+    # Ensure the fill command was called in the root folder of execution-spec-tests repo
+    cwd = Path(os.getcwd())
+    cwd_as_list = list(cwd.parts)
+    if cwd_as_list[-1].lower() != "execution-spec-tests":
+        pytest.exit(
+            "Please run the fill command in the root folder of the execution-spec-tests repo!"
+        )
+
     # Modify the block gas limit if specified.
     if config.getoption("block_gas_limit"):
         EnvironmentDefaults.gas_limit = config.getoption("block_gas_limit")


### PR DESCRIPTION
## 🗒️ Description
I keep accidentally running fill commands in subfolders, and then it will attempt to fill and after fairly long wait fail (but not without first polluting the subdir with a fixtures folder with a bunch of files. This PR attempts to prevent users from accidentally running a fill command from sth that is not the root dir.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist

- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
