### PR TITLE
chore(tooling): add `.vscode/launch.json` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,8 +52,6 @@ pip-delete-this-directory.txt
 *.code-workspace
 verify_kzg_proof
 .vscode/launch.json
-.vscode/launch.recommended.json
-.vscode/settings.local.recommended.json
 
 # docs
 .cache

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ pip-delete-this-directory.txt
 # misc
 *.code-workspace
 verify_kzg_proof
+.vscode/launch.json
 .vscode/launch.recommended.json
 .vscode/settings.local.recommended.json
 


### PR DESCRIPTION
I also noticed while working with VS Code's debugger that my personal launch.json file was being tracked by git. This PR adds it to .gitignore to prevent accidental commits of personal debugging configurations.

This addresses issue #1622

Fixes #1622.