### PR TITLE
refactor(tests): EIP-152: reuse `BLAKE2_PRECOMPILE_ADDRESS`

### DIFF
--- a/tests/istanbul/eip152_blake2/test_blake2_delegatecall.py
+++ b/tests/istanbul/eip152_blake2/test_blake2_delegatecall.py
@@ -13,10 +13,10 @@ from ethereum_test_tools import (
 )
 from ethereum_test_tools import Opcodes as Op
 
+from .spec import Spec
+
 REFERENCE_SPEC_GIT_PATH = "EIPS/eip-152.md"
 REFERENCE_SPEC_VERSION = "2762bfcff3e549ef263342e5239ef03ac2b07400"
-
-BLAKE2_PRECOMPILE_ADDRESS = 0x09
 
 
 @pytest.mark.valid_from("ConstantinopleFix")
@@ -29,7 +29,7 @@ def test_blake2_precompile_delegatecall(state_test: StateTestFiller, pre: Alloc,
             0,
             Op.DELEGATECALL(
                 gas=1,
-                address=BLAKE2_PRECOMPILE_ADDRESS,
+                address=Spec.BLAKE2_PRECOMPILE_ADDRESS,
             ),
         )
         + Op.STOP,


### PR DESCRIPTION
## 🗒️ Description
Reuse already defined constant `BLAKE2_PRECOMPILE_ADDRESS` in the blake2f precompile tests.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
