### PR TITLE
feat(tests/zkevm): Test jump and jumpdest

### DIFF
--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -304,7 +304,7 @@ def test_worst_jumps(
 
     # Create and deploy the jump-intensive contract
     jumps_code = sum([jump_seq() for _ in range(seqs_per_call)])
-    jumps_address = pre.deploy_contract(code=jumps_code)
+    jumps_address = pre.deploy_contract(code=bytes(jumps_code))
 
     # Call the contract repeatedly until gas runs out.
     caller_code = While(body=Op.POP(Op.CALL(address=jumps_address)))
@@ -339,7 +339,7 @@ def test_worst_jumpdests(
 
     # Create and deploy a contract with many JUMPDESTs
     jumpdests_code = sum([Op.JUMPDEST] * MAX_CODE_SIZE)
-    jumpdests_address = pre.deploy_contract(code=jumpdests_code)
+    jumpdests_address = pre.deploy_contract(code=bytes(jumpdests_code))
 
     # Call the contract repeatedly until gas runs out.
     caller_code = While(body=Op.POP(Op.CALL(address=jumpdests_address)))


### PR DESCRIPTION
## 🗒️ Description
Replay of https://github.com/ethereum/execution-spec-tests/pull/1528 which died because it targeted a feature branch.

Add two `JUMP`-heavy workloads to see how zkVMs handle this. Cycle counts from [the Reth fork](https://github.com/kevaundray/reth/tree/kw/stateless-experiment-zkvm-benchmarks):

### JUMP-heavy test 
```
[crates/zkvm-benchmarks/host/src/main.rs:57:9] &reports = [
    WorkloadMetrics {
        name: "tests/zkevm/test_worst_compute.py::test_worst_jumps[fork_Cancun-blockchain_test]-1",
        total_num_cycles: 700358751,
        region_cycles: {
            "validation": 449377028,
            "read_input": 250977795,
            "verify-witness": 342781,
        },
    },
]
 ```

## JUMPDEST-heavy test
```
[crates/zkvm-benchmarks/host/src/main.rs:57:9] &reports = [
    WorkloadMetrics {
        name: "tests/zkevm/test_worst_compute.py::test_worst_jumpdests[fork_Cancun-blockchain_test]-1",
        total_num_cycles: 1053017248,
        region_cycles: {
            "read_input": 250976958,
            "verify-witness": 543260,
            "validation": 802036362,
        },
    },
]
```

## 🔗 Related Issues
N/A

## ✅ Checklist

- [ ] All: Set appropriate labels for the changes. <- I seem to not have an abillity to set these, else I would use the same as https://github.com/ethereum/execution-spec-tests/pull/1514
- [X] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md). <- I don't see precedents for adding individual tests.
- [X] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65. <- Just using `ExecutionSpecsTransitionTool`
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
