### PR TITLE
chore(tooling): better mypy config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,6 @@ files = ["src", "tests"]
 exclude = [
     '^\.cache/',
     '^\.git/',
-    '^\.github/',
     '^\.pytest_cache/',
     '^\.ruff_cache/',
     '^\.tox/',


### PR DESCRIPTION
## 🗒️ Description
We should be explicit about which folders should be scanned [`src`, `tests`] and also about which folders can be ignored for performance reasons (via exclude list). On my machine, when I delete `.mypy_cache` and run `time uv run mypy .` from eest root then i get a time of 9 seconds. Any run after this will be cached and take less than 0.9 sec on my machine. Even if our CI can't make use of caching (here we should ask ourselves if maybe we can make this possible if it is not done already) I think 9 seconds is reasonable and I would like to avoid to pivot to `ty` until that tool is proven to work better than mypy and all of its to-be-expected initial flaws are fixed. I would like to avoid to abandon a tool that has been developed and improved for more than 10 years (Van Rossum himself has been working on mypy) for some rust clickbait alternative.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist

- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests)/[tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned @ported_from marker.
- [ ] Tests: A PR with removal of converted JSON/YML blockchain tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
