### PR TITLE
fix(tests): EIP-2537: Make pairing test dynamic to env.gas_limit

### DIFF
--- a/tests/prague/eip2537_bls_12_381_precompiles/conftest.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/conftest.py
@@ -90,7 +90,7 @@ def call_succeeds(
 @pytest.fixture
 def call_contract_code(
     precompile_address: int,
-    precompile_gas: int,
+    precompile_gas: int | None,
     precompile_gas_modifier: int,
     expected_output: bytes | SupportsBytes,
     call_succeeds: bool,
@@ -126,12 +126,18 @@ def call_contract_code(
     assert call_opcode in [Op.CALL, Op.CALLCODE, Op.DELEGATECALL, Op.STATICCALL]
     value = [0] if call_opcode in [Op.CALL, Op.CALLCODE] else []
 
+    precompile_gas_value_opcode: int | Op
+    if precompile_gas is None:
+        precompile_gas_value_opcode = Op.GAS
+    else:
+        precompile_gas_value_opcode = precompile_gas + precompile_gas_modifier
+
     code = (
         Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE())
         + Op.SSTORE(
             call_contract_post_storage.store_next(call_succeeds),
             call_opcode(
-                precompile_gas + precompile_gas_modifier,
+                precompile_gas_value_opcode,
                 precompile_address,
                 *value,  # Optional, only used for CALL and CALLCODE.
                 0,


### PR DESCRIPTION
## 🗒️ Description
Fixes multi-inf tests in EIP-2537 to make them dynamic according to the set evn.gas_limit.

Test was failing with fill parameter `--block-gas-limit=36000000` due to the hard-coded number of pairings.

The test now uses a look to search for the maximum number of pairings that can fit within limit.

## 🔗 Related Issues
None

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] ~~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.