### PR TITLE
zkevm: add empty block execution

### DIFF
--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -938,3 +938,20 @@ def test_worst_mod(
         post={},
         blocks=[Block(txs=[tx])],
     )
+
+
+@pytest.mark.valid_from("Cancun")
+def test_empty_block(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+):
+    """Test running an empty block as a baseline for fixed proving costs."""
+    env = Environment()
+
+    blockchain_test(
+        env=env,
+        pre=pre,
+        post={},
+        blocks=[Block(txs=[])],
+    )


### PR DESCRIPTION
This PR adds a test that executes an empty block (i.e., no txs).

This test mainly aims to discover the baseline cycle cost for zkVMs.