### PR TITLE
refactor: optimize jumpdest test case

### DIFF
--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -804,7 +804,7 @@ def test_worst_jumpdests(state_test: StateTestFiller, pre: Alloc, fork: Fork):
     code_suffix = Op.JUMP(Op.PUSH0)
     code_body = Op.JUMPDEST * (max_code_size - len(code_suffix))
     code = code_body + code_suffix
-    jumpdests_address = pre.deploy_contract(code=bytes(code))
+    jumpdests_address = pre.deploy_contract(code=code)
 
     tx = Transaction(
         to=jumpdests_address,


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

The legacy `JUMPDEST` implementation consists of one contract filled entirely with `JUMPDEST` operations, and another contract that continuously `CALLs` the former in a loop until all gas is consumed. This setup can be further optimized by appending a JUMP at the end of the code sequence, allowing the execution to loop back and reuse the same `JUMPDEST` operations.

The resulting code sequence would look like:

```
JUMPDEST
JUMPDEST
...
PUSH0
JUMP
```

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist

- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests)/[tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned @ported_from marker.
- [ ] Tests: A PR with removal of converted JSON/YML blockchain tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
