### PR TITLE
zkevm: memory opcodes

### DIFF
--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -953,6 +953,49 @@ def test_worst_mod(
 
 
 @pytest.mark.valid_from("Cancun")
+@pytest.mark.parametrize("opcode", [Op.MLOAD, Op.MSTORE, Op.MSTORE8])
+@pytest.mark.parametrize("offset", [0, 1, 31])
+@pytest.mark.parametrize("offset_initialized", [True, False])
+@pytest.mark.parametrize("big_memory_expansion", [True, False])
+def test_worst_memory_access(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    opcode: Op,
+    offset: int,
+    offset_initialized: bool,
+    big_memory_expansion: bool,
+):
+    """Test running a block with as many memory access instructions as possible."""
+    env = Environment()
+
+    mem_exp_code = Op.MSTORE8(10 * 1024, 1) if big_memory_expansion else Bytecode()
+    offset_set_code = Op.MSTORE(offset, 43) if offset_initialized else Bytecode()
+    code_prefix = mem_exp_code + offset_set_code + Op.PUSH1(42) + Op.PUSH1(offset) + Op.JUMPDEST
+
+    code_suffix = Op.JUMP(len(code_prefix) - 1)
+
+    loop_iter = Op.POP(Op.MLOAD(Op.DUP1)) if opcode == Op.MLOAD else opcode(Op.DUP2, Op.DUP2)
+
+    code_body_len = (MAX_CODE_SIZE - len(code_prefix) - len(code_suffix)) // len(loop_iter)
+    code_body = loop_iter * code_body_len
+    code = code_prefix + code_body + code_suffix
+    assert len(code) <= MAX_CODE_SIZE
+
+    tx = Transaction(
+        to=pre.deploy_contract(code=code),
+        gas_limit=env.gas_limit,
+        sender=pre.fund_eoa(),
+    )
+
+    state_test(
+        env=env,
+        pre=pre,
+        post={},
+        tx=tx,
+    )
+
+
+@pytest.mark.valid_from("Cancun")
 def test_empty_block(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,


### PR DESCRIPTION
This PR adds coverage for `MLOAD`, `MSTORE` and `MSTORE8`.

Cycles:
```
tests/zkevm/test_worst_compute.py::test_worst_memory_access[fork_Cancun-blockchain_test_from_state_test-big_memory_expansion_True-offset_initialized_False-offset_31-opcode_MSTORE8]-1  1084188951
tests/zkevm/test_worst_compute.py::test_worst_memory_access[fork_Cancun-blockchain_test_from_state_test-big_memory_expansion_True-offset_initialized_True-offset_31-opcode_MSTORE8]-1   1084190124
tests/zkevm/test_worst_compute.py::test_worst_memory_access[fork_Cancun-blockchain_test_from_state_test-big_memory_expansion_False-offset_initialized_False-offset_31-opcode_MSTORE8]-1 1084198564
tests/zkevm/test_worst_compute.py::test_worst_memory_access[fork_Cancun-blockchain_test_from_state_test-big_memory_expansion_False-offset_initialized_True-offset_31-opcode_MSTORE8]-1  1084199671
tests/zkevm/test_worst_compute.py::test_worst_memory_access[fork_Cancun-blockchain_test_from_state_test-big_memory_expansion_True-offset_initialized_False-offset_1-opcode_MSTORE8]-1   1092164267
tests/zkevm/test_worst_compute.py::test_worst_memory_access[fork_Cancun-blockchain_test_from_state_test-big_memory_expansion_True-offset_initialized_False-offset_0-opcode_MSTORE8]-1   1092164379
tests/zkevm/test_worst_compute.py::test_worst_memory_access[fork_Cancun-blockchain_test_from_state_test-big_memory_expansion_True-offset_initialized_True-offset_0-opcode_MSTORE8]-1    1092183601
tests/zkevm/test_worst_compute.py::test_worst_memory_access[fork_Cancun-blockchain_test_from_state_test-big_memory_expansion_True-offset_initialized_True-offset_1-opcode_MSTORE8]-1    1092183760
tests/zkevm/test_worst_compute.py::test_worst_memory_access[fork_Cancun-blockchain_test_from_state_test-big_memory_expansion_False-offset_initialized_False-offset_0-opcode_MSTORE8]-1  1092192709
tests/zkevm/test_worst_compute.py::test_worst_memory_access[fork_Cancun-blockchain_test_from_state_test-big_memory_expansion_False-offset_initialized_False-offset_1-opcode_MSTORE8]-1  1092192816
tests/zkevm/test_worst_compute.py::test_worst_memory_access[fork_Cancun-blockchain_test_from_state_test-big_memory_expansion_False-offset_initialized_True-offset_0-opcode_MSTORE8]-1   1092193710
tests/zkevm/test_worst_compute.py::test_worst_memory_access[fork_Cancun-blockchain_test_from_state_test-big_memory_expansion_False-offset_initialized_True-offset_1-opcode_MSTORE8]-1   1092212086
tests/zkevm/test_worst_compute.py::test_worst_memory_access[fork_Cancun-blockchain_test_from_state_test-big_memory_expansion_True-offset_initialized_False-offset_1-opcode_MLOAD]-1     1278004495
tests/zkevm/test_worst_compute.py::test_worst_memory_access[fork_Cancun-blockchain_test_from_state_test-big_memory_expansion_True-offset_initialized_True-offset_1-opcode_MLOAD]-1      1278005390
tests/zkevm/test_worst_compute.py::test_worst_memory_access[fork_Cancun-blockchain_test_from_state_test-big_memory_expansion_True-offset_initialized_False-offset_0-opcode_MLOAD]-1     1278022914
tests/zkevm/test_worst_compute.py::test_worst_memory_access[fork_Cancun-blockchain_test_from_state_test-big_memory_expansion_True-offset_initialized_False-offset_31-opcode_MLOAD]-1    1278023007
tests/zkevm/test_worst_compute.py::test_worst_memory_access[fork_Cancun-blockchain_test_from_state_test-big_memory_expansion_True-offset_initialized_True-offset_0-opcode_MLOAD]-1      1278023894
tests/zkevm/test_worst_compute.py::test_worst_memory_access[fork_Cancun-blockchain_test_from_state_test-big_memory_expansion_True-offset_initialized_True-offset_31-opcode_MLOAD]-1     1278024022
tests/zkevm/test_worst_compute.py::test_worst_memory_access[fork_Cancun-blockchain_test_from_state_test-big_memory_expansion_False-offset_initialized_False-offset_31-opcode_MLOAD]-1   1278038891
tests/zkevm/test_worst_compute.py::test_worst_memory_access[fork_Cancun-blockchain_test_from_state_test-big_memory_expansion_False-offset_initialized_False-offset_1-opcode_MLOAD]-1    1278039040
tests/zkevm/test_worst_compute.py::test_worst_memory_access[fork_Cancun-blockchain_test_from_state_test-big_memory_expansion_False-offset_initialized_True-offset_0-opcode_MLOAD]-1     1278039798
tests/zkevm/test_worst_compute.py::test_worst_memory_access[fork_Cancun-blockchain_test_from_state_test-big_memory_expansion_False-offset_initialized_True-offset_31-opcode_MLOAD]-1    1278039807
tests/zkevm/test_worst_compute.py::test_worst_memory_access[fork_Cancun-blockchain_test_from_state_test-big_memory_expansion_False-offset_initialized_False-offset_0-opcode_MLOAD]-1    1278057305
tests/zkevm/test_worst_compute.py::test_worst_memory_access[fork_Cancun-blockchain_test_from_state_test-big_memory_expansion_False-offset_initialized_True-offset_1-opcode_MLOAD]-1     1278058446
tests/zkevm/test_worst_compute.py::test_worst_memory_access[fork_Cancun-blockchain_test_from_state_test-big_memory_expansion_True-offset_initialized_False-offset_0-opcode_MSTORE]-1    1587777790
tests/zkevm/test_worst_compute.py::test_worst_memory_access[fork_Cancun-blockchain_test_from_state_test-big_memory_expansion_True-offset_initialized_True-offset_0-opcode_MSTORE]-1     1587797238
tests/zkevm/test_worst_compute.py::test_worst_memory_access[fork_Cancun-blockchain_test_from_state_test-big_memory_expansion_False-offset_initialized_False-offset_0-opcode_MSTORE]-1   1587822397
tests/zkevm/test_worst_compute.py::test_worst_memory_access[fork_Cancun-blockchain_test_from_state_test-big_memory_expansion_False-offset_initialized_True-offset_0-opcode_MSTORE]-1    1587841687
tests/zkevm/test_worst_compute.py::test_worst_memory_access[fork_Cancun-blockchain_test_from_state_test-big_memory_expansion_True-offset_initialized_False-offset_31-opcode_MSTORE]-1   1791618911
tests/zkevm/test_worst_compute.py::test_worst_memory_access[fork_Cancun-blockchain_test_from_state_test-big_memory_expansion_True-offset_initialized_True-offset_31-opcode_MSTORE]-1    1791638191
tests/zkevm/test_worst_compute.py::test_worst_memory_access[fork_Cancun-blockchain_test_from_state_test-big_memory_expansion_False-offset_initialized_False-offset_31-opcode_MSTORE]-1  1791688438
tests/zkevm/test_worst_compute.py::test_worst_memory_access[fork_Cancun-blockchain_test_from_state_test-big_memory_expansion_False-offset_initialized_True-offset_31-opcode_MSTORE]-1   1791689285
tests/zkevm/test_worst_compute.py::test_worst_memory_access[fork_Cancun-blockchain_test_from_state_test-big_memory_expansion_True-offset_initialized_False-offset_1-opcode_MSTORE]-1    1795634316
tests/zkevm/test_worst_compute.py::test_worst_memory_access[fork_Cancun-blockchain_test_from_state_test-big_memory_expansion_True-offset_initialized_True-offset_1-opcode_MSTORE]-1     1795635201
tests/zkevm/test_worst_compute.py::test_worst_memory_access[fork_Cancun-blockchain_test_from_state_test-big_memory_expansion_False-offset_initialized_False-offset_1-opcode_MSTORE]-1   1795667131
tests/zkevm/test_worst_compute.py::test_worst_memory_access[fork_Cancun-blockchain_test_from_state_test-big_memory_expansion_False-offset_initialized_True-offset_1-opcode_MSTORE]-1    1795668000
```
