### PR TITLE
feat(zkevm): add p256verify to worst compute tests

### DIFF
--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -706,6 +706,9 @@ def test_worst_precompile_fixed_cost(
     """Test running a block filled with a precompile with fixed cost."""
     env = Environment()
 
+    if precompile_address not in fork.precompiles():
+        pytest.skip("Precompile not enabled")
+
     concatenated_bytes: bytes
     if all(isinstance(p, str) for p in parameters):
         parameters_str = cast(list[str], parameters)

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -34,6 +34,7 @@ from ethereum_test_vm.opcode import Opcode
 from tests.cancun.eip4844_blobs.spec import Spec as BlobsSpec
 from tests.istanbul.eip152_blake2.common import Blake2bInput
 from tests.istanbul.eip152_blake2.spec import Spec as Blake2bSpec
+from tests.osaka.eip7951_p256verify_precompiles import spec as p256verify_spec
 from tests.prague.eip2537_bls_12_381_precompiles import spec as bls12381_spec
 from tests.prague.eip2537_bls_12_381_precompiles.spec import BytesConcatenation
 
@@ -679,6 +680,17 @@ def test_worst_modexp(state_test: StateTestFiller, pre: Alloc, fork: Fork):
                 bls12381_spec.FP2((bls12381_spec.Spec.P - 1, bls12381_spec.Spec.P - 1)),
             ],
             id="bls12_fp_to_g2",
+        ),
+        pytest.param(
+            p256verify_spec.Spec.P256VERIFY,
+            [
+                p256verify_spec.Spec.H0,
+                p256verify_spec.Spec.R0,
+                p256verify_spec.Spec.S0,
+                p256verify_spec.Spec.X0,
+                p256verify_spec.Spec.Y0,
+            ],
+            id="p256verify",
         ),
     ],
 )

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -35,6 +35,7 @@ from tests.cancun.eip4844_blobs.spec import Spec as BlobsSpec
 from tests.istanbul.eip152_blake2.common import Blake2bInput
 from tests.istanbul.eip152_blake2.spec import Spec as Blake2bSpec
 from tests.osaka.eip7951_p256verify_precompiles import spec as p256verify_spec
+from tests.osaka.eip7951_p256verify_precompiles.spec import FieldElement
 from tests.prague.eip2537_bls_12_381_precompiles import spec as bls12381_spec
 from tests.prague.eip2537_bls_12_381_precompiles.spec import BytesConcatenation
 
@@ -710,15 +711,15 @@ def test_worst_precompile_fixed_cost(
         parameters_str = cast(list[str], parameters)
         concatenated_hex_string = "".join(parameters_str)
         concatenated_bytes = bytes.fromhex(concatenated_hex_string)
-    elif all(isinstance(p, (bytes, BytesConcatenation)) for p in parameters):
+    elif all(isinstance(p, (bytes, BytesConcatenation, FieldElement)) for p in parameters):
         parameters_bytes_list = [
-            bytes(p) for p in cast(list[BytesConcatenation | bytes], parameters)
+            bytes(p) for p in cast(list[BytesConcatenation | bytes | FieldElement], parameters)
         ]
         concatenated_bytes = b"".join(parameters_bytes_list)
     else:
         raise TypeError(
             "parameters must be a list of strings (hex) "
-            "or a list of byte-like objects (bytes or BytesConcatenation)."
+            "or a list of byte-like objects (bytes, BytesConcatenation or FieldElement)."
         )
 
     padding_length = (32 - (len(concatenated_bytes) % 32)) % 32


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

Adding benchmark test for the `P256VERIFY` precompile contract.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

Issue: https://github.com/ethereum/execution-spec-tests/issues/1734

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.