### PR TITLE
docs(consume): add consume command documentation

### DIFF
--- a/docs/consuming_tests/consume.md
+++ b/docs/consuming_tests/consume.md
@@ -1,0 +1,191 @@
+# Consume Command
+
+The `consume` command provides a unified way to run test fixtures against execution clients directly within the execution-spec-tests framework. It offers several subcommands for different consumption methods and use cases.
+
+## What is Consume?
+
+The `consume` command is a tool designed to help client developers and testers run Ethereum test fixtures against execution clients in various ways. It acts as a bridge between the test fixtures and the client implementation, allowing you to verify that your client correctly processes the fixtures according to the Ethereum specification.
+
+## When Should It Be Used?
+
+You should use the `consume` command when:
+
+1. Testing a client implementation against official Ethereum test fixtures
+2. Verifying consensus rules in your client
+3. Debugging client behavior with specific test cases
+4. Running integration tests with Hive
+
+## How to Use It
+
+The `consume` command has several subcommands, each designed for a different method of consumption:
+
+```bash
+uv run consume [SUBCOMMAND] [OPTIONS]
+```
+
+### Subcommands
+
+#### `direct`
+
+```bash
+uv run consume direct --bin=/path/to/client [OPTIONS]
+```
+
+Clients consume directly via the `blocktest` or `statetest` interface. This is the most straightforward method of testing, where the client uses its built-in interface to process test fixtures.
+
+**Examples:**
+
+```bash
+# Run with a specific client implementation
+uv run consume direct --bin=./client/evm --input=./fixtures/state_tests
+
+# Run with multiple clients for comparison
+uv run consume direct --bin=./client1/evm --bin=./client2/evm --input=./fixtures/state_tests
+```
+
+#### `engine`
+
+```bash
+uv run consume engine [OPTIONS]
+```
+
+Client consumes via the Engine API. This method is used for testing post-Merge forks by sending payloads through the Engine API.
+
+**Examples:**
+
+```bash
+# Run Engine API tests with a specific client
+uv run consume engine --client=geth --input=./fixtures/blockchain_tests_engine
+```
+
+#### `rlp`
+
+```bash
+uv run consume rlp [OPTIONS]
+```
+
+Client consumes RLP-encoded blocks on startup. This is useful for testing block processing by providing pre-encoded blocks.
+
+**Examples:**
+
+```bash
+# Run RLP tests with specific clients
+uv run consume rlp --client=geth --input=./fixtures/blockchain_tests
+```
+
+#### `hive`
+
+```bash
+uv run consume hive [OPTIONS]
+```
+
+Client consumes via all available Hive methods (both `rlp` and `engine`). This is useful for comprehensive testing with Hive.
+
+**Examples:**
+
+```bash
+# Run all Hive tests
+uv run consume hive --client=geth --input=./fixtures/blockchain_tests
+```
+
+#### `cache`
+
+```bash
+uv run consume cache [OPTIONS]
+```
+
+This subcommand is used to download and cache test fixtures for later use. It's particularly useful for Hive testing where Docker can download fixtures as a cached step.
+
+**Examples:**
+
+```bash
+# Cache the latest stable release
+uv run consume cache --input=stable@latest
+
+# Cache a specific version
+uv run consume cache --input=stable@v4.2.0
+```
+
+### Common Options
+
+Here are the common options that can be used with all `consume` subcommands:
+
+- `--input=PATH`: Specify the path to test fixtures or a release spec (e.g., `stable@latest` or `develop@latest`)
+- `--client=NAME`: Specify the client implementation to test (for `engine`, `rlp`, and `hive`)
+- `--client-config=FILE`: Specify a client configuration file (for Hive methods)
+- `--dev`: Enable development mode which skips some validation steps
+- `--disable-strict-exception-matching`: Disable strict checking of exception messages (for Engine API)
+- `-k "EXPRESSION"`: Only run tests that match the given expression
+
+## Hive Considerations
+
+When running with Hive, there are additional options and behaviors to consider:
+
+### Development Mode
+
+The `--dev` flag enables development mode, which is particularly useful for Hive testing as it:
+
+- Relaxes certain validation requirements
+- Allows faster iteration during development
+- Skips checks that might be too strict for work-in-progress code
+
+```bash
+uv run consume hive --dev --client=geth
+```
+
+### Client Configuration
+
+The `--client-config` flag allows you to specify a configuration file for the client:
+
+```bash
+uv run consume hive --client=geth --client-config=./client_config.json
+```
+
+This is useful for:
+- Setting specific client options
+- Enabling or disabling features
+- Configuring network parameters
+
+### Environment Variables
+
+When running in Hive, the following environment variables are automatically handled:
+
+- `HIVE_TEST_PATTERN`: Converted to `--sim.limit` for test filtering
+- `HIVE_PARALLELISM`: Converted to `-n` for parallelism control
+
+## Using Release Fixtures
+
+The `consume` command can download and run fixtures directly from GitHub releases:
+
+```bash
+# Run latest stable fixtures
+uv run consume direct --bin=./client/evm --input=stable@latest
+
+# Run specific version
+uv run consume direct --bin=./client/evm --input=stable@v4.2.0
+
+# Run latest development fixtures
+uv run consume direct --bin=./client/evm --input=develop@latest
+```
+
+This eliminates the need to manually download and extract the fixture archives.
+
+## Debugging and Troubleshooting
+
+For detailed debugging output, add the `-v` or `--verbose` flag:
+
+```bash
+uv run consume direct --bin=./client/evm --input=./fixtures/state_tests -v
+```
+
+To enable trace collection for deeper analysis:
+
+```bash
+uv run consume direct --bin=./client/evm --input=./fixtures/state_tests --traces
+```
+
+For saving debug dumps to a directory:
+
+```bash
+uv run consume direct --bin=./client/evm --input=./fixtures/state_tests --dump-dir=./debug_output
+``` 

--- a/docs/consuming_tests/index.md
+++ b/docs/consuming_tests/index.md
@@ -24,6 +24,12 @@ Here's a top-level comparison of the different methods of consuming tests:
 
     The `fill` command uses `t8n` tools to generate fixtures. Whilst this will provide basic sanity checking of EVM behavior and a sub-set of post conditions are typically checked within test cases, it is not considered the actual test. The actual test is the execution of the fixture against the EVM which will check the entire post allocation and typically use different code paths than `t8n` commands.
 
+## Using the Consume Command
+
+The `consume` command provides a unified way to run test fixtures against execution clients directly within the execution-spec-tests framework. It offers several methods for consuming fixtures, including direct client testing, Engine API testing, and Hive integration.
+
+For detailed information on using the `consume` command, see the [Consume Command](./consume.md) documentation.
+
 ## Release Formats
 
 The @ethereum/execution-spec-tests repository provides [releases](https://github.com/ethereum/execution-spec-tests/releases) of fixtures in various formats (as of 2023-10-16):

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -27,6 +27,7 @@
       * [Transition Tool Support](filling_tests/transition_tool_support.md)
       * [Debugging Transition Tools](filling_tests/debugging_t8n_tools.md)
   * [Consuming Tests](consuming_tests/index.md)
+      * [Consume Command](consuming_tests/consume.md)
       * [State Tests](consuming_tests/state_test.md)
       * [Blockchain Tests](consuming_tests/blockchain_test.md)
       * [Blockchain Engine Tests](consuming_tests/blockchain_test_engine.md)


### PR DESCRIPTION
## 🗒️ Description
Created a detailed documentation page for the consume command (docs/consuming_tests/consume.md), which covers:
- What the consume command is and its purpose
- When to use it
- How to use it with different methods (direct, engine, rlp, hive)
- Examples and Hive considerations (including --dev mode and --client-config flag)
- Troubleshooting and debugging options

## 🔗 Related Issues
Fixes #1125 

## ✅ Checklist

- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
