### PR TITLE
feat(tests): add worst case tests for PUSH opcodes

### DIFF
--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -1919,7 +1919,7 @@ def test_worst_push(
     env = Environment()
 
     op = opcode[1] if opcode.has_data_portion() else opcode
-    opcode_sequence = op * fork.max_stack_height
+    opcode_sequence = op * fork.max_stack_height()
     target_contract_address = pre.deploy_contract(code=opcode_sequence)
 
     calldata = Bytecode()


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

This test case is designed to simulate the worst-case scenario for the PUSH operation in the EVM. It includes two approaches:
1. Repeatedly execute a PUSH-POP pattern to fill the contract code up to the maximum allowed size.
2. Deploy a contract that performs consecutive PUSH operations until the EVM stack reaches its maximum depth, then, deploy another contract that repeatedly performs `STATICCALL` to the first contract.

Based on the discussion in Berlinterop, and the analysis in PR https://github.com/ethereum/execution-spec-tests/pull/1737, we would only try the second approach


## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

Issue https://github.com/ethereum/execution-spec-tests/issues/1687

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
 with removal of converted JSON/YML blockchain tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.

