### PR TITLE
feat(fixtures,specs): Add `postStateHash` on `exclude_full_post_state_in_output`

### DIFF
--- a/src/ethereum_test_fixtures/blockchain.py
+++ b/src/ethereum_test_fixtures/blockchain.py
@@ -407,6 +407,7 @@ class BlockchainFixtureCommon(BaseFixture):
     genesis: FixtureHeader = Field(..., alias="genesisBlockHeader")
     pre: Alloc
     post_state: Alloc | None = Field(None)
+    post_state_hash: Hash | None = Field(None)
     last_block_hash: Hash = Field(..., alias="lastblockhash")  # FIXME: lastBlockHash
     config: FixtureConfig
 

--- a/src/ethereum_test_specs/blockchain.py
+++ b/src/ethereum_test_specs/blockchain.py
@@ -656,6 +656,7 @@ class BlockchainTest(BaseTest):
             last_block_hash=head,
             pre=pre,
             post_state=alloc if not self.exclude_full_post_state_in_output else None,
+            post_state_hash=alloc.state_root() if self.exclude_full_post_state_in_output else None,
             config=FixtureConfig(
                 fork=network_info,
                 blob_schedule=FixtureBlobSchedule.from_blob_schedule(fork.blob_schedule()),
@@ -754,6 +755,7 @@ class BlockchainTest(BaseTest):
             fcu_version=fcu_version,
             pre=pre,
             post_state=alloc if not self.exclude_full_post_state_in_output else None,
+            post_state_hash=alloc.state_root() if self.exclude_full_post_state_in_output else None,
             sync_payload=sync_payload,
             last_block_hash=head_hash,
             config=FixtureConfig(


### PR DESCRIPTION
## 🗒️ Description

Adds `postStateHash` field to `blockchain_test` and `blockchain_test_engine` fixtures when `exclude_full_post_state_in_output` is set to `True`.

Fixes coverage failures like this one:
https://github.com/ethereum/execution-spec-tests/actions/runs/15284120590/job/42990072007?pr=1660

## 🔗 Related Issues
None

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.