### PR TITLE
zkvm: add stateful opcodes attacks

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -176,8 +176,8 @@ jobs:
           # As when we translate from yul/solidity some dup/push opcodes could become untouched
           files="$files tests/homestead/coverage/test_coverage.py"
 
-          echo "uv run fill $files --clean --until=Cancun --evm-bin evmone-t8n >> filloutput.log 2>&1"
-          uv run fill $files --clean --until=Cancun --evm-bin evmone-t8n > >(tee -a filloutput.log) 2> >(tee -a filloutput.log >&2)
+          echo "uv run fill $files --clean --until=Cancun --evm-bin evmone-t8n --skip-evm-dump >> filloutput.log 2>&1"
+          uv run fill $files --clean --until=Cancun --evm-bin evmone-t8n --skip-evm-dump > >(tee -a filloutput.log) 2> >(tee -a filloutput.log >&2)
 
           if grep -q "FAILURES" filloutput.log; then
               echo "Error: failed to generate .py tests."
@@ -228,8 +228,8 @@ jobs:
           rm filloutput.log
 
           if [ -n "$files_fixed" ]; then
-              echo "uv run fill $files_fixed --clean --until=Cancun --evm-bin evmone-t8n >> filloutput.log 2>&1"
-              uv run fill $files_fixed --clean --until=Cancun --evm-bin evmone-t8n > >(tee -a filloutput.log) 2> >(tee -a filloutput.log >&2)
+              echo "uv run fill $files_fixed --clean --until=Cancun --evm-bin evmone-t8n --skip-evm-dump >> filloutput.log 2>&1"
+              uv run fill $files_fixed --clean --until=Cancun --evm-bin evmone-t8n --skip-evm-dump > >(tee -a filloutput.log) 2> >(tee -a filloutput.log >&2)
 
               if grep -q "FAILURES" filloutput.log; then
                 echo "Error: failed to generate .py tests from before the PR."

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -176,8 +176,8 @@ jobs:
           # As when we translate from yul/solidity some dup/push opcodes could become untouched
           files="$files tests/homestead/coverage/test_coverage.py"
 
-          echo "uv run fill $files --clean --until=Cancun --evm-bin evmone-t8n --skip-evm-dump >> filloutput.log 2>&1"
-          uv run fill $files --clean --until=Cancun --evm-bin evmone-t8n --skip-evm-dump > >(tee -a filloutput.log) 2> >(tee -a filloutput.log >&2)
+          echo "uv run fill $files --clean --until=Cancun --evm-bin evmone-t8n --skip-evm-dump --block-gas-limit 36000000 >> filloutput.log 2>&1"
+          uv run fill $files --clean --until=Cancun --evm-bin evmone-t8n --skip-evm-dump --block-gas-limit 36000000 > >(tee -a filloutput.log) 2> >(tee -a filloutput.log >&2)
 
           if grep -q "FAILURES" filloutput.log; then
               echo "Error: failed to generate .py tests."
@@ -228,8 +228,8 @@ jobs:
           rm filloutput.log
 
           if [ -n "$files_fixed" ]; then
-              echo "uv run fill $files_fixed --clean --until=Cancun --evm-bin evmone-t8n --skip-evm-dump >> filloutput.log 2>&1"
-              uv run fill $files_fixed --clean --until=Cancun --evm-bin evmone-t8n --skip-evm-dump > >(tee -a filloutput.log) 2> >(tee -a filloutput.log >&2)
+              echo "uv run fill $files_fixed --clean --until=Cancun --evm-bin evmone-t8n --skip-evm-dump --block-gas-limit 36000000 >> filloutput.log 2>&1"
+              uv run fill $files_fixed --clean --until=Cancun --evm-bin evmone-t8n --skip-evm-dump --block-gas-limit 36000000 > >(tee -a filloutput.log) 2> >(tee -a filloutput.log >&2)
 
               if grep -q "FAILURES" filloutput.log; then
                 echo "Error: failed to generate .py tests from before the PR."

--- a/tests/zkevm/test_worst_bytecode.py
+++ b/tests/zkevm/test_worst_bytecode.py
@@ -67,7 +67,7 @@ def test_worst_bytecode_single_opcode(
     """
     # We use 100G gas limit to be able to deploy a large number of contracts in a single block,
     # avoiding bloating the number of preparing blocks in the test.
-    env = Environment(gas_limit=1_000_000_000_000)
+    env = Environment(gas_limit=100_000_000_000)
     attack_gas_limit = Environment().gas_limit
 
     # The initcode will take its address as a starting point to the input to the keccak

--- a/tests/zkevm/test_worst_bytecode.py
+++ b/tests/zkevm/test_worst_bytecode.py
@@ -10,17 +10,9 @@ import math
 import pytest
 
 from ethereum_test_forks import Fork
-from ethereum_test_tools import (
-    Account,
-    Alloc,
-    Block,
-    BlockchainTestFiller,
-    Environment,
-    Hash,
-    Transaction,
-    While,
-    compute_create2_address,
-)
+from ethereum_test_tools import (Account, Alloc, Block, BlockchainTestFiller,
+                                 Environment, Hash, Transaction, While,
+                                 compute_create2_address)
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 REFERENCE_SPEC_GIT_PATH = "TODO"
@@ -39,12 +31,6 @@ XOR_TABLE = [Hash(i).sha256() for i in range(XOR_TABLE_SIZE)]
         Op.EXTCODEHASH,
     ],
 )
-@pytest.mark.parametrize(
-    "attack_gas_limit",
-    [
-        Environment().gas_limit,
-    ],
-)
 @pytest.mark.slow()
 @pytest.mark.valid_from("Cancun")
 def test_worst_bytecode_single_opcode(
@@ -52,7 +38,6 @@ def test_worst_bytecode_single_opcode(
     pre: Alloc,
     fork: Fork,
     opcode: Op,
-    attack_gas_limit: int,
 ):
     """
     Test a block execution where a single opcode execution maxes out the gas limit,
@@ -69,6 +54,7 @@ def test_worst_bytecode_single_opcode(
     # We use 100G gas limit to be able to deploy a large number of contracts in a single block,
     # avoiding bloating the number of preparing blocks in the test.
     env = Environment(gas_limit=100_000_000_000)
+    attack_gas_limit = Environment().gas_limit
 
     # The initcode will take its address as a starting point to the input to the keccak
     # hash function.

--- a/tests/zkevm/test_worst_bytecode.py
+++ b/tests/zkevm/test_worst_bytecode.py
@@ -10,9 +10,17 @@ import math
 import pytest
 
 from ethereum_test_forks import Fork
-from ethereum_test_tools import (Account, Alloc, Block, BlockchainTestFiller,
-                                 Environment, Hash, Transaction, While,
-                                 compute_create2_address)
+from ethereum_test_tools import (
+    Account,
+    Alloc,
+    Block,
+    BlockchainTestFiller,
+    Environment,
+    Hash,
+    Transaction,
+    While,
+    compute_create2_address,
+)
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 REFERENCE_SPEC_GIT_PATH = "TODO"

--- a/tests/zkevm/test_worst_bytecode.py
+++ b/tests/zkevm/test_worst_bytecode.py
@@ -144,7 +144,7 @@ def test_worst_bytecode_single_opcode(
     contracts_deployment_tx = Transaction(
         to=factory_caller_address,
         gas_limit=env.gas_limit,
-        gas_price=10**9,  # Bump required due to the amount of full blocks
+        gas_price=10**9,
         data=Hash(num_contracts),
         sender=pre.fund_eoa(),
     )
@@ -162,7 +162,7 @@ def test_worst_bytecode_single_opcode(
 
     attack_call = Bytecode()
     if opcode == Op.EXTCODECOPY:
-        attack_call = Op.EXTCODECOPY(address=Op.SHA3(32 - 20 - 1, 85), size=1000)
+        attack_call = Op.EXTCODECOPY(address=Op.SHA3(32 - 20 - 1, 85), dest_offset=85, size=1000)
     else:
         # For the rest of the opcodes, we can use the same generic attack call
         # since all only minimally need the `address` of the target.
@@ -171,7 +171,7 @@ def test_worst_bytecode_single_opcode(
         # Setup memory for later CREATE2 address generation loop.
         # 0xFF+[Address(20bytes)]+[seed(32bytes)]+[initcode keccak(32bytes)]
         Op.MSTORE(0, factory_address)
-        + Op.MSTORE8(32 - 20 - 1, 0xFF)  # 0xFF prefix byte
+        + Op.MSTORE8(32 - 20 - 1, 0xFF)
         + Op.MSTORE(32, 0)
         + Op.MSTORE(64, initcode.keccak256())
         # Main loop
@@ -190,7 +190,7 @@ def test_worst_bytecode_single_opcode(
     opcode_tx = Transaction(
         to=opcode_address,
         gas_limit=attack_gas_limit,
-        gas_price=10**9,  # Bump required due to the amount of full blocks
+        gas_price=10**9,
         sender=pre.fund_eoa(),
     )
 

--- a/tests/zkevm/test_worst_bytecode.py
+++ b/tests/zkevm/test_worst_bytecode.py
@@ -36,6 +36,7 @@ XOR_TABLE = [Hash(i).sha256() for i in range(XOR_TABLE_SIZE)]
     "opcode",
     [
         Op.EXTCODESIZE,
+        Op.EXTCODEHASH,
     ],
 )
 @pytest.mark.parametrize(
@@ -128,7 +129,7 @@ def test_worst_bytecode_single_opcode(
         gas_costs.G_KECCAK_256  # KECCAK static cost
         + math.ceil(85 / 32) * gas_costs.G_KECCAK_256_WORD  # KECCAK dynamic cost for CREATE2
         + gas_costs.G_VERY_LOW * 3  # ~MSTOREs+ADDs
-        + gas_costs.G_COLD_ACCOUNT_ACCESS  # EXTCODESIZE
+        + gas_costs.G_COLD_ACCOUNT_ACCESS  # Opcode cost
         + 30  # ~Gluing opcodes
     )
     max_number_of_contract_calls = (

--- a/tests/zkevm/test_worst_bytecode.py
+++ b/tests/zkevm/test_worst_bytecode.py
@@ -67,7 +67,7 @@ def test_worst_bytecode_single_opcode(
     """
     # We use 100G gas limit to be able to deploy a large number of contracts in a single block,
     # avoiding bloating the number of preparing blocks in the test.
-    env = Environment(gas_limit=100_000_000_000)
+    env = Environment(gas_limit=1_000_000_000_000)
     attack_gas_limit = Environment().gas_limit
 
     # The initcode will take its address as a starting point to the input to the keccak

--- a/tests/zkevm/test_worst_stateful_opcodes.py
+++ b/tests/zkevm/test_worst_stateful_opcodes.py
@@ -117,12 +117,6 @@ def test_worst_address_state_cold(
 
 @pytest.mark.valid_from("Cancun")
 @pytest.mark.parametrize(
-    "attack_gas_limit",
-    [
-        Environment().gas_limit,
-    ],
-)
-@pytest.mark.parametrize(
     "opcode",
     [
         Op.BALANCE,
@@ -145,7 +139,6 @@ def test_worst_address_state_warm(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
     fork: Fork,
-    attack_gas_limit: int,
     opcode: Op,
     absent_target: bool,
 ):
@@ -153,6 +146,7 @@ def test_worst_address_state_warm(
     Test running a block with as many stateful opcodes doing warm access for an account.
     """
     env = Environment(gas_limit=100_000_000_000)
+    attack_gas_limit = Environment().gas_limit
 
     # Setup
     target_addr = Address(100_000)

--- a/tests/zkevm/test_worst_stateful_opcodes.py
+++ b/tests/zkevm/test_worst_stateful_opcodes.py
@@ -10,17 +10,9 @@ import math
 import pytest
 
 from ethereum_test_forks import Fork
-from ethereum_test_tools import (
-    Account,
-    Address,
-    Alloc,
-    Block,
-    BlockchainTestFiller,
-    Bytecode,
-    Environment,
-    Transaction,
-    While,
-)
+from ethereum_test_tools import (Account, Address, Alloc, Block,
+                                 BlockchainTestFiller, Bytecode, Environment,
+                                 Transaction, While)
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 REFERENCE_SPEC_GIT_PATH = "TODO"
@@ -43,7 +35,7 @@ MAX_CODE_SIZE = 24 * 1024
     ],
 )
 @pytest.mark.parametrize(
-    "absent",
+    "absent_target",
     [
         True,
         False,
@@ -55,7 +47,7 @@ def test_worst_address_state_cold(
     fork: Fork,
     attack_gas_limit: int,
     opcode: Op,
-    absent: bool,
+    absent_target: bool,
 ):
     """
     Test running a block with as many stateful opcodes accessing cold accounts.
@@ -77,7 +69,7 @@ def test_worst_address_state_cold(
     # collisions with the addresses indirectly created by the testing framework.
     addr_offset = 100_000
 
-    if not absent:
+    if not absent_target:
         factory_code = Op.PUSH4(num_target_accounts) + While(
             body=Op.POP(Op.CALL(address=Op.ADD(addr_offset, Op.DUP6), value=10)),
             condition=Op.PUSH1(1) + Op.SWAP1 + Op.SUB + Op.DUP1 + Op.ISZERO + Op.ISZERO,
@@ -135,7 +127,7 @@ def test_worst_address_state_cold(
     ],
 )
 @pytest.mark.parametrize(
-    "absent",
+    "absent_target",
     [
         True,
         False,
@@ -147,7 +139,7 @@ def test_worst_address_state_warm(
     fork: Fork,
     attack_gas_limit: int,
     opcode: Op,
-    absent: bool,
+    absent_target: bool,
 ):
     """
     Test running a block with as many stateful opcodes doing warm access for an account.
@@ -157,7 +149,7 @@ def test_worst_address_state_warm(
     # Setup
     target_addr = Address(100_000)
     post = {target_addr: None}
-    if not absent:
+    if not absent_target:
         target_addr = pre.deploy_contract(balance=100, code=Op.JUMPDEST * 100)
         post[target_addr] = Account(balance=100, code=Op.JUMPDEST * 100)
 

--- a/tests/zkevm/test_worst_stateful_opcodes.py
+++ b/tests/zkevm/test_worst_stateful_opcodes.py
@@ -5,7 +5,6 @@ abstract: Tests zkEVMs worst-case stateful opcodes.
 Tests running worst-case stateful opcodes for zkEVMs.
 """
 
-
 import pytest
 
 from ethereum_test_forks import Fork
@@ -47,7 +46,6 @@ def test_worst_address_state_cold(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
     fork: Fork,
-    attack_gas_limit: int,
     opcode: Op,
     absent_targets: bool,
 ):
@@ -108,7 +106,7 @@ def test_worst_address_state_cold(
         pre=pre,
         post=post,
         blocks=blocks,
-        # TODO: add skip_post_check=True
+        exclude_full_post_state_in_output=True,
     )
 
 
@@ -145,7 +143,7 @@ def test_worst_address_state_warm(
 
     # Setup
     target_addr = Address(100_000)
-    post = {target_addr: None}
+    post = {}
     if not absent_target:
         code = Op.STOP + Op.JUMPDEST * 100
         target_addr = pre.deploy_contract(balance=100, code=code)
@@ -177,7 +175,6 @@ def test_worst_address_state_warm(
         post=post,
         blocks=[Block(txs=[op_tx])],
     )
-    # TODO: add skip_post_check=True
 
 
 class StorageAction:
@@ -273,16 +270,17 @@ def test_worst_storage_access_cold(
         )
         + Op.RETURN(0, Op.MSIZE)
     )
+    sender_addr = pre.fund_eoa()
     setup_tx = Transaction(
         to=None,
         gas_limit=env.gas_limit,
         data=creation_code,
         gas_price=10,
-        sender=pre.fund_eoa(),
+        sender=sender_addr,
     )
     blocks.append(Block(txs=[setup_tx]))
 
-    contract_address = compute_create_address(address=setup_tx.sender, nonce=0)
+    contract_address = compute_create_address(address=sender_addr, nonce=0)
 
     op_tx = Transaction(
         to=contract_address,
@@ -297,7 +295,7 @@ def test_worst_storage_access_cold(
         pre=pre,
         post={},
         blocks=blocks,
-        # TODO: add skip_post_check=True
+        exclude_full_post_state_in_output=True,
     )
 
 
@@ -349,16 +347,17 @@ def test_worst_storage_access_warm(
         )
         + Op.RETURN(0, Op.MSIZE)
     )
+    sender_addr = pre.fund_eoa()
     setup_tx = Transaction(
         to=None,
         gas_limit=env.gas_limit,
         data=creation_code,
         gas_price=10,
-        sender=pre.fund_eoa(),
+        sender=sender_addr,
     )
     blocks.append(Block(txs=[setup_tx]))
 
-    contract_address = compute_create_address(address=setup_tx.sender, nonce=0)
+    contract_address = compute_create_address(address=sender_addr, nonce=0)
 
     op_tx = Transaction(
         to=contract_address,
@@ -373,7 +372,6 @@ def test_worst_storage_access_warm(
         pre=pre,
         post={},
         blocks=blocks,
-        # TODO: add skip_post_check=True
     )
 
 

--- a/tests/zkevm/test_worst_stateful_opcodes.py
+++ b/tests/zkevm/test_worst_stateful_opcodes.py
@@ -70,7 +70,7 @@ def test_worst_address_state_cold(
     # The target addresses are going to be constructed (in the case of absent=False) and called
     # as addr_offset + i, where i is the index of the account. This is to avoid
     # collisions with the addresses indirectly created by the testing framework.
-    addr_offset = 100_000
+    addr_offset = int.from_bytes(pre.fund_eoa(amount=0))
 
     if not absent_accounts:
         factory_code = Op.PUSH4(num_target_accounts) + While(
@@ -82,7 +82,6 @@ def test_worst_address_state_cold(
         setup_tx = Transaction(
             to=factory_address,
             gas_limit=env.gas_limit,
-            gas_price=10,
             sender=pre.fund_eoa(),
         )
         blocks.append(Block(txs=[setup_tx]))
@@ -100,7 +99,6 @@ def test_worst_address_state_cold(
     op_tx = Transaction(
         to=op_address,
         gas_limit=attack_gas_limit,
-        gas_price=10,
         sender=pre.fund_eoa(),
     )
     blocks.append(Block(txs=[op_tx]))
@@ -170,7 +168,6 @@ def test_worst_address_state_warm(
     op_tx = Transaction(
         to=op_address,
         gas_limit=attack_gas_limit,
-        gas_price=10,
         sender=pre.fund_eoa(),
     )
 
@@ -281,7 +278,6 @@ def test_worst_storage_access_cold(
         to=None,
         gas_limit=env.gas_limit,
         data=creation_code,
-        gas_price=10,
         sender=sender_addr,
     )
     blocks.append(Block(txs=[setup_tx]))
@@ -291,7 +287,6 @@ def test_worst_storage_access_cold(
     op_tx = Transaction(
         to=contract_address,
         gas_limit=attack_gas_limit,
-        gas_price=10,
         sender=pre.fund_eoa(),
     )
     blocks.append(Block(txs=[op_tx]))
@@ -359,7 +354,6 @@ def test_worst_storage_access_warm(
         to=None,
         gas_limit=env.gas_limit,
         data=creation_code,
-        gas_price=10,
         sender=sender_addr,
     )
     blocks.append(Block(txs=[setup_tx]))
@@ -369,7 +363,6 @@ def test_worst_storage_access_warm(
     op_tx = Transaction(
         to=contract_address,
         gas_limit=attack_gas_limit,
-        gas_price=10,
         sender=pre.fund_eoa(),
     )
     blocks.append(Block(txs=[op_tx]))
@@ -403,7 +396,6 @@ def test_worst_blockhash(
     op_tx = Transaction(
         to=execution_code_address,
         gas_limit=env.gas_limit,
-        gas_price=10,
         sender=pre.fund_eoa(),
     )
     blocks.append(Block(txs=[op_tx]))
@@ -433,7 +425,6 @@ def test_worst_selfbalance(
     op_tx = Transaction(
         to=execution_code_address,
         gas_limit=env.gas_limit,
-        gas_price=10,
         sender=pre.fund_eoa(),
     )
 
@@ -479,7 +470,6 @@ def test_worst_extcodecopy_warm(
     op_tx = Transaction(
         to=execution_code_address,
         gas_limit=env.gas_limit,
-        gas_price=10,
         sender=pre.fund_eoa(),
     )
 

--- a/tests/zkevm/test_worst_stateful_opcodes.py
+++ b/tests/zkevm/test_worst_stateful_opcodes.py
@@ -10,15 +10,24 @@ import math
 import pytest
 
 from ethereum_test_forks import Fork
-from ethereum_test_tools import (Account, Address, Alloc, Block,
-                                 BlockchainTestFiller, Bytecode, Environment,
-                                 Transaction, While)
+from ethereum_test_tools import (
+    Account,
+    Address,
+    Alloc,
+    Block,
+    BlockchainTestFiller,
+    Bytecode,
+    Environment,
+    Transaction,
+    While,
+)
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 REFERENCE_SPEC_GIT_PATH = "TODO"
 REFERENCE_SPEC_VERSION = "TODO"
 
 MAX_CODE_SIZE = 24 * 1024
+
 
 @pytest.mark.valid_from("Cancun")
 @pytest.mark.parametrize(
@@ -46,10 +55,10 @@ def test_worst_address_state_cold(
     fork: Fork,
     attack_gas_limit: int,
     opcode: Op,
-    absent : bool,
+    absent: bool,
 ):
     """
-    Test running a block with as many stateful opcodes accessing cold accounts. 
+    Test running a block with as many stateful opcodes accessing cold accounts.
     """
     env = Environment(gas_limit=100_000_000_000)
 
@@ -84,7 +93,7 @@ def test_worst_address_state_cold(
         blocks.append(Block(txs=[setup_tx]))
 
         for i in range(num_target_accounts):
-            addr = Address(i+addr_offset+1)
+            addr = Address(i + addr_offset + 1)
             post[addr] = Account(balance=10)
 
     # Execution
@@ -108,6 +117,7 @@ def test_worst_address_state_cold(
         blocks=blocks,
         # TODO: add skip_post_check=True
     )
+
 
 @pytest.mark.valid_from("Cancun")
 @pytest.mark.parametrize(
@@ -140,23 +150,25 @@ def test_worst_address_state_warm(
     absent: bool,
 ):
     """
-    Test running a block with as many stateful opcodes doing warm access for an account. 
+    Test running a block with as many stateful opcodes doing warm access for an account.
     """
     env = Environment(gas_limit=100_000_000_000)
 
     # Setup
-    target_addr = Address(100_000) 
-    post = {target_addr:  None}
-    if not absent: 
+    target_addr = Address(100_000)
+    post = {target_addr: None}
+    if not absent:
         target_addr = pre.deploy_contract(balance=100, code=Op.JUMPDEST * 100)
-        post[target_addr] = Account(balance=100, code = Op.JUMPDEST * 100)
+        post[target_addr] = Account(balance=100, code=Op.JUMPDEST * 100)
 
     # Execution
     prep = Op.PUSH20(target_addr)
     jumpdest = Op.JUMPDEST
     jump_back = Op.JUMP(len(prep))
-    iter_block  = Op.POP(opcode(Op.DUP1))
-    max_iters_loop = (MAX_CODE_SIZE - len(prep) - len(jumpdest) - len(jump_back)) // len(iter_block)
+    iter_block = Op.POP(opcode(Op.DUP1))
+    max_iters_loop = (MAX_CODE_SIZE - len(prep) - len(jumpdest) - len(jump_back)) // len(
+        iter_block
+    )
     op_code = prep + jumpdest + sum([iter_block] * max_iters_loop) + jump_back
     if len(op_code) > MAX_CODE_SIZE:
         # Must never happen, but keep it as a sanity check.
@@ -175,4 +187,4 @@ def test_worst_address_state_warm(
         post=post,
         blocks=[Block(txs=[op_tx])],
     )
-        # TODO: add skip_post_check=True
+    # TODO: add skip_post_check=True

--- a/tests/zkevm/test_worst_stateful_opcodes.py
+++ b/tests/zkevm/test_worst_stateful_opcodes.py
@@ -32,12 +32,6 @@ MAX_CODE_SIZE = 24 * 1024
 
 @pytest.mark.valid_from("Cancun")
 @pytest.mark.parametrize(
-    "attack_gas_limit",
-    [
-        Environment().gas_limit,
-    ],
-)
-@pytest.mark.parametrize(
     "opcode",
     [
         Op.BALANCE,
@@ -62,6 +56,7 @@ def test_worst_address_state_cold(
     Test running a block with as many stateful opcodes accessing cold accounts.
     """
     env = Environment(gas_limit=100_000_000_000)
+    attack_gas_limit = Environment().gas_limit
 
     gas_costs = fork.gas_costs()
     intrinsic_gas_cost_calc = fork.transaction_intrinsic_cost_calculator()

--- a/tests/zkevm/test_worst_stateful_opcodes.py
+++ b/tests/zkevm/test_worst_stateful_opcodes.py
@@ -20,6 +20,7 @@ from ethereum_test_tools import (
     Environment,
     Transaction,
     While,
+    compute_create_address,
 )
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
@@ -43,7 +44,7 @@ MAX_CODE_SIZE = 24 * 1024
     ],
 )
 @pytest.mark.parametrize(
-    "absent_target",
+    "absent_targets",
     [
         True,
         False,
@@ -55,7 +56,7 @@ def test_worst_address_state_cold(
     fork: Fork,
     attack_gas_limit: int,
     opcode: Op,
-    absent_target: bool,
+    absent_targets: bool,
 ):
     """
     Test running a block with as many stateful opcodes accessing cold accounts.
@@ -77,7 +78,7 @@ def test_worst_address_state_cold(
     # collisions with the addresses indirectly created by the testing framework.
     addr_offset = 100_000
 
-    if not absent_target:
+    if not absent_targets:
         factory_code = Op.PUSH4(num_target_accounts) + While(
             body=Op.POP(Op.CALL(address=Op.ADD(addr_offset, Op.DUP6), value=10)),
             condition=Op.PUSH1(1) + Op.SWAP1 + Op.SUB + Op.DUP1 + Op.ISZERO + Op.ISZERO,
@@ -193,3 +194,111 @@ def test_worst_address_state_warm(
         blocks=[Block(txs=[op_tx])],
     )
     # TODO: add skip_post_check=True
+
+
+@pytest.mark.valid_from("Cancun")
+@pytest.mark.parametrize(
+    "attack_gas_limit",
+    [
+        Environment().gas_limit,
+    ],
+)
+@pytest.mark.parametrize(
+    "opcode",
+    [
+        Op.SSTORE,
+        Op.SLOAD,
+    ],
+)
+@pytest.mark.parametrize(
+    "absent_slots",
+    [
+        True,
+        False,
+    ],
+)
+def test_worst_storage_access_cold(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    attack_gas_limit: int,
+    opcode: Op,
+    absent_slots: bool,
+):
+    """
+    Test running a block with as many cold storage slot accesses as possible.
+    """
+    env = Environment(gas_limit=100_000_000_000)
+    gas_costs = fork.gas_costs()
+
+    cold_cost = None
+    if opcode == Op.SSTORE:
+        # We assume a write to a non-zero storage slot. Writing to a zero storage slot
+        # is very expensive and unrelated to execution cost (i.e. storage growth).
+        cold_cost = 2_900
+    elif opcode == Op.SLOAD:
+        cold_cost = gas_costs.G_COLD_SLOAD
+    else:
+        raise ValueError(f"Invalid opcode {opcode} for cold storage access")
+
+    intrinsic_gas_cost_calc = fork.transaction_intrinsic_cost_calculator()
+    num_target_slots = (attack_gas_limit - intrinsic_gas_cost_calc()) // cold_cost
+
+    blocks = []
+    post = {}
+
+    # Setup
+    execution_code_body = (
+        Op.POP(opcode(Op.DUP1)) if opcode == Op.SLOAD else opcode(Op.DUP1, Op.DUP1)
+    )
+    execution_code = Op.PUSH4(num_target_slots) + While(
+        body=execution_code_body,
+        condition=Op.PUSH1(1) + Op.SWAP1 + Op.SUB + Op.DUP1 + Op.ISZERO + Op.ISZERO,
+    )
+    execution_code_address = pre.deploy_contract(code=execution_code)
+    slots_init = Bytecode()
+    if not absent_slots:
+        slots_init = Op.PUSH4(num_target_slots) + While(
+            body=Op.SSTORE(Op.DUP1, Op.DUP1),
+            condition=Op.PUSH1(1) + Op.SWAP1 + Op.SUB + Op.DUP1 + Op.ISZERO + Op.ISZERO,
+        )
+
+    creation_code = (
+        slots_init
+        + Op.EXTCODECOPY(
+            address=execution_code_address,
+            dest_offset=0,
+            offset=0,
+            size=Op.EXTCODESIZE(execution_code_address),
+        )
+        + Op.RETURN(0, Op.MSIZE)
+    )
+    setup_tx = Transaction(
+        to=None,
+        gas_limit=env.gas_limit,
+        data=creation_code,
+        gas_price=10,
+        sender=pre.fund_eoa(),
+    )
+    blocks.append(Block(txs=[setup_tx]))
+
+    contract_address = compute_create_address(address=setup_tx.sender, nonce=0)
+    storage = {} if absent_slots else {i + 1: i + 1 for i in range(num_target_slots)}
+    post[contract_address] = Account(storage=storage)
+
+    # Execution
+    op_tx = Transaction(
+        to=contract_address,
+        gas_limit=attack_gas_limit,
+        gas_price=10,
+        sender=pre.fund_eoa(),
+    )
+    blocks.append(Block(txs=[op_tx]))
+
+    blockchain_test(
+        genesis_environment=env,
+        pre=pre,
+        post=post,
+        blocks=blocks,
+        # TODO: add skip_post_check=True
+    )

--- a/tests/zkevm/test_worst_stateful_opcodes.py
+++ b/tests/zkevm/test_worst_stateful_opcodes.py
@@ -1,0 +1,99 @@
+"""
+abstract: Tests zkEVMs worst-case stateful opcodes.
+    Tests zkEVMs worst-case stateful opcodes.
+
+Tests running worst-case stateful opcodes for zkEVMs.
+"""
+
+import math
+
+import pytest
+
+from ethereum_test_forks import Fork
+from ethereum_test_tools import (Account, Address, Alloc, Block,
+                                 BlockchainTestFiller, Environment,
+                                 Transaction, While)
+from ethereum_test_tools.vm.opcode import Opcodes as Op
+
+REFERENCE_SPEC_GIT_PATH = "TODO"
+REFERENCE_SPEC_VERSION = "TODO"
+
+
+@pytest.mark.valid_from("Cancun")
+@pytest.mark.parametrize(
+    "attack_gas_limit",
+    [
+        36_000_000,
+    ],
+)
+@pytest.mark.parametrize(
+    "opcode",
+    [
+        Op.BALANCE,
+    ],
+)
+def test_worst_address_state_cold(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    attack_gas_limit: int,
+    opcode: Op,
+):
+    """
+    Test running a block with as many stateful opcodes execution accessing
+    an account state as possible.
+    """
+    env = Environment(gas_limit=100_000_000_000)
+
+
+    # Setup
+    gas_costs = fork.gas_costs()
+    intrinsic_gas_cost_calc = fork.transaction_intrinsic_cost_calculator()
+    num_target_accounts = (
+        attack_gas_limit - intrinsic_gas_cost_calc()
+    ) // gas_costs.G_COLD_ACCOUNT_ACCESS
+
+    # Create num_target_accounts accounts by sending 10 wei to each. The addresses are 
+    # consecutive numbers starting from addr_offset so we avoid collisions.
+    addr_offset = 100_000
+    factory_code = Op.PUSH4(num_target_accounts) + While(
+        body=Op.POP(Op.CALL(address=Op.ADD(addr_offset, Op.DUP6), value=10)),
+        condition=Op.PUSH1(1) + Op.SWAP1 + Op.SUB + Op.DUP1 + Op.ISZERO + Op.ISZERO,
+    )
+    factory_address = pre.deploy_contract(code=factory_code, balance=10**18)
+
+    setup_tx = Transaction(
+        to=factory_address,
+        gas_limit=env.gas_limit,
+        gas_price=10,
+        sender=pre.fund_eoa(),
+    )
+
+    # Execution
+    op_code = Op.PUSH4(num_target_accounts) + While(
+        body=Op.POP(opcode(Op.ADD(addr_offset, Op.DUP1))),
+        condition=Op.PUSH1(1) + Op.SWAP1 + Op.SUB + Op.DUP1 + Op.ISZERO + Op.ISZERO,
+    )
+    op_address = pre.deploy_contract(code=op_code)
+    op_tx = Transaction(
+        to=op_address,
+        gas_limit=attack_gas_limit,
+        gas_price=10,
+        sender=pre.fund_eoa(),
+    )
+
+    post = {}
+    for i in range(num_target_accounts):
+        addr = Address(i+addr_offset+1)
+        post[addr] = Account(balance=10)
+
+    blockchain_test(
+        genesis_environment=env,
+        pre=pre,
+        post=post,
+        blocks=[
+            Block(txs=[setup_tx]),
+            Block(txs=[op_tx]),
+        ],
+        # TODO: add skip_post_check=True
+    )

--- a/tests/zkevm/test_worst_stateful_opcodes.py
+++ b/tests/zkevm/test_worst_stateful_opcodes.py
@@ -36,7 +36,7 @@ MAX_CODE_SIZE = 24 * 1024
 @pytest.mark.parametrize(
     "absent",
     [
-        # True,
+        True,
         False,
     ],
 )
@@ -61,7 +61,6 @@ def test_worst_address_state_cold(
 
     blocks = []
     post = {}
-
 
     # Setup
     # The target addresses are going to be constructed (in the case of absent=False) and called
@@ -121,6 +120,8 @@ def test_worst_address_state_cold(
     "opcode",
     [
         Op.BALANCE,
+        Op.EXTCODESIZE,
+        Op.EXTCODEHASH,
     ],
 )
 @pytest.mark.parametrize(
@@ -147,8 +148,8 @@ def test_worst_address_state_warm(
     target_addr = Address(100_000) 
     post = {target_addr:  None}
     if not absent: 
-        target_addr =pre.fund_eoa(100)
-        post[target_addr] = Account(balance=100)
+        target_addr = pre.deploy_contract(balance=100, code=Op.JUMPDEST * 100)
+        post[target_addr] = Account(balance=100, code = Op.JUMPDEST * 100)
 
     # Execution
     prep = Op.PUSH20(target_addr)

--- a/tests/zkevm/test_worst_stateful_opcodes.py
+++ b/tests/zkevm/test_worst_stateful_opcodes.py
@@ -5,7 +5,6 @@ abstract: Tests zkEVMs worst-case stateful opcodes.
 Tests running worst-case stateful opcodes for zkEVMs.
 """
 
-import math
 
 import pytest
 
@@ -52,9 +51,7 @@ def test_worst_address_state_cold(
     opcode: Op,
     absent_targets: bool,
 ):
-    """
-    Test running a block with as many stateful opcodes accessing cold accounts.
-    """
+    """Test running a block with as many stateful opcodes accessing cold accounts."""
     env = Environment(gas_limit=100_000_000_000)
     attack_gas_limit = Environment().gas_limit
 
@@ -142,9 +139,7 @@ def test_worst_address_state_warm(
     opcode: Op,
     absent_target: bool,
 ):
-    """
-    Test running a block with as many stateful opcodes doing warm access for an account.
-    """
+    """Test running a block with as many stateful opcodes doing warm access for an account."""
     env = Environment(gas_limit=100_000_000_000)
     attack_gas_limit = Environment().gas_limit
 
@@ -216,9 +211,7 @@ def test_worst_storage_access_cold(
     storage_action: StorageAction,
     absent_slots: bool,
 ):
-    """
-    Test running a block with as many cold storage slot accesses as possible.
-    """
+    """Test running a block with as many cold storage slot accesses as possible."""
     env = Environment(gas_limit=100_000_000_000)
     gas_costs = fork.gas_costs()
     attack_gas_limit = Environment().gas_limit
@@ -323,9 +316,7 @@ def test_worst_storage_access_warm(
     fork: Fork,
     storage_action: StorageAction,
 ):
-    """
-    Test running a block with as many warm storage slot accesses as possible.
-    """
+    """Test running a block with as many warm storage slot accesses as possible."""
     env = Environment(gas_limit=100_000_000_000)
     attack_gas_limit = Environment().gas_limit
 
@@ -392,9 +383,7 @@ def test_worst_blockhash(
     pre: Alloc,
     fork: Fork,
 ):
-    """
-    Test running a block with as many blockhash accessing oldest allowed block as possible.
-    """
+    """Test running a block with as many blockhash accessing oldest allowed block as possible."""
     env = Environment()
 
     # Create 256 dummy blocks to fill the blockhash window.
@@ -427,9 +416,7 @@ def test_worst_selfbalance(
     pre: Alloc,
     fork: Fork,
 ):
-    """
-    Test running a block with as many SELFBALANCE opcodes as possible.
-    """
+    """Test running a block with as many SELFBALANCE opcodes as possible."""
     env = Environment()
 
     execution_code = While(
@@ -466,9 +453,7 @@ def test_worst_extcodecopy_warm(
     fork: Fork,
     copied_size: int,
 ):
-    """
-    Test running a block with as many wamr EXTCODECOPY work as possible.
-    """
+    """Test running a block with as many wamr EXTCODECOPY work as possible."""
     env = Environment()
 
     copied_contract_address = pre.deploy_contract(

--- a/tests/zkevm/test_worst_stateful_opcodes.py
+++ b/tests/zkevm/test_worst_stateful_opcodes.py
@@ -56,6 +56,9 @@ def test_worst_address_state_cold(
 
     gas_costs = fork.gas_costs()
     intrinsic_gas_cost_calc = fork.transaction_intrinsic_cost_calculator()
+    # For calculation robustness, the calculation below ignores "glue" opcodes like  PUSH and POP.
+    # It should be considered a worst-case number of accounts, and a few of them might not be
+    # targeted before the attacking transaction runs out of gas.
     num_target_accounts = (
         attack_gas_limit - intrinsic_gas_cost_calc()
     ) // gas_costs.G_COLD_ACCOUNT_ACCESS

--- a/tests/zkevm/test_worst_stateful_opcodes.py
+++ b/tests/zkevm/test_worst_stateful_opcodes.py
@@ -42,6 +42,7 @@ MAX_CODE_SIZE = 24 * 1024
         False,
     ],
 )
+@pytest.mark.slow()
 def test_worst_address_state_cold(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
@@ -130,6 +131,7 @@ def test_worst_address_state_cold(
         False,
     ],
 )
+@pytest.mark.slow()
 def test_worst_address_state_warm(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
@@ -201,6 +203,7 @@ class StorageAction:
         False,
     ],
 )
+@pytest.mark.slow()
 def test_worst_storage_access_cold(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
@@ -308,6 +311,7 @@ def test_worst_storage_access_cold(
         pytest.param(StorageAction.WRITE_NEW_VALUE, id="SSTORE new value"),
     ],
 )
+@pytest.mark.slow()
 def test_worst_storage_access_warm(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
@@ -376,6 +380,7 @@ def test_worst_storage_access_warm(
 
 
 @pytest.mark.valid_from("Cancun")
+@pytest.mark.slow()
 def test_worst_blockhash(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
@@ -409,6 +414,7 @@ def test_worst_blockhash(
 
 
 @pytest.mark.valid_from("Cancun")
+@pytest.mark.slow()
 def test_worst_selfbalance(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
@@ -445,6 +451,7 @@ def test_worst_selfbalance(
         pytest.param(5 * 1024, id="5KiB"),
     ],
 )
+@pytest.mark.slow()
 def test_worst_extcodecopy_warm(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,

--- a/tests/zkevm/test_worst_stateful_opcodes.py
+++ b/tests/zkevm/test_worst_stateful_opcodes.py
@@ -36,7 +36,7 @@ MAX_CODE_SIZE = 24 * 1024
     ],
 )
 @pytest.mark.parametrize(
-    "absent_targets",
+    "absent_accounts",
     [
         True,
         False,
@@ -48,7 +48,7 @@ def test_worst_address_state_cold(
     pre: Alloc,
     fork: Fork,
     opcode: Op,
-    absent_targets: bool,
+    absent_accounts: bool,
 ):
     """Test running a block with as many stateful opcodes accessing cold accounts."""
     env = Environment(gas_limit=100_000_000_000)
@@ -72,7 +72,7 @@ def test_worst_address_state_cold(
     # collisions with the addresses indirectly created by the testing framework.
     addr_offset = 100_000
 
-    if not absent_targets:
+    if not absent_accounts:
         factory_code = Op.PUSH4(num_target_accounts) + While(
             body=Op.POP(Op.CALL(address=Op.ADD(addr_offset, Op.DUP6), value=10)),
             condition=Op.PUSH1(1) + Op.SWAP1 + Op.SUB + Op.DUP1 + Op.ISZERO + Op.ISZERO,

--- a/tests/zkevm/test_worst_stateful_opcodes.py
+++ b/tests/zkevm/test_worst_stateful_opcodes.py
@@ -199,9 +199,9 @@ class StorageAction:
 @pytest.mark.parametrize(
     "storage_action",
     [
-        StorageAction.READ,
-        StorageAction.WRITE_SAME_VALUE,
-        StorageAction.WRITE_NEW_VALUE,
+        pytest.param(StorageAction.READ, id="SSLOAD"),
+        pytest.param(StorageAction.WRITE_SAME_VALUE, id="SSTORE same value"),
+        pytest.param(StorageAction.WRITE_NEW_VALUE, id="SSTORE new value"),
     ],
 )
 @pytest.mark.parametrize(
@@ -314,9 +314,9 @@ def test_worst_storage_access_cold(
 @pytest.mark.parametrize(
     "storage_action",
     [
-        # StorageAction.READ,
-        # StorageAction.WRITE_SAME_VALUE,
-        StorageAction.WRITE_NEW_VALUE,
+        pytest.param(StorageAction.READ, id="SLOAD"),
+        pytest.param(StorageAction.WRITE_SAME_VALUE, id="SSTORE same value"),
+        pytest.param(StorageAction.WRITE_NEW_VALUE, id="SSTORE new value"),
     ],
 )
 def test_worst_storage_access_warm(

--- a/tests/zkevm/test_worst_stateful_opcodes.py
+++ b/tests/zkevm/test_worst_stateful_opcodes.py
@@ -242,8 +242,8 @@ def test_worst_storage_access_cold(
         # That is, storage slot `i` is initialized to `i`.
         execution_code_body = Op.SSTORE(Op.DUP1, Op.DUP1)
     elif storage_action == StorageAction.WRITE_NEW_VALUE:
-        # To generate a new value, we need to use a different value leveraging ADDRESS as a value.
-        execution_code_body = Op.SSTORE(Op.DUP2, Op.ADDRESS)
+        # The new value 2^256-1 is guaranteed to be different from the initial value.
+        execution_code_body = Op.SSTORE(Op.DUP2, Op.NOT(0))
     elif storage_action == StorageAction.READ:
         execution_code_body = Op.POP(Op.SLOAD(Op.DUP1))
 

--- a/tox.ini
+++ b/tox.ini
@@ -79,7 +79,7 @@ commands = pytest -n auto -m "not slow and not zkevm" --skip-evm-dump --output=/
 [testenv:tests-deployed-zkevm]
 description = Fill zkEVM test cases in ./tests/ for deployed mainnet forks, using evmone-t8n.
 commands_pre = solc-select use {[testenv]solc_version} --always-install
-commands = pytest -n auto -m "zkevm" --skip-evm-dump --output=/tmp/fixtures-tox --clean --evm-bin=evmone-t8n
+commands = pytest -n auto -m "zkevm" --skip-evm-dump --block-gas-limit 36000000 --output=/tmp/fixtures-tox --clean --evm-bin=evmone-t8n
 
 [testenv:tests-develop]
 description = Fill test cases in ./tests/ for deployed and development mainnet forks


### PR DESCRIPTION
This PR adds zkvm tests for the cases described in https://github.com/ethereum/execution-spec-tests/issues/1583.

Soon I'll add here the run results.

Closes https://github.com/ethereum/execution-spec-tests/issues/1583

Cycles ascending:
```
tests/zkevm/test_worst_stateful_opcodes.py::test_worst_storage_access_cold[fork_Cancun-blockchain_test-absent_slots_True-SSTORE same value]-2   21508283
tests/zkevm/test_worst_stateful_opcodes.py::test_worst_storage_access_cold[fork_Cancun-blockchain_test-absent_slots_True-SSTORE new value]-2    21635414
tests/zkevm/test_worst_stateful_opcodes.py::test_worst_address_state_cold[fork_Cancun-blockchain_test-absent_targets_True-opcode_BALANCE]-1     116777803
tests/zkevm/test_worst_stateful_opcodes.py::test_worst_storage_access_cold[fork_Cancun-blockchain_test-absent_slots_True-SSLOAD]-2      139376838
tests/zkevm/test_worst_stateful_opcodes.py::test_worst_storage_access_cold[fork_Cancun-blockchain_test-absent_slots_False-SSTORE new value]-2   277129618
tests/zkevm/test_worst_stateful_opcodes.py::test_worst_extcodecopy_warm[fork_Cancun-blockchain_test-5KiB]-1     333202083
tests/zkevm/test_worst_stateful_opcodes.py::test_worst_address_state_warm[fork_Cancun-blockchain_test-absent_target_True-opcode_BALANCE]-1      333982180
tests/zkevm/test_worst_stateful_opcodes.py::test_worst_address_state_warm[fork_Cancun-blockchain_test-absent_target_False-opcode_BALANCE]-1     334004554
tests/zkevm/test_worst_stateful_opcodes.py::test_worst_address_state_warm[fork_Cancun-blockchain_test-absent_target_True-opcode_EXTCODESIZE]-1  385946832
tests/zkevm/test_worst_stateful_opcodes.py::test_worst_address_state_warm[fork_Cancun-blockchain_test-absent_target_False-opcode_EXTCODESIZE]-1 397306261
tests/zkevm/test_worst_stateful_opcodes.py::test_worst_extcodecopy_warm[fork_Cancun-blockchain_test-1KiB]-1     409351907
tests/zkevm/test_worst_stateful_opcodes.py::test_worst_address_state_cold[fork_Cancun-blockchain_test-absent_targets_False-opcode_BALANCE]-2    428620831
tests/zkevm/test_worst_stateful_opcodes.py::test_worst_extcodecopy_warm[fork_Cancun-blockchain_test-512]-1      442123831
tests/zkevm/test_worst_stateful_opcodes.py::test_worst_address_state_warm[fork_Cancun-blockchain_test-absent_target_False-opcode_EXTCODEHASH]-1 472921842
tests/zkevm/test_worst_stateful_opcodes.py::test_worst_storage_access_warm[fork_Cancun-blockchain_test-SLOAD]-2 487563179
tests/zkevm/test_worst_stateful_opcodes.py::test_worst_storage_access_cold[fork_Cancun-blockchain_test-absent_slots_False-SSLOAD]-2     561811688
tests/zkevm/test_worst_stateful_opcodes.py::test_worst_address_state_warm[fork_Cancun-blockchain_test-absent_target_True-opcode_EXTCODEHASH]-1  595139097
tests/zkevm/test_worst_stateful_opcodes.py::test_worst_storage_access_cold[fork_Cancun-blockchain_test-absent_slots_False-SSTORE same value]-2  601076177
tests/zkevm/test_worst_stateful_opcodes.py::test_worst_blockhash[fork_Cancun-blockchain_test]-257       700388121
tests/zkevm/test_worst_stateful_opcodes.py::test_worst_storage_access_warm[fork_Cancun-blockchain_test-SSTORE same value]-2     1107137030
tests/zkevm/test_worst_stateful_opcodes.py::test_worst_storage_access_warm[fork_Cancun-blockchain_test-SSTORE new value]-2      1404783732
tests/zkevm/test_worst_stateful_opcodes.py::test_worst_selfbalance[fork_Cancun-blockchain_test]-1       1682620163
tests/zkevm/test_worst_stateful_opcodes.py::test_worst_address_state_warm[fork_Cancun-blockchain_test-absent_target_True-opcode_DELEGATECALL]-1 1853842474
tests/zkevm/test_worst_stateful_opcodes.py::test_worst_address_state_warm[fork_Cancun-blockchain_test-absent_target_True-opcode_STATICCALL]-1   2262849316
tests/zkevm/test_worst_stateful_opcodes.py::test_worst_address_state_warm[fork_Cancun-blockchain_test-absent_target_True-opcode_CALL]-1 2285484236
tests/zkevm/test_worst_stateful_opcodes.py::test_worst_address_state_warm[fork_Cancun-blockchain_test-absent_target_True-opcode_CALLCODE]-1     2299603188
tests/zkevm/test_worst_stateful_opcodes.py::test_worst_address_state_warm[fork_Cancun-blockchain_test-absent_target_False-opcode_DELEGATECALL]-1 RISCV-EMULATOR-CRASH
tests/zkevm/test_worst_stateful_opcodes.py::test_worst_address_state_warm[fork_Cancun-blockchain_test-absent_target_False-opcode_STATICCALL]-1   RISCV-EMULATOR-CRASH
tests/zkevm/test_worst_stateful_opcodes.py::test_worst_address_state_warm[fork_Cancun-blockchain_test-absent_target_False-opcode_CALL]-1 RISCV-EMULATOR-CRASH
tests/zkevm/test_worst_stateful_opcodes.py::test_worst_address_state_warm[fork_Cancun-blockchain_test-absent_target_False-opcode_CALLCODE]-1     RISCV-EMULATOR-CRASH
```