### PR TITLE
feat(fill,zkevm): suppress high tx gas limit warnings for zkevm tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,8 @@ A new fork `EOFv1` has additionally been created to fill and consume EOF related
 
 #### `fill`
 
+- ✨ Don't warn about a "high Transaction gas_limit" for `zkevm` tests ([#1598](https://github.com/ethereum/execution-spec-tests/pull/1598)).
+
 #### `consume`
 
 ### 📋 Misc

--- a/src/ethereum_test_specs/base.py
+++ b/src/ethereum_test_specs/base.py
@@ -142,7 +142,10 @@ class BaseTest(BaseModel):
     def is_tx_gas_heavy_test(self) -> bool:
         """Check if the test is gas-heavy for transaction execution."""
         if self._request is not None and hasattr(self._request, "node"):
-            return self._request.node.get_closest_marker("slow") is not None
+            node = self._request.node
+            has_slow_marker = node.get_closest_marker("slow") is not None
+            has_zkevm_marker = node.get_closest_marker("zkevm") is not None
+            return has_slow_marker or has_zkevm_marker
         return False
 
     def is_exception_test(self) -> bool | None:

--- a/src/ethereum_test_specs/base.py
+++ b/src/ethereum_test_specs/base.py
@@ -139,8 +139,8 @@ class BaseTest(BaseModel):
             str(current_value),
         )
 
-    def is_slow_test(self) -> bool:
-        """Check if the test is slow."""
+    def is_tx_gas_heavy_test(self) -> bool:
+        """Check if the test is gas-heavy for transaction execution."""
         if self._request is not None and hasattr(self._request, "node"):
             return self._request.node.get_closest_marker("slow") is not None
         return False

--- a/src/ethereum_test_specs/blockchain.py
+++ b/src/ethereum_test_specs/blockchain.py
@@ -397,7 +397,6 @@ class BlockchainTest(BaseTest):
         previous_env: Environment,
         previous_alloc: Alloc,
         eips: Optional[List[int]] = None,
-        slow: bool = False,
     ) -> Tuple[FixtureHeader, List[Transaction], List[Bytes] | None, Alloc, Environment]:
         """Generate common block data for both make_fixture and make_hive_fixture."""
         if block.rlp and block.exception is not None:
@@ -412,7 +411,7 @@ class BlockchainTest(BaseTest):
 
         txs: List[Transaction] = []
         for tx in block.txs:
-            if not self.is_slow_test() and tx.gas_limit >= Environment().gas_limit:
+            if not self.is_tx_gas_heavy_test() and tx.gas_limit >= Environment().gas_limit:
                 warnings.warn(
                     f"{self.node_id()} uses a high Transaction gas_limit: {tx.gas_limit}",
                     stacklevel=2,
@@ -441,7 +440,7 @@ class BlockchainTest(BaseTest):
             blob_schedule=fork.blob_schedule(),
             eips=eips,
             debug_output_path=self.get_next_transition_tool_output_path(),
-            slow_request=slow,
+            slow_request=self.is_tx_gas_heavy_test(),
         )
 
         try:
@@ -593,7 +592,6 @@ class BlockchainTest(BaseTest):
                     previous_env=env,
                     previous_alloc=alloc,
                     eips=eips,
-                    slow=self.is_slow_test(),
                 )
                 fixture_block = FixtureBlockBase(
                     header=header,
@@ -682,7 +680,6 @@ class BlockchainTest(BaseTest):
                 previous_env=env,
                 previous_alloc=alloc,
                 eips=eips,
-                slow=self.is_slow_test(),
             )
             if block.rlp is None:
                 fixture_payloads.append(

--- a/src/ethereum_test_specs/state.py
+++ b/src/ethereum_test_specs/state.py
@@ -170,7 +170,7 @@ class StateTest(BaseTest):
 
         env = self.env.set_fork_requirements(fork)
         tx = self.tx.with_signature_and_sender(keep_secret_key=True)
-        if not self.is_slow_test() and tx.gas_limit >= Environment().gas_limit:
+        if not self.is_tx_gas_heavy_test() and tx.gas_limit >= Environment().gas_limit:
             warnings.warn(
                 f"{self.node_id()} uses a high Transaction gas_limit: {tx.gas_limit}",
                 stacklevel=2,
@@ -193,7 +193,7 @@ class StateTest(BaseTest):
             eips=eips,
             debug_output_path=self.get_next_transition_tool_output_path(),
             state_test=True,
-            slow_request=self.is_slow_test(),
+            slow_request=self.is_tx_gas_heavy_test(),
         )
 
         try:


### PR DESCRIPTION
## 🗒️ Description
Suppress high tx gas limit warnings for zkevm tests

## 🔗 Related Issues
See https://github.com/ethereum/execution-spec-tests/pull/1591#discussion_r2086922876 from
- #1591

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).

