### PR TITLE
feat: add support for ethrex client

### DIFF
--- a/src/ethereum_clis/clis/ethrex.py
+++ b/src/ethereum_clis/clis/ethrex.py
@@ -10,9 +10,7 @@ class EthrexExceptionMapper(ExceptionMapper):
         TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED: (
             "Exceeded MAX_BLOB_GAS_PER_BLOCK"
         ),
-        TransactionException.INVALID_DEPOSIT_EVENT_LAYOUT: (
-            "Requests hash does not match the one in the header after executing"
-        ),
+        TransactionException.INVALID_DEPOSIT_EVENT_LAYOUT: ("Invalid deposit request layout"),
         BlockException.INVALID_REQUESTS: (
             "Requests hash does not match the one in the header after executing"
         ),

--- a/src/ethereum_clis/clis/ethrex.py
+++ b/src/ethereum_clis/clis/ethrex.py
@@ -27,7 +27,7 @@ class EthrexExceptionMapper(ExceptionMapper):
             "World State Root does not match the one in the header after executing",
         ),
         BlockException.INVALID_GAS_USED: "Gas used doesn't match value in header",
-        BlockException.INCORRECT_BLOB_GAS_USED: "Blob gas used doesn't match value in header"
+        BlockException.INCORRECT_BLOB_GAS_USED: "Blob gas used doesn't match value in header",
     }
     mapping_regex = {
         TransactionException.SENDER_NOT_EOA: (
@@ -73,19 +73,9 @@ class EthrexExceptionMapper(ExceptionMapper):
         TransactionException.INITCODE_SIZE_EXCEEDED: (
             r"create initcode size limit|Initcode size exceeded"
         ),
-        BlockException.SYSTEM_CONTRACT_CALL_FAILED: (
-            r"failed to apply .* requests contract call"
-        ),
-        BlockException.INCORRECT_BLOB_GAS_USED: (
-            r"Blob gas used doesn't match value in header"
-        ),
-        BlockException.RLP_STRUCTURES_ENCODING: (
-            r"Error decoding field '\D+' of type \w+.*"
-        ),
-        BlockException.INCORRECT_EXCESS_BLOB_GAS: (
-            r".* Excess blob gas is incorrect"
-        ),
-        BlockException.INVALID_BLOCK_HASH: (
-            r"Invalid block hash. Expected \w+, got \w+"
-        )
+        BlockException.SYSTEM_CONTRACT_CALL_FAILED: (r"failed to apply .* requests contract call"),
+        BlockException.INCORRECT_BLOB_GAS_USED: (r"Blob gas used doesn't match value in header"),
+        BlockException.RLP_STRUCTURES_ENCODING: (r"Error decoding field '\D+' of type \w+.*"),
+        BlockException.INCORRECT_EXCESS_BLOB_GAS: (r".* Excess blob gas is incorrect"),
+        BlockException.INVALID_BLOCK_HASH: (r"Invalid block hash. Expected \w+, got \w+"),
     }

--- a/src/ethereum_clis/clis/ethrex.py
+++ b/src/ethereum_clis/clis/ethrex.py
@@ -7,13 +7,9 @@ class EthrexExceptionMapper(ExceptionMapper):
     """Ethrex exception mapper."""
 
     mapping_substring = {
-        TransactionException.PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS: (
-            "(?i)priority fee is greater than max fee"
-        ),
         TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED: (
             "Exceeded MAX_BLOB_GAS_PER_BLOCK"
         ),
-        TransactionException.TYPE_4_EMPTY_AUTHORIZATION_LIST: "(?i)empty authorization list",
         TransactionException.INVALID_DEPOSIT_EVENT_LAYOUT: (
             "Requests hash does not match the one in the header after executing"
         ),
@@ -30,6 +26,10 @@ class EthrexExceptionMapper(ExceptionMapper):
         BlockException.INCORRECT_BLOB_GAS_USED: "Blob gas used doesn't match value in header",
     }
     mapping_regex = {
+        TransactionException.PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS: (
+            r"(?i)priority fee is greater than max fee"
+        ),
+        TransactionException.TYPE_4_EMPTY_AUTHORIZATION_LIST: r"(?i)empty authorization list",
         TransactionException.SENDER_NOT_EOA: (
             r"reject transactions from senders with deployed code|"
             r"Sender account should not have bytecode"

--- a/src/ethereum_clis/clis/ethrex.py
+++ b/src/ethereum_clis/clis/ethrex.py
@@ -24,7 +24,7 @@ class EthrexExceptionMapper(ExceptionMapper):
             "Receipts Root does not match the one in the header after executing"
         ),
         BlockException.INVALID_STATE_ROOT: (
-            "World State Root does not match the one in the header after executing",
+            "World State Root does not match the one in the header after executing"
         ),
         BlockException.INVALID_GAS_USED: "Gas used doesn't match value in header",
         BlockException.INCORRECT_BLOB_GAS_USED: "Blob gas used doesn't match value in header",

--- a/src/ethereum_clis/clis/ethrex.py
+++ b/src/ethereum_clis/clis/ethrex.py
@@ -7,50 +7,68 @@ class EthrexExceptionMapper(ExceptionMapper):
     """Ethrex exception mapper."""
 
     mapping_substring = {
-        TransactionException.PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS: "(?i)priority fee is greater than max fee",
-        TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED: "Exceeded MAX_BLOB_GAS_PER_BLOCK",
+        TransactionException.PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS: (
+            "(?i)priority fee is greater than max fee"
+        ),
+        TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED: (
+            "Exceeded MAX_BLOB_GAS_PER_BLOCK"
+        ),
         TransactionException.TYPE_4_EMPTY_AUTHORIZATION_LIST: "(?i)empty authorization list",
-        TransactionException.INVALID_DEPOSIT_EVENT_LAYOUT: "Requests hash does not match the one in the header after executing",
-        BlockException.INVALID_REQUESTS: "Requests hash does not match the one in the header after executing",
-        BlockException.INVALID_RECEIPTS_ROOT: "Receipts Root does not match the one in the header after executing",
-        BlockException.INVALID_STATE_ROOT: "World State Root does not match the one in the header after executing",
+        TransactionException.INVALID_DEPOSIT_EVENT_LAYOUT: (
+            "Requests hash does not match the one in the header after executing"
+        ),
+        BlockException.INVALID_REQUESTS: (
+            "Requests hash does not match the one in the header after executing"
+        ),
+        BlockException.INVALID_RECEIPTS_ROOT: (
+            "Receipts Root does not match the one in the header after executing"
+        ),
+        BlockException.INVALID_STATE_ROOT: (
+            "World State Root does not match the one in the header after executing",
+        ),
         BlockException.INVALID_GAS_USED: "Gas used doesn't match value in header",
         BlockException.INCORRECT_BLOB_GAS_USED: "Blob gas used doesn't match value in header"
     }
     mapping_regex = {
         TransactionException.SENDER_NOT_EOA: (
-            r"reject transactions from senders with deployed code|Sender account should not have bytecode"
+            r"reject transactions from senders with deployed code|"
+            r"Sender account should not have bytecode"
         ),
         TransactionException.NONCE_MISMATCH_TOO_LOW: r"nonce \d+ too low, expected \d+",
         TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED: (
             r"blob gas used \d+ exceeds maximum allowance \d+"
         ),
         TransactionException.TYPE_3_TX_ZERO_BLOBS: (
-            r"blob transactions present in pre-cancun payload|empty blobs|Type 3 transaction without blobs"
+            r"blob transactions present in pre-cancun payload|empty blobs|"
+            r"Type 3 transaction without blobs"
         ),
         TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH: (
             r"blob version not supported|Invalid blob versioned hash"
         ),
         TransactionException.TYPE_3_TX_PRE_FORK: (
-            r"blob versioned hashes not supported|Type 3 transactions are not supported before the Cancun fork"
+            r"blob versioned hashes not supported|"
+            r"Type 3 transactions are not supported before the Cancun fork"
         ),
         TransactionException.TYPE_4_TX_CONTRACT_CREATION: (
             r"unexpected length|Contract creation in type 4 transaction"
         ),
         TransactionException.TYPE_4_TX_PRE_FORK: (
-            r"eip 7702 transactions present in pre-prague payload|Type 4 transactions are not supported before the Prague fork"
+            r"eip 7702 transactions present in pre-prague payload|"
+            r"Type 4 transactions are not supported before the Prague fork"
         ),
         TransactionException.INSUFFICIENT_ACCOUNT_FUNDS: (
             r"lack of funds \(\d+\) for max fee \(\d+\)|Insufficient account founds"
         ),
         TransactionException.INTRINSIC_GAS_TOO_LOW: (
-            r"gas floor exceeds the gas limit|call gas cost exceeds the gas limit|Intrinsic gas too low"
+            r"gas floor exceeds the gas limit|call gas cost exceeds the gas limit|"
+            r"Intrinsic gas too low"
         ),
         TransactionException.INSUFFICIENT_MAX_FEE_PER_GAS: (
             r"gas price is less than basefee|Insufficient max fee per gas"
         ),
         TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS: (
-            r"blob gas price is greater than max fee per blob gas|Insufficient max fee per blob gas"
+            r"blob gas price is greater than max fee per blob gas|"
+            r"Insufficient max fee per blob gas"
         ),
         TransactionException.INITCODE_SIZE_EXCEEDED: (
             r"create initcode size limit|Initcode size exceeded"

--- a/src/ethereum_clis/clis/ethrex.py
+++ b/src/ethereum_clis/clis/ethrex.py
@@ -1,0 +1,73 @@
+"""Ethrex execution client transition tool."""
+
+from ethereum_test_exceptions import BlockException, ExceptionMapper, TransactionException
+
+
+class EthrexExceptionMapper(ExceptionMapper):
+    """Ethrex exception mapper."""
+
+    mapping_substring = {
+        TransactionException.PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS: "(?i)priority fee is greater than max fee",
+        TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED: "Exceeded MAX_BLOB_GAS_PER_BLOCK",
+        TransactionException.TYPE_4_EMPTY_AUTHORIZATION_LIST: "(?i)empty authorization list",
+        TransactionException.INVALID_DEPOSIT_EVENT_LAYOUT: "Requests hash does not match the one in the header after executing",
+        BlockException.INVALID_REQUESTS: "Requests hash does not match the one in the header after executing",
+        BlockException.INVALID_RECEIPTS_ROOT: "Receipts Root does not match the one in the header after executing",
+        BlockException.INVALID_STATE_ROOT: "World State Root does not match the one in the header after executing",
+        BlockException.INVALID_GAS_USED: "Gas used doesn't match value in header",
+        BlockException.INCORRECT_BLOB_GAS_USED: "Blob gas used doesn't match value in header"
+    }
+    mapping_regex = {
+        TransactionException.SENDER_NOT_EOA: (
+            r"reject transactions from senders with deployed code|Sender account should not have bytecode"
+        ),
+        TransactionException.NONCE_MISMATCH_TOO_LOW: r"nonce \d+ too low, expected \d+",
+        TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED: (
+            r"blob gas used \d+ exceeds maximum allowance \d+"
+        ),
+        TransactionException.TYPE_3_TX_ZERO_BLOBS: (
+            r"blob transactions present in pre-cancun payload|empty blobs|Type 3 transaction without blobs"
+        ),
+        TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH: (
+            r"blob version not supported|Invalid blob versioned hash"
+        ),
+        TransactionException.TYPE_3_TX_PRE_FORK: (
+            r"blob versioned hashes not supported|Type 3 transactions are not supported before the Cancun fork"
+        ),
+        TransactionException.TYPE_4_TX_CONTRACT_CREATION: (
+            r"unexpected length|Contract creation in type 4 transaction"
+        ),
+        TransactionException.TYPE_4_TX_PRE_FORK: (
+            r"eip 7702 transactions present in pre-prague payload|Type 4 transactions are not supported before the Prague fork"
+        ),
+        TransactionException.INSUFFICIENT_ACCOUNT_FUNDS: (
+            r"lack of funds \(\d+\) for max fee \(\d+\)|Insufficient account founds"
+        ),
+        TransactionException.INTRINSIC_GAS_TOO_LOW: (
+            r"gas floor exceeds the gas limit|call gas cost exceeds the gas limit|Intrinsic gas too low"
+        ),
+        TransactionException.INSUFFICIENT_MAX_FEE_PER_GAS: (
+            r"gas price is less than basefee|Insufficient max fee per gas"
+        ),
+        TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS: (
+            r"blob gas price is greater than max fee per blob gas|Insufficient max fee per blob gas"
+        ),
+        TransactionException.INITCODE_SIZE_EXCEEDED: (
+            r"create initcode size limit|Initcode size exceeded"
+        ),
+        BlockException.SYSTEM_CONTRACT_CALL_FAILED: (
+            r"failed to apply .* requests contract call"
+        ),
+        BlockException.INCORRECT_BLOB_GAS_USED: (
+            r"Blob gas used doesn't match value in header"
+        ),
+        BlockException.RLP_STRUCTURES_ENCODING: (
+            r"Error decoding field '\D+' of type \w+.*"
+        ),
+        BlockException.INCORRECT_EXCESS_BLOB_GAS: (
+            r".* Excess blob gas is incorrect"
+        ),
+        BlockException.INVALID_BLOCK_HASH: (
+            r"Invalid block hash. Expected \w+, got \w+"
+        )
+    }

--- a/src/pytest_plugins/consume/hive_simulators/exceptions.py
+++ b/src/pytest_plugins/consume/hive_simulators/exceptions.py
@@ -10,6 +10,7 @@ from ethereum_clis.clis.geth import GethExceptionMapper
 from ethereum_clis.clis.nethermind import NethermindExceptionMapper
 from ethereum_clis.clis.nimbus import NimbusExceptionMapper
 from ethereum_clis.clis.reth import RethExceptionMapper
+from ethereum_clis.clis.ethrex import EthrexExceptionMapper
 from ethereum_test_exceptions import ExceptionMapper
 from ethereum_test_fixtures.blockchain import FixtureHeader
 
@@ -70,4 +71,5 @@ EXCEPTION_MAPPERS: Dict[str, ExceptionMapper] = {
     "reth": RethExceptionMapper(),
     "nimbus": NimbusExceptionMapper(),
     "ethereumjs": EthereumJSExceptionMapper(),
+    "ethrex": EthrexExceptionMapper(),
 }

--- a/src/pytest_plugins/consume/hive_simulators/exceptions.py
+++ b/src/pytest_plugins/consume/hive_simulators/exceptions.py
@@ -6,11 +6,11 @@ from typing import Dict, List, Tuple
 from ethereum_clis.clis.besu import BesuExceptionMapper
 from ethereum_clis.clis.erigon import ErigonExceptionMapper
 from ethereum_clis.clis.ethereumjs import EthereumJSExceptionMapper
+from ethereum_clis.clis.ethrex import EthrexExceptionMapper
 from ethereum_clis.clis.geth import GethExceptionMapper
 from ethereum_clis.clis.nethermind import NethermindExceptionMapper
 from ethereum_clis.clis.nimbus import NimbusExceptionMapper
 from ethereum_clis.clis.reth import RethExceptionMapper
-from ethereum_clis.clis.ethrex import EthrexExceptionMapper
 from ethereum_test_exceptions import ExceptionMapper
 from ethereum_test_fixtures.blockchain import FixtureHeader
 


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
Adds exception mapping for [ethrex](https://github.com/lambdaclass/ethrex) errors on consume tests
## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist

- [ ] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
