### PR TITLE
[tests]: fix typo in test_gas.py

### DIFF
--- a/tests/unscheduled/eip7692_eof_v1/eip7069_extcall/test_gas.py
+++ b/tests/unscheduled/eip7692_eof_v1/eip7069_extcall/test_gas.py
@@ -155,7 +155,7 @@ def test_transfer_gas_is_cleared(
 ):
     """
     Test that EXT*CALL call doesn't charge for value transfer, even if the outer call
-    transfered value.
+    transferred value.
 
     NOTE: This is particularly possible for EXTDELEGATECALL, which carries over the value sent
     in the outer call, however, we extend the test to all 3 EXT*CALL opcodes for good measure.


### PR DESCRIPTION
## 🗒️ Description

transfered ------> transferred 

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist

- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests)/[tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned @ported_from marker.
- [ ] Tests: A PR with removal of converted JSON/YML blockchain tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
