### PR TITLE
fix(gentest): update imports to fix template

### DIFF
--- a/src/cli/gentest/templates/blockchain_test/transaction.py.j2
+++ b/src/cli/gentest/templates/blockchain_test/transaction.py.j2
@@ -8,7 +8,13 @@ from typing import Dict
 
 import pytest
 
-from ethereum_test_tools import Account, Environment, StateTestFiller, Storage, Transaction
+from ethereum_test_rpc.types import TransactionByHashResponse
+from ethereum_test_tools import (
+    Account,
+    Environment,
+    StateTestFiller,
+    Storage,
+)
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"


### PR DESCRIPTION
## 🗒️ Description
When playing around with `uv run gentest` it generated a file which could not be ran directly since it imported stuff which was not the method which was being used. Keeping this as draft, because we might want to update some things for `gentest`:

- [ ] The generated file was invalid and could not be ran. We should add a test for this to ensure the output runs out-of-the-box
- [ ] The tracer works using `debug_traceCall`. We should change this to `debug_traceTransaction`, because my endpoint does not support `debug_traceCall`. I also think that `traceCall` produces incorrect results if your tx is not in index 0, because it will run the call on top of the block and not after executing the previous txs. `debug_traceTransaction` also supports the prestate tracer and it works out of the box.

For the change in `debug_traceTransaction` I have this local fix (in `src/ethereum_test_rpc/rpc.py`):

```
    def trace_call(self, tr: dict[str, str], block_number: str):
        """`debug_traceCall`: Returns pre state required for transaction."""
        return self.post_request(
            "traceTransaction",
            "<hardcoded tx hash>",
            {"tracer": "prestateTracer"},
        )
```

This `gentest` tool is extremely helpful to sandbox a tx and use it to check against clients to see if something funny is happening there! :smile: :+1: 

CC @raxhvl, feel free to take over this PR :smile: :+1: 

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes ethereum/execution-spec-tests#123) -->

## ✅ Checklist

- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests)/[tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned @ported_from marker.
- [ ] Tests: A PR with removal of converted JSON/YML blockchain tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
