### PR TITLE
fix(github/coverage,tox): Use skip-evm-dump for fill, add block-gas-limit to zkevm tox

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -176,8 +176,8 @@ jobs:
           # As when we translate from yul/solidity some dup/push opcodes could become untouched
           files="$files tests/homestead/coverage/test_coverage.py"
 
-          echo "uv run fill $files --clean --until=Cancun --evm-bin evmone-t8n >> filloutput.log 2>&1"
-          uv run fill $files --clean --until=Cancun --evm-bin evmone-t8n > >(tee -a filloutput.log) 2> >(tee -a filloutput.log >&2)
+          echo "uv run fill $files --clean --until=Cancun --evm-bin evmone-t8n --skip-evm-dump >> filloutput.log 2>&1"
+          uv run fill $files --clean --until=Cancun --evm-bin evmone-t8n --skip-evm-dump > >(tee -a filloutput.log) 2> >(tee -a filloutput.log >&2)
 
           if grep -q "FAILURES" filloutput.log; then
               echo "Error: failed to generate .py tests."
@@ -228,8 +228,8 @@ jobs:
           rm filloutput.log
 
           if [ -n "$files_fixed" ]; then
-              echo "uv run fill $files_fixed --clean --until=Cancun --evm-bin evmone-t8n >> filloutput.log 2>&1"
-              uv run fill $files_fixed --clean --until=Cancun --evm-bin evmone-t8n > >(tee -a filloutput.log) 2> >(tee -a filloutput.log >&2)
+              echo "uv run fill $files_fixed --clean --until=Cancun --evm-bin evmone-t8n --skip-evm-dump >> filloutput.log 2>&1"
+              uv run fill $files_fixed --clean --until=Cancun --evm-bin evmone-t8n --skip-evm-dump > >(tee -a filloutput.log) 2> >(tee -a filloutput.log >&2)
 
               if grep -q "FAILURES" filloutput.log; then
                 echo "Error: failed to generate .py tests from before the PR."

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -176,8 +176,8 @@ jobs:
           # As when we translate from yul/solidity some dup/push opcodes could become untouched
           files="$files tests/homestead/coverage/test_coverage.py"
 
-          echo "uv run fill $files --clean --until=Cancun --evm-bin evmone-t8n --skip-evm-dump >> filloutput.log 2>&1"
-          uv run fill $files --clean --until=Cancun --evm-bin evmone-t8n --skip-evm-dump > >(tee -a filloutput.log) 2> >(tee -a filloutput.log >&2)
+          echo "uv run fill $files --clean --until=Cancun --evm-bin evmone-t8n --skip-evm-dump --block-gas-limit 36000000 >> filloutput.log 2>&1"
+          uv run fill $files --clean --until=Cancun --evm-bin evmone-t8n --skip-evm-dump --block-gas-limit 36000000 > >(tee -a filloutput.log) 2> >(tee -a filloutput.log >&2)
 
           if grep -q "FAILURES" filloutput.log; then
               echo "Error: failed to generate .py tests."
@@ -228,8 +228,8 @@ jobs:
           rm filloutput.log
 
           if [ -n "$files_fixed" ]; then
-              echo "uv run fill $files_fixed --clean --until=Cancun --evm-bin evmone-t8n --skip-evm-dump >> filloutput.log 2>&1"
-              uv run fill $files_fixed --clean --until=Cancun --evm-bin evmone-t8n --skip-evm-dump > >(tee -a filloutput.log) 2> >(tee -a filloutput.log >&2)
+              echo "uv run fill $files_fixed --clean --until=Cancun --evm-bin evmone-t8n --skip-evm-dump --block-gas-limit 36000000 >> filloutput.log 2>&1"
+              uv run fill $files_fixed --clean --until=Cancun --evm-bin evmone-t8n --skip-evm-dump --block-gas-limit 36000000 > >(tee -a filloutput.log) 2> >(tee -a filloutput.log >&2)
 
               if grep -q "FAILURES" filloutput.log; then
                 echo "Error: failed to generate .py tests from before the PR."

--- a/tox.ini
+++ b/tox.ini
@@ -79,7 +79,7 @@ commands = pytest -n auto -m "not slow and not zkevm" --skip-evm-dump --output=/
 [testenv:tests-deployed-zkevm]
 description = Fill zkEVM test cases in ./tests/ for deployed mainnet forks, using evmone-t8n.
 commands_pre = solc-select use {[testenv]solc_version} --always-install
-commands = pytest -n auto -m "zkevm" --skip-evm-dump --output=/tmp/fixtures-tox --clean --evm-bin=evmone-t8n
+commands = pytest -n auto -m "zkevm" --skip-evm-dump --block-gas-limit 36000000 --output=/tmp/fixtures-tox --clean --evm-bin=evmone-t8n
 
 [testenv:tests-develop]
 description = Fill test cases in ./tests/ for deployed and development mainnet forks


### PR DESCRIPTION
## 🗒️ Description
Introduces to fixes to the CI:
- Coverage script now uses `--skip-evm-dump` to avoid dumping too many files to storage
- Coverage script also now uses `--block-gas-limit 36000000` to limit runtime of gas-intensive tests
- Tox workflow `zkevm` now also uses `--block-gas-limit 36000000`

## 🔗 Related Issues
None

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] ~~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.