### PR TITLE
feat(github): Add zkevm 60M, 90M, 120M

### DIFF
--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -11,7 +11,7 @@ static:
   evm-type: static
   fill-params: --until=Prague --fill-static-tests ./tests/static
   solc: 0.8.21
-zkevm:
+zkevm_36M:
   evm-type: zkevm
   fill-params: --from=Cancun --until=Prague --block-gas-limit 36000000 -m zkevm ./tests
   solc: 0.8.21

--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -16,6 +16,21 @@ zkevm:
   fill-params: --from=Cancun --until=Prague --block-gas-limit 36000000 -m zkevm ./tests
   solc: 0.8.21
   feature_only: true
+zkevm_60M:
+  evm-type: zkevm
+  fill-params: --from=Cancun --until=Prague --block-gas-limit 60000000 -m zkevm ./tests
+  solc: 0.8.21
+  feature_only: true
+zkevm_90M:
+  evm-type: zkevm
+  fill-params: --from=Cancun --until=Prague --block-gas-limit 90000000 -m zkevm ./tests
+  solc: 0.8.21
+  feature_only: true
+zkevm_120M:
+  evm-type: zkevm
+  fill-params: --from=Cancun --until=Prague --block-gas-limit 120000000 -m zkevm ./tests
+  solc: 0.8.21
+  feature_only: true
 eip7692:
   evm-type: eip7692
   fill-params: --fork=EOFv1 ./tests/unscheduled

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,12 +8,18 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 ### 💥 Breaking Change
 
-### 💥 Important Change for `fill` Users
+#### 💥 Important Change for `fill` Users
 
 The output behavior of `fill` has changed ([#1608](https://github.com/ethereum/execution-spec-tests/pull/1608)):
 
 - Before: `fill` wrote fixtures into the directory specified by the `--output` flag (default: `fixtures`). This could have many unintended consequences, including unexpected errors if old or invalid fixtures existed in the directory (for details see [#1030](https://github.com/ethereum/execution-spec-tests/issues/1030)).
 - Now: `fill` will exit without filling any tests if the specified directory exists and is not-empty. This may be overridden by adding the `--clean` flag, which will first remove the specified directory.
+
+#### Feature `zkevm` expanded to `zkevm_36M`, `zkevm_60M`, `zkevm_90M`, `zkevm_120M`
+
+Renames `zkevm` to `zkevm_36M` and further expands the zkEVM features to run using 60M, 90M and 120M block gas limits in `fixtures_zkevm_36M.tar.gz`, `fixtures_zkevm_60M.tar.gz`, `fixtures_zkevm_90M.tar.gz` and `fixtures_zkevm_120M.tar.gz` respectively.
+
+Users can select any of the artifacts depending on their testing needs for their provers.
 
 ### 🛠️ Framework
 

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -578,6 +578,8 @@ parametrization
 parametrizing
 popen
 prevrandao
+prover
+provers
 pytestconfig
 pytester
 pytestmark


### PR DESCRIPTION
## 🗒️ Description
Add features:
- zkEVM with 60 million block gas limit
- zkEVM with 90 million block gas limit
- zkEVM with 120 million block gas limit

## 🔗 Related Issues
None

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.