### PR TITLE
feat(ci): add feature skips to main release process

### DIFF
--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -15,8 +15,10 @@ zkevm:
   evm-type: zkevm
   fill-params: --from=Cancun --until=Prague -m zkevm ./tests
   solc: 0.8.21
+  feature_only: true
 eip7692:
   evm-type: eip7692
   fill-params: --fork=EOFv1 ./tests/unscheduled
   solc: 0.8.21
   eofwrap: true
+  feature_only: true

--- a/.github/workflows/fixtures.yaml
+++ b/.github/workflows/fixtures.yaml
@@ -17,7 +17,16 @@ jobs:
         id: parse
         shell: bash
         run: |
-          echo "features=$(grep -Po "^[0-9a-zA-Z_\-]+" ./.github/configs/feature.yaml | jq -R . | jq -cs .)" >> "$GITHUB_OUTPUT"
+          # Get all features without `feature_only: true`
+          grep -Po "^[0-9a-zA-Z_\-]+" ./.github/configs/feature.yaml | \
+          while read feature; do
+            if ! awk "/^$feature:/{flag=1; next} /^[[:alnum:]]/{flag=0} flag && /feature_only:.*true/{exit 1}" \
+                  ./.github/configs/feature.yaml; then
+              continue
+            fi
+            echo "$feature"
+          done | jq -R . | jq -cs . > features.json
+          echo "features=$(cat features.json)" >> "$GITHUB_OUTPUT"
   build:
     needs: features
     runs-on: self-hosted

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,15 +20,12 @@ A new fork `EOFv1` has additionally been created to fill and consume EOF related
 
 - ✨ Add an empty account function for usage within fill and execute ([#1482](https://github.com/ethereum/execution-spec-tests/pull/1482)).
 
-#### `fill`
-
-#### `consume`
-
 ### 📋 Misc
 
 - ✨ Engine API updates for Osaka, add `get_blobs` rpc method ([#1510](https://github.com/ethereum/execution-spec-tests/pull/1510)).
 - ✨ The EIP Version checker has been moved from `fill` and `execute` to it's own command-line tool `check_eip_versions` that gets ran daily as a Github Action ([#1537](https://github.com/ethereum/execution-spec-tests/pull/1537)).
 🔀 Add new `tests/unscheduled` folder, move EOF from Osaka to unscheduled, add `EOFv1` fork name for EOF tests ([#1507](https://github.com/ethereum/execution-spec-tests/pull/1507)).
+- ✨ CI features now contain an optional field to skip them from EEST full releases, `zkevm` and EOF features are now feature only ([#1596](https://github.com/ethereum/execution-spec-tests/pull/1596)).
 
 ### 🧪 Test Cases
 


### PR DESCRIPTION
## 🗒️ Description
Allows us to add `feature_only: <BOOL>` field to our features within release CI.
This lets us easily skip features for new full releases.

Currently we can't fill for EOF as the fork name required is missing for evmone.

Both zkevm and EOF both now have `feature_only: true`, meaning there releases must be created manually via the feature release process.

## 🔗 Related Issues
N/A

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
