### PR TITLE
fix(github/coverage): Fix coverage script on PRs that do not convert tests

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -120,10 +120,9 @@ jobs:
           new_sources=$(echo "$CHANGED_TEST_FILES" | tr ',' '\n')
           echo "Changed or new test files: $new_sources"
 
-          # uv run returns an error code if no tests detected in changed files. ignore it by setting || true.
-          files=$(uv run fill $new_sources --show-ported-from --clean --quiet --links-as-filled | grep .json || true)
+          uv run fill $new_sources --show-ported-from --clean --quiet --links-as-filled --ported-from-output-file ported_from_files.txt
+          files=$(cat ported_from_files.txt)
           echo "Extracted converted tests: $files"
-
           if [[ -z "$files" ]]; then
               echo "No ported fillers found, check updates instead:"
               echo "converted_skip=true" >> $GITHUB_ENV

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -41,6 +41,7 @@ Users can select any of the artifacts depending on their testing needs for their
 - ✨ Added a new `eest` sub-command, `eest info`, to easily print a cloned EEST repository's version and the versions of relevant tools, e.g., `python`, `uv` ([#1621](https://github.com/ethereum/execution-spec-tests/pull/1621)).
 - ✨ Add `CONTRIBUTING.md` for execution-spec-tests and improve coding standards documentation ([#1604](https://github.com/ethereum/execution-spec-tests/pull/1604)).
 - 🔀 Updated from pytest 7 to [pytest 8](https://docs.pytest.org/en/stable/changelog.html#features-and-improvements), benefits include improved type hinting and hook typing, stricter mark handling, and clearer error messages for plugin and metadata development [#1433](https://github.com/ethereum/execution-spec-tests/pull/1433).
+- 🐞 Fix bug in ported-from plugin and coverage script that made PRs fail with modified tests that contained no ported tests ([#1661](https://github.com/ethereum/execution-spec-tests/pull/1661)).
 
 ### 🧪 Test Cases
 


### PR DESCRIPTION
Fixes the coverage script on PRs that convert no tests by adding `--ported-from-output-file` to the fill command.