### PR TITLE
zkevm: add SELFDESTRUCT coverage

### DIFF
--- a/tests/zkevm/test_worst_stateful_opcodes.py
+++ b/tests/zkevm/test_worst_stateful_opcodes.py
@@ -496,7 +496,7 @@ def test_worst_selfdestruct_existing(
     # Create an account that will be used as the beneficiary of the SELFDESTRUCT calls, to avoid
     # account creation costs. All SELFDESTRUCT calls will target the same account to avoid
     # cold costs.
-    selfdestruct_beneficiary = pre.fund_eoa(amount=100)
+    selfdestruct_beneficiary = pre.fund_eoa()
 
     # Template code that will be used to deploy a large number of contracts.
     selfdestructable_contract_addr = pre.deploy_contract(
@@ -563,7 +563,34 @@ def test_worst_selfdestruct_existing(
         sender=pre.fund_eoa(),
     )
 
-    post = {}
+    code = (
+        # Setup memory for later CREATE2 address generation loop.
+        # 0xFF+[Address(20bytes)]+[seed(32bytes)]+[initcode keccak(32bytes)]
+        Op.MSTORE(0, factory_address)
+        + Op.MSTORE8(32 - 20 - 1, 0xFF)
+        + Op.MSTORE(32, 0)
+        + Op.MSTORE(64, initcode.keccak256())
+        # Main loop
+        + While(
+            body=Op.POP(Op.CALL(address=Op.SHA3(32 - 20 - 1, 85)))
+            + Op.MSTORE(32, Op.ADD(Op.MLOAD(32), 1)),
+            # Stop before we run out of gas for the whole tx execution.
+            # The value was discovered practically rounded to the next 1000 multiple.
+            condition=Op.GT(Op.GAS, 28_000),
+        )
+        + Op.SSTORE(0, 42)  # Done for successful tx execution assertion below.
+    )
+    code_addr = pre.deploy_contract(code=code)
+    opcode_tx = Transaction(
+        to=code_addr,
+        gas_limit=attack_gas_limit,
+        gas_price=10**9,
+        sender=pre.fund_eoa(),
+    )
+
+    post = {
+        code_addr: Account(storage={0: 42})  # Check for successful execution.
+    }
     deployed_contract_addresses = []
     for i in range(num_contracts):
         deployed_contract_address = compute_create2_address(
@@ -574,32 +601,6 @@ def test_worst_selfdestruct_existing(
         post[deployed_contract_address] = Account(nonce=1)
         deployed_contract_addresses.append(deployed_contract_address)
 
-    attack_call = Op.POP(Op.CALL(address=Op.SHA3(32 - 20 - 1, 85)))
-    attack_code = (
-        # Setup memory for later CREATE2 address generation loop.
-        # 0xFF+[Address(20bytes)]+[seed(32bytes)]+[initcode keccak(32bytes)]
-        Op.MSTORE(0, factory_address)
-        + Op.MSTORE8(32 - 20 - 1, 0xFF)
-        + Op.MSTORE(32, 0)
-        + Op.MSTORE(64, initcode.keccak256())
-        # Main loop
-        + While(
-            body=attack_call + Op.MSTORE(32, Op.ADD(Op.MLOAD(32), 1)),
-            # The condition is having enough gas for at least one more iteration.
-            # 2+2600+5000 is the `attack_call` gas cost, and 2* is a rough safety margin.
-            condition=Op.GT(Op.GAS, 2 * (2 + 2600 + 5000)),
-        )
-    )
-    assert len(attack_code) <= MAX_CONTRACT_SIZE
-
-    attack_code_addr = pre.deploy_contract(code=attack_code)
-    opcode_tx = Transaction(
-        to=attack_code_addr,
-        gas_limit=attack_gas_limit,
-        gas_price=10**9,
-        sender=pre.fund_eoa(),
-    )
-
     blockchain_test(
         genesis_environment=env,
         pre=pre,
@@ -609,4 +610,75 @@ def test_worst_selfdestruct_existing(
             Block(txs=[opcode_tx]),
         ],
         exclude_full_post_state_in_output=True,
+    )
+
+
+@pytest.mark.valid_from("Cancun")
+@pytest.mark.parametrize("value_bearing", [True, False])
+def test_worst_selfdestruct_created(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    value_bearing: bool,
+):
+    """
+    Test running a block with as SELFDESTRUCT calls as possible for deployed contracts in
+    the same transaction.
+    """
+    env = Environment()
+
+    # Create an account that will be used as the beneficiary of the SELFDESTRUCT calls, to avoid
+    # account creation costs. All SELFDESTRUCT calls will target the same account to avoid
+    # cold costs.
+    selfdestruct_beneficiary = pre.fund_eoa()
+
+    # Template code that will be used to deploy a large number of contracts.
+    selfdestructable_contract_addr = pre.deploy_contract(
+        code=Op.SELFDESTRUCT(selfdestruct_beneficiary)
+    )
+    initcode = Op.EXTCODECOPY(
+        address=selfdestructable_contract_addr,
+        dest_offset=0,
+        offset=0,
+        size=Op.EXTCODESIZE(selfdestructable_contract_addr),
+    ) + Op.RETURN(0, Op.EXTCODESIZE(selfdestructable_contract_addr))
+    initcode_address = pre.deploy_contract(code=initcode)
+
+    code = (
+        Op.EXTCODECOPY(
+            address=initcode_address,
+            dest_offset=0,
+            offset=0,
+            size=Op.EXTCODESIZE(initcode_address),
+        )
+        + While(
+            body=Op.POP(
+                Op.CALL(
+                    address=Op.CREATE(
+                        value=1 if value_bearing else 0,
+                        offset=0,
+                        size=Op.EXTCODESIZE(initcode_address),
+                    )
+                )
+            ),
+            # Stop before we run out of gas for the whole tx execution.
+            # The value was discovered practically rounded to the next 1000 multiple.
+            condition=Op.GT(Op.GAS, 40_000),
+        )
+        + Op.SSTORE(0, 42)  # Done for successful tx execution assertion below.
+    )
+    code_addr = pre.deploy_contract(code=code)
+    code_tx = Transaction(
+        to=code_addr,
+        gas_limit=env.gas_limit,
+        gas_price=10**9,
+        sender=pre.fund_eoa(),
+    )
+
+    post = {code_addr: Account(storage={0: 42})}  # Check for successful execution.
+
+    state_test(
+        env=env,
+        pre=pre,
+        post=post,
+        tx=code_tx,
     )

--- a/tests/zkevm/test_worst_stateful_opcodes.py
+++ b/tests/zkevm/test_worst_stateful_opcodes.py
@@ -5,6 +5,8 @@ abstract: Tests zkEVMs worst-case stateful opcodes.
 Tests running worst-case stateful opcodes for zkEVMs.
 """
 
+import math
+
 import pytest
 
 from ethereum_test_forks import Fork
@@ -16,9 +18,11 @@ from ethereum_test_tools import (
     BlockchainTestFiller,
     Bytecode,
     Environment,
+    Hash,
     StateTestFiller,
     Transaction,
     While,
+    compute_create2_address,
     compute_create_address,
 )
 from ethereum_test_tools.vm.opcode import Opcodes as Op
@@ -26,7 +30,7 @@ from ethereum_test_tools.vm.opcode import Opcodes as Op
 REFERENCE_SPEC_GIT_PATH = "TODO"
 REFERENCE_SPEC_VERSION = "TODO"
 
-MAX_CODE_SIZE = 24 * 1024
+MAX_CONTRACT_SIZE = 24 * 1024  # TODO: This could be a fork property
 
 
 @pytest.mark.valid_from("Cancun")
@@ -157,13 +161,13 @@ def test_worst_address_state_warm(
     jumpdest = Op.JUMPDEST
     jump_back = Op.JUMP(len(prep))
     iter_block = Op.POP(opcode(address=Op.MLOAD(0)))
-    max_iters_loop = (MAX_CODE_SIZE - len(prep) - len(jumpdest) - len(jump_back)) // len(
+    max_iters_loop = (MAX_CONTRACT_SIZE - len(prep) - len(jumpdest) - len(jump_back)) // len(
         iter_block
     )
     op_code = prep + jumpdest + sum([iter_block] * max_iters_loop) + jump_back
-    if len(op_code) > MAX_CODE_SIZE:
+    if len(op_code) > MAX_CONTRACT_SIZE:
         # Must never happen, but keep it as a sanity check.
-        raise ValueError(f"Code size {len(op_code)} exceeds maximum code size {MAX_CODE_SIZE}")
+        raise ValueError(f"Code size {len(op_code)} exceeds maximum code size {MAX_CONTRACT_SIZE}")
     op_address = pre.deploy_contract(code=op_code)
     tx = Transaction(
         to=op_address,
@@ -474,4 +478,135 @@ def test_worst_extcodecopy_warm(
         pre=pre,
         post={},
         tx=tx,
+    )
+
+
+@pytest.mark.valid_from("Cancun")
+@pytest.mark.parametrize("value_bearing", [True, False])
+def test_worst_selfdestruct_existing(
+    blockchain_test: BlockchainTestFiller,
+    fork: Fork,
+    pre: Alloc,
+    value_bearing: bool,
+):
+    """Test running a block with as SELFDESTRUCT calls as possible for existing contracts."""
+    env = Environment(gas_limit=100_000_000_000)
+    attack_gas_limit = Environment().gas_limit
+
+    # Create an account that will be used as the beneficiary of the SELFDESTRUCT calls, to avoid
+    # account creation costs. All SELFDESTRUCT calls will target the same account to avoid
+    # cold costs.
+    selfdestruct_beneficiary = pre.fund_eoa(amount=100)
+
+    # Template code that will be used to deploy a large number of contracts.
+    selfdestructable_contract_addr = pre.deploy_contract(
+        code=Op.SELFDESTRUCT(selfdestruct_beneficiary)
+    )
+    initcode = Op.EXTCODECOPY(
+        address=selfdestructable_contract_addr,
+        dest_offset=0,
+        offset=0,
+        size=Op.EXTCODESIZE(selfdestructable_contract_addr),
+    ) + Op.RETURN(0, Op.EXTCODESIZE(selfdestructable_contract_addr))
+    initcode_address = pre.deploy_contract(code=initcode)
+
+    # Create a factory that deployes a new SELFDESTRUCT contract instance pre-funded depending on
+    # the value_bearing parameter. We use CREATE2 so the caller contract can easily reproduce
+    # the addresses in a loop for CALLs.
+    factory_code = (
+        Op.EXTCODECOPY(
+            address=initcode_address,
+            dest_offset=0,
+            offset=0,
+            size=Op.EXTCODESIZE(initcode_address),
+        )
+        + Op.MSTORE(
+            0,
+            Op.CREATE2(
+                value=1 if value_bearing else 0,
+                offset=0,
+                size=Op.EXTCODESIZE(initcode_address),
+                salt=Op.SLOAD(0),
+            ),
+        )
+        + Op.SSTORE(0, Op.ADD(Op.SLOAD(0), 1))
+        + Op.RETURN(0, 32)
+    )
+    factory_address = pre.deploy_contract(code=factory_code, balance=10**18)
+
+    factory_caller_code = Op.CALLDATALOAD(0) + While(
+        body=Op.POP(Op.CALL(address=factory_address)),
+        condition=Op.PUSH1(1) + Op.SWAP1 + Op.SUB + Op.DUP1 + Op.ISZERO + Op.ISZERO,
+    )
+    factory_caller_address = pre.deploy_contract(code=factory_caller_code)
+
+    gas_costs = fork.gas_costs()
+    intrinsic_gas_cost_calc = fork.transaction_intrinsic_cost_calculator()
+    loop_cost = (
+        gas_costs.G_KECCAK_256  # KECCAK static cost
+        + math.ceil(85 / 32) * gas_costs.G_KECCAK_256_WORD  # KECCAK dynamic cost for CREATE2
+        + gas_costs.G_VERY_LOW * 3  # ~MSTOREs+ADDs
+        + gas_costs.G_COLD_ACCOUNT_ACCESS  # CALL to self-destructing contract
+        + gas_costs.G_SELF_DESTRUCT
+        + 30  # ~Gluing opcodes
+    )
+    num_contracts = (
+        # Base available gas = GAS_LIMIT - intrinsic - (out of loop MSTOREs)
+        attack_gas_limit - intrinsic_gas_cost_calc() - gas_costs.G_VERY_LOW * 4
+    ) // loop_cost
+
+    contracts_deployment_tx = Transaction(
+        to=factory_caller_address,
+        gas_limit=env.gas_limit,
+        gas_price=10**9,
+        data=Hash(num_contracts),
+        sender=pre.fund_eoa(),
+    )
+
+    post = {}
+    deployed_contract_addresses = []
+    for i in range(num_contracts):
+        deployed_contract_address = compute_create2_address(
+            address=factory_address,
+            salt=i,
+            initcode=initcode,
+        )
+        post[deployed_contract_address] = Account(nonce=1)
+        deployed_contract_addresses.append(deployed_contract_address)
+
+    attack_call = Op.POP(Op.CALL(address=Op.SHA3(32 - 20 - 1, 85)))
+    attack_code = (
+        # Setup memory for later CREATE2 address generation loop.
+        # 0xFF+[Address(20bytes)]+[seed(32bytes)]+[initcode keccak(32bytes)]
+        Op.MSTORE(0, factory_address)
+        + Op.MSTORE8(32 - 20 - 1, 0xFF)
+        + Op.MSTORE(32, 0)
+        + Op.MSTORE(64, initcode.keccak256())
+        # Main loop
+        + While(
+            body=attack_call + Op.MSTORE(32, Op.ADD(Op.MLOAD(32), 1)),
+            # The condition is having enough gas for at least one more iteration.
+            # 2+2600+5000 is the `attack_call` gas cost, and 2* is a rough safety margin.
+            condition=Op.GT(Op.GAS, 2 * (2 + 2600 + 5000)),
+        )
+    )
+    assert len(attack_code) <= MAX_CONTRACT_SIZE
+
+    attack_code_addr = pre.deploy_contract(code=attack_code)
+    opcode_tx = Transaction(
+        to=attack_code_addr,
+        gas_limit=attack_gas_limit,
+        gas_price=10**9,
+        sender=pre.fund_eoa(),
+    )
+
+    blockchain_test(
+        genesis_environment=env,
+        pre=pre,
+        post=post,
+        blocks=[
+            Block(txs=[contracts_deployment_tx]),
+            Block(txs=[opcode_tx]),
+        ],
+        exclude_full_post_state_in_output=True,
     )

--- a/tests/zkevm/test_worst_stateful_opcodes.py
+++ b/tests/zkevm/test_worst_stateful_opcodes.py
@@ -575,12 +575,13 @@ def test_worst_selfdestruct_existing(
             body=Op.POP(Op.CALL(address=Op.SHA3(32 - 20 - 1, 85)))
             + Op.MSTORE(32, Op.ADD(Op.MLOAD(32), 1)),
             # Stop before we run out of gas for the whole tx execution.
-            # The value was discovered practically rounded to the next 1000 multiple.
-            condition=Op.GT(Op.GAS, 28_000),
+            # The value was found by trial-error rounded to the next 1000 multiple.
+            condition=Op.GT(Op.GAS, 12_000),
         )
         + Op.SSTORE(0, 42)  # Done for successful tx execution assertion below.
     )
-    code_addr = pre.deploy_contract(code=code)
+    # The 0 storage slot is initialize to avoid creation costs in SSTORE above.
+    code_addr = pre.deploy_contract(code=code, storage={0: 1})
     opcode_tx = Transaction(
         to=code_addr,
         gas_limit=attack_gas_limit,
@@ -661,12 +662,13 @@ def test_worst_selfdestruct_created(
                 )
             ),
             # Stop before we run out of gas for the whole tx execution.
-            # The value was discovered practically rounded to the next 1000 multiple.
-            condition=Op.GT(Op.GAS, 40_000),
+            # The value was found by trial-error rounded to the next 1000 multiple.
+            condition=Op.GT(Op.GAS, 33_000),
         )
         + Op.SSTORE(0, 42)  # Done for successful tx execution assertion below.
     )
-    code_addr = pre.deploy_contract(code=code)
+    # The 0 storage slot is initialize to avoid creation costs in SSTORE above.
+    code_addr = pre.deploy_contract(code=code, storage={0: 1})
     code_tx = Transaction(
         to=code_addr,
         gas_limit=env.gas_limit,


### PR DESCRIPTION
This PR adds coverage for `SELFDESTRUCT` covering two main scenarios:
- SELFDESTRUCTing contracts that already exist.
- SELFDESTRUCTing contracts that were created in the same tx.
since both cases are relevant for the current way `SELFDESTRUCT` works.

Each case covers both value-bearing and non-value-bearing destructions.

Cycles:
```
tests/zkevm/test_worst_stateful_opcodes.py::test_worst_selfdestruct_created[fork_Cancun-blockchain_test_from_state_test-value_bearing_True]-1   14300646
tests/zkevm/test_worst_stateful_opcodes.py::test_worst_selfdestruct_created[fork_Cancun-blockchain_test_from_state_test-value_bearing_False]-1  35151520
tests/zkevm/test_worst_stateful_opcodes.py::test_worst_selfdestruct_existing[fork_Cancun-blockchain_test-value_bearing_False]-2 251534485
tests/zkevm/test_worst_stateful_opcodes.py::test_worst_selfdestruct_existing[fork_Cancun-blockchain_test-value_bearing_True]-2  358925545
```

Note that `*created` scenarios are very costly to execute since they involve deploying the transactions we want to SELFDESTRUCT. This means that each attempt requires a lot of gas, and most of it isn't coming from SELFDESTRUCT. While this was known before doing it, I decided, for completeness, to cover the scenario anyway.

Targets #1657