### PR TITLE
zkvm: allow using entire gas in bytecode attack

### DIFF
--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -13,7 +13,7 @@ static:
   solc: 0.8.21
 zkevm:
   evm-type: zkevm
-  fill-params: --from=Cancun --until=Prague -m zkevm ./tests
+  fill-params: --from=Cancun --until=Prague --block-gas-limit 36000000 -m zkevm ./tests
   solc: 0.8.21
   feature_only: true
 eip7692:

--- a/tests/zkevm/test_worst_bytecode.py
+++ b/tests/zkevm/test_worst_bytecode.py
@@ -27,9 +27,6 @@ REFERENCE_SPEC_GIT_PATH = "TODO"
 REFERENCE_SPEC_VERSION = "TODO"
 
 MAX_CONTRACT_SIZE = 24 * 1024  # TODO: This could be a fork property
-BLOCK_GAS_LIMIT = 36_000_000  # TODO: Parametrize using the (yet to be implemented) block gas limit
-# OPCODE_GAS_LIMIT = BLOCK_GAS_LIMIT  # TODO: Reduced in order to run the test in a reasonable time
-OPCODE_GAS_LIMIT = 100_000
 
 XOR_TABLE_SIZE = 256
 XOR_TABLE = [Hash(i).sha256() for i in range(XOR_TABLE_SIZE)]
@@ -41,12 +38,19 @@ XOR_TABLE = [Hash(i).sha256() for i in range(XOR_TABLE_SIZE)]
         Op.EXTCODESIZE,
     ],
 )
+@pytest.mark.parametrize(
+    "attack_gas_limit",
+    [
+        Environment().gas_limit,
+    ],
+)
 @pytest.mark.valid_from("Cancun")
 def test_worst_bytecode_single_opcode(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
     fork: Fork,
     opcode: Op,
+    attack_gas_limit: int,
 ):
     """
     Test a block execution where a single opcode execution maxes out the gas limit,
@@ -60,7 +64,9 @@ def test_worst_bytecode_single_opcode(
     The test is performed in the last block of the test, and the entire block gas limit is
     consumed by repeated opcode executions.
     """
-    env = Environment(gas_limit=BLOCK_GAS_LIMIT)
+    # We use 100G gas limit to be able to deploy a large number of contracts in a single block,
+    # avoiding bloating the number of preparing blocks in the test.
+    env = Environment(gas_limit=100_000_000_000)
 
     # The initcode will take its address as a starting point to the input to the keccak
     # hash function.
@@ -126,19 +132,19 @@ def test_worst_bytecode_single_opcode(
     )
     max_number_of_contract_calls = (
         # Base available gas = GAS_LIMIT - intrinsic - (out of loop MSTOREs)
-        OPCODE_GAS_LIMIT - intrinsic_gas_cost_calc() - gas_costs.G_VERY_LOW * 4
+        attack_gas_limit - intrinsic_gas_cost_calc() - gas_costs.G_VERY_LOW * 4
     ) // loop_cost
 
     total_contracts_to_deploy = max_number_of_contract_calls
     approximate_gas_per_deployment = 4_970_000  # Obtained from evm tracing
-    contracts_deployed_per_tx = BLOCK_GAS_LIMIT // approximate_gas_per_deployment
+    contracts_deployed_per_tx = env.gas_limit // approximate_gas_per_deployment
 
     deploy_txs = []
 
     def generate_deploy_tx(contracts_to_deploy: int):
         return Transaction(
             to=factory_caller_address,
-            gas_limit=BLOCK_GAS_LIMIT,
+            gas_limit=env.gas_limit,
             gas_price=10**9,  # Bump required due to the amount of full blocks
             data=Hash(contracts_deployed_per_tx),
             sender=pre.fund_eoa(),
@@ -171,8 +177,7 @@ def test_worst_bytecode_single_opcode(
         + Op.MSTORE(64, initcode.keccak256())
         # Main loop
         + While(
-            body=Op.POP(Op.EXTCODESIZE(Op.SHA3(32 - 20 - 1, 85)))
-            + Op.MSTORE(32, Op.ADD(Op.MLOAD(32), 1)),
+            body=Op.POP(opcode(Op.SHA3(32 - 20 - 1, 85))) + Op.MSTORE(32, Op.ADD(Op.MLOAD(32), 1)),
         )
     )
 
@@ -185,7 +190,7 @@ def test_worst_bytecode_single_opcode(
     opcode_address = pre.deploy_contract(code=opcode_code)
     opcode_tx = Transaction(
         to=opcode_address,
-        gas_limit=OPCODE_GAS_LIMIT,
+        gas_limit=attack_gas_limit,
         gas_price=10**9,  # Bump required due to the amount of full blocks
         sender=pre.fund_eoa(),
     )
@@ -198,4 +203,5 @@ def test_worst_bytecode_single_opcode(
             *[Block(txs=[deploy_tx]) for deploy_tx in deploy_txs],
             Block(txs=[opcode_tx]),
         ],
+        exclude_full_post_state_in_output=True,
     )

--- a/tests/zkevm/test_worst_bytecode.py
+++ b/tests/zkevm/test_worst_bytecode.py
@@ -44,6 +44,7 @@ XOR_TABLE = [Hash(i).sha256() for i in range(XOR_TABLE_SIZE)]
         Environment().gas_limit,
     ],
 )
+@pytest.mark.slow()
 @pytest.mark.valid_from("Cancun")
 def test_worst_bytecode_single_opcode(
     blockchain_test: BlockchainTestFiller,


### PR DESCRIPTION
This PR proposes a way to fill the bytecode attack, solving two main problems:
- Creating so many 24KiB contracts with 36M gas limit takes a lot of blocks, which bloats the generated fixture in size and generation time.
- Even if so many blocks in the fixture aren't a problem, all the ~300MiB of code appears in the `postState`, which also bloats the fixture. (This PR now uses a new feature introduced in https://github.com/ethereum/execution-spec-tests/pull/1578)

Results:
- I tested in Geth, and it runs exactly as expected.
- Filling this test on my machine with `--block-gas-limit 36M`
  - Only two blocks are needed in the fixture. 
  - Block 1 only has a single tx creating all contracts.
  - Block 2 has the actual attack.
- Takes 2 mins to fill the test, which sounds quite fast considering it creates 300MiB of contracts.
- The fixture json file size is ~35KiB, so very small as wanted.

Fill command: `uv run fill --from=Cancun --until=Cancun -m "zkevm and blockchain_test" --block-gas-limit 36000000 -k test_worst_bytecode`
