### PR TITLE
fix(static_tests): adjusted gasLimit to only allow gasLimit of up to 30mil as enforced in eip-7825

### DIFF
--- a/tests/static/state_tests/Cancun/stEIP1153_transientStorage/transStorageOKFiller.yml
+++ b/tests/static/state_tests/Cancun/stEIP1153_transientStorage/transStorageOKFiller.yml
@@ -810,7 +810,7 @@ transStorageOK:
     - :label static_call :abi staticCall()
 
     gasLimit:
-    - 80000000
+    - 30000000
     gasPrice: 10
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/Cancun/stEIP1153_transientStorage/transStorageResetFiller.yml
+++ b/tests/static/state_tests/Cancun/stEIP1153_transientStorage/transStorageResetFiller.yml
@@ -247,7 +247,7 @@ transStorageReset:
 
 
     gasLimit:
-    - 80000000
+    - 30000000
     gasPrice: 10
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmArithmeticTest/addFiller.yml
+++ b/tests/static/state_tests/VMTests/vmArithmeticTest/addFiller.yml
@@ -101,7 +101,7 @@ add:
     - :label add_0_0       :abi f(uint) 3
     - :label add_1_neg1    :abi f(uint) 4
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmArithmeticTest/addmodFiller.yml
+++ b/tests/static/state_tests/VMTests/vmArithmeticTest/addmodFiller.yml
@@ -200,7 +200,7 @@ addmod:
     - :label addmod_1_0_0        :abi f(uint) 0x0e
     - :label addmod_0_0_0_min_1  :abi f(uint) 0x0f
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmArithmeticTest/arithFiller.yml
+++ b/tests/static/state_tests/VMTests/vmArithmeticTest/arithFiller.yml
@@ -66,7 +66,7 @@ arith:
     data:
     - :raw 0x00
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmArithmeticTest/divByZeroFiller.yml
+++ b/tests/static/state_tests/VMTests/vmArithmeticTest/divByZeroFiller.yml
@@ -206,7 +206,7 @@ divByZero:
 
 
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmArithmeticTest/divFiller.yml
+++ b/tests/static/state_tests/VMTests/vmArithmeticTest/divFiller.yml
@@ -123,7 +123,7 @@ div:
     - :label div_2_0       :abi f(uint) 6
     - :label div_0_add     :abi f(uint) 7
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmArithmeticTest/expFiller.yml
+++ b/tests/static/state_tests/VMTests/vmArithmeticTest/expFiller.yml
@@ -173,7 +173,7 @@ exp:
     - :label exp_2_big      :abi f(uint) 9
     - :label exp_2_15       :abi f(uint) 0x0a
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmArithmeticTest/expPower256Filler.yml
+++ b/tests/static/state_tests/VMTests/vmArithmeticTest/expPower256Filler.yml
@@ -78,7 +78,7 @@ expPower256:
     data:
     - :abi f(uint) 0
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmArithmeticTest/expPower256Of256Filler.yml
+++ b/tests/static/state_tests/VMTests/vmArithmeticTest/expPower256Of256Filler.yml
@@ -87,7 +87,7 @@ expPower256Of256:
     data:
     - :abi f(uint) 0
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmArithmeticTest/expPower2Filler.yml
+++ b/tests/static/state_tests/VMTests/vmArithmeticTest/expPower2Filler.yml
@@ -54,7 +54,7 @@ expPower2:
     data:
     - :abi f(uint) 0
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmArithmeticTest/fibFiller.yml
+++ b/tests/static/state_tests/VMTests/vmArithmeticTest/fibFiller.yml
@@ -48,7 +48,7 @@ fib:
     data: 
     - :raw 0x01
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmArithmeticTest/modFiller.yml
+++ b/tests/static/state_tests/VMTests/vmArithmeticTest/modFiller.yml
@@ -112,7 +112,7 @@ mod:
     - :label mod_neg2_3 :abi f(uint) 4
     - :label mod_16_0   :abi f(uint) 5
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmArithmeticTest/mulFiller.yml
+++ b/tests/static/state_tests/VMTests/vmArithmeticTest/mulFiller.yml
@@ -174,7 +174,7 @@ mul:
     - :label big_pow_3                   :abi f(uint) 7
     - :label stack_underflow             :abi f(uint) 8
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmArithmeticTest/mulmodFiller.yml
+++ b/tests/static/state_tests/VMTests/vmArithmeticTest/mulmodFiller.yml
@@ -258,7 +258,7 @@ mulmod:
     - :label one_minus_mm_0_0_0   :abi f(uint) 0x0e
     - :label mm_5_1_0             :abi f(uint) 0x0d
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmArithmeticTest/notFiller.yml
+++ b/tests/static/state_tests/VMTests/vmArithmeticTest/notFiller.yml
@@ -48,7 +48,7 @@ not:
     data:
     - :abi f(uint) 0
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmArithmeticTest/sdivFiller.yml
+++ b/tests/static/state_tests/VMTests/vmArithmeticTest/sdivFiller.yml
@@ -297,7 +297,7 @@ sdiv:
 
 
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmArithmeticTest/signextendFiller.yml
+++ b/tests/static/state_tests/VMTests/vmArithmeticTest/signextendFiller.yml
@@ -245,7 +245,7 @@ signextend:
     - :label byte31_neg          :abi f(uint) 0x0E
 
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmArithmeticTest/smodFiller.yml
+++ b/tests/static/state_tests/VMTests/vmArithmeticTest/smodFiller.yml
@@ -107,7 +107,7 @@ smod:
     - :label smod_neg2_3 :abi f(uint) 4
     - :label smod_16_0   :abi f(uint) 5
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmArithmeticTest/subFiller.yml
+++ b/tests/static/state_tests/VMTests/vmArithmeticTest/subFiller.yml
@@ -97,7 +97,7 @@ sub:
     - :label sub_0_neg1 :abi f(uint) 3
     - :label sub_neg1_0 :abi f(uint) 4
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmArithmeticTest/twoOpsFiller.yml
+++ b/tests/static/state_tests/VMTests/vmArithmeticTest/twoOpsFiller.yml
@@ -1189,7 +1189,7 @@ twoOps:
     data: 
     - :raw 0x00
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmBitwiseLogicOperation/andFiller.yml
+++ b/tests/static/state_tests/VMTests/vmBitwiseLogicOperation/andFiller.yml
@@ -99,7 +99,7 @@ and:
     - :label and_allones_bignum :abi f(uint) 3
     - :label and_allones_eefee  :abi f(uint) 4
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmBitwiseLogicOperation/byteFiller.yml
+++ b/tests/static/state_tests/VMTests/vmBitwiseLogicOperation/byteFiller.yml
@@ -199,7 +199,7 @@ byte:
     # A test for all possible byte positions
     - :label byte_all        :abi f(uint) 0x200
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmBitwiseLogicOperation/eqFiller.yml
+++ b/tests/static/state_tests/VMTests/vmBitwiseLogicOperation/eqFiller.yml
@@ -70,7 +70,7 @@ eq:
     - :label eq_0_0         :abi f(uint) 1
     - :label eq_neg1_neg1   :abi f(uint) 2
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmBitwiseLogicOperation/gtFiller.yml
+++ b/tests/static/state_tests/VMTests/vmBitwiseLogicOperation/gtFiller.yml
@@ -84,7 +84,7 @@ gt:
     - :label gt_neg1_0   :abi f(uint) 2
     - :label gt_0_neg1   :abi f(uint) 3
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmBitwiseLogicOperation/iszeroFiller.yml
+++ b/tests/static/state_tests/VMTests/vmBitwiseLogicOperation/iszeroFiller.yml
@@ -70,7 +70,7 @@ iszero:
     - :label iszero_0       :abi f(uint) 1
     - :label iszero_neg2    :abi f(uint) 2
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmBitwiseLogicOperation/ltFiller.yml
+++ b/tests/static/state_tests/VMTests/vmBitwiseLogicOperation/ltFiller.yml
@@ -84,7 +84,7 @@ lt:
     - :label lt_neg1_0   :abi f(uint) 2
     - :label lt_0_neg1   :abi f(uint) 3
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmBitwiseLogicOperation/notFiller.yml
+++ b/tests/static/state_tests/VMTests/vmBitwiseLogicOperation/notFiller.yml
@@ -116,7 +116,7 @@ not:
     - :label not_neg_2_pow_256 :abi f(uint) 4
     - :label not_neg0          :abi f(uint) 5
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmBitwiseLogicOperation/orFiller.yml
+++ b/tests/static/state_tests/VMTests/vmBitwiseLogicOperation/orFiller.yml
@@ -114,7 +114,7 @@ or:
     - :label or_allones_1110s  :abi f(uint) 4
     - :label or_allones_eefee  :abi f(uint) 5
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmBitwiseLogicOperation/sgtFiller.yml
+++ b/tests/static/state_tests/VMTests/vmBitwiseLogicOperation/sgtFiller.yml
@@ -84,7 +84,7 @@ sgt:
     - :label sgt_neg1_0   :abi f(uint) 2
     - :label sgt_0_neg1   :abi f(uint) 3
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmBitwiseLogicOperation/sltFiller.yml
+++ b/tests/static/state_tests/VMTests/vmBitwiseLogicOperation/sltFiller.yml
@@ -84,7 +84,7 @@ slt:
     - :label slt_neg1_0   :abi f(uint) 2
     - :label slt_0_neg1   :abi f(uint) 3
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmBitwiseLogicOperation/xorFiller.yml
+++ b/tests/static/state_tests/VMTests/vmBitwiseLogicOperation/xorFiller.yml
@@ -114,7 +114,7 @@ xor:
     - :label xor_allones_1110s  :abi f(uint) 4
     - :label xor_allones_eefee  :abi f(uint) 5
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmIOandFlowOperations/codecopyFiller.yml
+++ b/tests/static/state_tests/VMTests/vmIOandFlowOperations/codecopyFiller.yml
@@ -145,7 +145,7 @@ codecopy:
 
 
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmIOandFlowOperations/gasFiller.yml
+++ b/tests/static/state_tests/VMTests/vmIOandFlowOperations/gasFiller.yml
@@ -67,7 +67,7 @@ gas:
     - :label gas1 :abi f(uint) 0
     - :label gas2 :abi f(uint) 1
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmIOandFlowOperations/jumpFiller.yml
+++ b/tests/static/state_tests/VMTests/vmIOandFlowOperations/jumpFiller.yml
@@ -352,7 +352,7 @@ jump:
 
 
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmIOandFlowOperations/jumpToPushFiller.yml
+++ b/tests/static/state_tests/VMTests/vmIOandFlowOperations/jumpToPushFiller.yml
@@ -1834,7 +1834,7 @@ jumpToPush:
     - :label jump-fail    :abi f(uint) 0x20C
 
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmIOandFlowOperations/jumpiFiller.yml
+++ b/tests/static/state_tests/VMTests/vmIOandFlowOperations/jumpiFiller.yml
@@ -533,7 +533,7 @@ jumpi:
 
 
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmIOandFlowOperations/loop_stacklimitFiller.yml
+++ b/tests/static/state_tests/VMTests/vmIOandFlowOperations/loop_stacklimitFiller.yml
@@ -82,7 +82,7 @@ loop_stacklimit:
     - :label loop_1021  :abi f(uint) 0
     - :label loop_1020  :abi f(uint) 1
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmIOandFlowOperations/loopsConditionalsFiller.yml
+++ b/tests/static/state_tests/VMTests/vmIOandFlowOperations/loopsConditionalsFiller.yml
@@ -219,7 +219,7 @@ loopsConditionals:
     - :label for_loop1   :abi f(uint) 9
     - :label for_loop2   :abi f(uint) 10
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmIOandFlowOperations/mloadFiller.yml
+++ b/tests/static/state_tests/VMTests/vmIOandFlowOperations/mloadFiller.yml
@@ -80,7 +80,7 @@ mload:
     - :label mloadOOG :abi f(uint) 1
     - :label mloadOOG :abi f(uint) 2
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmIOandFlowOperations/msizeFiller.yml
+++ b/tests/static/state_tests/VMTests/vmIOandFlowOperations/msizeFiller.yml
@@ -141,7 +141,7 @@ msize:
     # Off in hyperspace, is the chunk size still 0x20?
     - :label farChunk :abi f(uint) 5
     gasLimit:
-    - 0x10000000
+    - 0x1c9c380
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmIOandFlowOperations/mstore8Filler.yml
+++ b/tests/static/state_tests/VMTests/vmIOandFlowOperations/mstore8Filler.yml
@@ -80,7 +80,7 @@ mstore8:
     - :label mstore8_twobytes  :abi f(uint) 1
     - :label mstore8_neg1      :abi f(uint) 2
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmIOandFlowOperations/mstoreFiller.yml
+++ b/tests/static/state_tests/VMTests/vmIOandFlowOperations/mstoreFiller.yml
@@ -106,7 +106,7 @@ mstore:
     - :label mstore_byte32    :abi f(uint) 3
     - :label mstore_byte31    :abi f(uint) 4
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmIOandFlowOperations/pcFiller.yml
+++ b/tests/static/state_tests/VMTests/vmIOandFlowOperations/pcFiller.yml
@@ -63,7 +63,7 @@ pc:
     - :label pc1 :abi f(uint) 0
     - :label pc2 :abi f(uint) 1
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmIOandFlowOperations/popFiller.yml
+++ b/tests/static/state_tests/VMTests/vmIOandFlowOperations/popFiller.yml
@@ -65,7 +65,7 @@ pop:
     - :label pop1 :abi f(uint) 0
     - :label pop2 :abi f(uint) 1
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmIOandFlowOperations/returnFiller.yml
+++ b/tests/static/state_tests/VMTests/vmIOandFlowOperations/returnFiller.yml
@@ -141,7 +141,7 @@ return:
     - :label returnOld     :abi f(uint) 4
 
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmIOandFlowOperations/sstore_sloadFiller.yml
+++ b/tests/static/state_tests/VMTests/vmIOandFlowOperations/sstore_sloadFiller.yml
@@ -85,7 +85,7 @@ sstore_sload:
     - :label sstore_sload_noinit :abi f(uint) 1
     - :label sstore_sload_4      :abi f(uint) 2
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmLogTest/log0Filler.yml
+++ b/tests/static/state_tests/VMTests/vmLogTest/log0Filler.yml
@@ -144,7 +144,7 @@ log0:
     - :label logTwice         :abi f(uint) 10
 
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmLogTest/log1Filler.yml
+++ b/tests/static/state_tests/VMTests/vmLogTest/log1Filler.yml
@@ -160,7 +160,7 @@ log1:
     - :label maxTopic         :abi f(uint) 8
 
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmLogTest/log2Filler.yml
+++ b/tests/static/state_tests/VMTests/vmLogTest/log2Filler.yml
@@ -164,7 +164,7 @@ log2:
     - :label maxTopic         :abi f(uint) 8
 
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmLogTest/log3Filler.yml
+++ b/tests/static/state_tests/VMTests/vmLogTest/log3Filler.yml
@@ -177,7 +177,7 @@ log3:
     - :label maxTopic         :abi f(uint) 8
     - :label pc               :abi f(uint) 9
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmLogTest/log4Filler.yml
+++ b/tests/static/state_tests/VMTests/vmLogTest/log4Filler.yml
@@ -177,7 +177,7 @@ log4:
     - :label maxTopic         :abi f(uint) 8
     - :label pc               :abi f(uint) 9
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmTests/blockInfoFiller.yml
+++ b/tests/static/state_tests/VMTests/vmTests/blockInfoFiller.yml
@@ -91,7 +91,7 @@ blockInfo:
     - :label number       :abi f(uint) 3
     - :label timestamp    :abi f(uint) 4
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmTests/envInfoFiller.yml
+++ b/tests/static/state_tests/VMTests/vmTests/envInfoFiller.yml
@@ -167,7 +167,7 @@ envInfo:
     - :label origin              :abi f(uint) 8
     - :label calldatasize        :abi f(uint) 9
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: 0x1234
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmTests/randomFiller.yml
+++ b/tests/static/state_tests/VMTests/vmTests/randomFiller.yml
@@ -92,7 +92,7 @@ random:
     - :label random5  :abi f(uint) 5
 
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmTests/sha3Filler.yml
+++ b/tests/static/state_tests/VMTests/vmTests/sha3Filler.yml
@@ -290,7 +290,7 @@ sha3:
 
 
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmTests/suicideFiller.yml
+++ b/tests/static/state_tests/VMTests/vmTests/suicideFiller.yml
@@ -73,7 +73,7 @@ suicide:
     - :label random   :abi f(uint) 0x1001
     - :label myself   :abi f(uint) 0x1002
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/VMTests/vmTests/swapFiller.yml
+++ b/tests/static/state_tests/VMTests/vmTests/swapFiller.yml
@@ -268,7 +268,7 @@ swap:
     - :label swap16 :abi f(uint) 15
 
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/stBadOpcode/invalidAddrFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/invalidAddrFiller.yml
@@ -330,7 +330,7 @@ invalidAddr:
 
 
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/stBadOpcode/invalidDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/invalidDiffPlacesFiller.yml
@@ -661,7 +661,7 @@ invalidDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/measureGasFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/measureGasFiller.yml
@@ -214,7 +214,7 @@ measureGas:
     - :label EXTCODE      :abi f(uint) 0x3B
 
     gasLimit:
-    - 80000000
+    - 30000000
     gasPrice: 10
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/stBadOpcode/opc0CDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opc0CDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opc0CDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opc0DDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opc0DDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opc0DDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opc0EDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opc0EDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opc0EDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opc0FDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opc0FDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opc0FDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opc1EDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opc1EDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opc1EDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opc1FDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opc1FDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opc1FDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opc21DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opc21DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opc21DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opc22DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opc22DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opc22DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opc23DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opc23DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opc23DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opc24DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opc24DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opc24DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opc25DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opc25DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opc25DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opc26DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opc26DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opc26DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opc27DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opc27DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opc27DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opc28DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opc28DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opc28DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opc29DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opc29DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opc29DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opc2ADiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opc2ADiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opc2ADiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opc2BDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opc2BDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opc2BDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opc2CDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opc2CDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opc2CDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opc2DDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opc2DDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opc2DDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opc2EDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opc2EDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opc2EDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opc2FDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opc2FDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opc2FDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opc49DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opc49DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opc49DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opc4ADiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opc4ADiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opc4ADiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opc4BDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opc4BDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opc4BDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opc4CDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opc4CDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opc4CDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opc4DDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opc4DDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opc4DDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opc4EDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opc4EDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opc4EDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opc4FDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opc4FDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opc4FDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opc5CDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opc5CDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opc5CDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opc5DDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opc5DDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opc5DDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opc5EDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opc5EDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opc5EDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opc5FDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opc5FDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opc5FDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcA5DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcA5DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcA5DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcA6DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcA6DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcA6DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcA7DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcA7DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcA7DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcA8DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcA8DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcA8DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcA9DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcA9DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcA9DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcAADiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcAADiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcAADiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcABDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcABDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcABDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcACDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcACDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcACDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcADDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcADDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcADDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcAEDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcAEDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcAEDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcAFDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcAFDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcAFDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcB0DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcB0DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcB0DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcB1DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcB1DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcB1DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcB2DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcB2DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcB2DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcB3DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcB3DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcB3DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcB4DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcB4DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcB4DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcB5DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcB5DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcB5DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcB6DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcB6DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcB6DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcB7DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcB7DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcB7DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcB8DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcB8DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcB8DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcB9DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcB9DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcB9DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcBADiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcBADiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcBADiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcBBDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcBBDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcBBDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcBCDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcBCDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcBCDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcBDDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcBDDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcBDDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcBEDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcBEDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcBEDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcBFDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcBFDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcBFDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcC0DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcC0DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcC0DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcC1DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcC1DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcC1DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcC2DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcC2DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcC2DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcC3DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcC3DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcC3DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcC4DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcC4DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcC4DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcC5DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcC5DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcC5DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcC6DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcC6DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcC6DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcC7DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcC7DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcC7DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcC8DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcC8DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcC8DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcC9DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcC9DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcC9DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcCADiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcCADiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcCADiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcCBDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcCBDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcCBDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcCCDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcCCDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcCCDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcCDDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcCDDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcCDDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcCEDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcCEDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcCEDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcCFDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcCFDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcCFDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcD0DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcD0DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcD0DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcD1DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcD1DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcD1DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcD2DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcD2DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcD2DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcD3DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcD3DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcD3DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcD4DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcD4DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcD4DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcD5DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcD5DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcD5DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcD6DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcD6DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcD6DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcD7DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcD7DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcD7DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcD8DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcD8DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcD8DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcD9DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcD9DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcD9DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcDADiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcDADiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcDADiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcDBDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcDBDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcDBDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcDCDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcDCDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcDCDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcDDDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcDDDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcDDDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcDEDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcDEDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcDEDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcDFDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcDFDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcDFDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcE0DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcE0DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcE0DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcE1DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcE1DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcE1DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcE2DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcE2DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcE2DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcE3DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcE3DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcE3DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcE4DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcE4DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcE4DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcE5DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcE5DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcE5DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcE6DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcE6DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcE6DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcE7DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcE7DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcE7DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcE8DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcE8DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcE8DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcE9DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcE9DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcE9DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcEADiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcEADiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcEADiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcEBDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcEBDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcEBDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcECDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcECDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcECDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcEDDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcEDDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcEDDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcEEDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcEEDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcEEDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcEFDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcEFDiffPlacesFiller.yml
@@ -717,7 +717,7 @@ opcEFDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcF6DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcF6DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcF6DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcF7DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcF7DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcF7DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcF8DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcF8DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcF8DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcF9DiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcF9DiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcF9DiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcFBDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcFBDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcFBDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcFCDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcFCDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcFCDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/opcFEDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/opcFEDiffPlacesFiller.yml
@@ -787,7 +787,7 @@ opcFEDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stBadOpcode/operationDiffGasFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/operationDiffGasFiller.yml
@@ -215,7 +215,7 @@ operationDiffGas:
     - :label EXTCODE      :abi f(uint,uint,uint) 0x3B 0 100
 
     gasLimit:
-    - 80000000
+    - 30000000
     gasPrice: 10
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/stBadOpcode/undefinedOpcodeFirstByteFiller.yml
+++ b/tests/static/state_tests/stBadOpcode/undefinedOpcodeFirstByteFiller.yml
@@ -1330,7 +1330,7 @@ undefinedOpcodeFirstByte:
     data: 
       - ''
     gasLimit:
-      - 70000000
+      - 30000000
     gasPrice: 10
     nonce: 0
     secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8

--- a/tests/static/state_tests/stCreate2/CREATE2_FirstByte_loopFiller.yml
+++ b/tests/static/state_tests/stCreate2/CREATE2_FirstByte_loopFiller.yml
@@ -35,7 +35,7 @@ CREATE2_FirstByte_loop:
     data: 
       - ''
     gasLimit:
-      - 70000000
+      - 30000000
     gasPrice: 10
     nonce: 0
     secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8

--- a/tests/static/state_tests/stCreate2/CREATE2_HighNonceDelegatecallFiller.yml
+++ b/tests/static/state_tests/stCreate2/CREATE2_HighNonceDelegatecallFiller.yml
@@ -180,7 +180,7 @@ CREATE2_HighNonceDelegatecall:
       - ':label A_MaxNonce_Call_B_MaxNonce_Create2 :abi f(uint,uint,uint,uint) 0x02 0xffffffffffffffff 0xffffffffffffffff 0x1'
 
     gasLimit:
-      - 70000000
+      - 30000000
     gasPrice: 10
     nonce: 0
     secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8

--- a/tests/static/state_tests/stCreate2/CREATE2_HighNonceFiller.yml
+++ b/tests/static/state_tests/stCreate2/CREATE2_HighNonceFiller.yml
@@ -31,7 +31,7 @@ CREATE2_HighNonce:
     data: 
       - ''
     gasLimit:
-      - 70000000
+      - 30000000
     gasPrice: 10
     nonce: 0
     secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8

--- a/tests/static/state_tests/stCreate2/CREATE2_HighNonceMinus1Filler.yml
+++ b/tests/static/state_tests/stCreate2/CREATE2_HighNonceMinus1Filler.yml
@@ -31,7 +31,7 @@ CREATE2_HighNonceMinus1:
     data: 
       - ''
     gasLimit:
-      - 70000000
+      - 30000000
     gasPrice: 10
     nonce: 0
     secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8

--- a/tests/static/state_tests/stCreateTest/CREATE_ContractRETURNBigOffsetFiller.yml
+++ b/tests/static/state_tests/stCreateTest/CREATE_ContractRETURNBigOffsetFiller.yml
@@ -36,7 +36,7 @@ CREATE_ContractRETURNBigOffset:
     - ':raw 0x62051eb962074ac2f3'
     - ':raw 0x620d15bc62074ac2f3'
     gasLimit:
-    - '0x5000001'
+    - '0x1c9c380'
     gasPrice: '0x0a'
     nonce: '0x00'
     secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8

--- a/tests/static/state_tests/stCreateTest/CREATE_FirstByte_loopFiller.yml
+++ b/tests/static/state_tests/stCreateTest/CREATE_FirstByte_loopFiller.yml
@@ -35,7 +35,7 @@ CREATE_FirstByte_loop:
     data: 
       - ''
     gasLimit:
-      - 70000000
+      - 30000000
     gasPrice: 10
     nonce: 0
     secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8

--- a/tests/static/state_tests/stCreateTest/CREATE_HighNonceFiller.yml
+++ b/tests/static/state_tests/stCreateTest/CREATE_HighNonceFiller.yml
@@ -34,7 +34,7 @@ CREATE_HighNonce:
     data: 
       - ''
     gasLimit:
-      - 70000000
+      - 30000000
     gasPrice: 10
     nonce: 0
     secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8

--- a/tests/static/state_tests/stCreateTest/CREATE_HighNonceMinus1Filler.yml
+++ b/tests/static/state_tests/stCreateTest/CREATE_HighNonceMinus1Filler.yml
@@ -34,7 +34,7 @@ CREATE_HighNonceMinus1:
     data: 
       - ''
     gasLimit:
-      - 70000000
+      - 30000000
     gasPrice: 10
     nonce: 0
     secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8

--- a/tests/static/state_tests/stCreateTest/CreateAddressWarmAfterFailFiller.yml
+++ b/tests/static/state_tests/stCreateTest/CreateAddressWarmAfterFailFiller.yml
@@ -319,7 +319,7 @@ CreateAddressWarmAfterFail:
       - :label create-ok                 :abi fail(uint) 7   # Successfully create the account
       - :label create2-ok                :abi fail(uint) 17  # Successfully create2 the account
     gasLimit:
-      - 400000000
+      - 30000000
     gasPrice: 10
     nonce: 0
     to: "00000000000000000000000000000000000c0deC"

--- a/tests/static/state_tests/stCreateTest/CreateCollisionResultsFiller.yml
+++ b/tests/static/state_tests/stCreateTest/CreateCollisionResultsFiller.yml
@@ -144,7 +144,7 @@ CreateCollisionResults:
     - :raw 0x01
     - :raw 0x02
     gasLimit:
-    - 0xf0000000
+    - 0x1c9c380
 
     gasPrice: '10'
     nonce: '0'

--- a/tests/static/state_tests/stCreateTest/CreateOOGafterMaxCodesizeFiller.yml
+++ b/tests/static/state_tests/stCreateTest/CreateOOGafterMaxCodesizeFiller.yml
@@ -165,7 +165,7 @@ CreateOOGafterMaxCodesize:
     # - High number of contracts (250): Create 250 contracts at 0xc0dea, 250 contracts at 0xc0deb, don't OOG on 0xc0deb, call 494 out of 500 contracts to self-destruct.
     - :label HighContractCount_DelegateCreate_CallCreate_SelfDestruct :abi f(uint,uint,bool,uint) 0xfa 0xfa 0x00 0x01ee
     gasLimit:
-    - 0x100000000
+    - 0x1c9c380
     gasPrice: '10'
     nonce: '0'
     to: 00000000000000000000000000000000000c0dea

--- a/tests/static/state_tests/stCreateTest/createFailResultFiller.yml
+++ b/tests/static/state_tests/stCreateTest/createFailResultFiller.yml
@@ -292,7 +292,7 @@ createFailResult:
     - :label CREATE--BAD-BOOM :abi f(uint,uint) 0xEE 0x0BAD
 
     gasLimit:
-    - 80000000
+    - 30000000
     gasPrice: 10
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/stCreateTest/createLargeResultFiller.yml
+++ b/tests/static/state_tests/stCreateTest/createLargeResultFiller.yml
@@ -125,7 +125,7 @@ createLargeResult:
 
 
     gasLimit:
-    - 80000000
+    - 30000000
     gasPrice: 10
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/stEIP150singleCodeGasPrices/eip2929-ffFiller.yml
+++ b/tests/static/state_tests/stEIP150singleCodeGasPrices/eip2929-ffFiller.yml
@@ -110,7 +110,7 @@ eip2929-ff:
     - :label staticcall   :abi f(uint) 0xFA
 
     gasLimit: 
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/stEIP150singleCodeGasPrices/eip2929Filler.yml
+++ b/tests/static/state_tests/stEIP150singleCodeGasPrices/eip2929Filler.yml
@@ -221,7 +221,7 @@ eip2929:
 
 
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/stEIP150singleCodeGasPrices/eip2929OOGFiller.yml
+++ b/tests/static/state_tests/stEIP150singleCodeGasPrices/eip2929OOGFiller.yml
@@ -184,7 +184,7 @@ eip2929OOG:
     - :label failEIP2929 :abi f(uint,uint) 0x10FA 1750
 
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/stEIP150singleCodeGasPrices/gasCostBerlinFiller.yml
+++ b/tests/static/state_tests/stEIP150singleCodeGasPrices/gasCostBerlinFiller.yml
@@ -321,7 +321,7 @@ gasCostBerlin:
 
 
     gasLimit:
-    - 80000000
+    - 30000000
     gasPrice: 10
     nonce: 0
     to: 095e7baea6a6c7c4c2dfeb977efac326af552d87

--- a/tests/static/state_tests/stEIP150singleCodeGasPrices/gasCostExpFiller.yml
+++ b/tests/static/state_tests/stEIP150singleCodeGasPrices/gasCostExpFiller.yml
@@ -76,7 +76,7 @@ gasCostExp:
 
 
     gasLimit:
-    - 80000000
+    - 30000000
     gasPrice: 10
     nonce: 0
     to: 095e7baea6a6c7c4c2dfeb977efac326af552d87

--- a/tests/static/state_tests/stEIP150singleCodeGasPrices/gasCostFiller.yml
+++ b/tests/static/state_tests/stEIP150singleCodeGasPrices/gasCostFiller.yml
@@ -326,7 +326,7 @@ gasCost:
 
 
     gasLimit:
-    - 80000000
+    - 30000000
     gasPrice: 10
     nonce: 0
     to: 095e7baea6a6c7c4c2dfeb977efac326af552d87

--- a/tests/static/state_tests/stEIP150singleCodeGasPrices/gasCostJumpFiller.yml
+++ b/tests/static/state_tests/stEIP150singleCodeGasPrices/gasCostJumpFiller.yml
@@ -174,7 +174,7 @@ gasCostJump:
 
 
     gasLimit:
-    - 80000000
+    - 30000000
     gasPrice: 10
     nonce: 0
     to: 095e7baea6a6c7c4c2dfeb977efac326af552d87

--- a/tests/static/state_tests/stEIP150singleCodeGasPrices/gasCostMemSegFiller.yml
+++ b/tests/static/state_tests/stEIP150singleCodeGasPrices/gasCostMemSegFiller.yml
@@ -234,7 +234,7 @@ gasCostMemSeg:
 
 
     gasLimit:
-    - 80000000
+    - 30000000
     gasPrice: 10
     nonce: 0
     to: 095e7baea6a6c7c4c2dfeb977efac326af552d87

--- a/tests/static/state_tests/stEIP150singleCodeGasPrices/gasCostMemoryFiller.yml
+++ b/tests/static/state_tests/stEIP150singleCodeGasPrices/gasCostMemoryFiller.yml
@@ -332,7 +332,7 @@ gasCostMemory:
 
 
     gasLimit:
-    - 80000000
+    - 30000000
     gasPrice: 10
     nonce: 0
     to: 095e7baea6a6c7c4c2dfeb977efac326af552d87

--- a/tests/static/state_tests/stEIP150singleCodeGasPrices/gasCostReturnFiller.yml
+++ b/tests/static/state_tests/stEIP150singleCodeGasPrices/gasCostReturnFiller.yml
@@ -96,7 +96,7 @@ gasCostReturn:
     data:
     - :raw 0x00
     gasLimit:
-    - 80000000
+    - 30000000
     gasPrice: 10
     nonce: 0
     to: 095e7baea6a6c7c4c2dfeb977efac326af552d87

--- a/tests/static/state_tests/stEIP1559/baseFeeDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stEIP1559/baseFeeDiffPlacesFiller.yml
@@ -675,7 +675,7 @@ baseFeeDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stEIP1559/gasPriceDiffPlacesFiller.yml
+++ b/tests/static/state_tests/stEIP1559/gasPriceDiffPlacesFiller.yml
@@ -633,7 +633,7 @@ gasPriceDiffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stEIP1559/outOfFundsFiller.yml
+++ b/tests/static/state_tests/stEIP1559/outOfFundsFiller.yml
@@ -36,7 +36,7 @@ outOfFunds:
     maxFeePerGas: 10000000000
     maxPriorityFeePerGas:  10000000000
     gasLimit:
-    - 40000000000000
+    - 30000000
     - 40000
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/stEIP1559/outOfFundsOldTypesFiller.yml
+++ b/tests/static/state_tests/stEIP1559/outOfFundsOldTypesFiller.yml
@@ -36,7 +36,7 @@ outOfFundsOldTypes:
           accessList: []
     gasPrice: 10000000000
     gasLimit:
-    - 40000000000000
+    - 30000000
     - 40000
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/stEIP2930/addressOpcodesFiller.yml
+++ b/tests/static/state_tests/stEIP2930/addressOpcodesFiller.yml
@@ -509,7 +509,7 @@ addressOpcodes:
 
 
     gasLimit:
-    - '40000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8

--- a/tests/static/state_tests/stEIP2930/coinbaseT01Filler.yml
+++ b/tests/static/state_tests/stEIP2930/coinbaseT01Filler.yml
@@ -73,7 +73,7 @@ coinbaseT01:
 
 
     gasLimit:
-    - 40000000
+    - 30000000
     gasPrice: 1000
     nonce: 1
     secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8

--- a/tests/static/state_tests/stEIP2930/coinbaseT2Filler.yml
+++ b/tests/static/state_tests/stEIP2930/coinbaseT2Filler.yml
@@ -66,7 +66,7 @@ coinbaseT2:
         storageKeys: []
 
     gasLimit:
-    - 40000000
+    - 30000000
     maxFeePerGas: 10000
     maxPriorityFeePerGas: 100
     nonce: 1

--- a/tests/static/state_tests/stEIP2930/variedContextFiller.yml
+++ b/tests/static/state_tests/stEIP2930/variedContextFiller.yml
@@ -1105,7 +1105,7 @@ variedContext:
 
 
     gasLimit:
-    - '40000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8

--- a/tests/static/state_tests/stExample/yulExampleFiller.yml
+++ b/tests/static/state_tests/stExample/yulExampleFiller.yml
@@ -53,7 +53,7 @@ yulExample:
     data:
     - ""
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: 095e7baea6a6c7c4c2dfeb977efac326af552d87

--- a/tests/static/state_tests/stExtCodeHash/extcodehashEmpty_ParisFiller.yml
+++ b/tests/static/state_tests/stExtCodeHash/extcodehashEmpty_ParisFiller.yml
@@ -233,7 +233,7 @@ extcodehashEmpty_Paris:
 
 
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/stMemoryTest/bufferFiller.yml
+++ b/tests/static/state_tests/stMemoryTest/bufferFiller.yml
@@ -652,7 +652,7 @@ buffer:
 
 
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/stMemoryTest/bufferSrcOffsetFiller.yml
+++ b/tests/static/state_tests/stMemoryTest/bufferSrcOffsetFiller.yml
@@ -299,7 +299,7 @@ bufferSrcOffset:
     - :label fail :abi f(uint,uint,uint) 0x13E 11 1  
 
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/stMemoryTest/memCopySelfFiller.yml
+++ b/tests/static/state_tests/stMemoryTest/memCopySelfFiller.yml
@@ -65,7 +65,7 @@ memCopySelf:
     data: 
     - 0x
     gasLimit:
-    - 80000000
+    - 30000000
     gasPrice: 10
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/stMemoryTest/oogFiller.yml
+++ b/tests/static/state_tests/stMemoryTest/oogFiller.yml
@@ -402,7 +402,7 @@ oog:
 
 
     gasLimit:
-    - 80000000
+    - 30000000
     gasPrice: 10
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/stPreCompiledContracts/modexpTestsFiller.yml
+++ b/tests/static/state_tests/stPreCompiledContracts/modexpTestsFiller.yml
@@ -187,7 +187,7 @@ modexpTests:
     - :label 39936_1_55201 :abi f(uint,uint,uint) 39936 1 55201
     - :label 55190_55190_42965 :abi f(uint,uint,uint) 55190 55190 42965
     gasLimit:
-    - 80000000
+    - 30000000
     gasPrice: 10
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/stPreCompiledContracts/precompsEIP2929CancunFiller.yml
+++ b/tests/static/state_tests/stPreCompiledContracts/precompsEIP2929CancunFiller.yml
@@ -861,7 +861,7 @@ precompsEIP2929Cancun:
     - :label yes :abi f(uint,uint) 0x101157 0x3b      # 395
 
     gasLimit:
-    - '40000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8

--- a/tests/static/state_tests/stPreCompiledContracts2/ecrecoverWeirdVFiller.yml
+++ b/tests/static/state_tests/stPreCompiledContracts2/ecrecoverWeirdVFiller.yml
@@ -143,7 +143,7 @@ ecrecoverWeirdV:
     - :label fail :abi f(uint,uint,uint,uint) 0x01 0xdeadbeef0100 0x541c4ce1565a646ddde26e1b483a88a6500ce15bd24622492f05cdd18b97161d 0x1827e364c15cfa61dab02339904b1e542f3939c6e8d6367d352026e71ffd6af5
 
     gasLimit:
-    - 40000000
+    - 30000000
     gasPrice: 10
     nonce: 1
     to: 000000000000000000000000000000000000c0de

--- a/tests/static/state_tests/stRandom/randomStatetest384Filler.yml
+++ b/tests/static/state_tests/stRandom/randomStatetest384Filler.yml
@@ -209,7 +209,7 @@ randomStatetest384:
     data:
     - 0x
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stReturnDataTest/clearReturnBufferFiller.yml
+++ b/tests/static/state_tests/stReturnDataTest/clearReturnBufferFiller.yml
@@ -521,7 +521,7 @@ clearReturnBuffer:
 
 
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/stReturnDataTest/revertRetDataSizeFiller.yml
+++ b/tests/static/state_tests/stReturnDataTest/revertRetDataSizeFiller.yml
@@ -350,7 +350,7 @@ revertRetDataSize:
 
 
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/stReturnDataTest/tooLongReturnDataCopyFiller.yml
+++ b/tests/static/state_tests/stReturnDataTest/tooLongReturnDataCopyFiller.yml
@@ -222,7 +222,7 @@ tooLongReturnDataCopy:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stRevertTest/costRevertFiller.yml
+++ b/tests/static/state_tests/stRevertTest/costRevertFiller.yml
@@ -240,7 +240,7 @@ costRevert:
     - :label stackOver  :abi f(uint,uint) 0x1006 3
 
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/stRevertTest/stateRevertFiller.yml
+++ b/tests/static/state_tests/stRevertTest/stateRevertFiller.yml
@@ -139,7 +139,7 @@ stateRevert:
     - :label stackUnder :abi f(uint) 5
     - :label stackOver  :abi f(uint) 6
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/stSStoreTest/sstoreGasFiller.yml
+++ b/tests/static/state_tests/stSStoreTest/sstoreGasFiller.yml
@@ -114,7 +114,7 @@ sstoreGas:
     data:
     - 0x
     gasLimit:
-    - 80000000
+    - 30000000
     gasPrice: 10
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc

--- a/tests/static/state_tests/stSelfBalance/diffPlacesFiller.yml
+++ b/tests/static/state_tests/stSelfBalance/diffPlacesFiller.yml
@@ -633,7 +633,7 @@ diffPlaces:
 
 
     gasLimit:
-    - 0x10000000000000
+    - 0x1c9c380
     nonce: 1
     to: cccccccccccccccccccccccccccccccccccccccc
     value:

--- a/tests/static/state_tests/stShift/shiftCombinationsFiller.yml
+++ b/tests/static/state_tests/stShift/shiftCombinationsFiller.yml
@@ -2143,7 +2143,7 @@ shiftCombinations:
     data:
     - ''
     gasLimit:
-    - '80000000'
+    - '30000000'
     gasPrice: '10'
     nonce: '0'
     secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8

--- a/tests/static/state_tests/stShift/shiftSignedCombinationsFiller.yml
+++ b/tests/static/state_tests/stShift/shiftSignedCombinationsFiller.yml
@@ -993,7 +993,7 @@ shiftSignedCombinations:
     data:
       - ''
     gasLimit:
-      - '80000000'
+      - '30000000'
     gasPrice: '10'
     nonce: '0'
     secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8

--- a/tests/static/state_tests/stSystemOperationsTest/doubleSelfdestructTestFiller.yml
+++ b/tests/static/state_tests/stSystemOperationsTest/doubleSelfdestructTestFiller.yml
@@ -86,7 +86,7 @@ doubleSelfdestructTest:
     - :label caller-self-destruct :raw 0xFA1001c0de   # STATICCALL
 
     gasLimit:
-    - 1000000000
+    - 30000000
     gasPrice: 10
     nonce: 1
     secretKey: 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8


### PR DESCRIPTION
## 🗒️ Description
For now this is only for static_tests we have. Currently filling and executing to see if it all still works. Please thoroughly review this PR. These changes were done via a Python script that has no notion of what any of this means, next thing we should do is within our framework at fill check whether gasLimit is in allowed range

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist

- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
