### PR TITLE
fix(cli): Add `pytest_plugins.pytest_hive.pytest_hive` to Hive processor

### DIFF
--- a/src/cli/pytest_commands/processors.py
+++ b/src/cli/pytest_commands/processors.py
@@ -92,6 +92,8 @@ class HiveEnvironmentProcessor(ArgumentProcessor):
         if os.getenv("HIVE_LOGLEVEL") is not None:
             warnings.warn("HIVE_LOG_LEVEL is not yet supported.", stacklevel=2)
 
+        modified_args.extend(["-p", "pytest_plugins.pytest_hive.pytest_hive"])
+
         return modified_args
 
     def _has_regex_or_sim_limit(self, args: List[str]) -> bool:


### PR DESCRIPTION
## 🗒️ Description
Fixes an issue introduced in #1654: `pytest_plugins.pytest_hive.pytest_hive` was not added to the arguments required to execute consume with hive.

## 🔗 Related Issues
None

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] ~~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.