### PR TITLE
fix(pytest): Add `ported_from` to execute

### DIFF
--- a/pytest-execute-hive.ini
+++ b/pytest-execute-hive.ini
@@ -6,6 +6,7 @@ testpaths = tests/
 markers =
     slow
     pre_alloc_modify
+    ported_from
 addopts = 
     -p pytest_plugins.concurrency
     -p pytest_plugins.execute.sender

--- a/pytest-execute.ini
+++ b/pytest-execute.ini
@@ -6,6 +6,7 @@ testpaths = tests/
 markers =
     slow
     pre_alloc_modify
+    ported_from
 addopts = 
     -p pytest_plugins.concurrency
     -p pytest_plugins.execute.sender


### PR DESCRIPTION
## 🗒️ Description
Adds the `ported_from` marker to the `pytest-execute*.ini` files to suppress a warning from appearing when running the command.

## 🔗 Related Issues
None

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] ~~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.