### PR TITLE
chore(fill): fix eip checklist marker warning

### DIFF
--- a/src/pytest_plugins/filler/filler.py
+++ b/src/pytest_plugins/filler/filler.py
@@ -224,7 +224,16 @@ def pytest_configure(config):
         called before the pytest-html plugin's pytest_configure to ensure that
         it uses the modified `htmlpath` option.
     """
-    # Modify the block gas limit if specified.
+    # Add eip checklist marker
+    config.addinivalue_line(
+        "markers",
+        (
+            "eip_checklist(item: str): specifies the item in the eip checklist that this test "
+            "checks off."
+        ),
+    )
+
+    # Modify the block gas limit if specified
     if config.getoption("block_gas_limit"):
         EnvironmentDefaults.gas_limit = config.getoption("block_gas_limit")
 


### PR DESCRIPTION
## 🗒️ Description
Removes the following warnigns:
```
tests/osaka/eip7951_p256verify_precompiles/test_p256verify_precompile_module.py:96
  .../execution-spec-tests/tests/osaka/eip7951_p256verify_precompiles/test_p256verify_precompile_module.py:96: PytestUnknownMarkWarning: Unknown pytest.mark.eip_checklist - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.eip_checklist("new_precompile/test/inputs/invalid")
```

## 🔗 Related Issues
N/A

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] ~~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
