### PR TITLE
refactor(tests): use the `pre` fixture in `SELFDESTRUCT` collision tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,6 +38,7 @@ The output behavior of `fill` has changed ([#1608](https://github.com/ethereum/e
 ### 🧪 Test Cases
 
 - 🔀 Refactored `BLOBHASH` opcode context tests to use the `pre_alloc` plugin in order to avoid contract and EOA address collisions ([#1637](https://github.com/ethereum/execution-spec-tests/pull/1637)).
+- 🔀 Refactored `SELFDESTRUCT` opcode collision tests to use the `pre_alloc` plugin in order to avoid contract and EOA address collisions ([#1642](https://github.com/ethereum/execution-spec-tests/pull/1642)).
 
 ## [v4.5.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v4.5.0) - 2025-05-14
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,7 +38,7 @@ The output behavior of `fill` has changed ([#1608](https://github.com/ethereum/e
 ### 🧪 Test Cases
 
 - 🔀 Refactored `BLOBHASH` opcode context tests to use the `pre_alloc` plugin in order to avoid contract and EOA address collisions ([#1637](https://github.com/ethereum/execution-spec-tests/pull/1637)).
-- 🔀 Refactored `SELFDESTRUCT` opcode collision tests to use the `pre_alloc` plugin in order to avoid contract and EOA address collisions ([#1642](https://github.com/ethereum/execution-spec-tests/pull/1642)).
+- 🔀 Refactored `SELFDESTRUCT` opcode collision tests to use the `pre_alloc` plugin in order to avoid contract and EOA address collisions ([#1643](https://github.com/ethereum/execution-spec-tests/pull/1643)).
 
 ## [v4.5.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v4.5.0) - 2025-05-14
 


### PR DESCRIPTION
## 🗒️ Description
This PR refactors the `SELFDESTRUCT` collision tests that used hard-coded addresses to instead use the `pre` fixture from the `pre_alloc` plugin.

Diffed the traces and evm execution is identical, interestingly:
1. Call data size changed: e.g. from 0x23 to 0x35 (line 3) - because now the initcode contains full 20 byte addresses instead of hard-coded addresses that occupy less bytes.
2. Gas values are slightly different: due to different initial allocations.

## 🔗 Related Issues
None

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
