### PR TITLE
fix(github): Use evmone for zkevm release

### DIFF
--- a/.github/configs/evm.yaml
+++ b/.github/configs/evm.yaml
@@ -12,9 +12,10 @@ static:
   ref: master
   targets: ["evmone-t8n", "evmone-eofparse"]
 zkevm:
-  impl: eels
-  repo: null
-  ref: null
+  impl: evmone
+  repo: ethereum/evmone
+  ref: master
+  targets: ["evmone-t8n", "evmone-eofparse"]
 eip7692:
   impl: evmone
   repo: ethereum/evmone


### PR DESCRIPTION
## 🗒️ Description
Modifies zkevm github action to build with evmone due to these being gas intenstive tests.

Long term solution is to dynamically increase the EELS timeout with a ceiling depending on how much gas the test is requesting.