### PR TITLE
coverage fix

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -118,7 +118,12 @@ jobs:
         run: |
           source $GITHUB_ENV
           new_sources=$(echo "$CHANGED_TEST_FILES" | tr ',' '\n')
-          files=$(uv run fill $new_sources --show-ported-from --clean --quiet --links-as-filled | grep .json)
+          echo "Changed or new test files: $new_sources"
+
+          # uv run returns an error code if no tests detected in changed files. ignore it by setting || true.
+          files=$(uv run fill $new_sources --show-ported-from --clean --quiet --links-as-filled | grep .json || true)
+          echo "Extracted converted tests: $files"
+
           if [[ -z "$files" ]]; then
               echo "No ported fillers found, check updates instead:"
               echo "converted_skip=true" >> $GITHUB_ENV


### PR DESCRIPTION
## 🗒️ Description
uv run fill return error code if no tests found in .py files
account for that

## 🔗 Related Issues


## ✅ Checklist

- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests)/[tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned @ported_from marker.
- [ ] Tests: A PR with removal of converted JSON/YML blockchain tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
