### PR TITLE
chore(coverage,ci): remove `GeneralStateTests` from ethereum/tests coverage

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -99,7 +99,6 @@ jobs:
           repository: ethereum/tests
           path: testpath
           sparse-checkout: |
-            GeneralStateTests
             BlockchainTests
             EOFTests
 
@@ -147,7 +146,7 @@ jobs:
               fi
 
               # Do not search EOF files in legacy tests (assuming blockchain files we do not cover yet)
-              if [[ "$file" == *"GeneralStateTests"* ]]; then
+              if [[ "$file" != *"EOFTests"* ]]; then
                   file_path=${{ github.workspace }}/legacytestpath/Cancun/$file
                   base_name=$(basename "$file")
                   legacy_file_name="legacy_$base_name"


### PR DESCRIPTION
## 🗒️ Description
To avoid confusion, I removed GeneralStateTests from ethereum/tests repo.
this pr adjusts the coverage script for that 

Note: leaving the checkbox `A PR with removal of converted JSON/YML tests from ` on, since we have BlockchainTests to port. But converted state tests does not require a pr, since ALL are deleted in ethereum/tests.
ethereum-converted-tests.txt still required. but we can start thinking to replace it with  pytest marker logic soon.


## 🔗 Related Issues
https://github.com/ethereum/tests/pull/1491

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [x] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
