### PR TITLE
tooling(ux): better logging in python tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -23,3 +23,11 @@ addopts =
 # these customizations require the pytest-custom-report plugin
 report_passed_verbose = FILLED
 report_xpassed_verbose = XFILLED
+# Allow logging via logging.debug(), .info(), .warning(), .error() and .critical()
+log_cli = True
+log_cli_level = INFO
+log_cli_format = %(asctime)s %(levelname)s %(filename)s:%(lineno)d - %(message)s
+log_cli_date_format = %Y-%m-%d %H:%M:%S
+
+
+# Note: Never put a comment at the end of an actual line of code here!


### PR DESCRIPTION
## 🗒️ Description
Small change, big impact: With this instead of relying of of `print()` + `-s` we now can just use `logging.info("abc")`. This is better for many reasons:
* No need to add `-s` flag
* Shows in which FILE at which LINE the log is issued (great observability)
* Coloring of log levels
* Easy to format (e.g. show current date + time in specified format)
* Never again `if verboseLogging then foo else bar', just use logging.debug() and then temporarily toggle the log level to debug in the pytest.ini

These are the supported debugging levels that have a different color in the terminal:
* logging.debug("i am not shown by default cuz we defined log level INFO for now")
* logging.info("i am GREEN")
* logging.warning("i am BROWN")
* logging.error("i am light RED")
* logging.critical("im dark RED (much danger)")

Next steps:
* Replace all calls of "print()" we have today with logging equivalents

Visualization (subset of output of fill command of a test that uses new logging):
<img width="1233" alt="loggingYay" src="https://github.com/user-attachments/assets/a0e7f043-43f3-497a-a176-2644e4bc0303" />


## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist

- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
