### PR TITLE
zkevm: add temp memory opcodes

### DIFF
--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -9,7 +9,7 @@ import math
 import operator
 import random
 from enum import Enum, auto
-from typing import Optional, cast
+from typing import cast
 
 import pytest
 from py_ecc.bn128 import G1, G2, multiply


### PR DESCRIPTION
This PR adds tests for `TLOAD` and `TSTORE` under different scenarios.

Cycles:
```
tests/zkevm/test_worst_compute.py::test_worst_tload[fork_Cancun-blockchain_test_from_state_test-val_mut_False-key_mut_True]-1   102655021
tests/zkevm/test_worst_compute.py::test_worst_tload[fork_Cancun-blockchain_test_from_state_test-val_mut_False-key_mut_False]-1  105422512
tests/zkevm/test_worst_compute.py::test_worst_tload[fork_Cancun-blockchain_test_from_state_test-val_mut_True-key_mut_True]-1    372113852
tests/zkevm/test_worst_compute.py::test_worst_tload[fork_Cancun-blockchain_test_from_state_test-val_mut_True-key_mut_False]-1   376385880
tests/zkevm/test_worst_compute.py::test_worst_tstore[fork_Cancun-blockchain_test_from_state_test-dense_val_mut_False-key_mut_False]-1   521616177
tests/zkevm/test_worst_compute.py::test_worst_tstore[fork_Cancun-blockchain_test_from_state_test-dense_val_mut_False-key_mut_True]-1    524215317
tests/zkevm/test_worst_compute.py::test_worst_tstore[fork_Cancun-blockchain_test_from_state_test-dense_val_mut_True-key_mut_False]-1    1023777662
tests/zkevm/test_worst_compute.py::test_worst_tstore[fork_Cancun-blockchain_test_from_state_test-dense_val_mut_True-key_mut_True]-1     1028785489
```

Targets #1657

