### PR TITLE
feat(zkevm/tests): add worst case tests for SWAP opcodes

### DIFF
--- a/tests/zkevm/test_worst_compute.py
+++ b/tests/zkevm/test_worst_compute.py
@@ -1720,3 +1720,54 @@ def test_worst_calldataload(
         post={},
         tx=tx,
     )
+
+
+@pytest.mark.parametrize(
+    "opcode",
+    [
+        Op.SWAP1,
+        Op.SWAP2,
+        Op.SWAP3,
+        Op.SWAP4,
+        Op.SWAP5,
+        Op.SWAP6,
+        Op.SWAP7,
+        Op.SWAP8,
+        Op.SWAP9,
+        Op.SWAP10,
+        Op.SWAP11,
+        Op.SWAP12,
+        Op.SWAP13,
+        Op.SWAP14,
+        Op.SWAP15,
+        Op.SWAP16,
+    ],
+)
+def test_worst_swap(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    opcode: Opcode,
+):
+    """Test running a block with as many SWAP as possible."""
+    env = Environment()
+    max_code_size = fork.max_code_size()
+
+    code_prefix = Op.JUMPDEST + Op.PUSH0 * opcode.min_stack_height
+    code_suffix = Op.PUSH0 + Op.JUMP
+    opcode_sequence = opcode * (max_code_size - len(code_prefix) - len(code_suffix))
+    code = code_prefix + opcode_sequence + code_suffix
+    assert len(code) <= max_code_size
+
+    tx = Transaction(
+        to=pre.deploy_contract(code=code),
+        gas_limit=env.gas_limit,
+        sender=pre.fund_eoa(),
+    )
+
+    state_test(
+        env=env,
+        pre=pre,
+        post={},
+        tx=tx,
+    )


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

Create worst test cases for SWAP1-16 opcode.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

Issue https://github.com/ethereum/execution-spec-tests/issues/1687

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.