### PR TITLE
zkevm: add CALLDATALOAD benchmark

### DIFF
--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -1069,14 +1069,18 @@ def _generate_bn128_pairs(n: int, seed: int = 0):
 
 
 @pytest.mark.parametrize(
-    "empty_calldata",
-    [False, True],
+    "calldata",
+    [
+        pytest.param(b"", id="empty"),
+        pytest.param(b"\x00", id="zero-loop"),
+        pytest.param(b"\x00" * 31 + b"\x20", id="one-loop"),
+    ],
 )
 def test_worst_calldataload(
     state_test: StateTestFiller,
     pre: Alloc,
     fork: Fork,
-    empty_calldata: bool,
+    calldata: bytes,
 ):
     """Test running a block with as many CALLDATALOAD as possible."""
     env = Environment()
@@ -1091,7 +1095,7 @@ def test_worst_calldataload(
 
     tx = Transaction(
         to=pre.deploy_contract(code=code),
-        data=[] if empty_calldata else [0x00],
+        data=calldata,
         gas_limit=env.gas_limit,
         sender=pre.fund_eoa(),
     )

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -1080,17 +1080,17 @@ def test_worst_calldataload(
     """Test running a block with as many CALLDATALOAD as possible."""
     env = Environment()
 
-    code_prefix = Op.JUMPDEST
-    code_suffix = Op.PUSH0 + Op.JUMP
+    code_prefix = Op.PUSH0 + Op.JUMPDEST
+    code_suffix = Op.PUSH1(1) + Op.JUMP
     code_body_len = MAX_CODE_SIZE - len(code_prefix) - len(code_suffix)
-    code_loop_iter = Op.POP(Op.PUSH0 + Op.CALLDATALOAD)
+    code_loop_iter = Op.CALLDATALOAD
     code_body = code_loop_iter * (code_body_len // len(code_loop_iter))
     code = code_prefix + code_body + code_suffix
     assert len(code) <= MAX_CODE_SIZE
 
     tx = Transaction(
         to=pre.deploy_contract(code=code),
-        data=[] if empty_calldata else [0x42] * 32,
+        data=[] if empty_calldata else [0x00],
         gas_limit=env.gas_limit,
         sender=pre.fund_eoa(),
     )

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -1027,6 +1027,7 @@ def test_amortized_bn128_pairings(
         to=code_address,
         gas_limit=env.gas_limit,
         data=_generate_bn128_pairs(optimal_per_call_num_pairings, 42),
+        sender=pre.fund_eoa(),
     )
 
     state_test(

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -1086,7 +1086,7 @@ def test_worst_calldataload(
     code_loop_iter = Op.POP(Op.PUSH0 + Op.CALLDATALOAD)
     code_body = code_loop_iter * (code_body_len // len(code_loop_iter))
     code = code_prefix + code_body + code_suffix
-    assert len(code) == MAX_CODE_SIZE
+    assert len(code) <= MAX_CODE_SIZE
 
     tx = Transaction(
         to=pre.deploy_contract(code=code),


### PR DESCRIPTION
This PR adds a benchmark for `CALLDATALOAD` covering both existinga and absent referenced calldata word.

Cycles:
```
tests/zkevm/test_worst_compute.py::test_worst_calldataload[fork_Cancun-blockchain_test_from_state_test-empty]-1 2015522043
tests/zkevm/test_worst_compute.py::test_worst_calldataload[fork_Cancun-blockchain_test_from_state_test-one-loop]-1      2363234163
tests/zkevm/test_worst_compute.py::test_worst_calldataload[fork_Cancun-blockchain_test_from_state_test-zero-loop]-1     2423217008
```

Targets #1657