### PR TITLE
fix(filler): Fix shared-pre-state on xdist

### DIFF
--- a/src/ethereum_test_fixtures/shared_alloc.py
+++ b/src/ethereum_test_fixtures/shared_alloc.py
@@ -30,8 +30,10 @@ class SharedPreStateGroup(CamelModel):
     fork: Fork = Field(..., alias="network")
     pre: Alloc
 
-    def __model_post_init__(self) -> None:
+    def model_post_init(self, __context):
         """Post-init hook to ensure pre is not None."""
+        super().model_post_init(__context)
+
         self.pre = Alloc.merge(
             Alloc.model_validate(self.fork.pre_allocation_blockchain()),
             self.pre,
@@ -61,7 +63,7 @@ class SharedPreStateGroup(CamelModel):
                                 f"Account {account} already exists in shared pre-allocation"
                             )
                         self.pre[account] = previous_shared_pre_state_group.pre[account]
-                        self.pre_account_count += 1
+                    self.pre_account_count += previous_shared_pre_state_group.pre_account_count
                     self.test_count += previous_shared_pre_state_group.test_count
                     self.test_ids.extend(previous_shared_pre_state_group.test_ids)
 

--- a/src/ethereum_test_fixtures/shared_alloc.py
+++ b/src/ethereum_test_fixtures/shared_alloc.py
@@ -58,11 +58,8 @@ class SharedPreStateGroup(CamelModel):
                         f.read()
                     )
                     for account in previous_shared_pre_state_group.pre:
-                        if account in self.pre:
-                            raise ValueError(
-                                f"Account {account} already exists in shared pre-allocation"
-                            )
-                        self.pre[account] = previous_shared_pre_state_group.pre[account]
+                        if account not in self.pre:
+                            self.pre[account] = previous_shared_pre_state_group.pre[account]
                     self.pre_account_count += previous_shared_pre_state_group.pre_account_count
                     self.test_count += previous_shared_pre_state_group.test_count
                     self.test_ids.extend(previous_shared_pre_state_group.test_ids)


### PR DESCRIPTION
## 🗒️ Description
Performs two fixes:
- Use correct name for function `model_post_init`
- Don't raise exception on duplicated accounts in the pre for multiple xdist workers. Reason being that we normally have consistent contracts across tests, for example system contracts.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist

- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.