### PR TITLE
feat(zkevm/test): add worst case test for multiple DUP opcodes

### DIFF
--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -1790,7 +1790,7 @@ def test_worst_dup(
     env = Environment()
     max_stack_height = 1024
 
-    min_stack_height = opcode.min_stack_height()
+    min_stack_height = opcode.min_stack_height
     code_prefix = Op.PUSH0 * min_stack_height
     opcode_sequence = opcode * (max_stack_height - min_stack_height)
     target_contract_address = pre.deploy_contract(code=code_prefix + opcode_sequence)

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -1757,3 +1757,59 @@ def test_worst_swap(
         post={},
         tx=tx,
     )
+
+
+@pytest.mark.parametrize(
+    "opcode",
+    [
+        pytest.param(Op.DUP1),
+        pytest.param(Op.DUP2),
+        pytest.param(Op.DUP3),
+        pytest.param(Op.DUP4),
+        pytest.param(Op.DUP5),
+        pytest.param(Op.DUP6),
+        pytest.param(Op.DUP7),
+        pytest.param(Op.DUP8),
+        pytest.param(Op.DUP9),
+        pytest.param(Op.DUP10),
+        pytest.param(Op.DUP11),
+        pytest.param(Op.DUP12),
+        pytest.param(Op.DUP13),
+        pytest.param(Op.DUP14),
+        pytest.param(Op.DUP15),
+        pytest.param(Op.DUP16),
+    ],
+)
+def test_worst_dup(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    opcode: Op,
+):
+    """Test running a block with as many DUP as possible."""
+    env = Environment()
+    max_stack_height = 1024
+
+    min_stack_height = opcode.min_stack_height()
+    code_prefix = Op.PUSH0 * min_stack_height
+    opcode_sequence = opcode * (max_stack_height - min_stack_height)
+    target_contract_address = pre.deploy_contract(code=code_prefix + opcode_sequence)
+
+    calldata = Bytecode()
+    attack_block = Op.POP(Op.STATICCALL(Op.GAS, target_contract_address, 0, 0, 0, 0))
+
+    code = code_loop_precompile_call(calldata, attack_block, fork)
+    code_address = pre.deploy_contract(code=code)
+
+    tx = Transaction(
+        to=code_address,
+        gas_limit=env.gas_limit,
+        sender=pre.fund_eoa(),
+    )
+
+    state_test(
+        env=env,
+        pre=pre,
+        post={},
+        tx=tx,
+    )

--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -1788,7 +1788,7 @@ def test_worst_dup(
 ):
     """Test running a block with as many DUP as possible."""
     env = Environment()
-    max_stack_height = 1024
+    max_stack_height = fork.max_stack_height()
 
     min_stack_height = opcode.min_stack_height
     code_prefix = Op.PUSH0 * min_stack_height


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

Add the DUP opcode for zkevm tests.

This PR would be blocked until the PR https://github.com/ethereum/execution-spec-tests/pull/1768 is merged, as it would use EVM stack limit as a parameter.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

Issue https://github.com/ethereum/execution-spec-tests/issues/1687

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.