### PR TITLE
tooling(ruff): now warns about TODO comments (shown in vsc under problems)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,9 +118,10 @@ ethereum_test_forks = ["forks/contracts/*.bin"]
 line-length = 99
 
 [tool.ruff.lint]
-select = ["E", "F", "B", "W", "I", "A", "N", "D", "C"]
+select = ["E", "F", "B", "W", "I", "A", "N", "D", "C", "TD"]
 fixable = ["I", "B", "E", "F", "W", "D", "C"]
-ignore = ["D205", "D203", "D212", "D415", "C901", "A005", "C420"]
+ignore = ["D205", "D203", "D212", "D415", "C901", "A005", "C420", "TD003", "TD006"]
+
 
 [tool.mypy]
 mypy_path = ["src", "$MYPY_CONFIG_FILE_DIR/stubs"]


### PR DESCRIPTION
## 🗒️ Description
It is common to use comments like `# TODO: foo` while working on a feature, but it's easy to forget these things. With this PR ruff displays it as a 'Problem' in VSC so that we don't forget these

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist

- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests)/[tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned @ported_from marker.
- [ ] Tests: A PR with removal of converted JSON/YML blockchain tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
