### PR TITLE
zkevm: add 0-param opcodes coverage

### DIFF
--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -206,11 +206,11 @@ class ReturnDataStyle(Enum):
         ReturnDataStyle.IDENTITY,
     ],
 )
-@pytest.mark.parametrize("returned_size", [True, False])
+@pytest.mark.parametrize("returned_size", [1, 0])
 def test_worst_returndatasize_nonzero(
     state_test: StateTestFiller,
     pre: Alloc,
-    returned_size: bool,
+    returned_size: int,
     return_data_style: ReturnDataStyle,
 ):
     """

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -153,7 +153,13 @@ def test_worst_tx_callvalue(
     non_zero_value: bool,
     from_origin: bool,
 ):
-    """Test running a block with as many CALLVALUE as possible."""
+    """
+    Test running a block with as many CALLVALUE opcodes as possible.
+
+    The `non_zero_value` parameter controls whether opcode must return non-zero value.
+    The `from_origin` parameter controls whether the call frame is the immediate from the
+    transaction or a previous CALL.
+    """
     env = Environment()
 
     code_prefix = Op.JUMPDEST

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -223,7 +223,7 @@ def test_worst_returndatasize(
 
     dummy_contract_call = Bytecode()
     if non_zero_size:
-        if return_data_style == ReturnDataStyle.IDENTITY:
+        if return_data_style != ReturnDataStyle.IDENTITY:
             dummy_contract_call = Op.STATICCALL(
                 address=pre.deploy_contract(
                     code=Op.REVERT(0, 1)

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -75,6 +75,7 @@ def make_dup(index: int) -> Opcode:
         Op.BASEFEE,
         Op.BLOBBASEFEE,
         Op.GAS,
+        # Note that other 0-param opcodes are covered in separate tests.
     ],
 )
 def test_worst_zero_param(

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -15,7 +15,6 @@ from py_ecc.bn128 import G1, G2, multiply
 from ethereum_test_base_types.base_types import Bytes
 from ethereum_test_forks import Fork
 from ethereum_test_tools import (
-    Account,
     Address,
     Alloc,
     Block,
@@ -229,16 +228,16 @@ def test_worst_returndatasize(
 
 
 @pytest.mark.valid_from("Cancun")
-@pytest.mark.parametrize("mem_size", [0, 10, 10_000, 100_000])
+@pytest.mark.parametrize("mem_size", [100_000])
 def test_worst_msize(
     state_test: StateTestFiller,
     pre: Alloc,
-    mem_size: bool,
+    mem_size: int,
 ):
     """
     Test running a block with as many MSIZE opcodes as possible.
 
-    The `mem_size` parameter indicates by how much the memory is expanded before MSIZE calls.
+    The `mem_size` parameter indicates by how much the memory is expanded.
     """
     env = Environment()
 
@@ -254,12 +253,12 @@ def test_worst_msize(
         to=pre.deploy_contract(code=bytes(code)),
         gas_limit=env.gas_limit,
         sender=pre.fund_eoa(),
+        value=mem_size,
     )
 
     state_test(
         env=env,
         pre=pre,
-        value=mem_size,
         post={},
         tx=tx,
     )

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -82,7 +82,7 @@ def test_worst_zero_param(
     pre: Alloc,
     opcode: Op,
 ):
-    """Test running a block with as many zero-parameter precompile as possible."""
+    """Test running a block with as many zero-parameter opcodes as possible."""
     env = Environment()
 
     code_prefix = Op.JUMPDEST

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -237,25 +237,25 @@ def test_worst_returndatasize(
                 args_size=1,
             )
 
-        code_prefix = dummy_contract_call + Op.JUMPDEST
-        iter_loop = Op.POP(Op.RETURNDATASIZE)
-        code_suffix = Op.JUMP(len(code_prefix) - 1)
-        code_iter_len = (MAX_CODE_SIZE - len(code_prefix) - len(code_suffix)) // len(iter_loop)
-        code = code_prefix + iter_loop * code_iter_len + code_suffix
-        assert len(code) <= MAX_CODE_SIZE
+    code_prefix = dummy_contract_call + Op.JUMPDEST
+    iter_loop = Op.POP(Op.RETURNDATASIZE)
+    code_suffix = Op.JUMP(len(code_prefix) - 1)
+    code_iter_len = (MAX_CODE_SIZE - len(code_prefix) - len(code_suffix)) // len(iter_loop)
+    code = code_prefix + iter_loop * code_iter_len + code_suffix
+    assert len(code) <= MAX_CODE_SIZE
 
-        tx = Transaction(
-            to=pre.deploy_contract(code=bytes(code)),
-            gas_limit=env.gas_limit,
-            sender=pre.fund_eoa(),
-        )
+    tx = Transaction(
+        to=pre.deploy_contract(code=bytes(code)),
+        gas_limit=env.gas_limit,
+        sender=pre.fund_eoa(),
+    )
 
-        state_test(
-            env=env,
-            pre=pre,
-            post={},
-            tx=tx,
-        )
+    state_test(
+        env=env,
+        pre=pre,
+        post={},
+        tx=tx,
+    )
 
 
 @pytest.mark.valid_from("Cancun")

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -228,7 +228,7 @@ def test_worst_returndatasize(
 
 
 @pytest.mark.valid_from("Cancun")
-@pytest.mark.parametrize("mem_size", [100_000])
+@pytest.mark.parametrize("mem_size", [0, 1_000, 100_000, 1_000_000])
 def test_worst_msize(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -228,7 +228,7 @@ def test_worst_returndatasize(
 
 
 @pytest.mark.valid_from("Cancun")
-@pytest.mark.parametrize("mem_size", [0, 1_000, 100_000, 1_000_000])
+@pytest.mark.parametrize("mem_size", [0, 1, 1_000, 100_000, 1_000_000])
 def test_worst_msize(
     state_test: StateTestFiller,
     pre: Alloc,


### PR DESCRIPTION
This PR adds coverage for many 0-param opcodes.

Cycles:
```
tests/zkevm/test_worst_compute.py::test_worst_zero_param[fork_Cancun-blockchain_test_from_state_test-opcode_GAS]-1      927313344
tests/zkevm/test_worst_compute.py::test_worst_zero_param[fork_Cancun-blockchain_test_from_state_test-opcode_TIMESTAMP]-1        945280386
tests/zkevm/test_worst_compute.py::test_worst_zero_param[fork_Cancun-blockchain_test_from_state_test-opcode_GASLIMIT]-1 945298712
tests/zkevm/test_worst_compute.py::test_worst_zero_param[fork_Cancun-blockchain_test_from_state_test-opcode_NUMBER]-1   945298968
tests/zkevm/test_worst_compute.py::test_worst_callvalue[fork_Cancun-blockchain_test_from_state_test-from_origin_False-non_zero_value_True]-1    983444990
tests/zkevm/test_worst_compute.py::test_worst_callvalue[fork_Cancun-blockchain_test_from_state_test-from_origin_False-non_zero_value_False]-1   983643412
tests/zkevm/test_worst_compute.py::test_worst_returndatasize[fork_Cancun-blockchain_test_from_state_test-return_data_style_ReturnDataStyle.IDENTITY-non_zero_size_True]-1      999200881
tests/zkevm/test_worst_compute.py::test_worst_returndatasize[fork_Cancun-blockchain_test_from_state_test-return_data_style_ReturnDataStyle.REVERT-non_zero_size_False]-1       999224296
tests/zkevm/test_worst_compute.py::test_worst_returndatasize[fork_Cancun-blockchain_test_from_state_test-return_data_style_ReturnDataStyle.RETURN-non_zero_size_False]-1       999224436
tests/zkevm/test_worst_compute.py::test_worst_returndatasize[fork_Cancun-blockchain_test_from_state_test-return_data_style_ReturnDataStyle.IDENTITY-non_zero_size_False]-1     999243170
tests/zkevm/test_worst_compute.py::test_worst_returndatasize[fork_Cancun-blockchain_test_from_state_test-return_data_style_ReturnDataStyle.REVERT-non_zero_size_True]-1        999255038
tests/zkevm/test_worst_compute.py::test_worst_returndatasize[fork_Cancun-blockchain_test_from_state_test-return_data_style_ReturnDataStyle.RETURN-non_zero_size_True]-1        999255252
tests/zkevm/test_worst_compute.py::test_worst_callvalue[fork_Cancun-blockchain_test_from_state_test-from_origin_True-non_zero_value_False]-1    999255426
tests/zkevm/test_worst_compute.py::test_worst_callvalue[fork_Cancun-blockchain_test_from_state_test-from_origin_True-non_zero_value_True]-1     999255815
tests/zkevm/test_worst_compute.py::test_worst_msize[fork_Cancun-blockchain_test_from_state_test-mem_size_1000000]-1     1003494103
tests/zkevm/test_worst_compute.py::test_worst_zero_param[fork_Cancun-blockchain_test_from_state_test-opcode_BASEFEE]-1  1008247999
tests/zkevm/test_worst_compute.py::test_worst_zero_param[fork_Cancun-blockchain_test_from_state_test-opcode_CHAINID]-1  1008248041
tests/zkevm/test_worst_compute.py::test_worst_calldatasize[fork_Cancun-blockchain_test_from_state_test-calldata_length_10000]-1 1016269218
tests/zkevm/test_worst_compute.py::test_worst_calldatasize[fork_Cancun-blockchain_test_from_state_test-calldata_length_1000]-1  1017146773
tests/zkevm/test_worst_compute.py::test_worst_calldatasize[fork_Cancun-blockchain_test_from_state_test-calldata_length_0]-1     1017240664
tests/zkevm/test_worst_compute.py::test_worst_msize[fork_Cancun-blockchain_test_from_state_test-mem_size_100000]-1      1061373497
tests/zkevm/test_worst_compute.py::test_worst_msize[fork_Cancun-blockchain_test_from_state_test-mem_size_0]-1   1062172501
tests/zkevm/test_worst_compute.py::test_worst_msize[fork_Cancun-blockchain_test_from_state_test-mem_size_1]-1   1062172990
tests/zkevm/test_worst_compute.py::test_worst_msize[fork_Cancun-blockchain_test_from_state_test-mem_size_1000]-1        1062191325
tests/zkevm/test_worst_compute.py::test_worst_zero_param[fork_Cancun-blockchain_test_from_state_test-opcode_GASPRICE]-1 1098175506
tests/zkevm/test_worst_compute.py::test_worst_zero_param[fork_Cancun-blockchain_test_from_state_test-opcode_CODESIZE]-1 1125153539
tests/zkevm/test_worst_compute.py::test_worst_zero_param[fork_Cancun-blockchain_test_from_state_test-opcode_BLOBBASEFEE]-1      1161106202
tests/zkevm/test_worst_compute.py::test_worst_zero_param[fork_Cancun-blockchain_test_from_state_test-opcode_ADDRESS]-1  1394917237
tests/zkevm/test_worst_compute.py::test_worst_zero_param[fork_Cancun-blockchain_test_from_state_test-opcode_COINBASE]-1 1394917330
tests/zkevm/test_worst_compute.py::test_worst_zero_param[fork_Cancun-blockchain_test_from_state_test-opcode_ORIGIN]-1   1394917381
tests/zkevm/test_worst_compute.py::test_worst_zero_param[fork_Cancun-blockchain_test_from_state_test-opcode_CALLER]-1   1394935861
tests/zkevm/test_worst_compute.py::test_worst_zero_param[fork_Cancun-blockchain_test_from_state_test-opcode_PREVRANDAO]-1       1898529166
```

Close https://github.com/ethereum/execution-spec-tests/issues/1651