### PR TITLE
fix(tests/zkevm): update jump seq for valid dest

### DIFF
--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -764,14 +764,14 @@ def test_worst_jumps(state_test: StateTestFiller, pre: Alloc, fork: Fork):
     env = Environment()
     max_code_size = fork.max_code_size()
 
-    def jump_seq():
-        return Op.JUMP(Op.ADD(Op.PC, 1)) + Op.JUMPDEST
+    def jump_seq(dest: int):
+        return Op.JUMP(Op.PUSH2(dest)) + Op.JUMPDEST
 
     bytes_per_seq = len(jump_seq())
     seqs_per_call = max_code_size // bytes_per_seq
 
     # Create and deploy the jump-intensive contract
-    jumps_code = sum([jump_seq() for _ in range(seqs_per_call)])
+    jumps_code = sum([jump_seq(4 + 5 * i) for i in range(seqs_per_call)])
     jumps_address = pre.deploy_contract(code=bytes(jumps_code))
 
     # Call the contract repeatedly until gas runs out.

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -27,7 +27,6 @@ from ethereum_test_tools import (
     Transaction,
     add_kzg_version,
 )
-from ethereum_test_tools.code.generators import While
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 from ethereum_test_types import TransactionType
 from ethereum_test_vm.opcode import Opcode
@@ -762,24 +761,12 @@ def code_loop_precompile_call(calldata: Bytecode, attack_block: Bytecode, fork: 
 def test_worst_jumps(state_test: StateTestFiller, pre: Alloc, fork: Fork):
     """Test running a JUMP-intensive contract."""
     env = Environment()
-    max_code_size = fork.max_code_size()
 
-    def jump_seq(dest: int):
-        return Op.JUMP(Op.PUSH2(dest)) + Op.JUMPDEST
-
-    bytes_per_seq = len(jump_seq())
-    seqs_per_call = max_code_size // bytes_per_seq
-
-    # Create and deploy the jump-intensive contract
-    jumps_code = sum([jump_seq(4 + 5 * i) for i in range(seqs_per_call)])
-    jumps_address = pre.deploy_contract(code=bytes(jumps_code))
-
-    # Call the contract repeatedly until gas runs out.
-    caller_code = While(body=Op.POP(Op.CALL(address=jumps_address)))
-    caller_address = pre.deploy_contract(caller_code)
+    jumps_code = Op.JUMPDEST + Op.JUMP(Op.PUSH0)
+    jumps_address = pre.deploy_contract(jumps_code)
 
     tx = Transaction(
-        to=caller_address,
+        to=jumps_address,
         gas_limit=env.gas_limit,
         sender=pre.fund_eoa(),
     )

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -758,7 +758,7 @@ def code_loop_precompile_call(calldata: Bytecode, attack_block: Bytecode, fork: 
 @pytest.mark.zkevm
 @pytest.mark.valid_from("Cancun")
 @pytest.mark.slow
-def test_worst_jumps(state_test: StateTestFiller, pre: Alloc, fork: Fork):
+def test_worst_jumps(state_test: StateTestFiller, pre: Alloc):
     """Test running a JUMP-intensive contract."""
     env = Environment()
 


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

There is an issue with the original test case: the jump target is not a valid `JUMPDEST` operation.
More details could be found in the [discussion](https://github.com/ethereum/execution-spec-tests/pull/1693#discussion_r2122967972). 

The updated version precomputes valid jump destinations to improve the density of `JUMP` operations.

The repeated pattern is structured as follows:
```
0x00 PUSH2 DEST
0x03 JUMP
0x04 JUMPDEST
...
```
The first `JUMPDEST` is at offset `0x04`. Since each pattern occupies 5 bytes, subsequent `JUMPDEST` locations can be calculated as `4 + 5 * i`, where i is the pattern index. The total code size must remain within the allowed limit.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.