### PR TITLE
fix(tests): Change INVALID_DEPOSIT_EVENT_LAYOUT to BlockException

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,6 +37,7 @@ Users can select any of the artifacts depending on their testing needs for their
 - 🐞 `fill` no longer writes generated fixtures into an existing, non-empty output directory; it must now be empty or `--clean` must be used to delete it first ([#1608](https://github.com/ethereum/execution-spec-tests/pull/1608)).
 - 🐞 zkEVM marked tests have been removed from `tests-deployed` tox environment into its own separate workflow `tests-deployed-zkevm` and are filled by `evmone-t8n` ([#1617](https://github.com/ethereum/execution-spec-tests/pull/1617)).
 - ✨ Field `postStateHash` is now added to all `blockchain_test` and `blockchain_test_engine` tests that use `exclude_full_post_state_in_output` in place of `postState`. Fixes `evmone-blockchaintest` test consumption and indirectly fixes coverage runs for these tests ([#1667](https://github.com/ethereum/execution-spec-tests/pull/1667)).
+- changed INVALID_DEPOSIT_EVENT_LAYOUT to a BlockException instead of a TransactionException
 
 #### `consume`
 

--- a/src/ethereum_clis/clis/besu.py
+++ b/src/ethereum_clis/clis/besu.py
@@ -317,6 +317,11 @@ class BesuExceptionMapper(ExceptionMapper):
         BlockException.SYSTEM_CONTRACT_EMPTY: (
             r"(Invalid system call, no code at address)|" r"(Invalid system call address:)"
         ),
+        BlockException.INVALID_DEPOSIT_EVENT_LAYOUT: (
+            r"Invalid (amount|index|pubKey|signature|withdrawalCred) (offset|size): "
+            r"expected (\d+), but got (-?\d+)|"
+            r"Invalid deposit log length\. Must be \d+ bytes, but is \d+ bytes"
+        ),
         TransactionException.INITCODE_SIZE_EXCEEDED: (
             r"transaction invalid Initcode size of \d+ exceeds maximum size of \d+"
         ),
@@ -336,11 +341,6 @@ class BesuExceptionMapper(ExceptionMapper):
         ),
         TransactionException.NONCE_MISMATCH_TOO_LOW: (
             r"transaction invalid transaction nonce \d+ below sender account nonce \d+"
-        ),
-        TransactionException.INVALID_DEPOSIT_EVENT_LAYOUT: (
-            r"Invalid (amount|index|pubKey|signature|withdrawalCred) (offset|size): "
-            r"expected (\d+), but got (-?\d+)|"
-            r"Invalid deposit log length\. Must be \d+ bytes, but is \d+ bytes"
         ),
         TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM: (
             r"transaction invalid Transaction gas limit must be at most \d+"

--- a/src/ethereum_clis/clis/erigon.py
+++ b/src/ethereum_clis/clis/erigon.py
@@ -35,7 +35,7 @@ class ErigonExceptionMapper(ExceptionMapper):
         ),
         TransactionException.TYPE_4_TX_CONTRACT_CREATION: "wrong size for To: 0",
         TransactionException.TYPE_4_TX_PRE_FORK: "setCode tx is not supported by signer",
-        TransactionException.INVALID_DEPOSIT_EVENT_LAYOUT: "could not parse requests logs",
+        BlockException.INVALID_DEPOSIT_EVENT_LAYOUT: "could not parse requests logs",
         BlockException.SYSTEM_CONTRACT_EMPTY: "Syscall failure: Empty Code at",
         BlockException.SYSTEM_CONTRACT_CALL_FAILED: "Unprecedented Syscall failure",
         BlockException.INVALID_REQUESTS: "invalid requests root hash in header",

--- a/src/ethereum_clis/clis/ethereumjs.py
+++ b/src/ethereum_clis/clis/ethereumjs.py
@@ -90,12 +90,12 @@ class EthereumJSExceptionMapper(ExceptionMapper):
             "sender doesn't have enough funds to send tx"
         ),
         TransactionException.NONCE_MISMATCH_TOO_LOW: "the tx doesn't have the correct nonce",
-        TransactionException.INVALID_DEPOSIT_EVENT_LAYOUT: (
-            "Error verifying block while running: error: number exceeds 53 bits"
-        ),
         TransactionException.GAS_ALLOWANCE_EXCEEDED: "tx has a higher gas limit than the block",
         BlockException.INCORRECT_EXCESS_BLOB_GAS: "Invalid 4844 transactions",
         BlockException.INVALID_RECEIPTS_ROOT: "invalid receipttrie",
+        BlockException.INVALID_DEPOSIT_EVENT_LAYOUT: (
+            "Error verifying block while running: error: number exceeds 53 bits"
+        ),
         # TODO EVMONE needs to differentiate when the section is missing in the header or body
         EOFException.MISSING_STOP_OPCODE: "err: no_terminating_instruction",
         EOFException.MISSING_CODE_HEADER: "err: code_section_missing",

--- a/src/ethereum_clis/clis/ethrex.py
+++ b/src/ethereum_clis/clis/ethrex.py
@@ -10,7 +10,7 @@ class EthrexExceptionMapper(ExceptionMapper):
         TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED: (
             "Exceeded MAX_BLOB_GAS_PER_BLOCK"
         ),
-        TransactionException.INVALID_DEPOSIT_EVENT_LAYOUT: ("Invalid deposit request layout"),
+        BlockException.INVALID_DEPOSIT_EVENT_LAYOUT: ("Invalid deposit request layout"),
         BlockException.INVALID_REQUESTS: (
             "Requests hash does not match the one in the header after executing"
         ),

--- a/src/ethereum_clis/clis/execution_specs.py
+++ b/src/ethereum_clis/clis/execution_specs.py
@@ -163,6 +163,7 @@ class ExecutionSpecsExceptionMapper(ExceptionMapper):
         TransactionException.GAS_ALLOWANCE_EXCEEDED: "ion: ",
         BlockException.SYSTEM_CONTRACT_EMPTY: "System contract address",
         BlockException.SYSTEM_CONTRACT_CALL_FAILED: "call failed:",
+        BlockException.INVALID_DEPOSIT_EVENT_LAYOUT: "deposit",
         # TODO EVMONE needs to differentiate when the section is missing in the header or body
         EOFException.MISSING_STOP_OPCODE: "err: no_terminating_instruction",
         EOFException.MISSING_CODE_HEADER: "err: code_section_missing",

--- a/src/ethereum_clis/clis/geth.py
+++ b/src/ethereum_clis/clis/geth.py
@@ -73,7 +73,7 @@ class GethExceptionMapper(ExceptionMapper):
         TransactionException.TYPE_4_TX_PRE_FORK: ("transaction type not supported"),
         TransactionException.INITCODE_SIZE_EXCEEDED: "max initcode size exceeded",
         TransactionException.NONCE_MISMATCH_TOO_LOW: "nonce too low",
-        TransactionException.INVALID_DEPOSIT_EVENT_LAYOUT: "unable to parse deposit data",
+        BlockException.INVALID_DEPOSIT_EVENT_LAYOUT: "unable to parse deposit data",
         BlockException.INCORRECT_BLOB_GAS_USED: "blob gas used mismatch",
         BlockException.INCORRECT_EXCESS_BLOB_GAS: "invalid excessBlobGas",
         BlockException.INVALID_VERSIONED_HASHES: "invalid number of versionedHashes",

--- a/src/ethereum_clis/clis/nethermind.py
+++ b/src/ethereum_clis/clis/nethermind.py
@@ -360,7 +360,7 @@ class NethermindExceptionMapper(ExceptionMapper):
         BlockException.INVALID_GAS_USED_ABOVE_LIMIT: (
             "ExceededGasLimit: Gas used exceeds gas limit."
         ),
-        TransactionException.INVALID_DEPOSIT_EVENT_LAYOUT: (
+        BlockException.INVALID_DEPOSIT_EVENT_LAYOUT: (
             "DepositsInvalid: Invalid deposit event layout:"
         ),
     }

--- a/src/ethereum_clis/clis/reth.py
+++ b/src/ethereum_clis/clis/reth.py
@@ -29,7 +29,7 @@ class RethExceptionMapper(ExceptionMapper):
         TransactionException.TYPE_4_TX_PRE_FORK: (
             "eip 7702 transactions present in pre-prague payload"
         ),
-        TransactionException.INVALID_DEPOSIT_EVENT_LAYOUT: (
+        BlockException.INVALID_DEPOSIT_EVENT_LAYOUT: (
             "failed to decode deposit requests from receipts"
         ),
         BlockException.INVALID_REQUESTS: "mismatched block requests hash",

--- a/src/ethereum_test_exceptions/exceptions.py
+++ b/src/ethereum_test_exceptions/exceptions.py
@@ -395,11 +395,6 @@ class TransactionException(ExceptionBase):
     """
     Transaction type 4 included before activation fork.
     """
-    INVALID_DEPOSIT_EVENT_LAYOUT = auto()
-    """
-    Transaction emits a `DepositEvent` in the deposit contract (EIP-6110), but the layout
-    of the event does not match the required layout.
-    """
 
 
 @unique
@@ -603,6 +598,11 @@ class BlockException(ExceptionBase):
     INVALID_BLOCK_HASH = auto()
     """
     Block header's hash does not match the actually computed hash of the block.
+    """
+    INVALID_DEPOSIT_EVENT_LAYOUT = auto()
+    """
+    Transaction emits a `DepositEvent` in the deposit contract (EIP-6110), but the layout
+    of the event does not match the required layout.
     """
 
 

--- a/tests/prague/eip6110_deposits/test_modified_contract.py
+++ b/tests/prague/eip6110_deposits/test_modified_contract.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from ethereum_test_exceptions.exceptions import TransactionException
+from ethereum_test_exceptions.exceptions import BlockException
 from ethereum_test_tools import (
     Account,
     Alloc,
@@ -178,13 +178,12 @@ def test_invalid_layout(
         to=Spec.DEPOSIT_CONTRACT_ADDRESS,
         sender=sender,
         gas_limit=100_000,
-        error=TransactionException.INVALID_DEPOSIT_EVENT_LAYOUT,
     )
 
     blockchain_test(
         pre=pre,
         blocks=[
-            Block(txs=[tx], exception=TransactionException.INVALID_DEPOSIT_EVENT_LAYOUT),
+            Block(txs=[tx], exception=BlockException.INVALID_DEPOSIT_EVENT_LAYOUT),
         ],
         post={},
     )
@@ -223,13 +222,12 @@ def test_invalid_log_length(blockchain_test: BlockchainTestFiller, pre: Alloc, s
         to=Spec.DEPOSIT_CONTRACT_ADDRESS,
         sender=sender,
         gas_limit=100_000,
-        error=TransactionException.INVALID_DEPOSIT_EVENT_LAYOUT,
     )
 
     blockchain_test(
         pre=pre,
         blocks=[
-            Block(txs=[tx], exception=TransactionException.INVALID_DEPOSIT_EVENT_LAYOUT),
+            Block(txs=[tx], exception=BlockException.INVALID_DEPOSIT_EVENT_LAYOUT),
         ],
         post={},
     )


### PR DESCRIPTION
## 🗒️ Description
Some of the tests in tests/prague/eip6110_deposits/test_modified_contract.py fail to parse the deposit logs corresponding to a transaction and expect the transaction to be marked as rejected. However, the parsing of the logs happen outside of the transaction. So the transaction itself is not rejected rather, the block is invalid. We should expect an Invalid Block here in place of a invalid transaction

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests)/[tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned @ported_from marker.
- [ ] Tests: A PR with removal of converted JSON/YML blockchain tests from [ethereum/tests](/ethereum/tests) have been opened.
- [x] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
