### PR TITLE
chore(fill): Silence tarfile DeprecationWarning in fixture download

### DIFF
--- a/src/pytest_plugins/consume/consume.py
+++ b/src/pytest_plugins/consume/consume.py
@@ -89,7 +89,7 @@ class FixtureDownloader:
         response.raise_for_status()
 
         with tarfile.open(fileobj=BytesIO(response.content), mode="r:gz") as tar:
-            tar.extractall(path=self.extract_to)
+            tar.extractall(path=self.extract_to, filter="data")
 
         return self.detect_extracted_directory()
 


### PR DESCRIPTION
## 🗒️ Description
Silences tarfile `DeprecationWarning` for fixture downloads in python 3.13!

## 🔗 Related Issues
Fixes #1423.

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] ~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
