### PR TITLE
chore(fill): deprecate --flat-output flag

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,6 +37,7 @@ Users can select any of the artifacts depending on their testing needs for their
 - 🐞 `fill` no longer writes generated fixtures into an existing, non-empty output directory; it must now be empty or `--clean` must be used to delete it first ([#1608](https://github.com/ethereum/execution-spec-tests/pull/1608)).
 - 🐞 zkEVM marked tests have been removed from `tests-deployed` tox environment into its own separate workflow `tests-deployed-zkevm` and are filled by `evmone-t8n` ([#1617](https://github.com/ethereum/execution-spec-tests/pull/1617)).
 - ✨ Field `postStateHash` is now added to all `blockchain_test` and `blockchain_test_engine` tests that use `exclude_full_post_state_in_output` in place of `postState`. Fixes `evmone-blockchaintest` test consumption and indirectly fixes coverage runs for these tests ([#1667](https://github.com/ethereum/execution-spec-tests/pull/1667)).
+- 🔀 Deprecated the `--flat-output` flag. This flag will be removed in a future version [1632](https://github.com/ethereum/execution-spec-tests/pull/1632).
 
 #### `consume`
 

--- a/docs/filling_tests/filling_tests_command_line.md
+++ b/docs/filling_tests/filling_tests_command_line.md
@@ -159,7 +159,7 @@ Arguments defining filler location and output:
                         in '.tar.gz', then the specified tarball is additionally created (the fixtures
                         are still written to the specified path without the '.tar.gz' suffix). Can be
                         deleted. Default: './fixtures'.
-  --flat-output         Output each test case in the directory without the folder structure.
+  --flat-output         [DEPRECATED] Output each test case in the directory without the folder structure. This flag will be removed in a future version.
   --single-fixture-per-file
                         Don't group fixtures in JSON files by test function; write each fixture to its
                         own file. This can be used to increase the granularity of --verify-fixtures.

--- a/src/pytest_plugins/filler/filler.py
+++ b/src/pytest_plugins/filler/filler.py
@@ -193,7 +193,8 @@ def pytest_addoption(parser: pytest.Parser):
         action="store_true",
         dest="flat_output",
         default=False,
-        help="Output each test case in the directory without the folder structure.",
+        help="[DEPRECATED] Output each test case in the directory without the folder structure. "
+        "This flag will be removed in a future version.",
     )
     test_group.addoption(
         "--single-fixture-per-file",
@@ -321,6 +322,16 @@ def pytest_configure(config):
     # Modify the block gas limit if specified.
     if config.getoption("block_gas_limit"):
         EnvironmentDefaults.gas_limit = config.getoption("block_gas_limit")
+    if config.option.collectonly:
+        return
+
+    # Show a deprecation warning for the flat-output flag
+    if config.getoption("flat_output"):
+        warnings.warn(
+            "The --flat-output flag is deprecated and will be removed in a future version.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
     # Initialize fixture output configuration
     config.fixture_output = FixtureOutput.from_config(config)


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
- Added [DEPRECATED] to help message
- Added runtime warning when flag is used
- Updated documentation to indicate deprecation
- Added entry to CHANGELOG.md"

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->
Fixes #1603

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
