### PR TITLE
tooling(fix): use --version instead of -v for version checking t8n tool

### DIFF
--- a/src/ethereum_clis/ethereum_cli.py
+++ b/src/ethereum_clis/ethereum_cli.py
@@ -41,7 +41,7 @@ class EthereumCLI:
     binary: Path
     default_binary: Path
     detect_binary_pattern: Pattern
-    version_flag: str = "-v"
+    version_flag: str = "--version"  # geth's evm supports both -v and --version but nethtest only supports --version  # noqa: E501
     cached_version: Optional[str] = None
 
     def __init__(self, *, binary: Optional[Path] = None):


### PR DESCRIPTION
## 🗒️ Description
Geth's `evm` supports both `-v` and `--version` but Nethermind's `nethtest` only supports `--version`. This does not mean that we can consume direct with nethtest now, but it's one of multiple fixes we must make. Next thing to work on would be `assert cls.detect_binary_pattern is not None -> AttributeError: type object 'CollectOnlyFixtureConsumer' has no attribute 'detect_binary_pattern'` to eventually enabling consume direct via nethtest

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist

- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
