### PR TITLE
fix(execute): default to False if the option doesn't exist

### DIFF
--- a/src/pytest_plugins/shared/helpers.py
+++ b/src/pytest_plugins/shared/helpers.py
@@ -13,12 +13,11 @@ from ethereum_test_tools import BaseTest
 def is_help_or_collectonly_mode(config: pytest.Config) -> bool:
     """Check if pytest is running in a help or collectonly mode."""
     return (
-        config.getoption("markers")
-        or config.getoption("collectonly")
-        or config.getoption("markers")
-        or config.getoption("show_ported_from")
-        or config.getoption("links_as_filled")
-        or config.getoption("help")
+        config.getoption("markers", default=False)
+        or config.getoption("collectonly", default=False)
+        or config.getoption("show_ported_from", default=False)
+        or config.getoption("links_as_filled", default=False)
+        or config.getoption("help", default=False)
     )
 
 


### PR DESCRIPTION
## 🗒️ Description
See #1680. 

@marioevz, can you please check whether this fix is enough?

## 🔗 Related Issues
Fixes:
- #1680 

## ✅ Checklist

- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests)/[tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned @ported_from marker.
- [ ] Tests: A PR with removal of converted JSON/YML blockchain tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
