### PR TITLE
feat(ci,tox): Create `tests-deployed-zkevm` tox env, and ci workflow

### DIFF
--- a/.github/workflows/tox_verify.yaml
+++ b/.github/workflows/tox_verify.yaml
@@ -160,3 +160,34 @@ jobs:
         env:
           EELS_RESOLUTIONS_FILE: ${{ github.workspace }}/.github/configs/eels_resolutions.json
         run: uvx --with=tox-uv tox -e tests-deployed
+  tests_deployed_zkevm:
+    name: Fill zkEVM test cases, deployed, ${{ matrix.os }}, ${{ matrix.python }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          # Still getting requests.exceptions.ReadTimeout: UnixHTTPConnectionPool() in CI, even with local EELS
+          # - os: ubuntu-latest
+          #  python: "3.10"
+          - os: ubuntu-latest
+            python: "3.11"
+          - os: macos-latest
+            python: "3.12"
+    steps:
+      - name: Checkout ethereum/execution-spec-tests
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Install uv ${{ vars.UV_VERSION }} and python ${{ matrix.python }}
+        uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+          version: ${{ vars.UV_VERSION }}
+          python-version: ${{ matrix.python }}
+      - name: Build EVMONE EVM
+        uses: ./.github/actions/build-evm-client/evmone
+        with:
+          targets: "evmone-t8n"
+      - name: Run tox - fill tests for deployed forks
+        env:
+          EELS_RESOLUTIONS_FILE: ${{ github.workspace }}/.github/configs/eels_resolutions.json
+        run: uvx --with=tox-uv tox -e tests-deployed-zkevm

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ The output behavior of `fill` has changed ([#1608](https://github.com/ethereum/e
 - 🔀 Refactor: Encapsulate `fill`'s fixture output options (`--output`, `--flat-output`, `--single-fixture-per-file`) into a `FixtureOutput` class ([#1471](https://github.com/ethereum/execution-spec-tests/pull/1471),[#1612](https://github.com/ethereum/execution-spec-tests/pull/1612)).
 - ✨ Don't warn about a "high Transaction gas_limit" for `zkevm` tests ([#1598](https://github.com/ethereum/execution-spec-tests/pull/1598)).
 - 🐞 `fill` no longer writes generated fixtures into an existing, non-empty output directory; it must now be empty or `--clean` must be used to delete it first ([#1608](https://github.com/ethereum/execution-spec-tests/pull/1608)).
+- 🐞 zkEVM marked tests have been removed from `tests-deployed` tox environment into its own separate workflow `tests-deployed-zkevm` ([#1617](https://github.com/ethereum/execution-spec-tests/pull/1617)).
 
 #### `consume`
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,7 +22,7 @@ The output behavior of `fill` has changed ([#1608](https://github.com/ethereum/e
 - 🔀 Refactor: Encapsulate `fill`'s fixture output options (`--output`, `--flat-output`, `--single-fixture-per-file`) into a `FixtureOutput` class ([#1471](https://github.com/ethereum/execution-spec-tests/pull/1471),[#1612](https://github.com/ethereum/execution-spec-tests/pull/1612)).
 - ✨ Don't warn about a "high Transaction gas_limit" for `zkevm` tests ([#1598](https://github.com/ethereum/execution-spec-tests/pull/1598)).
 - 🐞 `fill` no longer writes generated fixtures into an existing, non-empty output directory; it must now be empty or `--clean` must be used to delete it first ([#1608](https://github.com/ethereum/execution-spec-tests/pull/1608)).
-- 🐞 zkEVM marked tests have been removed from `tests-deployed` tox environment into its own separate workflow `tests-deployed-zkevm` ([#1617](https://github.com/ethereum/execution-spec-tests/pull/1617)).
+- 🐞 zkEVM marked tests have been removed from `tests-deployed` tox environment into its own separate workflow `tests-deployed-zkevm` and are filled by `evmone-t8n` ([#1617](https://github.com/ethereum/execution-spec-tests/pull/1617)).
 
 #### `consume`
 

--- a/tox.ini
+++ b/tox.ini
@@ -69,7 +69,7 @@ develop = Prague
 eip7692 = EOFv1
 
 [testenv:tests-deployed]
-description = Fill test cases in ./tests/ for deployed mainnet forks, except for slow/zkEVM.
+description = Fill test cases in ./tests/ for deployed mainnet forks, except for slow/zkevm.
 setenv =
     # Use custom EELS_RESOLUTIONS_FILE if it is set via the environment (eg, in CI)
     EELS_RESOLUTIONS_FILE = {env:EELS_RESOLUTIONS_FILE:}

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ env_list =
     spellcheck
     pytest
     tests-deployed
+    tests-deployed-zkevm
     mkdocs
 
 [testenv]
@@ -68,12 +69,17 @@ develop = Prague
 eip7692 = EOFv1
 
 [testenv:tests-deployed]
-description = Fill test cases in ./tests/ for deployed mainnet forks.
+description = Fill test cases in ./tests/ for deployed mainnet forks, except for slow/zkEVM.
 setenv =
     # Use custom EELS_RESOLUTIONS_FILE if it is set via the environment (eg, in CI)
     EELS_RESOLUTIONS_FILE = {env:EELS_RESOLUTIONS_FILE:}
 commands_pre = solc-select use {[testenv]solc_version} --always-install
-commands = pytest -n auto -k "not slow" --skip-evm-dump --output=/tmp/fixtures-tox --clean
+commands = pytest -n auto -m "not slow and not zkevm" --skip-evm-dump --output=/tmp/fixtures-tox --clean
+
+[testenv:tests-deployed-zkevm]
+description = Fill zkEVM test cases in ./tests/ for deployed mainnet forks, using evmone-t8n.
+commands_pre = solc-select use {[testenv]solc_version} --always-install
+commands = pytest -n auto -m "zkevm" --skip-evm-dump --output=/tmp/fixtures-tox --clean --evm-bin=evmone-t8n
 
 [testenv:tests-develop]
 description = Fill test cases in ./tests/ for deployed and development mainnet forks
@@ -81,7 +87,7 @@ setenv =
     # Use custom EELS_RESOLUTIONS_FILE if it is set via the environment (eg, in CI)
     EELS_RESOLUTIONS_FILE = {env:EELS_RESOLUTIONS_FILE:}
 commands_pre = solc-select use {[testenv]solc_version} --always-install
-commands = pytest -n auto --until={[forks]develop} -k "not slow" --skip-evm-dump --output=/tmp/fixtures-tox --clean
+commands = pytest -n auto --until={[forks]develop} -k "not slow and not zkevm" --skip-evm-dump --output=/tmp/fixtures-tox --clean
 
 # ----------------------------------------------------------------------------------------------
 # ALIAS ENVIRONMENTS
@@ -119,15 +125,18 @@ extras =
     {[testenv:typecheck]extras}
     {[testenv:spellcheck]extras}
     {[testenv:tests-deployed]extras}
+    {[testenv:tests-deployed-zkevm]extras}
 setenv = 
     {[testenv:pytest]setenv}
 commands_pre = 
     {[testenv:tests-deployed]:commands_pre}    
+    {[testenv:tests-deployed-zkevm]:commands_pre}
 commands =
     {[testenv:lint]commands}
     {[testenv:typecheck]commands}
     {[testenv:spellcheck]commands}
     {[testenv:tests-deployed]commands}
+    {[testenv:tests-deployed-zkevm]commands}
 
 # ALIAS that runs checks on ./docs/: spellcheck, markdownlint, mkdocs
 # uvx --with=tox-uv tox -e spellcheck,markdownlint,mkdocs

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -521,6 +521,7 @@ yml
 yParity
 yul
 zfill
+zkEVM
 
 addoption
 addinivalue


### PR DESCRIPTION
## 🗒️ Description
Fixes timeouts during CI runs due to gas-intensive zkevm tests timing out in EELS.

It does so by:
- Creating a `tests-deployed-zkevm` tox environment which runs only zkevm tests and it uses `evmone-t8n` to do so.
- Removing `zkevm` marked tests from `tests-deployed` tox environment.

## 🔗 Related Issues
None

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.