### PR TITLE
chore(ci|tests): more updates for fusaka devnet 2 release

### DIFF
--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -37,7 +37,7 @@ eip7692:
   solc: 0.8.21
   eofwrap: true
   feature_only: true
-fusaka-devnet-2:
+fusaka-devnet-3:
   evm-type: develop
-  fill-params: --from=Prague --until=Osaka -k "((test_precompiles and address_0x100) or (test_set_code_to_precompile and precompile_0x0000000000000000000000000000000000000100)) or (eip198_modexp) or (test_sufficient_balance_blob_tx) or (test_valid_blob_tx_combinations)" tests/osaka tests/byzantium/eip198_modexp_precompile ./tests/cancun/eip4844_blobs/test_blob_txs.py::test_sufficient_balance_blob_tx ./tests/cancun/eip4844_blobs/test_blob_txs.py::test_valid_blob_tx_combinations
+  fill-params: --from=Prague --until=Osaka ./tests/osaka ./tests/shanghai/eip3860_initcode ./tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_precompile ./tests/byzantium/eip198_modexp_precompile ./tests/frontier/precompiles/test_precompiles.py ./tests/cancun/eip4844_blobs/test_blob_txs.py::test_sufficient_balance_blob_tx ./tests/cancun/eip4844_blobs/test_blob_txs.py::test_valid_blob_tx_combinations
   feature_only: true

--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -37,7 +37,7 @@ eip7692:
   solc: 0.8.21
   eofwrap: true
   feature_only: true
-fusaka-devnet-3:
+fusaka-devnet-2:
   evm-type: develop
   fill-params: --from=Prague --until=Osaka ./tests/osaka ./tests/shanghai/eip3860_initcode ./tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_precompile ./tests/byzantium/eip198_modexp_precompile ./tests/frontier/precompiles/test_precompiles.py ./tests/cancun/eip4844_blobs/test_blob_txs.py::test_sufficient_balance_blob_tx ./tests/cancun/eip4844_blobs/test_blob_txs.py::test_valid_blob_tx_combinations
   feature_only: true

--- a/eels_resolutions.json
+++ b/eels_resolutions.json
@@ -42,6 +42,6 @@
     "Osaka": {
         "git_url": "https://github.com/spencer-tb/execution-specs.git",
         "branch": "forks/osaka",
-        "commit": "99734284b89766883ecb680e57b07fbca47da51b"
+        "commit": "bc829598ff1923f9215a6a407ef74621077fd3bb"
     }
 }

--- a/eels_resolutions.json
+++ b/eels_resolutions.json
@@ -40,8 +40,8 @@
         "commit": "bb0eb750d643ced0ebf5dec732cdd23558d0b7f2"
     },
     "Osaka": {
-        "git_url": "https://github.com/spencer-tb/execution-specs.git",
+        "git_url": "https://github.com/ethereum/execution-specs.git",
         "branch": "forks/osaka",
-        "commit": "bc829598ff1923f9215a6a407ef74621077fd3bb"
+        "commit": "f947ab1744aaf12f652a85e28ac5d155af26dd25"
     }
 }

--- a/tests/shanghai/eip3860_initcode/test_initcode.py
+++ b/tests/shanghai/eip3860_initcode/test_initcode.py
@@ -547,7 +547,7 @@ class TestCreateInitcode:
                     1: expected_gas_usage,
                 },
             )
-
+        # Temp change to trigger coverage script.
         state_test(
             env=env,
             pre=pre,

--- a/tests/shanghai/eip3860_initcode/test_initcode.py
+++ b/tests/shanghai/eip3860_initcode/test_initcode.py
@@ -547,7 +547,7 @@ class TestCreateInitcode:
                     1: expected_gas_usage,
                 },
             )
-        # Temp change to trigger coverage script.
+
         state_test(
             env=env,
             pre=pre,


### PR DESCRIPTION
## 🗒️ Description

#### A collection updates for fusaka devnet 2

- Fixes issues with the CLZ (EIP-7939) transition tests. Previously not catched when running `uv run fill --fork Osaka`. **Note this is correctly added in the devnet 2 release.**
- Fixes the `feature.yaml` fill params from previous PR.

## 🔗 Related Issues
#1774

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] ~~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
