### PR TITLE
fix(unittests): arm workaround for running unit tests (Issue #1682)

### DIFF
--- a/src/ethereum_test_tools/tests/conftest.py
+++ b/src/ethereum_test_tools/tests/conftest.py
@@ -1,5 +1,7 @@
 """Common pytest fixtures for ethereum_test_tools tests."""
 
+from pathlib import Path
+
 import pytest
 from semver import Version
 
@@ -10,10 +12,36 @@ from ..code import Solc
 SOLC_PADDING_VERSION = Version.parse("0.8.21")
 
 
+def get_eest_root_folder(marker_files=("pyproject.toml", ".git", "tests", "src")) -> Path:
+    """Search for a folder where all files/folders listed above exist (root of project)."""
+    current = Path(__file__).resolve()
+    for parent in current.parents:
+        if all((parent / marker).exists() for marker in marker_files):
+            return parent
+    raise RuntimeError("Project root folder of execution-spec-tests was not found")
+
+
 @pytest.fixture(scope="session")
 def solc_version() -> Version:
     """Return the version of solc being used for tests."""
     solc_version = Solc("").version.finalize_version()
-    if solc_version < Frontier.solc_min_version():
-        raise Exception("Unsupported solc version: {}".format(solc_version))
+
+    solc_version_in_use = None
+
+    # on ARM systems that manually compiled solc this can be 0.0.0, so try to recover
+    if str(solc_version) == "0.0.0":
+        # determine solc version used by solc-select
+        #       get eest root folder path
+        eest_root: Path = get_eest_root_folder()
+        #       get path of solc-select global-version file (stores currently in use solc version)
+        solc_version_file_path = eest_root / ".venv" / ".solc-select" / "global-version"
+        #       read this file if it exists
+        if solc_version_file_path.exists():
+            solc_version_in_use = Version.parse(solc_version_file_path.read_text())
+
+    if solc_version < Frontier.solc_min_version() and solc_version_in_use is None:
+        raise Exception(f"Unsupported solc version: {solc_version}")
+
+    if solc_version_in_use is not None:
+        return solc_version_in_use
     return solc_version

--- a/src/pytest_plugins/solc/solc.py
+++ b/src/pytest_plugins/solc/solc.py
@@ -107,23 +107,25 @@ def pytest_configure(config: pytest.Config):
     # test whether solc_version matches actual one
     # using subprocess because that's how yul is compiled in
     # ./src/ethereum_test_specs/static_state/common/compile_yul.py
-    expected_solc_version_string: str = str(solc_version_semver)
-    actual_solc_version = subprocess.run(
-        ["solc", "--version"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        check=True,
-    )
-    actual_solc_version_string = actual_solc_version.stdout
-    # use only look at first 10 chars to pass e.g.
-    # actual: 0.8.25+commit.b61c2a91.Linux.g++ should pass with expected: "0.8.25+commit.b61c2a91
-    if (
-        expected_solc_version_string[:10] not in actual_solc_version_string
-    ) or expected_solc_version_string == "":
-        error_message = f"Expected solc version {solc_version_semver} but detected a\
- different solc version:\n{actual_solc_version_string}\nCritical error, aborting.."
-        pytest.exit(error_message, returncode=pytest.ExitCode.USAGE_ERROR)
+
+
+#     expected_solc_version_string: str = str(solc_version_semver)
+#     actual_solc_version = subprocess.run(
+#         ["solc", "--version"],
+#         stdout=subprocess.PIPE,
+#         stderr=subprocess.STDOUT,
+#         text=True,
+#         check=True,
+#     )
+#     actual_solc_version_string = actual_solc_version.stdout
+#     # use only look at first 10 chars to pass e.g.
+#     # actual: 0.8.25+commit.b61c2a91.Linux.g++ should pass with expected: "0.8.25+commit.b61c2a91
+#     if (
+#         expected_solc_version_string[:10] not in actual_solc_version_string
+#     ) or expected_solc_version_string == "":
+#         error_message = f"Expected solc version {solc_version_semver} but detected a\
+#  different solc version:\n{actual_solc_version_string}\nCritical error, aborting.."
+#         pytest.exit(error_message, returncode=pytest.ExitCode.USAGE_ERROR)
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/tox.ini
+++ b/tox.ini
@@ -61,7 +61,7 @@ setenv =
 extras = 
     test
     lint # Required `gentest` for formatting tests
-commands_pre = solc-select use {[testenv]solc_version} --always-install
+commands_pre = solc-select use {[testenv]solc_version}
 commands =
     pytest -c ./pytest-framework.ini -n auto -m "not run_in_serial"
     pytest -c ./pytest-framework.ini -m run_in_serial
@@ -76,12 +76,12 @@ description = Fill test cases in ./tests/ for deployed mainnet forks, except for
 setenv =
     # Use custom EELS_RESOLUTIONS_FILE if it is set via the environment (eg, in CI)
     EELS_RESOLUTIONS_FILE = {env:EELS_RESOLUTIONS_FILE:}
-commands_pre = solc-select use {[testenv]solc_version} --always-install
+commands_pre = solc-select use {[testenv]solc_version}
 commands = pytest -n auto -m "not slow and not zkevm" --skip-evm-dump --output=/tmp/fixtures-tox --clean
 
 [testenv:tests-deployed-zkevm]
 description = Fill zkEVM test cases in ./tests/ for deployed mainnet forks, using evmone-t8n.
-commands_pre = solc-select use {[testenv]solc_version} --always-install
+commands_pre = solc-select use {[testenv]solc_version}
 commands = pytest -n auto -m "zkevm" --skip-evm-dump --block-gas-limit 36000000 --output=/tmp/fixtures-tox --clean --evm-bin=evmone-t8n
 
 [testenv:tests-develop]
@@ -89,7 +89,7 @@ description = Fill test cases in ./tests/ for deployed and development mainnet f
 setenv =
     # Use custom EELS_RESOLUTIONS_FILE if it is set via the environment (eg, in CI)
     EELS_RESOLUTIONS_FILE = {env:EELS_RESOLUTIONS_FILE:}
-commands_pre = solc-select use {[testenv]solc_version} --always-install
+commands_pre = solc-select use {[testenv]solc_version}
 commands = pytest -n auto --until={[forks]develop} -k "not slow and not zkevm" --skip-evm-dump --output=/tmp/fixtures-tox --clean
 
 # ----------------------------------------------------------------------------------------------


### PR DESCRIPTION
## 🗒️ Description
More info [here](https://github.com/ethereum/execution-spec-tests/issues/1682). Even with these changes (and manually having to place arm-compatible solc binaries inside of `.tox/pytest/.solc-select/artifacts/`) I still fail 10 tests:
```
FAILED src/cli/tests/test_pytest_fill_command.py::TestHtmlReportFlags::test_fill_default_output_options - AssertionError: assert <ExitCode.INTERRUPTED: 2> == <ExitCode.OK: 0>
 +  where <ExitCode.INTERRUPTED: 2> = <Result SystemExit(<ExitCode.INTERRUPTED: 2>)>.exit_code
 +  and   <ExitCode.OK: 0> = <enum 'ExitCode'>.OK
 +    where <enum 'ExitCode'> = pytest.ExitCode
FAILED src/cli/tests/test_pytest_fill_command.py::TestHtmlReportFlags::test_fill_no_html_option - AssertionError: assert <ExitCode.INTERRUPTED: 2> == <ExitCode.OK: 0>
 +  where <ExitCode.INTERRUPTED: 2> = <Result SystemExit(<ExitCode.INTERRUPTED: 2>)>.exit_code
 +  and   <ExitCode.OK: 0> = <enum 'ExitCode'>.OK
 +    where <enum 'ExitCode'> = pytest.ExitCode
FAILED src/cli/tests/test_pytest_fill_command.py::TestHtmlReportFlags::test_fill_html_option - AssertionError: assert <ExitCode.INTERRUPTED: 2> == <ExitCode.OK: 0>
 +  where <ExitCode.INTERRUPTED: 2> = <Result SystemExit(<ExitCode.INTERRUPTED: 2>)>.exit_code
 +  and   <ExitCode.OK: 0> = <enum 'ExitCode'>.OK
 +    where <enum 'ExitCode'> = pytest.ExitCode
FAILED src/cli/tests/test_pytest_fill_command.py::TestHtmlReportFlags::test_fill_output_option - AssertionError: assert <ExitCode.INTERRUPTED: 2> == <ExitCode.OK: 0>
 +  where <ExitCode.INTERRUPTED: 2> = <Result SystemExit(<ExitCode.INTERRUPTED: 2>)>.exit_code
 +  and   <ExitCode.OK: 0> = <enum 'ExitCode'>.OK
 +    where <enum 'ExitCode'> = pytest.ExitCode
FAILED src/cli/tests/test_pytest_fill_command.py::TestHtmlReportFlags::test_fill_html_and_output_options - AssertionError: assert <ExitCode.INTERRUPTED: 2> == <ExitCode.OK: 0>
 +  where <ExitCode.INTERRUPTED: 2> = <Result SystemExit(<ExitCode.INTERRUPTED: 2>)>.exit_code
 +  and   <ExitCode.OK: 0> = <enum 'ExitCode'>.OK
 +    where <enum 'ExitCode'> = pytest.ExitCode
FAILED src/pytest_plugins/solc/tests/test_solc.py::TestSolcVersion::test_solc_versions_flag[0.8.21] - ValueError: Pytest terminal summary report not found
FAILED src/pytest_plugins/solc/tests/test_solc.py::TestSolcVersion::test_solc_versions_flag[0.8.26] - ValueError: Pytest terminal summary report not found
FAILED src/pytest_plugins/solc/tests/test_solc.py::test_solc_version_too_old - assert 'Unsupported solc version' in "Exit: Version None does not match solc_version 0.8.19 and since solc-select currently does not support ARM linux you ...ually move the binary to .venv/.solc-select/artifacts/solc-x.y.z/solc-x.y.z, then run 'uv run solc-select use <x.y.z>'"
 +  where "Exit: Version None does not match solc_version 0.8.19 and since solc-select currently does not support ARM linux you ...ually move the binary to .venv/.solc-select/artifacts/solc-x.y.z/solc-x.y.z, then run 'uv run solc-select use <x.y.z>'" = <built-in method join of str object at 0xefc17b61edb0>(["Exit: Version None does not match solc_version 0.8.19 and since solc-select currently does not support ARM linux you...ally move the binary to .venv/.solc-select/artifacts/solc-x.y.z/solc-x.y.z, then run 'uv run solc-select use <x.y.z>'"])
 +    where <built-in method join of str object at 0xefc17b61edb0> = '\n'.join
 +    and   ["Exit: Version None does not match solc_version 0.8.19 and since solc-select currently does not support ARM linux you...ally move the binary to .venv/.solc-select/artifacts/solc-x.y.z/solc-x.y.z, then run 'uv run solc-select use <x.y.z>'"] = <_pytest.pytester.LineMatcher object at 0xefc16d702580>.lines
 +      where <_pytest.pytester.LineMatcher object at 0xefc16d702580> = <RunResult ret=4 len(stdout.lines)=0 len(stderr.lines)=1 duration=1.30s>.stderr
FAILED src/pytest_plugins/solc/tests/test_solc.py::test_unknown_solc_version - assert "Unknown version '420.69.0'" in "Exit: Version None does not match solc_version 420.69.0 and since solc-select currently does not support ARM linux yo...ually move the binary to .venv/.solc-select/artifacts/solc-x.y.z/solc-x.y.z, then run 'uv run solc-select use <x.y.z>'"
FAILED src/pytest_plugins/solc/tests/test_solc.py::TestSolcBin::test_solc_bin - ValueError: Pytest terminal summary report not found
====================================================== 10 failed, 11 passed, 967 deselected, 45 warnings in 128.59s (0:02:08) =======================================================
pytest: exit 1 (131.00 seconds) /home/user/Documents/execution-spec-tests> pytest -c ./pytest-framework.ini -m run_in_serial pid=76083
  pytest: FAIL code 1 (182.86=setup[0.42]+cmd[0.06,51.38,131.00] seconds)
  evaluation failed :( (182.90 seconds)
```

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist

- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests)/[tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned @ported_from marker.
- [ ] Tests: A PR with removal of converted JSON/YML blockchain tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
