### PR TITLE
refactor(tests/zkevm): downgrade to state tests

### DIFF
--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -57,7 +57,7 @@ def make_dup(index: int) -> Opcode:
 
 @pytest.mark.valid_from("Cancun")
 def test_worst_keccak(
-    blockchain_test: BlockchainTestFiller,
+    state_test: StateTestFiller,
     pre: Alloc,
     fork: Fork,
 ):
@@ -122,11 +122,11 @@ def test_worst_keccak(
         sender=pre.fund_eoa(),
     )
 
-    blockchain_test(
+    state_test(
         env=env,
         pre=pre,
         post={},
-        blocks=[Block(txs=[tx])],
+        tx=tx,
     )
 
 
@@ -141,7 +141,7 @@ def test_worst_keccak(
 )
 @pytest.mark.slow()
 def test_worst_precompile_only_data_input(
-    blockchain_test: BlockchainTestFiller,
+    state_test: StateTestFiller,
     pre: Alloc,
     fork: Fork,
     address: Address,
@@ -203,19 +203,18 @@ def test_worst_precompile_only_data_input(
         sender=pre.fund_eoa(),
     )
 
-    blockchain_test(
+    state_test(
         env=env,
         pre=pre,
         post={},
-        blocks=[Block(txs=[tx])],
+        tx=tx,
     )
 
 
 @pytest.mark.valid_from("Cancun")
 def test_worst_modexp(
-    blockchain_test: BlockchainTestFiller,
+    state_test: StateTestFiller,
     pre: Alloc,
-    fork: Fork,
 ):
     """Test running a block with as many MODEXP calls as possible."""
     env = Environment()
@@ -252,11 +251,11 @@ def test_worst_modexp(
         sender=pre.fund_eoa(),
     )
 
-    blockchain_test(
+    state_test(
         env=env,
         pre=pre,
         post={},
-        blocks=[Block(txs=[tx])],
+        tx=tx,
     )
 
 
@@ -407,7 +406,7 @@ def test_worst_modexp(
 )
 @pytest.mark.slow()
 def test_worst_precompile_fixed_cost(
-    blockchain_test: BlockchainTestFiller,
+    state_test: StateTestFiller,
     pre: Alloc,
     precompile_address: Address,
     parameters: list[str] | list[BytesConcatenation] | list[bytes],
@@ -452,11 +451,11 @@ def test_worst_precompile_fixed_cost(
         sender=pre.fund_eoa(),
     )
 
-    blockchain_test(
+    state_test(
         env=env,
         pre=pre,
         post={},
-        blocks=[Block(txs=[tx])],
+        tx=tx,
     )
 
 
@@ -480,9 +479,8 @@ def code_loop_precompile_call(calldata: Bytecode, attack_block: Bytecode):
 @pytest.mark.valid_from("Cancun")
 @pytest.mark.slow
 def test_worst_jumps(
-    blockchain_test: BlockchainTestFiller,
+    state_test: StateTestFiller,
     pre: Alloc,
-    fork: Fork,
 ):
     """Test running a JUMP-intensive contract."""
     env = Environment()
@@ -501,19 +499,17 @@ def test_worst_jumps(
     caller_code = While(body=Op.POP(Op.CALL(address=jumps_address)))
     caller_address = pre.deploy_contract(caller_code)
 
-    txs = [
-        Transaction(
-            to=caller_address,
-            gas_limit=env.gas_limit,
-            sender=pre.fund_eoa(),
-        )
-    ]
+    tx = Transaction(
+        to=caller_address,
+        gas_limit=env.gas_limit,
+        sender=pre.fund_eoa(),
+    )
 
-    blockchain_test(
+    state_test(
         genesis_environment=env,
         pre=pre,
         post={},
-        blocks=[Block(txs=txs)],
+        tx=tx,
     )
 
 
@@ -521,9 +517,8 @@ def test_worst_jumps(
 @pytest.mark.valid_from("Cancun")
 @pytest.mark.slow
 def test_worst_jumpdests(
-    blockchain_test: BlockchainTestFiller,
+    state_test: StateTestFiller,
     pre: Alloc,
-    fork: Fork,
 ):
     """Test running a JUMPDEST-intensive contract."""
     env = Environment()
@@ -536,19 +531,17 @@ def test_worst_jumpdests(
     caller_code = While(body=Op.POP(Op.CALL(address=jumpdests_address)))
     caller_address = pre.deploy_contract(caller_code)
 
-    txs = [
-        Transaction(
-            to=caller_address,
-            gas_limit=env.gas_limit,
-            sender=pre.fund_eoa(),
-        )
-    ]
+    tx = Transaction(
+        to=caller_address,
+        gas_limit=env.gas_limit,
+        sender=pre.fund_eoa(),
+    )
 
-    blockchain_test(
+    state_test(
         genesis_environment=env,
         pre=pre,
         post={},
-        blocks=[Block(txs=txs)],
+        tx=tx,
     )
 
 
@@ -676,7 +669,7 @@ DEFAULT_BINOP_ARGS = (
     ids=lambda param: "" if isinstance(param, tuple) else param,
 )
 def test_worst_binop_simple(
-    blockchain_test: BlockchainTestFiller,
+    state_test: StateTestFiller,
     pre: Alloc,
     opcode: Op,
     opcode_args: tuple[int, int],
@@ -704,18 +697,18 @@ def test_worst_binop_simple(
         sender=pre.fund_eoa(),
     )
 
-    blockchain_test(
+    state_test(
         env=env,
         pre=pre,
         post={},
-        blocks=[Block(txs=[tx])],
+        tx=tx,
     )
 
 
 @pytest.mark.valid_from("Cancun")
 @pytest.mark.parametrize("opcode", [Op.ISZERO, Op.NOT])
 def test_worst_unop(
-    blockchain_test: BlockchainTestFiller,
+    state_test: StateTestFiller,
     pre: Alloc,
     opcode: Op,
 ):
@@ -738,18 +731,18 @@ def test_worst_unop(
         sender=pre.fund_eoa(),
     )
 
-    blockchain_test(
+    state_test(
         env=env,
         pre=pre,
         post={},
-        blocks=[Block(txs=[tx])],
+        tx=tx,
     )
 
 
 @pytest.mark.valid_from("Cancun")
 @pytest.mark.parametrize("shift_right", [Op.SHR, Op.SAR])
 def test_worst_shifts(
-    blockchain_test: BlockchainTestFiller,
+    state_test: StateTestFiller,
     pre: Alloc,
     shift_right: Op,
 ):
@@ -822,11 +815,11 @@ def test_worst_shifts(
         sender=pre.fund_eoa(),
     )
 
-    blockchain_test(
+    state_test(
         env=env,
         pre=pre,
         post={},
-        blocks=[Block(txs=[tx])],
+        tx=tx,
     )
 
 
@@ -834,7 +827,7 @@ def test_worst_shifts(
 @pytest.mark.parametrize("mod_bits", [255, 191, 127, 63])
 @pytest.mark.parametrize("op", [Op.MOD, Op.SMOD])
 def test_worst_mod(
-    blockchain_test: BlockchainTestFiller,
+    state_test: StateTestFiller,
     pre: Alloc,
     mod_bits: int,
     op: Op,
@@ -944,11 +937,11 @@ def test_worst_mod(
         sender=pre.fund_eoa(),
     )
 
-    blockchain_test(
+    state_test(
         env=env,
         pre=pre,
         post={},
-        blocks=[Block(txs=[tx])],
+        tx=tx,
     )
 
 
@@ -956,7 +949,6 @@ def test_worst_mod(
 def test_empty_block(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
-    fork: Fork,
 ):
     """Test running an empty block as a baseline for fixed proving costs."""
     env = Environment()

--- a/tests/zkevm/test_worst_stateful_opcodes.py
+++ b/tests/zkevm/test_worst_stateful_opcodes.py
@@ -16,6 +16,7 @@ from ethereum_test_tools import (
     BlockchainTestFiller,
     Bytecode,
     Environment,
+    StateTestFiller,
     Transaction,
     While,
     compute_create_address,
@@ -134,9 +135,8 @@ def test_worst_address_state_cold(
 )
 @pytest.mark.slow()
 def test_worst_address_state_warm(
-    blockchain_test: BlockchainTestFiller,
+    state_test: StateTestFiller,
     pre: Alloc,
-    fork: Fork,
     opcode: Op,
     absent_target: bool,
 ):
@@ -165,17 +165,17 @@ def test_worst_address_state_warm(
         # Must never happen, but keep it as a sanity check.
         raise ValueError(f"Code size {len(op_code)} exceeds maximum code size {MAX_CODE_SIZE}")
     op_address = pre.deploy_contract(code=op_code)
-    op_tx = Transaction(
+    tx = Transaction(
         to=op_address,
         gas_limit=attack_gas_limit,
         sender=pre.fund_eoa(),
     )
 
-    blockchain_test(
+    state_test(
         genesis_environment=env,
         pre=pre,
         post=post,
-        blocks=[Block(txs=[op_tx])],
+        tx=tx,
     )
 
 
@@ -313,7 +313,6 @@ def test_worst_storage_access_cold(
 def test_worst_storage_access_warm(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
-    fork: Fork,
     storage_action: StorageAction,
 ):
     """Test running a block with as many warm storage slot accesses as possible."""
@@ -380,7 +379,6 @@ def test_worst_storage_access_warm(
 def test_worst_blockhash(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
-    fork: Fork,
 ):
     """Test running a block with as many blockhash accessing oldest allowed block as possible."""
     env = Environment()
@@ -411,9 +409,8 @@ def test_worst_blockhash(
 @pytest.mark.valid_from("Cancun")
 @pytest.mark.slow()
 def test_worst_selfbalance(
-    blockchain_test: BlockchainTestFiller,
+    state_test: StateTestFiller,
     pre: Alloc,
-    fork: Fork,
 ):
     """Test running a block with as many SELFBALANCE opcodes as possible."""
     env = Environment()
@@ -422,17 +419,17 @@ def test_worst_selfbalance(
         body=Op.POP(Op.SELFBALANCE),
     )
     execution_code_address = pre.deploy_contract(code=execution_code)
-    op_tx = Transaction(
+    tx = Transaction(
         to=execution_code_address,
         gas_limit=env.gas_limit,
         sender=pre.fund_eoa(),
     )
 
-    blockchain_test(
+    state_test(
         genesis_environment=env,
         pre=pre,
         post={},
-        blocks=[Block(txs=[op_tx])],
+        tx=tx,
     )
 
 
@@ -447,9 +444,8 @@ def test_worst_selfbalance(
 )
 @pytest.mark.slow()
 def test_worst_extcodecopy_warm(
-    blockchain_test: BlockchainTestFiller,
+    state_test: StateTestFiller,
     pre: Alloc,
-    fork: Fork,
     copied_size: int,
 ):
     """Test running a block with as many wamr EXTCODECOPY work as possible."""
@@ -467,15 +463,15 @@ def test_worst_extcodecopy_warm(
         )
     )
     execution_code_address = pre.deploy_contract(code=execution_code)
-    op_tx = Transaction(
+    tx = Transaction(
         to=execution_code_address,
         gas_limit=env.gas_limit,
         sender=pre.fund_eoa(),
     )
 
-    blockchain_test(
+    state_test(
         genesis_environment=env,
         pre=pre,
         post={},
-        blocks=[Block(txs=[op_tx])],
+        tx=tx,
     )


### PR DESCRIPTION
## 🗒️ Description
Convert benchmarks with single transaction to `state_test()`.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests)/[tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned @ported_from marker.
- [ ] Tests: A PR with removal of converted JSON/YML blockchain tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
