### PR TITLE
feat(tests): add two more benchmarks for DIV and SDIV

### DIFF
--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -848,16 +848,36 @@ DEFAULT_BINOP_ARGS = (
             (
                 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F,
                 # We want the first divisor to be slightly bigger than 2**128:
-                # this is the worst case for the division algorithm.
+                # this is the worst case for the division algorithm with optimized paths
+                # for division by 1 and 2 words.
                 0x100000000000000000000000000000033,
             ),
         ),
         (
-            # Same as DIV, but the numerator made positive, and the divisor made negative.
+            # This has the cycle of 2, see above.
+            Op.DIV,
+            (
+                0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F,
+                # We want the first divisor to be slightly bigger than 2**64:
+                # this is the worst case for the division algorithm with an optimized path
+                # for division by 1 word.
+                0x10000000000000033,
+            ),
+        ),
+        (
+            # Same as DIV-0, but the numerator made positive, and the divisor made negative.
             Op.SDIV,
             (
                 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F,
                 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFCD,
+            ),
+        ),
+        (
+            # Same as DIV-1, but the numerator made positive, and the divisor made negative.
+            Op.SDIV,
+            (
+                0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F,
+                0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFCD,
             ),
         ),
         (


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

## 🔗 Related Issues
https://github.com/ethereum/execution-spec-tests/issues/1571

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests)/[tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned @ported_from marker.
- [ ] Tests: A PR with removal of converted JSON/YML blockchain tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
