### PR TITLE
 fix(tests,eof): Specify Env(gas_limit)

### DIFF
--- a/.github/actions/build-fixtures/action.yaml
+++ b/.github/actions/build-fixtures/action.yaml
@@ -31,23 +31,28 @@ runs:
       id: evm-builder
       with:
         type: ${{ steps.properties.outputs.evm-type }}
+    - name: Generate fixtures using fill
+      shell: bash
+      run: |
+        uv run fill -n ${{ steps.evm-builder.outputs.x-dist }} --evm-bin=${{ steps.evm-builder.outputs.evm-bin }} --solc-version=${{ steps.properties.outputs.solc }} --skip-evm-dump ${{ steps.properties.outputs.fill-params }} --output=fixtures_${{ inputs.release_name }}.tar.gz --build-name ${{ inputs.release_name }}
     - name: Wrap ethereum/tests fixtures with eofwrap tool
       shell: bash
       if: ${{ steps.properties.outputs.eofwrap }}
       run: |
         curl -L ${tests_url}${tests_version}.tar.gz | tar -xz
         ls -l
-        uv run eofwrap tests-${tests_version}/BlockchainTests/GeneralStateTests/ fixtures_${{ inputs.release_name }}/${output_path}
-        mkdir -p ./fixtures_${{ inputs.release_name }}/.meta/
-        mv fixtures_${{ inputs.release_name }}/${output_path}/metrics.json ./fixtures_${{ inputs.release_name }}/.meta/eofwrap_metrics.json
+        uv run eofwrap tests-${tests_version}/BlockchainTests/GeneralStateTests/ fixtures/${output_path}
+        rm -rf fixtures_${{ inputs.release_name }}
+        mkdir -p ./fixtures/.meta
+        mv fixtures/${output_path}/metrics.json ./fixtures/.meta/eofwrap_metrics.json
+        gunzip fixtures_${{ inputs.release_name }}.tar.gz
+        tar rf fixtures_${{ inputs.release_name }}.tar fixtures
+        gzip fixtures_${{ inputs.release_name }}.tar
+        rm -rf fixtures
       env:
         tests_url: https://github.com/ethereum/tests/archive/refs/tags/v
         tests_version: 14.1
         output_path: blockchain_tests/unscheduled/eofwrap
-    - name: Generate fixtures using fill
-      shell: bash
-      run: |
-        uv run fill -n ${{ steps.evm-builder.outputs.x-dist }} --evm-bin=${{ steps.evm-builder.outputs.evm-bin }} --solc-version=${{ steps.properties.outputs.solc }} --skip-evm-dump ${{ steps.properties.outputs.fill-params }} --output=fixtures_${{ inputs.release_name }}.tar.gz --build-name ${{ inputs.release_name }}
     - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       with:
         name: fixtures_${{ inputs.release_name }}

--- a/.github/configs/evm.yaml
+++ b/.github/configs/evm.yaml
@@ -19,5 +19,5 @@ zkevm:
 eip7692:
   impl: evmone
   repo: ethereum/evmone
-  ref: master
+  ref: evmc-experimental
   targets: ["evmone-t8n", "evmone-eofparse"]

--- a/.github/configs/evm.yaml
+++ b/.github/configs/evm.yaml
@@ -19,5 +19,5 @@ zkevm:
 eip7692:
   impl: evmone
   repo: ethereum/evmone
-  ref: evmc-experimental
+  ref: master
   targets: ["evmone-t8n", "evmone-eofparse"]

--- a/tests/unscheduled/eip7692_eof_v1/eip7069_extcall/test_calldata.py
+++ b/tests/unscheduled/eip7692_eof_v1/eip7069_extcall/test_calldata.py
@@ -507,7 +507,7 @@ def test_extcalls_input_offset(
     The `test_arg` param is the value passed into the field being tested (offset or size),
     intending to trigger integer size bugs for that particular field.
     """
-    env = Environment()
+    env = Environment(gas_limit=1_000_000_000)
 
     sender = pre.fund_eoa()
 

--- a/tests/unscheduled/eip7692_eof_v1/eip7620_eof_create/test_eofcreate.py
+++ b/tests/unscheduled/eip7692_eof_v1/eip7620_eof_create/test_eofcreate.py
@@ -486,7 +486,9 @@ def test_address_collision(
     pre: Alloc,
 ):
     """Tests address collision."""
-    env = Environment()
+    env = Environment(
+        gas_limit=300_000_000_000,
+    )
 
     slot_create_address_2 = slot_last_slot * 2 + slot_create_address
     slot_create_address_3 = slot_last_slot * 3 + slot_create_address

--- a/tests/unscheduled/eip7692_eof_v1/eip7620_eof_create/test_memory.py
+++ b/tests/unscheduled/eip7692_eof_v1/eip7620_eof_create/test_memory.py
@@ -75,7 +75,7 @@ def test_eofcreate_memory(
     The `test_arg` param is the value passed into the field being tested (offset or size),
     intending to trigger integer size bugs for that particular field.
     """
-    env = Environment()
+    env = Environment(gas_limit=2_000_000_000)
 
     sender = pre.fund_eoa(10**27)
 

--- a/tests/unscheduled/eip7692_eof_v1/eip7620_eof_create/test_returncode.py
+++ b/tests/unscheduled/eip7692_eof_v1/eip7620_eof_create/test_returncode.py
@@ -216,7 +216,7 @@ def test_returncode_memory_expansion(
     The `test_arg` param is the value passed into the field being tested (offset or size),
     intending to trigger integer size bugs for that particular field.
     """
-    env = Environment()
+    env = Environment(gas_limit=2_000_000_000)
     sender = pre.fund_eoa(10**27)
 
     eof_size_acceptable = offset_field or test_arg < MAX_BYTECODE_SIZE

--- a/tests/unscheduled/eip7692_eof_v1/eip7873_tx_create/test_txcreate.py
+++ b/tests/unscheduled/eip7692_eof_v1/eip7873_tx_create/test_txcreate.py
@@ -446,7 +446,9 @@ def test_address_collision(
     pre: Alloc,
 ):
     """Tests address collision."""
-    env = Environment()
+    env = Environment(
+        gas_limit=300_000_000_000,
+    )
 
     slot_create_address_2 = slot_last_slot * 2 + slot_create_address
     slot_create_address_3 = slot_last_slot * 3 + slot_create_address


### PR DESCRIPTION
## 🗒️ Description

Minor fixup to eof tests done in order to make a final release with the `EOFv1` pseudo-fork. This may make it easier to maintain EOF impl for teams which decide to.

## 🔗 Related Issues

NA

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests)/[tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned @ported_from marker.
- [ ] Tests: A PR with removal of converted JSON/YML blockchain tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
