### PR TITLE
fix(fill): insist `fill`'s output directory is empty or doesn't exist

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 ### 💥 Important Change for `fill` Users
 
-The output behavior of `fill` has changed ([#1473](https://github.com/ethereum/execution-spec-tests/pull/1473)):
+The output behavior of `fill` has changed ([#1608](https://github.com/ethereum/execution-spec-tests/pull/1608)):
 
 - Before: `fill` wrote fixtures into the directory specified by the `--output` flag (default: `fixtures`). This could have many unintended consequences, including unexpected errors if old or invalid fixtures existed in the directory (for details see [#1030](https://github.com/ethereum/execution-spec-tests/issues/1030)).
 - Now: `fill` will exit without filling any tests if the specified directory exists and is not-empty. This may be overridden by adding the `--clean` flag, which will first remove the specified directory.
@@ -21,7 +21,7 @@ The output behavior of `fill` has changed ([#1473](https://github.com/ethereum/e
 
 - 🔀 Refactor: Encapsulate `fill`'s fixture output options (`--output`, `--flat-output`, `--single-fixture-per-file`) into a `FixtureOutput` class ([#1471](https://github.com/ethereum/execution-spec-tests/pull/1471)).
 - ✨ Don't warn about a "high Transaction gas_limit" for `zkevm` tests ([#1598](https://github.com/ethereum/execution-spec-tests/pull/1598)).
-- 🐞 `fill` no longer writes generated fixtures into an existing, non-empty output directory; it must now be empty or `--clean` must be used to delete it first ([#1473](https://github.com/ethereum/execution-spec-tests/pull/1473)).
+- 🐞 `fill` no longer writes generated fixtures into an existing, non-empty output directory; it must now be empty or `--clean` must be used to delete it first ([#1608](https://github.com/ethereum/execution-spec-tests/pull/1608)).
 
 #### `consume`
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,12 +8,20 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 ### 💥 Breaking Change
 
+### 💥 Important Change for `fill` Users
+
+The output behavior of `fill` has changed ([#1473](https://github.com/ethereum/execution-spec-tests/pull/1473)):
+
+- Before: `fill` wrote fixtures into the directory specified by the `--output` flag (default: `fixtures`). This could have many unintended consequences, including unexpected errors if old or invalid fixtures existed in the directory (for details see [#1030](https://github.com/ethereum/execution-spec-tests/issues/1030)).
+- Now: `fill` will exit without filling any tests if the specified directory exists and is not-empty. This may be overridden by adding the `--clean` flag, which will first remove the specified directory.
+
 ### 🛠️ Framework
 
 #### `fill`
 
 - 🔀 Refactor: Encapsulate `fill`'s fixture output options (`--output`, `--flat-output`, `--single-fixture-per-file`) into a `FixtureOutput` class ([#1471](https://github.com/ethereum/execution-spec-tests/pull/1471)).
 - ✨ Don't warn about a "high Transaction gas_limit" for `zkevm` tests ([#1598](https://github.com/ethereum/execution-spec-tests/pull/1598)).
+- 🐞 `fill` no longer writes generated fixtures into an existing, non-empty output directory; it must now be empty or `--clean` must be used to delete it first ([#1473](https://github.com/ethereum/execution-spec-tests/pull/1473)).
 
 #### `consume`
 

--- a/src/cli/gentest/tests/test_cli.py
+++ b/src/cli/gentest/tests/test_cli.py
@@ -1,5 +1,7 @@
 """Tests for the gentest CLI command."""
 
+from tempfile import TemporaryDirectory
+
 import pytest
 from click.testing import CliRunner
 
@@ -111,5 +113,13 @@ def test_tx_type(tmp_path, monkeypatch, tx_type, transaction_hash):
     assert gentest_result.exit_code == 0
 
     ## Fill ##
-    fill_result = runner.invoke(fill, ["-c", "pytest.ini", "--skip-evm-dump", output_file])
+    args = [
+        "-c",
+        "pytest.ini",
+        "--skip-evm-dump",
+        "--output",
+        TemporaryDirectory().name,
+        output_file,
+    ]
+    fill_result = runner.invoke(fill, args)
     assert fill_result.exit_code == 0, f"Fill command failed:\n{fill_result.output}"

--- a/src/pytest_plugins/filler/fixture_output.py
+++ b/src/pytest_plugins/filler/fixture_output.py
@@ -1,5 +1,6 @@
 """Fixture output configuration for generated test fixtures."""
 
+import shutil
 import tarfile
 from pathlib import Path
 
@@ -21,6 +22,10 @@ class FixtureOutput(BaseModel):
             "Don't group fixtures in JSON files by test function; "
             "write each fixture to its own file"
         ),
+    )
+    clean: bool = Field(
+        default=False,
+        description="Clean (remove) the output directory before filling fixtures.",
     )
 
     @property
@@ -53,11 +58,78 @@ class FixtureOutput(BaseModel):
             return path.with_suffix("").with_suffix("")
         return path
 
-    def create_directories(self) -> None:
-        """Create output and metadata directories if needed."""
+    def is_directory_empty(self) -> bool:
+        """Check if the output directory is empty."""
+        if not self.directory.exists():
+            return True
+
+        return not any(self.directory.iterdir())
+
+    def get_directory_summary(self) -> str:
+        """Return a summary of directory contents for error reporting."""
+        if not self.directory.exists():
+            return "directory does not exist"
+
+        items = list(self.directory.iterdir())
+        if not items:
+            return "empty directory"
+
+        dirs = [d.name for d in items if d.is_dir()]
+        files = [f.name for f in items if f.is_file()]
+
+        max_dirs = 4
+        summary_parts = []
+        if dirs:
+            summary_parts.append(
+                f"{len(dirs)} directories"
+                + (
+                    f" ({', '.join(dirs[:max_dirs])}"
+                    + (f"... and {len(dirs) - max_dirs} more" if len(dirs) > max_dirs else "")
+                    + ")"
+                    if dirs
+                    else ""
+                )
+            )
+        if files:
+            summary_parts.append(
+                f"{len(files)} files"
+                + (
+                    f" ({', '.join(files[:3])}"
+                    + (f"... and {len(files) - 3} more" if len(files) > 3 else "")
+                    + ")"
+                    if files
+                    else ""
+                )
+            )
+
+        return " and ".join(summary_parts)
+
+    def create_directories(self, is_master: bool) -> None:
+        """
+        Create output and metadata directories if needed.
+
+        If clean flag is set, remove and recreate the directory.
+        Otherwise, verify the directory is empty before proceeding.
+        """
         if self.is_stdout:
             return
 
+        # Only the master process should delete/create directories if using pytest-xdist
+        if not is_master:
+            return
+
+        if self.directory.exists() and self.clean:
+            shutil.rmtree(self.directory)
+
+        if self.directory.exists() and not self.is_directory_empty():
+            summary = self.get_directory_summary()
+            raise ValueError(
+                f"Output directory '{self.directory}' is not empty. "
+                f"Contains: {summary}. Use --clean to remove all existing files "
+                "or specify a different output directory."
+            )
+
+        # Create directories
         self.directory.mkdir(parents=True, exist_ok=True)
         self.metadata_dir.mkdir(parents=True, exist_ok=True)
 
@@ -73,21 +145,11 @@ class FixtureOutput(BaseModel):
                     tar.add(file, arcname=arcname)
 
     @classmethod
-    def from_options(
-        cls, output_path: Path, flat_output: bool, single_fixture_per_file: bool
-    ) -> "FixtureOutput":
-        """Create a FixtureOutput instance from pytest options."""
-        return cls(
-            output_path=output_path,
-            flat_output=flat_output,
-            single_fixture_per_file=single_fixture_per_file,
-        )
-
-    @classmethod
     def from_config(cls, config: pytest.Config) -> "FixtureOutput":
         """Create a FixtureOutput instance from pytest configuration."""
         return cls(
             output_path=config.getoption("output"),
             flat_output=config.getoption("flat_output"),
             single_fixture_per_file=config.getoption("single_fixture_per_file"),
+            clean=config.getoption("clean"),
         )

--- a/src/pytest_plugins/filler/tests/test_output_directory.py
+++ b/src/pytest_plugins/filler/tests/test_output_directory.py
@@ -1,0 +1,262 @@
+"""Test the filler plugin's output directory handling."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+from pytest import TempPathFactory
+
+from cli.pytest_commands.fill import fill
+from pytest_plugins.filler.fixture_output import FixtureOutput
+
+
+@pytest.fixture(scope="module")
+def test_path() -> Path:
+    """Specify the test path to be filled."""
+    return Path("tests/istanbul/eip1344_chainid/test_chainid.py")
+
+
+@pytest.fixture(scope="module")
+def fill_fork_from() -> str:
+    """Specify the value for `fill`'s `--from` argument."""
+    return "Paris"
+
+
+@pytest.fixture(scope="module")
+def fill_fork_until() -> str:
+    """Specify the value for `fill`'s `--until` argument."""
+    return "Cancun"
+
+
+@pytest.fixture
+def run_fill(test_path: Path, fill_fork_from: str, fill_fork_until: str):
+    """Create a function to run the fill command with various output directory scenarios."""
+
+    def _run_fill(output_dir: Path, clean: bool = False, expect_failure: bool = False):
+        """Run the fill command with the specified output directory and clean flag."""
+        args = [
+            "-c",
+            "pytest.ini",
+            "--skip-evm-dump",
+            "-m",
+            "(not blockchain_test_engine) and (not eip_version_check)",
+            f"--from={fill_fork_from}",
+            f"--until={fill_fork_until}",
+            f"--output={str(output_dir)}",
+            str(test_path),
+        ]
+
+        if clean:
+            args.append("--clean")
+
+        result = CliRunner().invoke(fill, args)
+
+        if expect_failure:
+            assert result.exit_code != 0, "Fill command was expected to fail but succeeded"
+        else:
+            assert result.exit_code == 0, f"Fill command failed:\n{result.output}"
+
+        return result
+
+    return _run_fill
+
+
+def test_fill_to_empty_directory(tmp_path_factory: TempPathFactory, run_fill):
+    """Test filling to a new, empty directory."""
+    output_dir = tmp_path_factory.mktemp("empty_fixtures")
+
+    run_fill(output_dir)
+
+    assert any(output_dir.glob("state_tests/**/*.json")), "No fixture files were created"
+    assert (output_dir / ".meta").exists(), "Metadata directory was not created"
+
+
+def test_fill_to_nonexistent_directory(tmp_path_factory: TempPathFactory, run_fill):
+    """Test filling to a nonexistent directory."""
+    base_dir = tmp_path_factory.mktemp("base")
+    output_dir = base_dir / "nonexistent_fixtures"
+
+    run_fill(output_dir)
+
+    assert any(output_dir.glob("state_tests/**/*.json")), "No fixture files were created"
+    assert (output_dir / ".meta").exists(), "Metadata directory was not created"
+
+
+def test_fill_to_nonempty_directory_fails(tmp_path_factory: TempPathFactory, run_fill):
+    """Test filling to a non-empty directory fails without --clean."""
+    # Create a directory with a file
+    output_dir = tmp_path_factory.mktemp("nonempty_fixtures")
+    (output_dir / "existing_file.txt").write_text("This directory is not empty")
+
+    result = run_fill(output_dir, expect_failure=True)
+
+    assert "is not empty" in str(result.output), "Expected error about non-empty directory"
+    assert "Use --clean" in str(result.output), "Expected suggestion to use --clean flag"
+
+
+def test_fill_to_nonempty_directory_with_clean(tmp_path_factory: TempPathFactory, run_fill):
+    """Test filling to a non-empty directory succeeds with --clean."""
+    # Create a directory with a file
+    output_dir = tmp_path_factory.mktemp("nonempty_fixtures_clean")
+    (output_dir / "existing_file.txt").write_text("This directory will be cleaned")
+
+    run_fill(output_dir, clean=True)
+
+    # Verify the existing file was removed
+    assert not (output_dir / "existing_file.txt").exists(), "Existing file was not removed"
+
+    assert any(output_dir.glob("state_tests/**/*.json")), "No fixture files were created"
+
+
+def test_fill_to_directory_with_meta_fails(tmp_path_factory: TempPathFactory, run_fill):
+    """Test filling to a directory with .meta subdirectory fails without --clean."""
+    # Create a directory with .meta
+    output_dir = tmp_path_factory.mktemp("directory_with_meta")
+    meta_dir = output_dir / ".meta"
+    meta_dir.mkdir()
+    (meta_dir / "existing_meta_file.txt").write_text("This is metadata")
+
+    result = run_fill(output_dir, expect_failure=True)
+
+    assert "is not empty" in str(result.output), "Expected error about non-empty directory"
+
+
+def test_fill_to_directory_with_meta_with_clean(tmp_path_factory: TempPathFactory, run_fill):
+    """Test filling to a directory with .meta succeeds with --clean."""
+    # Create a directory with .meta
+    output_dir = tmp_path_factory.mktemp("directory_with_meta_clean")
+    meta_dir = output_dir / ".meta"
+    meta_dir.mkdir()
+    (meta_dir / "existing_meta_file.txt").write_text("This is metadata")
+
+    run_fill(output_dir, clean=True)
+
+    assert any(output_dir.glob("state_tests/**/*.json")), "No fixture files were created"
+    assert not (meta_dir / "existing_meta_file.txt").exists(), "Existing meta file was not removed"
+
+
+def test_fill_stdout_always_works(tmp_path_factory: TempPathFactory, run_fill):
+    """Test filling to stdout always works regardless of output state."""
+    stdout_path = Path("stdout")
+    # create a directory called "stdout" - it should not have any effect
+    output_dir = tmp_path_factory.mktemp(stdout_path.name)
+    meta_dir = output_dir / ".meta"
+    meta_dir.mkdir()
+    (meta_dir / "existing_meta_file.txt").write_text("This is metadata")
+
+    result = run_fill(stdout_path)
+
+    assert (
+        '"tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Cancun-state_test]": {'
+        in result.output
+    ), "Expected JSON output for state test"
+
+
+def test_fill_to_tarball_directory(tmp_path_factory: TempPathFactory, run_fill):
+    """Test filling to a tarball output."""
+    output_dir = tmp_path_factory.mktemp("tarball_fixtures")
+    tarball_path = output_dir / "fixtures.tar.gz"
+
+    run_fill(tarball_path)
+
+    assert tarball_path.exists(), "Tarball was not created"
+    extracted_dir = output_dir / "fixtures"
+    assert extracted_dir.exists(), "Extracted directory doesn't exist"
+
+    assert any(extracted_dir.glob("state_tests/**/*.json")), "No fixture files were created"
+
+
+# New tests for the is_master functionality
+def test_create_directories_skips_when_not_master():
+    """Test that create_directories skips operations when not the master process."""
+    fixture_output = FixtureOutput(
+        output_path=Path("/fake/path"),
+        clean=True,
+    )
+
+    # Mock directory operations to ensure they aren't called
+    with (
+        patch.object(FixtureOutput, "is_directory_empty") as mock_is_empty,
+        patch.object(Path, "exists", return_value=True),
+        patch.object(Path, "mkdir") as mock_mkdir,
+        patch("shutil.rmtree") as mock_rmtree,
+    ):
+        # Call with is_master=False (worker process)
+        fixture_output.create_directories(is_master=False)
+
+        # Verify no directory operations occurred
+        mock_is_empty.assert_not_called()
+        mock_mkdir.assert_not_called()
+        mock_rmtree.assert_not_called()
+
+
+def test_create_directories_operates_when_master():
+    """Test that create_directories performs operations when is the master process."""
+    fixture_output = FixtureOutput(
+        output_path=Path("/fake/path"),
+        clean=True,
+    )
+
+    # Mock directory operations
+    with (
+        patch.object(FixtureOutput, "is_directory_empty", return_value=True),
+        patch.object(Path, "exists", return_value=True),
+        patch.object(Path, "mkdir") as mock_mkdir,
+        patch("shutil.rmtree") as mock_rmtree,
+    ):
+        # Call with is_master=True (master process)
+        fixture_output.create_directories(is_master=True)
+
+        # Verify directory operations occurred
+        mock_rmtree.assert_called_once()
+        mock_mkdir.assert_called()
+
+
+def test_create_directories_checks_empty_when_master():
+    """Test that directory emptiness is checked only when is_master=True."""
+    fixture_output = FixtureOutput(
+        output_path=Path("/fake/path"),
+        clean=False,  # Don't clean, so we'll check if empty
+    )
+
+    # Mock directory operations
+    with (
+        patch.object(FixtureOutput, "is_directory_empty", return_value=False) as mock_is_empty,
+        patch.object(
+            FixtureOutput, "get_directory_summary", return_value="not empty"
+        ) as mock_summary,
+        patch.object(Path, "exists", return_value=True),
+        patch.object(Path, "mkdir"),
+    ):
+        # Call with is_master=True and expect an error about non-empty directory
+        with pytest.raises(ValueError, match="not empty"):
+            fixture_output.create_directories(is_master=True)
+
+        # Verify emptiness check was performed
+        mock_is_empty.assert_called_once()
+        mock_summary.assert_called_once()
+
+
+def test_stdout_skips_directory_operations_regardless_of_master():
+    """Test that stdout output skips directory operations regardless of is_master value."""
+    fixture_output = FixtureOutput(
+        output_path=Path("stdout"),
+        clean=True,
+    )
+
+    # Mock directory operations to ensure they aren't called
+    with (
+        patch.object(FixtureOutput, "is_directory_empty") as mock_is_empty,
+        patch.object(Path, "exists") as mock_exists,
+        patch.object(Path, "mkdir") as mock_mkdir,
+        patch("shutil.rmtree") as mock_rmtree,
+    ):
+        # Should skip operations even with is_master=True
+        fixture_output.create_directories(is_master=True)
+
+        # Verify no directory operations occurred
+        mock_is_empty.assert_not_called()
+        mock_exists.assert_not_called()
+        mock_mkdir.assert_not_called()
+        mock_rmtree.assert_not_called()

--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,7 @@ setenv =
     # Use custom EELS_RESOLUTIONS_FILE if it is set via the environment (eg, in CI)
     EELS_RESOLUTIONS_FILE = {env:EELS_RESOLUTIONS_FILE:}
 commands_pre = solc-select use {[testenv]solc_version} --always-install
-commands = pytest -n auto -k "not slow" --skip-evm-dump
+commands = pytest -n auto -k "not slow" --skip-evm-dump --output=/tmp/fixtures-tox --clean
 
 [testenv:tests-develop]
 description = Fill test cases in ./tests/ for deployed and development mainnet forks
@@ -81,7 +81,7 @@ setenv =
     # Use custom EELS_RESOLUTIONS_FILE if it is set via the environment (eg, in CI)
     EELS_RESOLUTIONS_FILE = {env:EELS_RESOLUTIONS_FILE:}
 commands_pre = solc-select use {[testenv]solc_version} --always-install
-commands = pytest -n auto --until={[forks]develop} -k "not slow" --skip-evm-dump
+commands = pytest -n auto --until={[forks]develop} -k "not slow" --skip-evm-dump --output=/tmp/fixtures-tox --clean
 
 # ----------------------------------------------------------------------------------------------
 # ALIAS ENVIRONMENTS


### PR DESCRIPTION
## 🗒️ Description

Requires:
- #1471

Make `fill`'s output behavior more robust: Do not write generated fixtures into an existing, non-empty output directory; it must now be empty or `--clean` must be used to delete it first.

## Todo

- [x] Make directory deletion/creation multip-thread/pytest-xdist friendly.

## 🔗 Related Issues
Fixes #1030:
- #1030 

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
