### PR TITLE
chore(cli): increase transition tool timeout

### DIFF
--- a/src/ethereum_clis/transition_tool.py
+++ b/src/ethereum_clis/transition_tool.py
@@ -35,7 +35,7 @@ from .types import (
 model_dump_config: Mapping = {"by_alias": True, "exclude_none": True}
 
 NORMAL_SERVER_TIMEOUT = 20
-SLOW_REQUEST_TIMEOUT = 60
+SLOW_REQUEST_TIMEOUT = 180
 
 
 class TransitionTool(EthereumCLI):


### PR DESCRIPTION
## 🗒️ Description
Increase t8n tool timeout to prevent errors when filling develop for full releases.

## 🔗 Related Issues
N/A

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] ~~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
