### PR TITLE
refactor(fw): move TransactionType enum to ethereum_test_types module

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,10 @@ Users can select any of the artifacts depending on their testing needs for their
 
 ### 🛠️ Framework
 
+#### 🔀 Refactoring
+
+- 🔀 Move `TransactionType` enum from test file to proper module location in `ethereum_test_types.transaction_types` for better code organization and reusability.
+
 #### `fill`
 
 - ✨ Add the `ported_from` test marker to track Python test cases that were converted from static fillers in [ethereum/tests](https://github.com/ethereum/tests) repository [#1590](https://github.com/ethereum/execution-spec-tests/pull/1590).

--- a/src/ethereum_test_specs/tests/test_fixtures.py
+++ b/src/ethereum_test_specs/tests/test_fixtures.py
@@ -20,7 +20,7 @@ from ethereum_test_fixtures import (
     StateFixture,
 )
 from ethereum_test_forks import Berlin, Cancun, Fork, Istanbul, London, Paris, Shanghai
-from ethereum_test_types import Alloc, Environment, Transaction
+from ethereum_test_types import Alloc, Environment, Transaction, TransactionType
 from ethereum_test_vm import Opcodes as Op
 
 from ..blockchain import Block, BlockchainTest, Header
@@ -93,16 +93,6 @@ def test_make_genesis(fork: Fork, fixture_hash: bytes, default_t8n: TransitionTo
 
     assert fixture.genesis.block_hash is not None
     assert fixture.genesis.block_hash.startswith(fixture_hash)
-
-
-class TransactionType(IntEnum):
-    """Transaction types."""
-
-    LEGACY = 0
-    ACCESS_LIST = 1
-    BASE_FEE = 2
-    BLOB_TRANSACTION = 3
-    SET_CODE = 4
 
 
 @pytest.mark.parametrize(

--- a/src/ethereum_test_types/__init__.py
+++ b/src/ethereum_test_types/__init__.py
@@ -27,6 +27,7 @@ from .transaction_types import (
     NetworkWrappedTransaction,
     Transaction,
     TransactionDefaults,
+    TransactionType,
 )
 from .utils import Removable, keccak256
 
@@ -46,6 +47,7 @@ __all__ = (
     "Transaction",
     "TransactionDefaults",
     "TransactionReceipt",
+    "TransactionType",
     "Withdrawal",
     "WithdrawalRequest",
     "add_kzg_version",

--- a/src/ethereum_test_types/transaction_types.py
+++ b/src/ethereum_test_types/transaction_types.py
@@ -1,6 +1,7 @@
 """Transaction-related types for Ethereum tests."""
 
 from dataclasses import dataclass
+from enum import IntEnum
 from functools import cached_property
 from typing import Any, ClassVar, Dict, Generic, List, Literal, Sequence
 
@@ -37,6 +38,16 @@ from .account_types import EOA
 from .blob_types import Blob
 from .receipt_types import TransactionReceipt
 from .utils import int_to_bytes, keccak256
+
+
+class TransactionType(IntEnum):
+    """Transaction types."""
+
+    LEGACY = 0
+    ACCESS_LIST = 1
+    BASE_FEE = 2
+    BLOB_TRANSACTION = 3
+    SET_CODE = 4
 
 
 @dataclass

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -14,7 +14,6 @@ from py_ecc.bn128 import G1, G2, multiply
 
 from ethereum_test_base_types.base_types import Bytes
 from ethereum_test_forks import Fork
-from ethereum_test_specs.tests.test_fixtures import TransactionType
 from ethereum_test_tools import (
     Address,
     Alloc,
@@ -28,6 +27,7 @@ from ethereum_test_tools import (
 )
 from ethereum_test_tools.code.generators import While
 from ethereum_test_tools.vm.opcode import Opcodes as Op
+from ethereum_test_types import TransactionType
 from ethereum_test_vm.opcode import Opcode
 from tests.cancun.eip4844_blobs.spec import Spec as BlobsSpec
 from tests.istanbul.eip152_blake2.common import Blake2bInput


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
 - Moved `TransactionType` enum from test_fixtures.py to ethereum_test_types/transaction_types.py
 - Added proper import for `IntEnum` in the `transaction_types` module
 - Updated exports in `ethereum_test_types/__init__.py` to include `TransactionType`
  
## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->
Fixes #1669 
## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests)/[tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned @ported_from marker.
- [ ] Tests: A PR with removal of converted JSON/YML blockchain tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
