### PR TITLE
feat(exceptions,tests): Add `TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST`

### DIFF
--- a/src/ethereum_clis/clis/besu.py
+++ b/src/ethereum_clis/clis/besu.py
@@ -330,6 +330,9 @@ class BesuExceptionMapper(ExceptionMapper):
         TransactionException.INTRINSIC_GAS_TOO_LOW: (
             r"transaction invalid intrinsic gas cost \d+ exceeds gas limit \d+"
         ),
+        TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST: (
+            r"transaction invalid intrinsic gas cost \d+ exceeds gas limit \d+"
+        ),
         TransactionException.SENDER_NOT_EOA: (
             r"transaction invalid Sender 0x[0-9a-f]+ has deployed code and so is not authorized "
             r"to send transactions"

--- a/src/ethereum_clis/clis/erigon.py
+++ b/src/ethereum_clis/clis/erigon.py
@@ -14,6 +14,7 @@ class ErigonExceptionMapper(ExceptionMapper):
         ),
         TransactionException.NONCE_IS_MAX: "nonce has max value",
         TransactionException.INTRINSIC_GAS_TOO_LOW: "intrinsic gas too low",
+        TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST: "intrinsic gas too low",
         TransactionException.INSUFFICIENT_MAX_FEE_PER_GAS: "fee cap less than block base fee",
         TransactionException.PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS: "tip higher than fee cap",
         TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS: "max fee per blob gas too low",

--- a/src/ethereum_clis/clis/ethereumjs.py
+++ b/src/ethereum_clis/clis/ethereumjs.py
@@ -77,6 +77,9 @@ class EthereumJSExceptionMapper(ExceptionMapper):
             "Invalid EIP-7702 transaction: authorization list is empty"
         ),
         TransactionException.INTRINSIC_GAS_TOO_LOW: "is lower than the minimum gas limit of",
+        TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST: (
+            "is lower than the minimum gas limit of"
+        ),
         TransactionException.INITCODE_SIZE_EXCEEDED: (
             "the initcode size of this transaction is too large"
         ),

--- a/src/ethereum_clis/clis/evmone.py
+++ b/src/ethereum_clis/clis/evmone.py
@@ -60,6 +60,7 @@ class EvmoneExceptionMapper(ExceptionMapper):
         ),
         TransactionException.TYPE_4_EMPTY_AUTHORIZATION_LIST: "empty authorization list",
         TransactionException.INTRINSIC_GAS_TOO_LOW: "intrinsic gas too low",
+        TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST: "intrinsic gas too low",
         TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED: "blob gas limit exceeded",
         TransactionException.INITCODE_SIZE_EXCEEDED: "max initcode size exceeded",
         TransactionException.INSUFFICIENT_ACCOUNT_FUNDS: (

--- a/src/ethereum_clis/clis/execution_specs.py
+++ b/src/ethereum_clis/clis/execution_specs.py
@@ -153,6 +153,7 @@ class ExecutionSpecsExceptionMapper(ExceptionMapper):
         TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED: " transaction: ",
         TransactionException.TYPE_3_TX_ZERO_BLOBS: "transaction: ",
         TransactionException.INTRINSIC_GAS_TOO_LOW: "ransaction: ",
+        TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST: "ransaction: ",
         TransactionException.INITCODE_SIZE_EXCEEDED: "ansaction: ",
         TransactionException.PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS: "nsaction: ",
         TransactionException.NONCE_MISMATCH_TOO_HIGH: "saction: ",

--- a/src/ethereum_clis/clis/geth.py
+++ b/src/ethereum_clis/clis/geth.py
@@ -33,6 +33,10 @@ class GethExceptionMapper(ExceptionMapper):
         TransactionException.INSUFFICIENT_ACCOUNT_FUNDS: (
             "insufficient funds for gas * price + value"
         ),
+        TransactionException.INTRINSIC_GAS_TOO_LOW: "intrinsic gas too low",
+        TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST: (
+            "insufficient gas for floor data gas cost"
+        ),
         TransactionException.NONCE_IS_MAX: "nonce has max value",
         TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED: (
             "would exceed maximum allowance"
@@ -117,9 +121,6 @@ class GethExceptionMapper(ExceptionMapper):
     mapping_regex: ClassVar[Dict[ExceptionBase, str]] = {
         TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED: (
             r"blob gas used \d+ exceeds maximum allowance \d+"
-        ),
-        TransactionException.INTRINSIC_GAS_TOO_LOW: (
-            r"intrinsic gas too low|insufficient gas for floor data gas cost"
         ),
         BlockException.BLOB_GAS_USED_ABOVE_LIMIT: (
             r"blob gas used \d+ exceeds maximum allowance \d+"

--- a/src/ethereum_clis/clis/nethermind.py
+++ b/src/ethereum_clis/clis/nethermind.py
@@ -324,6 +324,7 @@ class NethermindExceptionMapper(ExceptionMapper):
     mapping_substring = {
         TransactionException.SENDER_NOT_EOA: "sender has deployed code",
         TransactionException.INTRINSIC_GAS_TOO_LOW: "intrinsic gas too low",
+        TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST: "intrinsic gas too low",
         TransactionException.INSUFFICIENT_MAX_FEE_PER_GAS: "miner premium is negative",
         TransactionException.PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS: (
             "InvalidMaxPriorityFeePerGas: Cannot be higher than maxFeePerGas"

--- a/src/ethereum_clis/clis/nimbus.py
+++ b/src/ethereum_clis/clis/nimbus.py
@@ -89,6 +89,7 @@ class NimbusExceptionMapper(ExceptionMapper):
         TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED: "exceeds maximum allowance",
         TransactionException.TYPE_3_TX_ZERO_BLOBS: "blob transaction missing blob hashes",
         TransactionException.INTRINSIC_GAS_TOO_LOW: "intrinsic gas too low",
+        TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST: "intrinsic gas too low",
         TransactionException.INITCODE_SIZE_EXCEEDED: "max initcode size exceeded",
         # TODO EVMONE needs to differentiate when the section is missing in the header or body
         EOFException.MISSING_STOP_OPCODE: "err: no_terminating_instruction",

--- a/src/ethereum_clis/clis/reth.py
+++ b/src/ethereum_clis/clis/reth.py
@@ -40,7 +40,10 @@ class RethExceptionMapper(ExceptionMapper):
     mapping_regex = {
         TransactionException.NONCE_MISMATCH_TOO_LOW: r"nonce \d+ too low, expected \d+",
         TransactionException.INTRINSIC_GAS_TOO_LOW: (
-            r"(call gas cost|gas floor) \(\d+\) exceeds the gas limit \(\d+\)"
+            r"call gas cost \(\d+\) exceeds the gas limit \(\d+\)"
+        ),
+        TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST: (
+            r"gas floor \(\d+\) exceeds the gas limit \(\d+\)"
         ),
         TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED: (
             r"blob gas used \d+ exceeds maximum allowance \d+"

--- a/src/ethereum_test_exceptions/exceptions.py
+++ b/src/ethereum_test_exceptions/exceptions.py
@@ -323,6 +323,10 @@ class TransactionException(ExceptionBase):
     """
     Transaction's gas limit is too low.
     """
+    INTRINSIC_GAS_BELOW_FLOOR_GAS_COST = auto()
+    """
+    Transaction's gas limit is below the floor gas cost.
+    """
     INITCODE_SIZE_EXCEEDED = auto()
     """
     Transaction's initcode for a contract-creating transaction is too large.

--- a/tests/prague/eip7623_increase_calldata_cost/conftest.py
+++ b/tests/prague/eip7623_increase_calldata_cost/conftest.py
@@ -302,9 +302,14 @@ def tx_gas_limit(
 
 
 @pytest.fixture
-def tx_error(tx_gas_delta: int) -> TransactionException | None:
+def tx_error(tx_gas_delta: int, data_test_type: DataTestType) -> TransactionException | None:
     """Transaction error, only expected if the gas delta is negative."""
-    return TransactionException.INTRINSIC_GAS_TOO_LOW if tx_gas_delta < 0 else None
+    if tx_gas_delta < 0:
+        if data_test_type == DataTestType.FLOOR_GAS_COST_GREATER_THAN_INTRINSIC_GAS:
+            return TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST
+        else:
+            return TransactionException.INTRINSIC_GAS_TOO_LOW
+    return None
 
 
 @pytest.fixture


### PR DESCRIPTION
## 🗒️ Description
Fixes #1412 by adding a specific exception for when the cause of the intrinsic gas cost fail is specifically the data floor.

Some clients do not make this distinction and that is fine for the clients so the exception mapper now contains the new exception with the same expected message as `INTRINSIC_GAS_TOO_LOW`.

This is an important distinction to make when writing tests since it's possible that a test designed to fail due to intrinsic gas cost insufficiency fails instead due to the data floor.

## 🔗 Related Issues
None.

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
