### PR TITLE
fix(tests): Fix test_worst_selfdestruct_created

### DIFF
--- a/tests/zkevm/test_worst_stateful_opcodes.py
+++ b/tests/zkevm/test_worst_stateful_opcodes.py
@@ -515,7 +515,6 @@ def test_worst_selfdestruct_existing(
         + gas_costs.G_SELF_DESTRUCT
         + 63  # ~Gluing opcodes
     )
-    assert loop_cost == 7720
     final_storage_gas = (
         gas_costs.G_STORAGE_RESET + gas_costs.G_COLD_SLOAD + (gas_costs.G_VERY_LOW * 2)
     )


### PR DESCRIPTION
## 🗒️ Description
Fixes `test_worst_selfdestruct_created` and `test_worst_selfdestruct_initcode` to be filled in higher block gas limits.

## 🔗 Related Issues
None.

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.