### PR TITLE
fix(t8n): include system contracts in alloc for besu generated state tests

### DIFF
--- a/src/ethereum_test_specs/state.py
+++ b/src/ethereum_test_specs/state.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, ClassVar, Dict, Generator, List, Optional, Seq
 import pytest
 from pydantic import Field
 
-from ethereum_clis import TransitionTool
+from ethereum_clis import BesuTransitionTool, TransitionTool
 from ethereum_test_base_types import HexNumber
 from ethereum_test_exceptions import BlockException, EngineAPIError, TransactionException
 from ethereum_test_execution import (
@@ -175,10 +175,18 @@ class StateTest(BaseTest):
                 f"{self.node_id()} uses a high Transaction gas_limit: {tx.gas_limit}",
                 stacklevel=2,
             )
-        pre_alloc = Alloc.merge(
-            Alloc.model_validate(fork.pre_allocation()),
-            self.pre,
-        )
+
+        if isinstance(t8n, BesuTransitionTool):
+            pre_alloc = Alloc.merge(
+                Alloc.model_validate(fork.pre_allocation_blockchain()),
+                self.pre,
+            )
+        else:
+            pre_alloc = Alloc.merge(
+                Alloc.model_validate(fork.pre_allocation()),
+                self.pre,
+            )
+
         if empty_accounts := pre_alloc.empty_accounts():
             raise Exception(f"Empty accounts in pre state: {empty_accounts}")
 


### PR DESCRIPTION
## 🗒️ Description
This change includes the `pre_allocation_blockchain()` for the fork in the pre-alloc for the `state_test` format for the Besu `t8n` tool (`evmtool`). See related issues.

If the system contracts aren't present, then filing fails with an error similar to:
```
    transition_tool_output = t8n.evaluate(
src/ethereum_clis/clis/besu.py:166: in evaluate
    response.raise_for_status()  # exception visible in pytest failure output
.venv/lib/pypy3.10/site-packages/requests/models.py:1024: in raise_for_status
    raise HTTPError(http_error_msg, response=self)
E   requests.exceptions.HTTPError: 500 Server Error: Internal Server Error for url: http://localhost:34805/
```

This is a funny one, as the generated `state_test` fixtures won't pass when executed against any other clients, so I'm not sure if we should include it. But perhaps the commit is useful to the Besu Team while trying to fill Osaka tests.

## 🔗 Related Issues
These seem to be the changes that broke `fill`:
- https://github.com/hyperledger/besu/commit/7cd5407451c0797e594eea0260e31d5c8cc45ddd

from:
- https://github.com/hyperledger/besu/pull/8573

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.

