### PR TITLE
feat(filler): Add `coverage_missed_reason` keyword arguemtn to `ported_from` marker

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -121,7 +121,7 @@ jobs:
           new_sources=$(echo "$CHANGED_TEST_FILES" | tr ',' '\n')
           echo "Changed or new test files: $new_sources"
 
-          uv run fill $new_sources --show-ported-from --clean --quiet --links-as-filled --ported-from-output-file ported_from_files.txt
+          uv run fill $new_sources --show-ported-from --clean --quiet --links-as-filled --skip-coverage-missed-reason --ported-from-output-file ported_from_files.txt
           files=$(cat ported_from_files.txt)
           echo "Extracted converted tests: $files"
           if [[ -z "$files" ]]; then

--- a/src/pytest_plugins/filler/ported_tests.py
+++ b/src/pytest_plugins/filler/ported_tests.py
@@ -17,6 +17,7 @@ The plugin will:
 2. Extract either the file paths (first positional argument) or PR URLs (pr keyword argument)
 3. Output a deduplicated, sorted list, one per line
 4. Skip test execution (collection only)
+5. Exclude tests with coverage_missed_reason from output
 
 Marker Format:
 --------------
@@ -26,6 +27,7 @@ Marker Format:
         "https://github.com/ethereum/execution-spec-tests/pull/1234",
         "https://github.com/ethereum/execution-spec-tests/pull/5678",
     ],
+    coverage_missed_reason="Optional reason for accepted coverage miss",
 )
 """
 
@@ -73,6 +75,13 @@ def pytest_addoption(parser: pytest.Parser):
         ),
     )
     ported_from_group.addoption(
+        "--skip-coverage-missed-reason",
+        action="store_true",
+        dest="skip_coverage_missed_reason",
+        default=False,
+        help="Skip printing tests with coverage_missed_reason.",
+    )
+    ported_from_group.addoption(
         "--ported-from-output-file",
         action="store",
         dest="ported_from_output_file",
@@ -107,6 +116,7 @@ class PortedFromDisplay:
         self.show_mode = config.getoption("show_ported_from")
         self.links_as_filled = config.getoption("links_as_filled")
         self.ported_from_output_file = config.getoption("ported_from_output_file")
+        self.skip_coverage_missed_reason = config.getoption("skip_coverage_missed_reason")
 
     @pytest.hookimpl(hookwrapper=True, trylast=True)
     def pytest_collection_modifyitems(
@@ -128,6 +138,13 @@ class PortedFromDisplay:
         for item in items:
             ported_from_marker = item.get_closest_marker("ported_from")
             if ported_from_marker:
+                # Skip tests with coverage_missed_reason
+                if (
+                    "coverage_missed_reason" in ported_from_marker.kwargs
+                    and self.skip_coverage_missed_reason
+                ):
+                    continue
+
                 # Extract paths (first positional argument)
                 if ported_from_marker.args:
                     first_arg = ported_from_marker.args[0]

--- a/tests/frontier/identity_precompile/test_identity.py
+++ b/tests/frontier/identity_precompile/test_identity.py
@@ -44,49 +44,64 @@ from .common import CallArgs, generate_identity_call_bytecode
     [
         "call_args",
         "memory_values",
+        "contract_balance",
         "call_succeeds",
     ],
     [
-        pytest.param(CallArgs(gas=0xFF), (0x1,), True, id="identity_0"),
+        pytest.param(CallArgs(gas=0xFF), (0x1,), 0x0, True, id="identity_0"),
         pytest.param(
             CallArgs(args_size=0x0),
             (0x0,),
+            0x0,
             True,
             id="identity_1",
         ),
         pytest.param(
             CallArgs(gas=0x30D40, value=0x1, args_size=0x0),
-            None,
-            False,
+            (0x1,),
+            0x1,
+            True,
             id="identity_1_nonzerovalue",
+        ),
+        pytest.param(
+            CallArgs(gas=0x30D40, value=0x1, args_size=0x0),
+            None,
+            0x0,
+            False,
+            id="identity_1_nonzerovalue_insufficient_balance",
         ),
         pytest.param(
             CallArgs(args_size=0x25),
             (0xF34578907F,),
+            0x0,
             True,
             id="identity_2",
         ),
         pytest.param(
             CallArgs(args_size=0x25),
             (0xF34578907F,),
+            0x0,
             True,
             id="identity_3",
         ),
         pytest.param(
             CallArgs(gas=0x64),
             (0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF,),
+            0x0,
             True,
             id="identity_4",
         ),
         pytest.param(
             CallArgs(gas=0x11),
             (0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF,),
+            0x0,
             False,
             id="identity_4_insufficient_gas",
         ),
         pytest.param(
             CallArgs(gas=0x12),
             (0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF,),
+            0x0,
             True,
             id="identity_4_exact_gas",
         ),
@@ -100,6 +115,7 @@ def test_call_identity_precompile(
     memory_values: Tuple[int, ...],
     call_succeeds: bool,
     tx_gas_limit: int,
+    contract_balance: int,
 ):
     """Test identity precompile RETURNDATA is sized correctly based on the input size."""
     env = Environment()
@@ -116,6 +132,7 @@ def test_call_identity_precompile(
     account = pre.deploy_contract(
         contract_bytecode,
         storage=storage.canary(),
+        balance=contract_balance,
     )
 
     tx = Transaction(


### PR DESCRIPTION
## 🗒️ Description

Adds a `coverage_missed_reason` keyword arguemtn to `ported_from` marker, which allows the test to be skipped from coverage comparison when the coverage drop has already been manually reviewed and deemed acceptable or not applicable to the test.

## 🔗 Related Issues

None

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.