### PR TITLE
chore(ci): bump prague to stable and osaka to develop

### DIFF
--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -1,15 +1,15 @@
 # Unless filling for special features, all features should fill for previous forks (starting from Frontier) too
 stable:
   evm-type: stable
-  fill-params: --until=Cancun
+  fill-params: --until=Prague
   solc: 0.8.21
 develop:
   evm-type: develop
-  fill-params: --until=Prague
+  fill-params: --until=Osaka
   solc: 0.8.21
 static:
   evm-type: static
-  fill-params: --until=Prague --fill-static-tests ./tests/static
+  fill-params: --until=Osaka --fill-static-tests ./tests/static
   solc: 0.8.21
 zkevm:
   evm-type: zkevm

--- a/eels_resolutions.json
+++ b/eels_resolutions.json
@@ -35,8 +35,13 @@
         "same_as": "EELSMaster"
     },
     "Prague": {
-      "git_url": "https://github.com/marioevz/execution-specs.git",
-      "branch": "forks/prague",
-      "commit": "bb0eb750d643ced0ebf5dec732cdd23558d0b7f2"
+        "git_url": "https://github.com/marioevz/execution-specs.git",
+        "branch": "forks/prague",
+        "commit": "bb0eb750d643ced0ebf5dec732cdd23558d0b7f2"
+    },
+    "Osaka": {
+        "git_url": "https://github.com/spencer-tb/execution-specs.git",
+        "branch": "forks/osaka",
+        "commit": "e59c6e3eaed0dbbca639b6f5b6acaa832e51ca00"
     }
 }


### PR DESCRIPTION
## 🗒️ Description
Probably worth merging #1507 first.

I added a temp EELS branch so we can refill all our tests for Osaka:
- https://github.com/spencer-tb/execution-specs/tree/forks/osaka

Note the osaka branch is based off:
- https://github.com/marioevz/execution-specs/tree/forks/prague

So we should probably proceed with #1454 first as well.

## 🔗 Related Issues
N/A

## ✅ Checklist

- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
