### PR TITLE
feat(tests): EIP-7825: Transaction Gas Limit Cap

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -5,6 +5,7 @@ on:
     paths:
       - "tests/**" # This triggers the workflow for any changes in the tests folder
       - "!tests/prague/**" # exclude changes in 'tests/prague'
+      - "!tests/osaka/**" # exclude changes in 'tests/osaka'
       - "!tests/unscheduled/**" # exclude changes in 'tests/unscheduled'
 
 jobs:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -63,6 +63,7 @@ Users can select any of the artifacts depending on their testing needs for their
 - ✨ EIP-7594: Sanity test cases to send blob transactions and verify `engine_getBlobsVX` using the `execute` command ([#1644](https://github.com/ethereum/execution-spec-tests/pull/1644)).
 - 🔀 Refactored EIP-145 static tests into python ([#1683](https://github.com/ethereum/execution-spec-tests/pull/1683)).
 - ✨ EIP-7823, EIP-7883: Add test cases for ModExp precompile gas-cost updates and input limits on Osaka ([#1579](https://github.com/ethereum/execution-spec-tests/pull/1579)).
+- ✨ [EIP-7825](https://eips.ethereum.org/EIPS/eip-7825): Add test cases for the transaction gas limit of 30M gas ([#1711](https://github.com/ethereum/execution-spec-tests/pull/1711)).
 
 ## [v4.5.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v4.5.0) - 2025-05-14
 

--- a/eels_resolutions.json
+++ b/eels_resolutions.json
@@ -42,6 +42,6 @@
     "Osaka": {
         "git_url": "https://github.com/spencer-tb/execution-specs.git",
         "branch": "forks/osaka",
-        "commit": "e59c6e3eaed0dbbca639b6f5b6acaa832e51ca00"
+        "commit": "0d86ad789e7c0d25ec86f15d0e4adb9d9b308af3"
     }
 }

--- a/src/ethereum_clis/clis/besu.py
+++ b/src/ethereum_clis/clis/besu.py
@@ -342,4 +342,7 @@ class BesuExceptionMapper(ExceptionMapper):
             r"expected (\d+), but got (-?\d+)|"
             r"Invalid deposit log length\. Must be \d+ bytes, but is \d+ bytes"
         ),
+        TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM: (
+            r"transaction invalid Transaction gas limit must be at most \d+"
+        ),
     }

--- a/src/ethereum_clis/clis/erigon.py
+++ b/src/ethereum_clis/clis/erigon.py
@@ -42,6 +42,9 @@ class ErigonExceptionMapper(ExceptionMapper):
         BlockException.INVALID_BLOCK_HASH: "invalid block hash",
     }
     mapping_regex = {
+        TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM: (
+            r"invalid block, txnIdx=\d+, gas limit too high"
+        ),
         BlockException.INCORRECT_BLOB_GAS_USED: r"blobGasUsed by execution: \d+, in header: \d+",
         BlockException.INCORRECT_EXCESS_BLOB_GAS: r"invalid excessBlobGas: have \d+, want \d+",
         BlockException.INVALID_GAS_USED: r"gas used by execution: \w+, in header: \w+",

--- a/src/ethereum_clis/clis/geth.py
+++ b/src/ethereum_clis/clis/geth.py
@@ -67,6 +67,9 @@ class GethExceptionMapper(ExceptionMapper):
         TransactionException.TYPE_4_TX_CONTRACT_CREATION: (
             "input string too short for common.Address, decoding into (types.SetCodeTx).To"
         ),
+        TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM: (
+            "transaction exceeds maximum allowed gas limit"
+        ),
         TransactionException.TYPE_4_TX_PRE_FORK: ("transaction type not supported"),
         TransactionException.INITCODE_SIZE_EXCEEDED: "max initcode size exceeded",
         TransactionException.NONCE_MISMATCH_TOO_LOW: "nonce too low",

--- a/src/ethereum_clis/clis/nethermind.py
+++ b/src/ethereum_clis/clis/nethermind.py
@@ -377,6 +377,9 @@ class NethermindExceptionMapper(ExceptionMapper):
             r"BlockBlobGasExceeded: A block cannot have more than \d+ blob gas, blobs count \d+, "
             r"blobs gas used: \d+"
         ),
+        TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM: (
+            r"TxGasLimitCapExceeded: Gas limit \d+ exceeed cap of \d+\.?"
+        ),
         BlockException.INCORRECT_EXCESS_BLOB_GAS: (
             r"HeaderExcessBlobGasMismatch: Excess blob gas in header does not match calculated"
             r"|Overflow in excess blob gas"

--- a/src/ethereum_clis/clis/nethermind.py
+++ b/src/ethereum_clis/clis/nethermind.py
@@ -378,7 +378,7 @@ class NethermindExceptionMapper(ExceptionMapper):
             r"blobs gas used: \d+"
         ),
         TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM: (
-            r"TxGasLimitCapExceeded: Gas limit \d+ exceeed cap of \d+\.?"
+            r"TxGasLimitCapExceeded: Gas limit \d+ \w+ cap of \d+\.?"
         ),
         BlockException.INCORRECT_EXCESS_BLOB_GAS: (
             r"HeaderExcessBlobGasMismatch: Excess blob gas in header does not match calculated"

--- a/src/ethereum_clis/clis/nimbus.py
+++ b/src/ethereum_clis/clis/nimbus.py
@@ -85,6 +85,8 @@ class NimbusExceptionMapper(ExceptionMapper):
         TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH: (
             "invalid tx: one of blobVersionedHash has invalid version"
         ),
+        # TODO: temp solution until mapper for nimbus is fixed
+        TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM: ("zero gasUsed but transactions present"),
         # This message is the same as TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED
         TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED: "exceeds maximum allowance",
         TransactionException.TYPE_3_TX_ZERO_BLOBS: "blob transaction missing blob hashes",

--- a/src/ethereum_clis/clis/reth.py
+++ b/src/ethereum_clis/clis/reth.py
@@ -55,6 +55,9 @@ class RethExceptionMapper(ExceptionMapper):
         TransactionException.GAS_ALLOWANCE_EXCEEDED: (
             r"transaction gas limit \w+ is more than blocks available gas \w+"
         ),
+        TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM: (
+            r"transaction gas limit \(\d+\) is greater than the cap \(\d+\)"
+        ),
         BlockException.SYSTEM_CONTRACT_CALL_FAILED: r"failed to apply .* requests contract call",
         BlockException.INCORRECT_BLOB_GAS_USED: (
             r"blob gas used mismatch|blob gas used \d+ is not a multiple of blob gas per blob"

--- a/src/ethereum_test_exceptions/exceptions.py
+++ b/src/ethereum_test_exceptions/exceptions.py
@@ -363,6 +363,10 @@ class TransactionException(ExceptionBase):
     """
     Transaction causes block to go over blob gas limit.
     """
+    GAS_LIMIT_EXCEEDS_MAXIMUM = auto()
+    """
+    Transaction gas limit exceeds the maximum allowed limit of 30 million.
+    """
     TYPE_3_TX_ZERO_BLOBS = auto()
     """
     Transaction is type 3, but has no blobs.

--- a/src/ethereum_test_forks/base_fork.py
+++ b/src/ethereum_test_forks/base_fork.py
@@ -339,6 +339,12 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
 
     @classmethod
     @abstractmethod
+    def transaction_gas_limit_cap(cls, block_number: int = 0, timestamp: int = 0) -> int | None:
+        """Return the transaction gas limit cap, or None if no limit is imposed."""
+        pass
+
+    @classmethod
+    @abstractmethod
     def precompiles(cls, block_number: int = 0, timestamp: int = 0) -> List[Address]:
         """Return list pre-compiles supported by the fork."""
         pass

--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -355,6 +355,11 @@ class Frontier(BaseFork, solc_name="homestead"):
         return [0]
 
     @classmethod
+    def transaction_gas_limit_cap(cls, block_number: int = 0, timestamp: int = 0) -> int | None:
+        """At Genesis, no transaction gas limit cap is imposed."""
+        return None
+
+    @classmethod
     def precompiles(cls, block_number: int = 0, timestamp: int = 0) -> List[Address]:
         """At Genesis, no pre-compiles are present."""
         return []
@@ -1338,6 +1343,11 @@ class Osaka(Prague, solc_name="cancun"):
     def engine_get_blobs_version(cls, block_number: int = 0, timestamp: int = 0) -> Optional[int]:
         """At Osaka, the engine get blobs version is 2."""
         return 2
+
+    @classmethod
+    def transaction_gas_limit_cap(cls, block_number: int = 0, timestamp: int = 0) -> int | None:
+        """At Osaka, transaction gas limit is capped at 30 million."""
+        return 30_000_000
 
     @classmethod
     def is_deployed(cls) -> bool:

--- a/tests/osaka/eip7825_transaction_gas_limit_cap/__init__.py
+++ b/tests/osaka/eip7825_transaction_gas_limit_cap/__init__.py
@@ -1,0 +1,4 @@
+"""
+Test suite for
+[EIP-7825: Transaction Gas Limit Cap](https://eips.ethereum.org/EIPS/eip-7825).
+"""

--- a/tests/osaka/eip7825_transaction_gas_limit_cap/__init__.py
+++ b/tests/osaka/eip7825_transaction_gas_limit_cap/__init__.py
@@ -1,4 +1,4 @@
 """
-Test suite for
-[EIP-7825: Transaction Gas Limit Cap](https://eips.ethereum.org/EIPS/eip-7825).
+abstract: Tests [EIP-7825: Transaction Gas Limit Cap](https://eips.ethereum.org/EIPS/eip-7825).
+    Test cases for [EIP-7825: Transaction Gas Limit Cap](https://eips.ethereum.org/EIPS/eip-7825).
 """

--- a/tests/osaka/eip7825_transaction_gas_limit_cap/test_transaction_gas_limit_cap.py
+++ b/tests/osaka/eip7825_transaction_gas_limit_cap/test_transaction_gas_limit_cap.py
@@ -1,0 +1,202 @@
+"""
+abstract: Tests [EIP-7825 Transaction Gas Limit Cap](https://eips.ethereum.org/EIPS/eip-7825)
+    Test cases for [EIP-7825 Transaction Gas Limit Cap](https://eips.ethereum.org/EIPS/eip-7825)].
+"""
+
+from typing import List
+
+import pytest
+
+from ethereum_test_forks import Fork
+from ethereum_test_tools import (
+    Account,
+    Address,
+    Alloc,
+    AuthorizationTuple,
+    Block,
+    BlockchainTestFiller,
+    Environment,
+    StateTestFiller,
+    Storage,
+    Transaction,
+    TransactionException,
+    add_kzg_version,
+)
+from ethereum_test_tools.utility.pytest import ParameterSet
+from ethereum_test_tools.vm.opcode import Opcodes as Op
+
+REFERENCE_SPEC_GIT_PATH = "EIPS/eip-7825.md"
+REFERENCE_SPEC_VERSION = "47cbfed315988c0bd4d10002c110ae402504cd94"
+
+TX_GAS_LIMIT = 30_000_000
+BLOB_COMMITMENT_VERSION_KZG = 1
+
+
+def tx_gas_limit_cap_tests(fork: Fork) -> List[ParameterSet]:
+    """
+    Return a list of tests for transaction gas limit cap parametrized for each different
+    fork.
+    """
+    fork_tx_gas_limit_cap = fork.transaction_gas_limit_cap()
+    if fork_tx_gas_limit_cap is None:
+        # Use a default value for forks that don't have a transaction gas limit cap
+        return [
+            pytest.param(TX_GAS_LIMIT + 1, None, id="tx_gas_limit_cap_none"),
+        ]
+
+    return [
+        pytest.param(
+            fork_tx_gas_limit_cap + 1,
+            TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM,
+            id="tx_gas_limit_cap_exceeds_maximum",
+            marks=pytest.mark.exception_test,
+        ),
+        pytest.param(fork_tx_gas_limit_cap, None, id="tx_gas_limit_cap_none"),
+    ]
+
+
+@pytest.mark.parametrize_by_fork("tx_gas_limit,error", tx_gas_limit_cap_tests)
+@pytest.mark.with_all_tx_types
+@pytest.mark.valid_from("Prague")
+def test_transaction_gas_limit_cap(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    tx_gas_limit: int,
+    error: TransactionException | None,
+    tx_type: int,
+):
+    """
+    TODO: Enter a one-line test summary here.
+
+    TODO: (Optional) Enter a more detailed test function description here.
+    """
+    env = Environment()
+
+    # TODO: Modify pre-state allocations here.
+    sender = pre.fund_eoa()
+    storage = Storage()
+    contract_address = pre.deploy_contract(
+        code=Op.SSTORE(storage.store_next(1), 1) + Op.STOP,
+    )
+
+    tx_kwargs = {
+        "ty": tx_type,
+        "to": contract_address,
+        "gas_limit": tx_gas_limit,
+        "data": b"",
+        "value": 0,
+        "sender": sender,
+        "error": error,
+    }
+
+    # Add extra required fields based on transaction type
+    if tx_type >= 1:
+        # Type 1: EIP-2930 Access List Transaction
+        tx_kwargs["access_list"] = [
+            {
+                "address": contract_address,
+                "storage_keys": [0],
+            }
+        ]
+    if tx_type == 3:
+        # Type 3: EIP-4844 Blob Transaction
+        tx_kwargs["max_fee_per_blob_gas"] = fork.min_base_fee_per_blob_gas()
+        tx_kwargs["blob_versioned_hashes"] = add_kzg_version([0], BLOB_COMMITMENT_VERSION_KZG)
+    elif tx_type == 4:
+        # Type 4: EIP-7702 Set Code Transaction
+        signer = pre.fund_eoa(amount=0)
+        tx_kwargs["authorization_list"] = [
+            AuthorizationTuple(
+                signer=signer,
+                address=Address(0),
+                nonce=0,
+            )
+        ]
+
+    tx = Transaction(**tx_kwargs)
+    post = {contract_address: Account(storage=storage if error is None else {})}
+
+    state_test(env=env, pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.valid_at_transition_to("Osaka", subsequent_forks=True)
+@pytest.mark.exception_test
+def test_transaction_gas_limit_cap_at_transition(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+):
+    """
+    Test transaction gas limit cap behavior at the Osaka transition.
+
+    Before timestamp 15000: No gas limit cap (transactions with gas > 30M are valid)
+    At/after timestamp 15000: Gas limit cap of 30M is enforced
+    """
+    sender = pre.fund_eoa()
+    contract_address = pre.deploy_contract(
+        code=Op.SSTORE(0, Op.ADD(Op.SLOAD(0), 1)) + Op.STOP,
+    )
+
+    pre_cap = fork.transaction_gas_limit_cap()
+    if pre_cap is None:
+        pre_cap = TX_GAS_LIMIT
+
+    # Transaction with gas limit above 30M
+    high_gas_tx = Transaction(
+        ty=0,  # Legacy transaction
+        to=contract_address,
+        gas_limit=pre_cap + 1,
+        data=b"",
+        value=0,
+        sender=sender,
+    )
+
+    post_cap = fork.transaction_gas_limit_cap(timestamp=15_000)
+    post_cap_tx_error = TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM
+
+    assert post_cap is not None, "Post cap should not be None"
+    assert post_cap <= pre_cap, (
+        "Post cap should be less than or equal to pre cap, test needs update"
+    )
+
+    # Transaction with gas limit at the cap
+    cap_gas_tx = Transaction(
+        ty=0,  # Legacy transaction
+        to=contract_address,
+        gas_limit=post_cap + 1,
+        data=b"",
+        value=0,
+        sender=sender,
+        error=post_cap_tx_error,
+    )
+
+    blocks = []
+
+    # Before transition (timestamp < 15000): high gas transaction should succeed
+    blocks.append(
+        Block(
+            timestamp=14_999,
+            txs=[high_gas_tx],
+        )
+    )
+
+    # At transition (timestamp = 15000): high gas transaction should fail
+    blocks.append(
+        Block(
+            timestamp=15_000,
+            txs=[cap_gas_tx],  # Only transaction at the cap succeeds
+            exception=post_cap_tx_error,
+        )
+    )
+
+    # Post state: storage should be updated by successful transactions
+    post = {
+        contract_address: Account(
+            storage={
+                0: 1,  # Set by first transaction (before transition)
+            }
+        )
+    }
+
+    blockchain_test(pre=pre, blocks=blocks, post=post)

--- a/tests/osaka/eip7825_transaction_gas_limit_cap/test_tx_gas_limit.py
+++ b/tests/osaka/eip7825_transaction_gas_limit_cap/test_tx_gas_limit.py
@@ -66,14 +66,9 @@ def test_transaction_gas_limit_cap(
     error: TransactionException | None,
     tx_type: int,
 ):
-    """
-    TODO: Enter a one-line test summary here.
-
-    TODO: (Optional) Enter a more detailed test function description here.
-    """
+    """Test the transaction gas limit cap behavior for all transaction types."""
     env = Environment()
 
-    # TODO: Modify pre-state allocations here.
     sender = pre.fund_eoa()
     storage = Storage()
     contract_address = pre.deploy_contract(


### PR DESCRIPTION
## 🗒️ Description
Tests for [EIP-7825](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7825.md), imposing a 30 million gas limit to every transaction type.

## 🔗 Related Issues
N/A

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
