### PR TITLE
chore(tooling): add `.venv/`, `logs/`, `fixtures-*` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ __pycache__
 __pycache__/
 *.py[cod]
 *$py.class
-venv/
+*venv/
 /fixtures/
 /out/
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .DS_Store
-__pycache__
 .AppleDouble
 .LSOverride
 
@@ -7,8 +6,13 @@ __pycache__
 __pycache__/
 *.py[cod]
 *$py.class
-*venv/
-/fixtures/
+.venv/
+venv/
+
+# Artifacts created by `fill`
+fixtures/
+fixtures-*/
+logs/
 /out/
 
 # C extensions


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
Just a minor fix in `.gitignore`.

For newcomers, If they don't name their virtual environment `.venv`, the commands to install packages and possibly enter other cmds fail. You then get an instruction to either rename your virtual environment to `.venv` or use `--active`  to target the current virtual environment. If I decide to use `.venv` for simplicity, and for mere mortals like us using VS Code, `.venv` not being ignored by git puts a toll on the source control widget, which is quite useful for tracking files and resolving merge conflicts among other benefits.
 
![command line warning](https://i.imgur.com/C7ndt2K.png)

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
