### PR TITLE
refactor(forks): Make `Fork` Pydantic-Compatible

### DIFF
--- a/docs/writing_tests/fork_methods.md
+++ b/docs/writing_tests/fork_methods.md
@@ -153,7 +153,6 @@ fork.name()  # Returns the name of the fork
 fork.transition_tool_name(block_number=0, timestamp=0)  # Returns name for transition tools
 fork.solc_name()  # Returns name for the solc compiler
 fork.solc_min_version()  # Returns minimum solc version supporting this fork
-fork.blockchain_test_network_name()  # Returns network name for blockchain tests
 fork.is_deployed()  # Returns whether the fork is deployed to mainnet
 ```
 

--- a/src/ethereum_clis/clis/besu.py
+++ b/src/ethereum_clis/clis/besu.py
@@ -106,7 +106,6 @@ class BesuTransitionTool(TransitionTool):
         chain_id: int,
         reward: int,
         blob_schedule: BlobSchedule | None = None,
-        eips: Optional[List[int]] = None,
         debug_output_path: str = "",
         state_test: bool = False,
         slow_request: bool = False,
@@ -119,8 +118,6 @@ class BesuTransitionTool(TransitionTool):
             block_number=env.number,
             timestamp=env.timestamp,
         )
-        if eips is not None:
-            fork_name = "+".join([fork_name] + [str(eip) for eip in eips])
 
         input_json = TransitionToolInput(
             alloc=alloc,

--- a/src/ethereum_clis/transition_tool.py
+++ b/src/ethereum_clis/transition_tool.py
@@ -500,7 +500,6 @@ class TransitionTool(EthereumCLI):
         chain_id: int,
         reward: int,
         blob_schedule: BlobSchedule | None,
-        eips: Optional[List[int]] = None,
         debug_output_path: str = "",
         state_test: bool = False,
         slow_request: bool = False,
@@ -515,8 +514,6 @@ class TransitionTool(EthereumCLI):
             block_number=env.number,
             timestamp=env.timestamp,
         )
-        if eips is not None:
-            fork_name = "+".join([fork_name] + [str(eip) for eip in eips])
         if env.number == 0:
             reward = -1
         t8n_data = self.TransitionToolData(

--- a/src/ethereum_test_fixtures/base.py
+++ b/src/ethereum_test_fixtures/base.py
@@ -132,7 +132,7 @@ class BaseFixture(CamelModel):
         if _info_metadata:
             self.info.update(_info_metadata)
 
-    def get_fork(self) -> str | None:
+    def get_fork(self) -> Fork | None:
         """Return fork of the fixture as a string."""
         raise NotImplementedError
 

--- a/src/ethereum_test_fixtures/blockchain.py
+++ b/src/ethereum_test_fixtures/blockchain.py
@@ -386,7 +386,7 @@ class FixtureBlock(FixtureBlockBase):
 class FixtureConfig(CamelModel):
     """Chain configuration for a fixture."""
 
-    fork: str = Field(..., alias="network")
+    fork: Fork = Field(..., alias="network")
     chain_id: ZeroPaddedHexNumber = Field(ZeroPaddedHexNumber(1), alias="chainid")
     blob_schedule: FixtureBlobSchedule | None = None
 
@@ -402,7 +402,7 @@ class InvalidFixtureBlock(CamelModel):
 class BlockchainFixtureCommon(BaseFixture):
     """Base blockchain test fixture model."""
 
-    fork: str = Field(..., alias="network")
+    fork: Fork = Field(..., alias="network")
     genesis: FixtureHeader = Field(..., alias="genesisBlockHeader")
     pre: Alloc
     post_state: Alloc | None = Field(None)
@@ -435,7 +435,7 @@ class BlockchainFixtureCommon(BaseFixture):
                     data["config"]["chainid"] = "0x01"
         return data
 
-    def get_fork(self) -> str | None:
+    def get_fork(self) -> Fork | None:
         """Return fork of the fixture as a string."""
         return self.fork
 

--- a/src/ethereum_test_fixtures/consume.py
+++ b/src/ethereum_test_fixtures/consume.py
@@ -8,6 +8,7 @@ from typing import List, Optional, TextIO
 from pydantic import BaseModel, RootModel
 
 from ethereum_test_base_types import HexNumber
+from ethereum_test_forks import Fork
 
 from .base import BaseFixture, FixtureFormat
 from .file import Fixtures
@@ -44,7 +45,7 @@ class TestCaseBase(BaseModel):
 
     id: str
     fixture_hash: HexNumber | None
-    fork: str | None
+    fork: Fork | None
     format: FixtureFormat
     __test__ = False  # stop pytest from collecting this class as a test
 
@@ -80,7 +81,7 @@ class IndexFile(BaseModel):
     root_hash: HexNumber | None
     created_at: datetime.datetime
     test_count: int
-    forks: Optional[List[str]] = []
+    forks: Optional[List[Fork]] = []
     fixture_formats: Optional[List[str]] = []
     test_cases: List[TestCaseIndexFile]
 

--- a/src/ethereum_test_fixtures/eof.py
+++ b/src/ethereum_test_fixtures/eof.py
@@ -6,6 +6,7 @@ from pydantic import Field
 
 from ethereum_test_base_types import Bytes, CamelModel, Number
 from ethereum_test_exceptions.exceptions import EOFExceptionInstanceOrList
+from ethereum_test_forks import Fork
 from ethereum_test_types.eof.v1 import ContainerKind
 
 from .base import BaseFixture
@@ -34,7 +35,7 @@ class Vector(CamelModel):
 
     code: Bytes
     container_kind: ContainerKind = ContainerKind.RUNTIME
-    results: Mapping[str, Result]
+    results: Mapping[Fork, Result]
 
 
 class EOFFixture(BaseFixture):
@@ -45,6 +46,6 @@ class EOFFixture(BaseFixture):
 
     vectors: Mapping[Number, Vector]
 
-    def get_fork(self) -> str | None:
+    def get_fork(self) -> Fork | None:
         """Return fork of the fixture as a string."""
         return None

--- a/src/ethereum_test_fixtures/state.py
+++ b/src/ethereum_test_fixtures/state.py
@@ -14,6 +14,7 @@ from ethereum_test_base_types import (
     ZeroPaddedHexNumber,
 )
 from ethereum_test_exceptions import TransactionExceptionInstanceOrList
+from ethereum_test_forks import Fork
 from ethereum_test_types.block_types import EnvironmentGeneric
 from ethereum_test_types.transaction_types import (
     Transaction,
@@ -97,10 +98,10 @@ class StateFixture(BaseFixture):
     env: FixtureEnvironment
     pre: Alloc
     transaction: FixtureTransaction
-    post: Mapping[str, List[FixtureForkPost]]
+    post: Mapping[Fork, List[FixtureForkPost]]
     config: FixtureConfig
 
-    def get_fork(self) -> str | None:
+    def get_fork(self) -> Fork | None:
         """Return fork of the fixture as a string."""
         forks = list(self.post.keys())
         assert len(forks) == 1, "Expected state test fixture with single fork"

--- a/src/ethereum_test_fixtures/tests/test_base.py
+++ b/src/ethereum_test_fixtures/tests/test_base.py
@@ -12,7 +12,7 @@ def test_json_dict():
     """Test that the json_dict property does not include the info field."""
     fixture = TransactionFixture(
         txbytes="0x1234",
-        result={"fork": FixtureResult(intrinsic_gas=0)},
+        result={"Paris": FixtureResult(intrinsic_gas=0)},
     )
     assert "_info" not in fixture.json_dict, "json_dict should exclude the 'info' field"
 
@@ -38,7 +38,7 @@ def test_json_dict():
         pytest.param(
             TransactionFixture(
                 transaction="0x1234",
-                result={"fork": FixtureResult(intrinsic_gas=0)},
+                result={"Paris": FixtureResult(intrinsic_gas=0)},
             ),
             id="TransactionFixture",
         ),

--- a/src/ethereum_test_fixtures/tests/test_eof.py
+++ b/src/ethereum_test_fixtures/tests/test_eof.py
@@ -21,7 +21,7 @@ from ..eof import ContainerKind, EOFFixture, Result, Vector
                         code=Bytes(b"\x00"),
                         container_kind=ContainerKind.INITCODE,
                         results={
-                            "result1": Result(
+                            "Paris": Result(
                                 exception=None,
                                 valid=True,
                             ),
@@ -35,7 +35,7 @@ from ..eof import ContainerKind, EOFFixture, Result, Vector
                         "code": "0x00",
                         "containerKind": "INITCODE",
                         "results": {
-                            "result1": {
+                            "Paris": {
                                 "result": True,
                             },
                         },
@@ -52,7 +52,7 @@ from ..eof import ContainerKind, EOFFixture, Result, Vector
                         code=Bytes(b"\x00"),
                         container_kind=ContainerKind.RUNTIME,
                         results={
-                            "result1": Result(
+                            "Paris": Result(
                                 exception=EOFException.INVALID_MAGIC,
                                 valid=False,
                             ),
@@ -66,7 +66,7 @@ from ..eof import ContainerKind, EOFFixture, Result, Vector
                         "code": "0x00",
                         "containerKind": "RUNTIME",
                         "results": {
-                            "result1": {
+                            "Paris": {
                                 "exception": "EOFException.INVALID_MAGIC",
                                 "result": False,
                             },

--- a/src/ethereum_test_fixtures/transaction.py
+++ b/src/ethereum_test_fixtures/transaction.py
@@ -6,6 +6,7 @@ from pydantic import Field
 
 from ethereum_test_base_types import Address, Bytes, CamelModel, Hash, ZeroPaddedHexNumber
 from ethereum_test_exceptions import TransactionExceptionInstanceOrList
+from ethereum_test_forks import Fork
 
 from .base import BaseFixture
 
@@ -25,10 +26,10 @@ class TransactionFixture(BaseFixture):
     format_name: ClassVar[str] = "transaction_test"
     description: ClassVar[str] = "Tests that generate a transaction test fixture."
 
-    result: Mapping[str, FixtureResult]
+    result: Mapping[Fork, FixtureResult]
     transaction: Bytes = Field(..., alias="txbytes")
 
-    def get_fork(self) -> str | None:
+    def get_fork(self) -> Fork | None:
         """Return the fork of the fixture as a string."""
         forks = list(self.result.keys())
         assert len(forks) == 1, "Expected transaction test fixture with single fork"

--- a/src/ethereum_test_forks/__init__.py
+++ b/src/ethereum_test_forks/__init__.py
@@ -1,6 +1,6 @@
 """Ethereum test fork definitions."""
 
-from .base_fork import Fork, ForkAttribute
+from .base_fork import ForkAttribute
 from .forks.forks import (
     ArrowGlacier,
     Berlin,
@@ -24,12 +24,15 @@ from .forks.transition import (
     BerlinToLondonAt5,
     CancunToPragueAtTime15k,
     ParisToShanghaiAtTime15k,
+    PragueToOsakaAtTime15k,
     ShanghaiToCancunAtTime15k,
 )
 from .gas_costs import GasCosts
 from .helpers import (
+    Fork,
     ForkRangeDescriptor,
     InvalidForkError,
+    TransitionFork,
     forks_from,
     forks_from_until,
     get_closest_fork_with_solc_support,
@@ -53,6 +56,7 @@ from .helpers import (
 
 __all__ = [
     "Fork",
+    "TransitionFork",
     "ForkAttribute",
     "ArrowGlacier",
     "Berlin",
@@ -76,6 +80,7 @@ __all__ = [
     "Cancun",
     "CancunToPragueAtTime15k",
     "Prague",
+    "PragueToOsakaAtTime15k",
     "Osaka",
     "get_transition_forks",
     "forks_from",

--- a/src/ethereum_test_forks/base_fork.py
+++ b/src/ethereum_test_forks/base_fork.py
@@ -151,7 +151,6 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
     """
 
     _transition_tool_name: ClassVar[Optional[str]] = None
-    _blockchain_test_network_name: ClassVar[Optional[str]] = None
     _solc_name: ClassVar[Optional[str]] = None
     _ignore: ClassVar[bool] = False
 
@@ -159,13 +158,11 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
         cls,
         *,
         transition_tool_name: Optional[str] = None,
-        blockchain_test_network_name: Optional[str] = None,
         solc_name: Optional[str] = None,
         ignore: bool = False,
     ) -> None:
         """Initialize new fork with values that don't carry over to subclass forks."""
         cls._transition_tool_name = transition_tool_name
-        cls._blockchain_test_network_name = blockchain_test_network_name
         cls._solc_name = solc_name
         cls._ignore = ignore
 
@@ -534,13 +531,6 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
         pass
 
     @classmethod
-    def blockchain_test_network_name(cls) -> str:
-        """Return network configuration name to be used in BlockchainTests for this fork."""
-        if cls._blockchain_test_network_name is not None:
-            return cls._blockchain_test_network_name
-        return cls.name()
-
-    @classmethod
     def is_deployed(cls) -> bool:
         """
         Return whether the fork has been deployed to mainnet, or not.
@@ -563,7 +553,3 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
         if base_class == BaseFork:
             return None
         return base_class
-
-
-# Fork Type
-Fork = Type[BaseFork]

--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -818,7 +818,6 @@ class GrayGlacier(ArrowGlacier, solc_name="london", ignore=True):
 class Paris(
     London,
     transition_tool_name="Merge",
-    blockchain_test_network_name="Paris",
 ):
     """Paris (Merge) fork."""
 

--- a/src/ethereum_test_forks/forks/transition.py
+++ b/src/ethereum_test_forks/forks/transition.py
@@ -1,7 +1,7 @@
 """List of all transition fork definitions."""
 
 from ..transition_base_fork import transition_fork
-from .forks import Berlin, Cancun, London, Paris, Prague, Shanghai
+from .forks import Berlin, Cancun, London, Osaka, Paris, Prague, Shanghai
 
 
 # Transition Forks
@@ -13,7 +13,7 @@ class BerlinToLondonAt5(Berlin):
 
 
 @transition_fork(to_fork=Shanghai, at_timestamp=15_000)
-class ParisToShanghaiAtTime15k(Paris, blockchain_test_network_name="ParisToShanghaiAtTime15k"):
+class ParisToShanghaiAtTime15k(Paris):
     """Paris to Shanghai transition at Timestamp 15k."""
 
     pass
@@ -29,5 +29,12 @@ class ShanghaiToCancunAtTime15k(Shanghai):
 @transition_fork(to_fork=Prague, at_timestamp=15_000)
 class CancunToPragueAtTime15k(Cancun):
     """Cancun to Prague transition at Timestamp 15k."""
+
+    pass
+
+
+@transition_fork(to_fork=Osaka, at_timestamp=15_000)
+class PragueToOsakaAtTime15k(Prague):
+    """Prague to Osaka transition at Timestamp 15k."""
 
     pass

--- a/src/ethereum_test_forks/transition_base_fork.py
+++ b/src/ethereum_test_forks/transition_base_fork.py
@@ -3,7 +3,7 @@
 from inspect import signature
 from typing import Callable, List, Type
 
-from .base_fork import BaseFork, Fork
+from .base_fork import BaseFork
 
 ALWAYS_TRANSITIONED_BLOCK_NUMBER = 10_000
 ALWAYS_TRANSITIONED_BLOCK_TIMESTAMP = 10_000_000
@@ -13,12 +13,12 @@ class TransitionBaseClass:
     """Base class for transition forks."""
 
     @classmethod
-    def transitions_to(cls) -> Fork:
+    def transitions_to(cls) -> Type[BaseFork]:
         """Return fork where the transition ends."""
         raise Exception("Not implemented")
 
     @classmethod
-    def transitions_from(cls) -> Fork:
+    def transitions_from(cls) -> Type[BaseFork]:
         """Return fork where the transition starts."""
         raise Exception("Not implemented")
 
@@ -28,7 +28,7 @@ def base_fork_abstract_methods() -> List[str]:
     return list(BaseFork.__abstractmethods__)
 
 
-def transition_fork(to_fork: Fork, at_block: int = 0, at_timestamp: int = 0):
+def transition_fork(to_fork: Type[BaseFork], at_block: int = 0, at_timestamp: int = 0):
     """Mark a class as a transition fork."""
 
     def decorator(cls) -> Type[TransitionBaseClass]:
@@ -41,16 +41,15 @@ def transition_fork(to_fork: Fork, at_block: int = 0, at_timestamp: int = 0):
             TransitionBaseClass,
             BaseFork,
             transition_tool_name=cls._transition_tool_name,
-            blockchain_test_network_name=cls._blockchain_test_network_name,
             solc_name=cls._solc_name,
             ignore=cls._ignore,
         ):
             @classmethod
-            def transitions_to(cls) -> Fork:
+            def transitions_to(cls) -> Type[BaseFork]:
                 return to_fork
 
             @classmethod
-            def transitions_from(cls) -> Fork:
+            def transitions_from(cls) -> Type[BaseFork]:
                 return from_fork
 
         NewTransitionClass.name = lambda: transition_name  # type: ignore

--- a/src/ethereum_test_specs/base.py
+++ b/src/ethereum_test_specs/base.py
@@ -4,7 +4,7 @@ from abc import abstractmethod
 from functools import reduce
 from os import path
 from pathlib import Path
-from typing import Callable, ClassVar, Dict, Generator, List, Optional, Sequence, Type, TypeVar
+from typing import Callable, ClassVar, Dict, Generator, List, Sequence, Type, TypeVar
 
 import pytest
 from pydantic import BaseModel, Field, PrivateAttr
@@ -115,7 +115,6 @@ class BaseTest(BaseModel):
         t8n: TransitionTool,
         fork: Fork,
         fixture_format: FixtureFormat,
-        eips: Optional[List[int]] = None,
     ) -> BaseFixture:
         """Generate the list of test fixtures."""
         pass
@@ -125,7 +124,6 @@ class BaseTest(BaseModel):
         *,
         fork: Fork,
         execute_format: ExecuteFormat,
-        eips: Optional[List[int]] = None,
     ) -> BaseExecute:
         """Generate the list of test fixtures."""
         raise Exception(f"Unsupported execute format: {execute_format}")

--- a/src/ethereum_test_specs/blobs.py
+++ b/src/ethereum_test_specs/blobs.py
@@ -1,6 +1,6 @@
 """Test specification for blob tests."""
 
-from typing import Callable, ClassVar, Generator, List, Optional, Sequence, Type
+from typing import Callable, ClassVar, Generator, List, Sequence, Type
 
 from ethereum_clis import TransitionTool
 from ethereum_test_base_types import Alloc
@@ -35,7 +35,6 @@ class BlobsTest(BaseTest):
         t8n: TransitionTool,
         fork: Fork,
         fixture_format: FixtureFormat,
-        eips: Optional[List[int]] = None,
     ) -> BaseFixture:
         """Generate the list of test fixtures."""
         raise Exception(f"Unknown fixture format: {fixture_format}")
@@ -45,7 +44,6 @@ class BlobsTest(BaseTest):
         *,
         fork: Fork,
         execute_format: ExecuteFormat,
-        eips: Optional[List[int]] = None,
     ) -> BaseExecute:
         """Generate the list of test fixtures."""
         if execute_format == BlobTransaction:

--- a/src/ethereum_test_specs/eof.py
+++ b/src/ethereum_test_specs/eof.py
@@ -326,7 +326,6 @@ class EOFTest(BaseTest):
         self,
         *,
         fork: Fork,
-        eips: Optional[List[int]],
     ) -> EOFFixture:
         """Generate the EOF test fixture."""
         container_bytes = Bytes(self.container)
@@ -341,7 +340,7 @@ class EOFTest(BaseTest):
                 code=container_bytes,
                 container_kind=self.container_kind,
                 results={
-                    fork.blockchain_test_network_name(): Result(
+                    fork: Result(
                         exception=self.expect_exception,
                         valid=self.expect_exception is None,
                     ),
@@ -358,7 +357,7 @@ class EOFTest(BaseTest):
             return fixture
 
         for _, vector in fixture.vectors.items():
-            expected_result = vector.results.get(fork.blockchain_test_network_name())
+            expected_result = vector.results.get(fork)
             if expected_result is None:
                 raise Exception(f"EOF Fixture missing vector result for fork: {fork}")
             args = []
@@ -476,16 +475,15 @@ class EOFTest(BaseTest):
         *,
         t8n: TransitionTool,
         fork: Fork,
-        eips: Optional[List[int]] = None,
         fixture_format: FixtureFormat,
         **_,
     ) -> BaseFixture:
         """Generate the BlockchainTest fixture."""
         if fixture_format == EOFFixture:
-            return self.make_eof_test_fixture(fork=fork, eips=eips)
+            return self.make_eof_test_fixture(fork=fork)
         elif fixture_format in StateTest.supported_fixture_formats:
             return self.generate_state_test(fork).generate(
-                t8n=t8n, fork=fork, fixture_format=fixture_format, eips=eips
+                t8n=t8n, fork=fork, fixture_format=fixture_format
             )
         raise Exception(f"Unknown fixture format: {fixture_format}")
 
@@ -494,13 +492,10 @@ class EOFTest(BaseTest):
         *,
         fork: Fork,
         execute_format: ExecuteFormat,
-        eips: Optional[List[int]] = None,
     ) -> BaseExecute:
         """Generate the list of test fixtures."""
         if execute_format == TransactionPost:
-            return self.generate_state_test(fork).execute(
-                fork=fork, execute_format=execute_format, eips=eips
-            )
+            return self.generate_state_test(fork).execute(fork=fork, execute_format=execute_format)
         raise Exception(f"Unsupported execute format: {execute_format}")
 
 
@@ -633,7 +628,6 @@ class EOFStateTest(EOFTest, Transaction):
         *,
         t8n: TransitionTool,
         fork: Fork,
-        eips: Optional[List[int]] = None,
         fixture_format: FixtureFormat,
         **_,
     ) -> BaseFixture:
@@ -643,10 +637,10 @@ class EOFStateTest(EOFTest, Transaction):
                 # Gracefully skip duplicate tests because one EOFStateTest can generate multiple
                 # state fixtures with the same data.
                 pytest.skip(f"Duplicate EOF container on EOFStateTest: {self.node_id()}")
-            return self.make_eof_test_fixture(fork=fork, eips=eips)
+            return self.make_eof_test_fixture(fork=fork)
         elif fixture_format in StateTest.supported_fixture_formats:
             return self.generate_state_test(fork).generate(
-                t8n=t8n, fork=fork, fixture_format=fixture_format, eips=eips
+                t8n=t8n, fork=fork, fixture_format=fixture_format
             )
 
         raise Exception(f"Unknown fixture format: {fixture_format}")

--- a/src/ethereum_test_specs/state.py
+++ b/src/ethereum_test_specs/state.py
@@ -161,7 +161,6 @@ class StateTest(BaseTest):
         self,
         t8n: TransitionTool,
         fork: Fork,
-        eips: Optional[List[int]] = None,
     ) -> StateFixture:
         """Create a fixture from the state test definition."""
         # We can't generate a state test fixture that names a transition fork,
@@ -190,7 +189,6 @@ class StateTest(BaseTest):
             chain_id=self.chain_id,
             reward=0,  # Reward on state tests is always zero
             blob_schedule=fork.blob_schedule(),
-            eips=eips,
             debug_output_path=self.get_next_transition_tool_output_path(),
             state_test=True,
             slow_request=self.is_tx_gas_heavy_test(),
@@ -218,7 +216,7 @@ class StateTest(BaseTest):
             env=FixtureEnvironment(**env.model_dump(exclude_none=True)),
             pre=pre_alloc,
             post={
-                fork.blockchain_test_network_name(): [
+                fork: [
                     FixtureForkPost(
                         state_root=transition_tool_output.result.state_root,
                         logs_hash=transition_tool_output.result.logs_hash,
@@ -240,16 +238,15 @@ class StateTest(BaseTest):
         t8n: TransitionTool,
         fork: Fork,
         fixture_format: FixtureFormat,
-        eips: Optional[List[int]] = None,
     ) -> BaseFixture:
         """Generate the BlockchainTest fixture."""
         self.check_exception_test(exception=self.tx.error is not None)
         if fixture_format in BlockchainTest.supported_fixture_formats:
             return self.generate_blockchain_test(fork=fork).generate(
-                t8n=t8n, fork=fork, fixture_format=fixture_format, eips=eips
+                t8n=t8n, fork=fork, fixture_format=fixture_format
             )
         elif fixture_format == StateFixture:
-            return self.make_state_test_fixture(t8n, fork, eips)
+            return self.make_state_test_fixture(t8n, fork)
 
         raise Exception(f"Unknown fixture format: {fixture_format}")
 
@@ -258,7 +255,6 @@ class StateTest(BaseTest):
         *,
         fork: Fork,
         execute_format: ExecuteFormat,
-        eips: Optional[List[int]] = None,
     ) -> BaseExecute:
         """Generate the list of test fixtures."""
         if execute_format == TransactionPost:

--- a/src/ethereum_test_specs/transaction.py
+++ b/src/ethereum_test_specs/transaction.py
@@ -1,6 +1,6 @@
 """Ethereum transaction test spec definition and filler."""
 
-from typing import Callable, ClassVar, Generator, List, Optional, Sequence, Type
+from typing import Callable, ClassVar, Generator, Sequence, Type
 
 from ethereum_clis import TransitionTool
 from ethereum_test_execution import (
@@ -42,7 +42,6 @@ class TransactionTest(BaseTest):
     def make_transaction_test_fixture(
         self,
         fork: Fork,
-        eips: Optional[List[int]] = None,
     ) -> TransactionFixture:
         """Create a fixture from the transaction test definition."""
         if self.tx.error is not None:
@@ -69,7 +68,7 @@ class TransactionTest(BaseTest):
 
         return TransactionFixture(
             result={
-                fork.blockchain_test_network_name(): result,
+                fork: result,
             },
             transaction=self.tx.with_signature_and_sender().rlp(),
         )
@@ -79,12 +78,11 @@ class TransactionTest(BaseTest):
         t8n: TransitionTool,
         fork: Fork,
         fixture_format: FixtureFormat,
-        eips: Optional[List[int]] = None,
     ) -> BaseFixture:
         """Generate the TransactionTest fixture."""
         self.check_exception_test(exception=self.tx.error is not None)
         if fixture_format == TransactionFixture:
-            return self.make_transaction_test_fixture(fork, eips)
+            return self.make_transaction_test_fixture(fork)
 
         raise Exception(f"Unknown fixture format: {fixture_format}")
 
@@ -93,7 +91,6 @@ class TransactionTest(BaseTest):
         *,
         fork: Fork,
         execute_format: ExecuteFormat,
-        eips: Optional[List[int]] = None,
     ) -> BaseExecute:
         """Execute the transaction test by sending it to the live network."""
         if execute_format == TransactionPost:

--- a/src/ethereum_test_tools/tests/test_code.py
+++ b/src/ethereum_test_tools/tests/test_code.py
@@ -633,7 +633,6 @@ def test_switch(
         t8n=default_t8n,
         fork=Cancun,
         fixture_format=BlockchainFixture,
-        eips=None,
     )
 
 

--- a/src/pytest_plugins/consume/hive_simulators/conftest.py
+++ b/src/pytest_plugins/consume/hive_simulators/conftest.py
@@ -328,7 +328,7 @@ def fork_strict_exception_matching(
     """Return True if the fork should use strict exception matching."""
     # NOTE: `in` makes it easier for transition forks ("Prague" in "CancunToPragueAtTime15k")
     return not any(
-        fork.lower() in fixture.fork.lower() for fork in disable_strict_exception_matching
+        s.lower() in str(fixture.fork).lower() for s in disable_strict_exception_matching
     )
 
 

--- a/src/pytest_plugins/consume/hive_simulators/ruleset.py
+++ b/src/pytest_plugins/consume/hive_simulators/ruleset.py
@@ -7,7 +7,27 @@ Remove this file afterwards.
 
 from typing import Dict, List
 
-from ethereum_test_forks import Cancun, Fork, Osaka, Prague
+from ethereum_test_forks import (
+    Berlin,
+    BerlinToLondonAt5,
+    Byzantium,
+    Cancun,
+    CancunToPragueAtTime15k,
+    Constantinople,
+    ConstantinopleFix,
+    Fork,
+    Frontier,
+    Homestead,
+    Istanbul,
+    London,
+    Osaka,
+    Paris,
+    ParisToShanghaiAtTime15k,
+    Prague,
+    PragueToOsakaAtTime15k,
+    Shanghai,
+    ShanghaiToCancunAtTime15k,
+)
 
 
 def get_blob_schedule_entries(fork: Fork) -> Dict[str, int]:
@@ -36,8 +56,8 @@ def get_blob_schedule_entries(fork: Fork) -> Dict[str, int]:
     return entries
 
 
-ruleset = {
-    "Frontier": {
+ruleset: Dict[Fork, Dict[str, int]] = {
+    Frontier: {
         "HIVE_FORK_HOMESTEAD": 2000,
         "HIVE_FORK_DAO_BLOCK": 2000,
         "HIVE_FORK_TANGERINE": 2000,
@@ -49,7 +69,7 @@ ruleset = {
         "HIVE_FORK_BERLIN": 2000,
         "HIVE_FORK_LONDON": 2000,
     },
-    "Homestead": {
+    Homestead: {
         "HIVE_FORK_HOMESTEAD": 0,
         "HIVE_FORK_DAO_BLOCK": 2000,
         "HIVE_FORK_TANGERINE": 2000,
@@ -61,29 +81,7 @@ ruleset = {
         "HIVE_FORK_BERLIN": 2000,
         "HIVE_FORK_LONDON": 2000,
     },
-    "EIP150": {
-        "HIVE_FORK_HOMESTEAD": 0,
-        "HIVE_FORK_TANGERINE": 0,
-        "HIVE_FORK_SPURIOUS": 2000,
-        "HIVE_FORK_BYZANTIUM": 2000,
-        "HIVE_FORK_CONSTANTINOPLE": 2000,
-        "HIVE_FORK_PETERSBURG": 2000,
-        "HIVE_FORK_ISTANBUL": 2000,
-        "HIVE_FORK_BERLIN": 2000,
-        "HIVE_FORK_LONDON": 2000,
-    },
-    "EIP158": {
-        "HIVE_FORK_HOMESTEAD": 0,
-        "HIVE_FORK_TANGERINE": 0,
-        "HIVE_FORK_SPURIOUS": 0,
-        "HIVE_FORK_BYZANTIUM": 2000,
-        "HIVE_FORK_CONSTANTINOPLE": 2000,
-        "HIVE_FORK_PETERSBURG": 2000,
-        "HIVE_FORK_ISTANBUL": 2000,
-        "HIVE_FORK_BERLIN": 2000,
-        "HIVE_FORK_LONDON": 2000,
-    },
-    "Byzantium": {
+    Byzantium: {
         "HIVE_FORK_HOMESTEAD": 0,
         "HIVE_FORK_TANGERINE": 0,
         "HIVE_FORK_SPURIOUS": 0,
@@ -94,7 +92,7 @@ ruleset = {
         "HIVE_FORK_BERLIN": 2000,
         "HIVE_FORK_LONDON": 2000,
     },
-    "Constantinople": {
+    Constantinople: {
         "HIVE_FORK_HOMESTEAD": 0,
         "HIVE_FORK_TANGERINE": 0,
         "HIVE_FORK_SPURIOUS": 0,
@@ -105,7 +103,7 @@ ruleset = {
         "HIVE_FORK_BERLIN": 2000,
         "HIVE_FORK_LONDON": 2000,
     },
-    "ConstantinopleFix": {
+    ConstantinopleFix: {
         "HIVE_FORK_HOMESTEAD": 0,
         "HIVE_FORK_TANGERINE": 0,
         "HIVE_FORK_SPURIOUS": 0,
@@ -116,7 +114,7 @@ ruleset = {
         "HIVE_FORK_BERLIN": 2000,
         "HIVE_FORK_LONDON": 2000,
     },
-    "Istanbul": {
+    Istanbul: {
         "HIVE_FORK_HOMESTEAD": 0,
         "HIVE_FORK_TANGERINE": 0,
         "HIVE_FORK_SPURIOUS": 0,
@@ -127,7 +125,7 @@ ruleset = {
         "HIVE_FORK_BERLIN": 2000,
         "HIVE_FORK_LONDON": 2000,
     },
-    "Berlin": {
+    Berlin: {
         "HIVE_FORK_HOMESTEAD": 0,
         "HIVE_FORK_TANGERINE": 0,
         "HIVE_FORK_SPURIOUS": 0,
@@ -138,97 +136,7 @@ ruleset = {
         "HIVE_FORK_BERLIN": 0,
         "HIVE_FORK_LONDON": 2000,
     },
-    "FrontierToHomesteadAt5": {
-        "HIVE_FORK_HOMESTEAD": 5,
-        "HIVE_FORK_DAO_BLOCK": 2000,
-        "HIVE_FORK_TANGERINE": 2000,
-        "HIVE_FORK_SPURIOUS": 2000,
-        "HIVE_FORK_BYZANTIUM": 2000,
-        "HIVE_FORK_CONSTANTINOPLE": 2000,
-        "HIVE_FORK_PETERSBURG": 2000,
-        "HIVE_FORK_ISTANBUL": 2000,
-        "HIVE_FORK_BERLIN": 2000,
-        "HIVE_FORK_LONDON": 2000,
-    },
-    "HomesteadToEIP150At5": {
-        "HIVE_FORK_HOMESTEAD": 0,
-        "HIVE_FORK_TANGERINE": 5,
-        "HIVE_FORK_SPURIOUS": 2000,
-        "HIVE_FORK_BYZANTIUM": 2000,
-        "HIVE_FORK_CONSTANTINOPLE": 2000,
-        "HIVE_FORK_PETERSBURG": 2000,
-        "HIVE_FORK_ISTANBUL": 2000,
-        "HIVE_FORK_BERLIN": 2000,
-        "HIVE_FORK_LONDON": 2000,
-    },
-    "HomesteadToDaoAt5": {
-        "HIVE_FORK_HOMESTEAD": 0,
-        "HIVE_FORK_DAO_BLOCK": 5,
-        "HIVE_FORK_TANGERINE": 2000,
-        "HIVE_FORK_SPURIOUS": 2000,
-        "HIVE_FORK_BYZANTIUM": 2000,
-        "HIVE_FORK_CONSTANTINOPLE": 2000,
-        "HIVE_FORK_PETERSBURG": 2000,
-        "HIVE_FORK_ISTANBUL": 2000,
-        "HIVE_FORK_BERLIN": 2000,
-        "HIVE_FORK_LONDON": 2000,
-    },
-    "EIP158ToByzantiumAt5": {
-        "HIVE_FORK_HOMESTEAD": 0,
-        "HIVE_FORK_TANGERINE": 0,
-        "HIVE_FORK_SPURIOUS": 0,
-        "HIVE_FORK_BYZANTIUM": 5,
-        "HIVE_FORK_CONSTANTINOPLE": 2000,
-        "HIVE_FORK_PETERSBURG": 2000,
-        "HIVE_FORK_ISTANBUL": 2000,
-        "HIVE_FORK_BERLIN": 2000,
-        "HIVE_FORK_LONDON": 2000,
-    },
-    "ByzantiumToConstantinopleAt5": {
-        "HIVE_FORK_HOMESTEAD": 0,
-        "HIVE_FORK_TANGERINE": 0,
-        "HIVE_FORK_SPURIOUS": 0,
-        "HIVE_FORK_BYZANTIUM": 0,
-        "HIVE_FORK_CONSTANTINOPLE": 5,
-        "HIVE_FORK_PETERSBURG": 2000,
-        "HIVE_FORK_ISTANBUL": 2000,
-        "HIVE_FORK_BERLIN": 2000,
-        "HIVE_FORK_LONDON": 2000,
-    },
-    "ByzantiumToConstantinopleFixAt5": {
-        "HIVE_FORK_HOMESTEAD": 0,
-        "HIVE_FORK_TANGERINE": 0,
-        "HIVE_FORK_SPURIOUS": 0,
-        "HIVE_FORK_BYZANTIUM": 0,
-        "HIVE_FORK_CONSTANTINOPLE": 5,
-        "HIVE_FORK_PETERSBURG": 5,
-        "HIVE_FORK_ISTANBUL": 2000,
-        "HIVE_FORK_BERLIN": 2000,
-        "HIVE_FORK_LONDON": 2000,
-    },
-    "ConstantinopleFixToIstanbulAt5": {
-        "HIVE_FORK_HOMESTEAD": 0,
-        "HIVE_FORK_TANGERINE": 0,
-        "HIVE_FORK_SPURIOUS": 0,
-        "HIVE_FORK_BYZANTIUM": 0,
-        "HIVE_FORK_CONSTANTINOPLE": 0,
-        "HIVE_FORK_PETERSBURG": 0,
-        "HIVE_FORK_ISTANBUL": 5,
-        "HIVE_FORK_BERLIN": 2000,
-        "HIVE_FORK_LONDON": 2000,
-    },
-    "IstanbulToBerlinAt5": {
-        "HIVE_FORK_HOMESTEAD": 0,
-        "HIVE_FORK_TANGERINE": 0,
-        "HIVE_FORK_SPURIOUS": 0,
-        "HIVE_FORK_BYZANTIUM": 0,
-        "HIVE_FORK_CONSTANTINOPLE": 0,
-        "HIVE_FORK_PETERSBURG": 0,
-        "HIVE_FORK_ISTANBUL": 0,
-        "HIVE_FORK_BERLIN": 5,
-        "HIVE_FORK_LONDON": 2000,
-    },
-    "BerlinToLondonAt5": {
+    BerlinToLondonAt5: {
         "HIVE_FORK_HOMESTEAD": 0,
         "HIVE_FORK_TANGERINE": 0,
         "HIVE_FORK_SPURIOUS": 0,
@@ -239,7 +147,7 @@ ruleset = {
         "HIVE_FORK_BERLIN": 0,
         "HIVE_FORK_LONDON": 5,
     },
-    "London": {
+    London: {
         "HIVE_FORK_HOMESTEAD": 0,
         "HIVE_FORK_TANGERINE": 0,
         "HIVE_FORK_SPURIOUS": 0,
@@ -250,19 +158,7 @@ ruleset = {
         "HIVE_FORK_BERLIN": 0,
         "HIVE_FORK_LONDON": 0,
     },
-    "ArrowGlacierToMergeAtDiffC0000": {
-        "HIVE_FORK_HOMESTEAD": 0,
-        "HIVE_FORK_TANGERINE": 0,
-        "HIVE_FORK_SPURIOUS": 0,
-        "HIVE_FORK_BYZANTIUM": 0,
-        "HIVE_FORK_CONSTANTINOPLE": 0,
-        "HIVE_FORK_PETERSBURG": 0,
-        "HIVE_FORK_ISTANBUL": 0,
-        "HIVE_FORK_BERLIN": 0,
-        "HIVE_FORK_LONDON": 0,
-        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 786432,
-    },
-    "Merge": {
+    Paris: {
         "HIVE_FORK_HOMESTEAD": 0,
         "HIVE_FORK_TANGERINE": 0,
         "HIVE_FORK_SPURIOUS": 0,
@@ -275,20 +171,7 @@ ruleset = {
         "HIVE_FORK_MERGE": 0,
         "HIVE_TERMINAL_TOTAL_DIFFICULTY": 0,
     },
-    "Paris": {
-        "HIVE_FORK_HOMESTEAD": 0,
-        "HIVE_FORK_TANGERINE": 0,
-        "HIVE_FORK_SPURIOUS": 0,
-        "HIVE_FORK_BYZANTIUM": 0,
-        "HIVE_FORK_CONSTANTINOPLE": 0,
-        "HIVE_FORK_PETERSBURG": 0,
-        "HIVE_FORK_ISTANBUL": 0,
-        "HIVE_FORK_BERLIN": 0,
-        "HIVE_FORK_LONDON": 0,
-        "HIVE_FORK_MERGE": 0,
-        "HIVE_TERMINAL_TOTAL_DIFFICULTY": 0,
-    },
-    "Shanghai": {
+    Shanghai: {
         "HIVE_FORK_HOMESTEAD": 0,
         "HIVE_FORK_TANGERINE": 0,
         "HIVE_FORK_SPURIOUS": 0,
@@ -302,7 +185,7 @@ ruleset = {
         "HIVE_TERMINAL_TOTAL_DIFFICULTY": 0,
         "HIVE_SHANGHAI_TIMESTAMP": 0,
     },
-    "ParisToShanghaiAtTime15k": {
+    ParisToShanghaiAtTime15k: {
         "HIVE_FORK_HOMESTEAD": 0,
         "HIVE_FORK_TANGERINE": 0,
         "HIVE_FORK_SPURIOUS": 0,
@@ -316,7 +199,7 @@ ruleset = {
         "HIVE_TERMINAL_TOTAL_DIFFICULTY": 0,
         "HIVE_SHANGHAI_TIMESTAMP": 15000,
     },
-    "Cancun": {
+    Cancun: {
         "HIVE_FORK_HOMESTEAD": 0,
         "HIVE_FORK_TANGERINE": 0,
         "HIVE_FORK_SPURIOUS": 0,
@@ -332,7 +215,7 @@ ruleset = {
         "HIVE_CANCUN_TIMESTAMP": 0,
         **get_blob_schedule_entries(Cancun),
     },
-    "ShanghaiToCancunAtTime15k": {
+    ShanghaiToCancunAtTime15k: {
         "HIVE_FORK_HOMESTEAD": 0,
         "HIVE_FORK_TANGERINE": 0,
         "HIVE_FORK_SPURIOUS": 0,
@@ -348,7 +231,7 @@ ruleset = {
         "HIVE_CANCUN_TIMESTAMP": 15000,
         **get_blob_schedule_entries(Cancun),
     },
-    "Prague": {
+    Prague: {
         "HIVE_FORK_HOMESTEAD": 0,
         "HIVE_FORK_TANGERINE": 0,
         "HIVE_FORK_SPURIOUS": 0,
@@ -365,7 +248,7 @@ ruleset = {
         "HIVE_PRAGUE_TIMESTAMP": 0,
         **get_blob_schedule_entries(Prague),
     },
-    "CancunToPragueAtTime15k": {
+    CancunToPragueAtTime15k: {
         "HIVE_FORK_HOMESTEAD": 0,
         "HIVE_FORK_TANGERINE": 0,
         "HIVE_FORK_SPURIOUS": 0,
@@ -382,7 +265,7 @@ ruleset = {
         "HIVE_PRAGUE_TIMESTAMP": 15000,
         **get_blob_schedule_entries(Prague),
     },
-    "Osaka": {
+    Osaka: {
         "HIVE_FORK_HOMESTEAD": 0,
         "HIVE_FORK_TANGERINE": 0,
         "HIVE_FORK_SPURIOUS": 0,
@@ -400,7 +283,7 @@ ruleset = {
         "HIVE_OSAKA_TIMESTAMP": 0,
         **get_blob_schedule_entries(Osaka),
     },
-    "PragueToOsakaAtTime15k": {
+    PragueToOsakaAtTime15k: {
         "HIVE_FORK_HOMESTEAD": 0,
         "HIVE_FORK_TANGERINE": 0,
         "HIVE_FORK_SPURIOUS": 0,

--- a/src/pytest_plugins/execute/execute.py
+++ b/src/pytest_plugins/execute/execute.py
@@ -261,7 +261,6 @@ def base_test_parametrizer(cls: Type[BaseTest]):
         request: Any,
         fork: Fork,
         pre: Alloc,
-        eips: List[int],
         eth_rpc: EthRPC,
         engine_rpc: EngineRPC | None,
         collector: Collector,
@@ -311,7 +310,7 @@ def base_test_parametrizer(cls: Type[BaseTest]):
                     [str(eoa) for eoa in pre._funded_eoa]
                 )
 
-                execute = self.execute(fork=fork, execute_format=execute_format, eips=eips)
+                execute = self.execute(fork=fork, execute_format=execute_format)
                 execute.execute(fork=fork, eth_rpc=eth_rpc, engine_rpc=engine_rpc)
                 collector.collect(request.node.nodeid, execute)
 

--- a/src/pytest_plugins/execute/rpc/hive.py
+++ b/src/pytest_plugins/execute/rpc/hive.py
@@ -299,12 +299,12 @@ def environment(base_fork: Fork) -> dict:
     Define the environment that hive will start the client with using the fork
     rules specific for the simulator.
     """
-    assert base_fork.name() in ruleset, f"fork '{base_fork.name()}' missing in hive ruleset"
+    assert base_fork in ruleset, f"fork '{base_fork}' missing in hive ruleset"
     return {
         "HIVE_CHAIN_ID": "1",
         "HIVE_FORK_DAO_VOTE": "1",
         "HIVE_NODETYPE": "full",
-        **{k: f"{v:d}" for k, v in ruleset[base_fork.name()].items()},
+        **{k: f"{v:d}" for k, v in ruleset[base_fork].items()},
     }
 
 

--- a/src/pytest_plugins/filler/filler.py
+++ b/src/pytest_plugins/filler/filler.py
@@ -718,7 +718,6 @@ def base_test_parametrizer(cls: Type[BaseTest]):
         t8n: TransitionTool,
         fork: Fork,
         reference_spec: ReferenceSpec,
-        eips: List[int],
         pre: Alloc,
         output_dir: Path,
         dump_dir_parameter_level: Path | None,
@@ -756,7 +755,6 @@ def base_test_parametrizer(cls: Type[BaseTest]):
                     t8n=t8n,
                     fork=fork,
                     fixture_format=fixture_format,
-                    eips=eips,
                 )
                 fixture.fill_info(
                     t8n.version(),

--- a/src/pytest_plugins/shared/execute_fill.py
+++ b/src/pytest_plugins/shared/execute_fill.py
@@ -91,19 +91,6 @@ def pytest_configure(config: pytest.Config):
     )
 
 
-@pytest.fixture(autouse=True)
-def eips():
-    """
-    Fixture for specifying that, by default, no EIPs should be activated for
-    tests.
-
-    This fixture (function) may be redefined in test filler modules in order
-    to overwrite this default and return a list of integers specifying which
-    EIPs should be activated for the tests in scope.
-    """
-    return []
-
-
 @pytest.fixture
 def yul(fork: Fork, request: pytest.FixtureRequest):
     """

--- a/tests/unscheduled/eip7692_eof_v1/eip7873_tx_create/test_txcreate_failures.py
+++ b/tests/unscheduled/eip7692_eof_v1/eip7873_tx_create/test_txcreate_failures.py
@@ -4,7 +4,7 @@ import pytest
 
 from ethereum_test_base_types import Bytes
 from ethereum_test_base_types.base_types import Address, Hash
-from ethereum_test_forks.base_fork import Fork
+from ethereum_test_forks import Fork
 from ethereum_test_tools import (
     Account,
     Alloc,


### PR DESCRIPTION
## 🗒️ Description
Modifies `Fork` type definition to make it pydantic-friendly, and can now be serialized (into a string) and parsed back into the correct object:
```
class BlockchainTest(BaseModel):
    fork: Fork = Field(..., alias="network")
```
instead of:
```
class BlockchainTest(BaseModel):
    fork: str = Field(..., alias="network")
```
And the conversion happens on the fly in both directions everywhere.

## 🔗 Related Issues
None.

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.