### PR TITLE
ix: Fix misencoded newline

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,25 +21,25 @@ flowchart LR
   style H stroke:#F9A825,stroke-width:2px
   
   subgraph "ethereum/go-ethereum, ..."
-    C[<code>evm t8n</code>\nexternal executable]
+    C[<code>evm t8n</code><br>external executable]
   end
 
   subgraph ethereum/solidity
-    D[<code>solc</code>\nexternal executable]
+    D[<code>solc</code><br>external executable]
   end
 
   subgraph ethereum/EIPs
-    E(<code>EIPS/EIP-*.md</code>\nSHA digest via Github API)
+    E(<code>EIPS/EIP-*.md</code><br>SHA digest via Github API)
   end
 
   subgraph "ethereum/execution-spec-tests"
-    A(<code>./tests/**/*.py</code>\nPython Test Cases)
-    B([<code>$ fill ./tests/</code>\nPython Framework])
+    A(<code>./tests/**/*.py</code><br>Python Test Cases)
+    B([<code>$ fill ./tests/</code><br>Python Framework])
   end
 
   subgraph Test Fixture Consumers
     subgraph ethereum/hive
-      G([<code>$ hive ...</code>\nGo Test Framework])
+      G([<code>$ hive ...</code><br>Go Test Framework])
     end
     H([Client executables])
   end


### PR DESCRIPTION
## 🗒️ Description
In Mermaid syntax, \n does not render as a newline.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist

- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests)/[tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned @ported_from marker.
- [ ] Tests: A PR with removal of converted JSON/YML blockchain tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
