### PR TITLE
feat(zkevm): create pure ether transfer worst case

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -70,6 +70,7 @@ Users can select any of the artifacts depending on their testing needs for their
 - ✨ EIP-7823, EIP-7883: Add test cases for ModExp precompile gas-cost updates and input limits on Osaka ([#1579](https://github.com/ethereum/execution-spec-tests/pull/1579), [#1729](https://github.com/ethereum/execution-spec-tests/pull/1729)).
 - ✨ [EIP-7825](https://eips.ethereum.org/EIPS/eip-7825): Add test cases for the transaction gas limit of 30M gas ([#1711](https://github.com/ethereum/execution-spec-tests/pull/1711)).
 - ✨ [EIP-7951](https://eips.ethereum.org/EIPS/eip-7951): add test cases for `P256VERIFY` precompile to support secp256r1 curve [#1670](https://github.com/ethereum/execution-spec-tests/pull/1670).
+- ✨ Introduce blockchain tests for ZKEVM to cover the scenario of pure ether transfers [#1742](https://github.com/ethereum/execution-spec-tests/pull/1742).
 
 ## [v4.5.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v4.5.0) - 2025-05-14
 

--- a/tests/zkevm/test_worst_blocks.py
+++ b/tests/zkevm/test_worst_blocks.py
@@ -22,13 +22,13 @@ from ethereum_test_tools import (
 def iteration_count(fork: Fork):
     """Calculate the number of iterations based on the gas limit and intrinsic cost."""
     intrinsic_cost = fork.transaction_intrinsic_cost_calculator()
-    return min(5, Environment().gas_limit // intrinsic_cost())
+    return Environment().gas_limit // intrinsic_cost()
 
 
 @pytest.fixture
 def transfer_amount():
     """Ether to transfer in each transaction."""
-    return 0
+    return 1
 
 
 @pytest.fixture

--- a/tests/zkevm/test_worst_blocks.py
+++ b/tests/zkevm/test_worst_blocks.py
@@ -66,16 +66,14 @@ def get_single_receiver_list(pre: Alloc):
 
 @pytest.fixture
 def ether_transfer_case(
-    request,
+    case_id: str,
     pre: Alloc,
 ):
     """Generate the test parameters based on the case ID."""
-    case_id = request.param
-
     if case_id == "a_to_a":
         """Sending to self."""
         senders = get_single_sender_list(pre)
-        receivers = get_single_receiver_list(pre)
+        receivers = senders
 
     elif case_id == "a_to_b":
         """One sender → one receiver."""
@@ -105,13 +103,13 @@ def ether_transfer_case(
 
 @pytest.mark.valid_from("Cancun")
 @pytest.mark.parametrize(
-    "ether_transfer_case",
+    "case_id",
     ["a_to_a", "a_to_b", "diff_acc_to_b", "a_to_diff_acc", "diff_acc_to_diff_acc"],
-    indirect=True,
 )
 def test_block_full_of_ether_transfers(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
+    case_id: str,
     ether_transfer_case,
     iteration_count: int,
     transfer_amount: int,
@@ -146,8 +144,8 @@ def test_block_full_of_ether_transfers(
 
     # Only include post state for non a_to_a cases
     post_state = (
-        None
-        if ether_transfer_case == "a_to_a"
+        {}
+        if case_id == "a_to_a"
         else {receiver: Account(balance=balance) for receiver, balance in balances.items()}
     )
 

--- a/tests/zkevm/test_worst_blocks.py
+++ b/tests/zkevm/test_worst_blocks.py
@@ -1,0 +1,137 @@
+"""
+abstract: Tests zkEVMs worst-case block scenarios.
+    Tests zkEVMs worst-case block scenarios.
+
+Tests running worst-case block scenarios for zkEVMs.
+"""
+
+import pytest
+
+from ethereum_test_forks import Fork
+from ethereum_test_tools import (
+    Account,
+    Alloc,
+    Block,
+    BlockchainTestFiller,
+    Environment,
+    Transaction,
+)
+
+
+@pytest.fixture
+def iteration_count(fork: Fork):
+    """Calculate the number of iterations based on the gas limit and intrinsic cost."""
+    intrinsic_cost = fork.transaction_intrinsic_cost_calculator()
+    return min(5, Environment().gas_limit // intrinsic_cost())
+
+
+@pytest.fixture
+def transfer_amount():
+    """Ether to transfer in each transaction."""
+    return 0
+
+
+@pytest.fixture
+def eth_transfer_cost(fork: Fork):
+    """Transaction gas limit."""
+    intrinsic_cost = fork.transaction_intrinsic_cost_calculator()
+    return intrinsic_cost()
+
+
+@pytest.fixture
+def ether_transfer_case(
+    request,
+    pre: Alloc,
+    iteration_count: int,
+    transfer_amount: int,
+    eth_transfer_cost: int,
+):
+    """Generate the test parameters based on the case ID."""
+    case_id = request.param
+
+    senders = [pre.fund_eoa() for _ in range(iteration_count)]
+    receivers = [pre.fund_eoa(0) for _ in range(iteration_count)]
+
+    single_sender = pre.fund_eoa()
+    single_receiver = pre.fund_eoa(0)
+
+    if case_id == "a_to_a":
+        """Sending to self."""
+        total_balance = pre._eoa_fund_amount_default - eth_transfer_cost * iteration_count * 0x0A
+        sender_list = [single_sender for _ in range(iteration_count)]
+        receiver_list = [single_sender for _ in range(iteration_count)]
+        post = {single_sender: Account(balance=total_balance)}
+
+    elif case_id == "a_to_b":
+        """One sender → one receiver."""
+        sender_list = [single_sender for _ in range(iteration_count)]
+        receiver_list = [single_receiver for _ in range(iteration_count)]
+        post = {single_receiver: Account(balance=transfer_amount * iteration_count)}
+
+    elif case_id == "diff_acc_to_b":
+        """Multiple senders → one receiver."""
+        sender_list = senders.copy()
+        receiver_list = [single_receiver for _ in range(iteration_count)]
+        post = {single_receiver: Account(balance=transfer_amount * iteration_count)}
+
+    elif case_id == "a_to_diff_acc":
+        """One sender → multiple receivers."""
+        sender_list = [single_sender for _ in range(iteration_count)]
+        receiver_list = receivers.copy()
+        post = {receiver: Account(balance=transfer_amount) for receiver in receivers}
+
+    elif case_id == "diff_acc_to_diff_acc":
+        """Multiple senders → multiple receivers."""
+        sender_list = senders.copy()
+        receiver_list = receivers.copy()
+        post = {receiver: Account(balance=transfer_amount) for receiver in receivers}
+
+    else:
+        raise ValueError(f"Unknown case: {case_id}")
+
+    return sender_list, receiver_list, post
+
+
+@pytest.mark.valid_from("Cancun")
+@pytest.mark.parametrize(
+    "ether_transfer_case",
+    ["a_to_a", "a_to_b", "diff_acc_to_b", "a_to_diff_acc", "diff_acc_to_diff_acc"],
+    indirect=True,
+)
+def test_block_full_of_ether_transfers(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    ether_transfer_case,
+    iteration_count: int,
+    transfer_amount: int,
+    eth_transfer_cost: int,
+):
+    """
+    Single test for ether transfer scenarios.
+
+    Scenarios:
+    - a_to_a: one sender → one sender
+    - a_to_b: one sender → one receiver
+    - diff_acc_to_b: multiple senders → one receiver
+    - a_to_diff_acc: one sender → multiple receivers
+    - diff_acc_to_diff_acc: multiple senders → multiple receivers
+    """
+    sender_list, receiver_list, post = ether_transfer_case
+
+    blocks = []
+    for i in range(iteration_count):
+        tx = Transaction(
+            to=receiver_list[i],
+            value=transfer_amount,
+            gas_limit=eth_transfer_cost,
+            sender=sender_list[i],
+        )
+        blocks.append(Block(txs=[tx]))
+
+    blockchain_test(
+        genesis_environment=Environment(),
+        pre=pre,
+        post=post,
+        blocks=blocks,
+        exclude_full_post_state_in_output=True,
+    )

--- a/tests/zkevm/test_worst_blocks.py
+++ b/tests/zkevm/test_worst_blocks.py
@@ -19,10 +19,9 @@ from ethereum_test_tools import (
 
 
 @pytest.fixture
-def iteration_count(fork: Fork):
+def iteration_count(eth_transfer_cost: int):
     """Calculate the number of iterations based on the gas limit and intrinsic cost."""
-    intrinsic_cost = fork.transaction_intrinsic_cost_calculator()
-    return Environment().gas_limit // intrinsic_cost()
+    return min(5, Environment().gas_limit // eth_transfer_cost)
 
 
 @pytest.fixture
@@ -38,6 +37,28 @@ def eth_transfer_cost(fork: Fork):
     return intrinsic_cost()
 
 
+def get_distinct_sender_list(pre: Alloc, iteration_count: int):
+    """Get a list of distinct sender accounts."""
+    return [pre.fund_eoa() for _ in range(iteration_count)]
+
+
+def get_distinct_receiver_list(pre: Alloc, iteration_count: int):
+    """Get a list of distinct receiver accounts."""
+    return [pre.fund_eoa(0) for _ in range(iteration_count)]
+
+
+def get_single_sender_list(pre: Alloc, iteration_count: int):
+    """Get a list of single sender accounts."""
+    sender = pre.fund_eoa()
+    return [sender for _ in range(iteration_count)]
+
+
+def get_single_receiver_list(pre: Alloc, iteration_count: int):
+    """Get a list of single receiver accounts."""
+    receiver = pre.fund_eoa(0)
+    return [receiver for _ in range(iteration_count)]
+
+
 @pytest.fixture
 def ether_transfer_case(
     request,
@@ -49,42 +70,37 @@ def ether_transfer_case(
     """Generate the test parameters based on the case ID."""
     case_id = request.param
 
-    senders = [pre.fund_eoa() for _ in range(iteration_count)]
-    receivers = [pre.fund_eoa(0) for _ in range(iteration_count)]
-
-    single_sender = pre.fund_eoa()
-    single_receiver = pre.fund_eoa(0)
-
     if case_id == "a_to_a":
         """Sending to self."""
         total_balance = pre._eoa_fund_amount_default - eth_transfer_cost * iteration_count * 0x0A
-        sender_list = [single_sender for _ in range(iteration_count)]
-        receiver_list = [single_sender for _ in range(iteration_count)]
-        post = {single_sender: Account(balance=total_balance)}
+        account_list = get_single_sender_list(pre, iteration_count)
+        sender_list = account_list
+        receiver_list = account_list
+        post = {sender_list[0]: Account(balance=total_balance)}
 
     elif case_id == "a_to_b":
         """One sender → one receiver."""
-        sender_list = [single_sender for _ in range(iteration_count)]
-        receiver_list = [single_receiver for _ in range(iteration_count)]
-        post = {single_receiver: Account(balance=transfer_amount * iteration_count)}
+        sender_list = get_single_sender_list(pre, iteration_count)
+        receiver_list = get_single_receiver_list(pre, iteration_count)
+        post = {receiver_list[0]: Account(balance=transfer_amount * iteration_count)}
 
     elif case_id == "diff_acc_to_b":
         """Multiple senders → one receiver."""
-        sender_list = senders.copy()
-        receiver_list = [single_receiver for _ in range(iteration_count)]
-        post = {single_receiver: Account(balance=transfer_amount * iteration_count)}
+        sender_list = get_distinct_sender_list(pre, iteration_count)
+        receiver_list = get_single_receiver_list(pre, iteration_count)
+        post = {receiver_list[0]: Account(balance=transfer_amount * iteration_count)}
 
     elif case_id == "a_to_diff_acc":
         """One sender → multiple receivers."""
-        sender_list = [single_sender for _ in range(iteration_count)]
-        receiver_list = receivers.copy()
-        post = {receiver: Account(balance=transfer_amount) for receiver in receivers}
+        sender_list = get_single_sender_list(pre, iteration_count)
+        receiver_list = get_distinct_receiver_list(pre, iteration_count)
+        post = {receiver: Account(balance=transfer_amount) for receiver in receiver_list}
 
     elif case_id == "diff_acc_to_diff_acc":
         """Multiple senders → multiple receivers."""
-        sender_list = senders.copy()
-        receiver_list = receivers.copy()
-        post = {receiver: Account(balance=transfer_amount) for receiver in receivers}
+        sender_list = get_distinct_sender_list(pre, iteration_count)
+        receiver_list = get_distinct_receiver_list(pre, iteration_count)
+        post = {receiver: Account(balance=transfer_amount) for receiver in receiver_list}
 
     else:
         raise ValueError(f"Unknown case: {case_id}")


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

In Nethermind’s test case, a block is filled with simple Ether transfer transactions, each transferring 1 wei. The purpose of this PR is to reproduce a specific scenario and expand test coverage. Four scenarios are included, as outlined below:
1. Account A sends Ether to itself
2. Account A sends Ether to Account B
3. Account A sends Ether to multiple different accounts
4. Multiple different accounts send Ether to Account A

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

Issue https://github.com/ethereum/execution-spec-tests/issues/1734

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.