### PR TITLE
chore: use latest eels resolver

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,4 +131,4 @@ check-filenames = true
 ignore-words-list = "ingenuous"
 
 [tool.uv.sources]
-ethereum-spec-evm-resolver = { git = "https://github.com/petertdavies/ethereum-spec-evm-resolver", rev = "623ac4565025e72b65f45b926da2a3552041b469" }
+ethereum-spec-evm-resolver = { git = "https://github.com/petertdavies/ethereum-spec-evm-resolver", rev = "0e5609737ce4f86dc98cca1a5cf0eb64b8cddef2" }

--- a/uv.lock
+++ b/uv.lock
@@ -574,7 +574,7 @@ requires-dist = [
     { name = "eth-abi", specifier = ">=5.2.0" },
     { name = "ethereum-execution", specifier = "==1.17.0rc6.dev1" },
     { name = "ethereum-rlp", specifier = ">=0.1.3,<0.2" },
-    { name = "ethereum-spec-evm-resolver", git = "https://github.com/petertdavies/ethereum-spec-evm-resolver?rev=623ac4565025e72b65f45b926da2a3552041b469" },
+    { name = "ethereum-spec-evm-resolver", git = "https://github.com/petertdavies/ethereum-spec-evm-resolver?rev=0e5609737ce4f86dc98cca1a5cf0eb64b8cddef2" },
     { name = "ethereum-types", specifier = ">=0.2.1,<0.3" },
     { name = "filelock", specifier = ">=3.15.1,<4" },
     { name = "gitpython", specifier = ">=3.1.31,<4" },
@@ -637,7 +637,7 @@ wheels = [
 [[package]]
 name = "ethereum-spec-evm-resolver"
 version = "0.0.5"
-source = { git = "https://github.com/petertdavies/ethereum-spec-evm-resolver?rev=623ac4565025e72b65f45b926da2a3552041b469#623ac4565025e72b65f45b926da2a3552041b469" }
+source = { git = "https://github.com/petertdavies/ethereum-spec-evm-resolver?rev=0e5609737ce4f86dc98cca1a5cf0eb64b8cddef2#0e5609737ce4f86dc98cca1a5cf0eb64b8cddef2" }
 dependencies = [
     { name = "coincurve" },
     { name = "filelock" },


### PR DESCRIPTION
## 🗒️ Description
Bump eels resolver to use the latest commit which includes the following PR: https://github.com/petertdavies/ethereum-spec-evm-resolver/pull/10

The PR silences bloat GET request & I/O error messages so we can debug better when using `-s`.

## 🔗 Related Issues
N/A.

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
