### PR TITLE
feat(tests): add worst-case block test for 7702 set code

### DIFF
--- a/tests/zkevm/test_worst_blocks.py
+++ b/tests/zkevm/test_worst_blocks.py
@@ -12,6 +12,7 @@ from ethereum_test_tools import (
     Account,
     Address,
     Alloc,
+    AuthorizationTuple,
     Block,
     BlockchainTestFiller,
     Environment,
@@ -153,6 +154,46 @@ def test_block_full_of_ether_transfers(
         genesis_environment=Environment(),
         pre=pre,
         post=post_state,
+        blocks=[Block(txs=txs)],
+        exclude_full_post_state_in_output=True,
+    )
+
+
+@pytest.mark.valid_from("Prague")
+def test_block_full_of_7702_set_code(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    env: Environment,
+    iteration_count: int,
+):
+    """
+    Test worst-case block scenario with 7702 set code.
+
+    This test is designed to test the worst-case block scenario with 7702 set code.
+    """
+    attack_gas_limit = env.gas_limit
+    sender = pre.fund_eoa()
+
+    txs = []
+    for i in range(iteration_count):
+        txs.append(
+            Transaction(
+                gas_limit=attack_gas_limit,
+                to=sender,
+                authorization_list=[
+                    AuthorizationTuple(
+                        address=Address(0x0),
+                        nonce=i + 1,
+                        signer=sender,
+                    ),
+                ],
+                sender=sender,
+            )
+        )
+
+    blockchain_test(
+        genesis_environment=env,
+        pre=pre,
         blocks=[Block(txs=txs)],
         exclude_full_post_state_in_output=True,
     )


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

WIP

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist

- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests)/[tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned @ported_from marker.
- [ ] Tests: A PR with removal of converted JSON/YML blockchain tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
