### PR TITLE
refactor(tests): remove `secret_key` from `test_access_list`'s transaction

### DIFF
--- a/docs/writing_tests/index.md
+++ b/docs/writing_tests/index.md
@@ -16,7 +16,7 @@ and modify the generated test module to suit your needs.
 
 For help deciding which test format to select, see [Types of Tests](./types_of_tests.md), in particular [Deciding on a Test Type](./types_of_tests.md#deciding-on-a-test-type). Otherwise, some simple test case examples to get started with are:
 
-- [tests.berlin.eip2930_access_list.test_acl.test_access_list](../tests/berlin/eip2930_access_list/test_acl/test_access_list.md).
+- [tests.berlin.eip2930_access_list.test_acl.test_account_storage_warm_cold_state](../tests/berlin/eip2930_access_list/test_acl/test_account_storage_warm_cold_state.md).
 - [tests.istanbul.eip1344_chainid.test_chainid.test_chainid](../tests/istanbul/eip1344_chainid/test_chainid/test_chainid.md).
 
 ## Key Resources

--- a/tests/berlin/eip2930_access_list/test_acl.py
+++ b/tests/berlin/eip2930_access_list/test_acl.py
@@ -22,6 +22,8 @@ from ethereum_test_tools import Opcodes as Op
 REFERENCE_SPEC_GIT_PATH = "EIPS/eip-2930.md"
 REFERENCE_SPEC_VERSION = "c9db53a936c5c9cbe2db32ba0d1b86c4c6e73534"
 
+pytestmark = pytest.mark.valid_from("Berlin")
+
 
 @pytest.mark.parametrize(
     "account_warm,storage_key_warm",
@@ -45,7 +47,7 @@ def test_account_storage_warm_cold_state(
 
     storage_reader_contract = pre.deploy_contract(Op.SLOAD(1) + Op.STOP)
     overhead_cost = (
-        gas_costs.G_VERY_LOW * (Op.CALL.pushed_stack_items - 1)  # Call stack items
+        gas_costs.G_VERY_LOW * (Op.CALL.popped_stack_items - 1)  # Call stack items
         + gas_costs.G_BASE  # Call gas
         + gas_costs.G_VERY_LOW  # SLOAD Push
     )
@@ -198,7 +200,6 @@ def test_account_storage_warm_cold_state(
         pytest.param(False, id="not_enough_gas", marks=pytest.mark.exception_test),
     ],
 )
-@pytest.mark.valid_from("Berlin")
 def test_transaction_intrinsic_gas_cost(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/berlin/eip2930_access_list/test_acl.py
+++ b/tests/berlin/eip2930_access_list/test_acl.py
@@ -1,60 +1,166 @@
 """Test ACL Transaction Source Code Examples."""
 
+from typing import List
+
 import pytest
 
 from ethereum_test_tools import (
     AccessList,
     Account,
+    Address,
     Alloc,
     Environment,
+    Hash,
     StateTestFiller,
     Transaction,
+    TransactionException,
 )
 from ethereum_test_tools import Opcodes as Op
+from ethereum_test_types.types import Fork
 
 REFERENCE_SPEC_GIT_PATH = "EIPS/eip-2930.md"
 REFERENCE_SPEC_VERSION = "c9db53a936c5c9cbe2db32ba0d1b86c4c6e73534"
 
 
+@pytest.mark.parametrize(
+    "access_lists",
+    [
+        pytest.param(
+            [],
+            id="empty_access_list",
+        ),
+        pytest.param(
+            [AccessList(address=Address(0), storage_keys=[])],
+            id="single_address_multiple_no_storage_keys",
+        ),
+        pytest.param(
+            [AccessList(address=Address(0), storage_keys=[Hash(0)])],
+            id="single_address_single_storage_key",
+        ),
+        pytest.param(
+            [AccessList(address=Address(0), storage_keys=[Hash(0), Hash(1)])],
+            id="single_address_multiple_storage_keys",
+        ),
+        pytest.param(
+            [
+                AccessList(address=Address(0), storage_keys=[Hash(0), Hash(1)]),
+                AccessList(address=Address(1), storage_keys=[]),
+            ],
+            id="multiple_addresses_second_address_no_storage_keys",
+        ),
+        pytest.param(
+            [
+                AccessList(address=Address(0), storage_keys=[Hash(0), Hash(1)]),
+                AccessList(address=Address(1), storage_keys=[Hash(0)]),
+            ],
+            id="multiple_addresses_second_address_single_storage_key",
+        ),
+        pytest.param(
+            [
+                AccessList(address=Address(0), storage_keys=[Hash(0), Hash(1)]),
+                AccessList(address=Address(1), storage_keys=[Hash(0), Hash(1)]),
+            ],
+            id="multiple_addresses_second_address_multiple_storage_keys",
+        ),
+        pytest.param(
+            [
+                AccessList(address=Address(0), storage_keys=[]),
+                AccessList(address=Address(1), storage_keys=[Hash(0), Hash(1)]),
+            ],
+            id="multiple_addresses_first_address_no_storage_keys",
+        ),
+        pytest.param(
+            [
+                AccessList(address=Address(0), storage_keys=[Hash(0)]),
+                AccessList(address=Address(1), storage_keys=[Hash(0), Hash(1)]),
+            ],
+            id="multiple_addresses_first_address_single_storage_key",
+        ),
+        pytest.param(
+            [
+                AccessList(address=Address(0), storage_keys=[]),
+                AccessList(address=Address(1), storage_keys=[]),
+            ],
+            id="repeated_address_no_storage_keys",
+        ),
+        pytest.param(
+            [
+                AccessList(address=Address(0), storage_keys=[Hash(0)]),
+                AccessList(address=Address(0), storage_keys=[Hash(1)]),
+            ],
+            id="repeated_address_single_storage_key",
+        ),
+        pytest.param(
+            [
+                AccessList(address=Address(0), storage_keys=[Hash(0), Hash(1)]),
+                AccessList(address=Address(0), storage_keys=[Hash(0), Hash(1)]),
+            ],
+            id="repeated_address_multiple_storage_keys",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "enough_gas",
+    [
+        pytest.param(True, id="enough_gas"),
+        pytest.param(False, id="not_enough_gas", marks=pytest.mark.exception_test),
+    ],
+)
 @pytest.mark.valid_from("Berlin")
-def test_access_list(state_test: StateTestFiller, pre: Alloc):
+def test_access_list(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    access_lists: List[AccessList],
+    enough_gas: bool,
+):
     """Test type 1 transaction."""
     env = Environment()
 
+    contract_start_balance = 3
     contract_address = pre.deploy_contract(
-        Op.PC + Op.SLOAD + Op.POP + Op.PC + Op.SLOAD,
-        balance=0x03,
+        Op.STOP,
+        balance=contract_start_balance,
     )
-    sender = pre.fund_eoa(0x300000)
+    sender = pre.fund_eoa()
+    tx_value = 1
+    pre.fund_address(sender, tx_value)
+
+    contract_creation = False
+    tx_data = b""
+
+    intrinsic_gas_calculator = fork.transaction_intrinsic_cost_calculator()
+
+    tx_exception = None
+    tx_gas_limit = intrinsic_gas_calculator(
+        calldata=tx_data,
+        contract_creation=contract_creation,
+        access_list=access_lists,
+    )
+    if not enough_gas:
+        tx_gas_limit -= 1
+        tx_exception = TransactionException.INTRINSIC_GAS_TOO_LOW
 
     tx = Transaction(
         ty=1,
         chain_id=0x01,
+        data=tx_data,
         to=contract_address,
-        value=1,
-        gas_limit=323328,
-        gas_price=7,
-        access_list=[
-            AccessList(
-                address="0x0000000000000000000000000000000000000000",
-                storage_keys=[
-                    "0x0000000000000000000000000000000000000000000000000000000000000000",
-                ],
-            )
-        ],
+        value=tx_value,
+        gas_limit=tx_gas_limit,
+        access_list=access_lists,
         protected=True,
         sender=sender,
+        error=tx_exception,
     )
 
     post = {
         contract_address: Account(
-            code="0x5854505854",
-            balance=4,
+            balance=contract_start_balance + 1 if enough_gas else contract_start_balance,
             nonce=1,
         ),
         sender: Account(
-            balance=0x2CD931,
-            nonce=1,
+            nonce=1 if enough_gas else 0,
         ),
     }
     state_test(env=env, pre=pre, post=post, tx=tx)

--- a/tests/berlin/eip2930_access_list/test_acl.py
+++ b/tests/berlin/eip2930_access_list/test_acl.py
@@ -42,7 +42,6 @@ def test_access_list(state_test: StateTestFiller, pre: Alloc):
                 ],
             )
         ],
-        secret_key="0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
         protected=True,
         sender=sender,
     )

--- a/tests/berlin/eip2930_access_list/test_acl.py
+++ b/tests/berlin/eip2930_access_list/test_acl.py
@@ -4,6 +4,7 @@ from typing import List
 
 import pytest
 
+from ethereum_test_forks import Fork
 from ethereum_test_tools import (
     AccessList,
     Account,
@@ -16,7 +17,6 @@ from ethereum_test_tools import (
     TransactionException,
 )
 from ethereum_test_tools import Opcodes as Op
-from ethereum_test_types.types import Fork
 
 REFERENCE_SPEC_GIT_PATH = "EIPS/eip-2930.md"
 REFERENCE_SPEC_VERSION = "c9db53a936c5c9cbe2db32ba0d1b86c4c6e73534"

--- a/tests/berlin/eip2930_access_list/test_acl.py
+++ b/tests/berlin/eip2930_access_list/test_acl.py
@@ -45,7 +45,7 @@ def test_account_storage_warm_cold_state(
 
     storage_reader_contract = pre.deploy_contract(Op.SLOAD(1) + Op.STOP)
     overhead_cost = (
-        gas_costs.G_VERY_LOW * (len(Op.CALL.kwargs) - 1)  # Call stack items
+        gas_costs.G_VERY_LOW * (Op.CALL.pushed_stack_items - 1)  # Call stack items
         + gas_costs.G_BASE  # Call gas
         + gas_costs.G_VERY_LOW  # SLOAD Push
     )


### PR DESCRIPTION
## 🗒️ Description
Removes the unnecessary and hard-coded `secret_key` field from the `Transaction` used in `tests/berlin/eip2930_access_list/test_acl.py::test_access_list`. This is not required if `pre_alloc`'s `eoa_address_iterator` returns the default `TestAddress` and breaks in the case that the `eoa_address_iterator` has a global scope instead of the current function-level scope.

## 🔗 Related Issues
None

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- ~[ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~ skipped
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.

