### PR TITLE
chore(tooling): point to new coverage script

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -60,7 +60,7 @@ jobs:
         if: ${{  steps.changed-tests.outputs.tests_any_changed == 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
         with:
-          username: winsvega
+          username: felix314159
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Install deps
@@ -275,7 +275,7 @@ jobs:
         uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185
         if: ${{ steps.changed-tests.outputs.tests_any_changed == 'true' }}
         with:
-          image: winsvega/evmone-coverage-script:latest
+          image: felix314159/evmone-coverage-script:latest
           options: -v ${{ github.workspace }}/evmtest_coverage/coverage:/tests
           run: /entrypoint.sh --mode=cover --driver=native --testpath=/tests/BASE_TESTS --outputname=BASE
 
@@ -283,7 +283,7 @@ jobs:
         uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185
         if: ${{ steps.changed-tests.outputs.tests_any_changed == 'true' }}
         with:
-          image: winsvega/evmone-coverage-script:latest
+          image: felix314159/evmone-coverage-script:latest
           options: -v ${{ github.workspace }}/evmtest_coverage/coverage:/tests
           run: /entrypoint.sh --mode=cover --driver=native --testpath=/tests/PATCH_TESTS --outputname=PATCH
 
@@ -291,7 +291,7 @@ jobs:
         uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185
         if: ${{  steps.changed-tests.outputs.tests_any_changed == 'true' }}
         with:
-          image: winsvega/evmone-coverage-script:latest
+          image: felix314159/evmone-coverage-script:latest
           options: -v ${{ github.workspace }}/evmtest_coverage/coverage:/tests
           run: /entrypoint.sh --mode=diff --basefile=coverage_BASE.lcov --patchfile=coverage_PATCH.lcov
 
@@ -313,6 +313,6 @@ jobs:
         uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185
         if: ${{ steps.changed-tests.outputs.tests_any_changed == 'true' }}
         with:
-          image: winsvega/evmone-coverage-script:latest
+          image: felix314159/evmone-coverage-script:latest
           options: -v ${{ github.workspace }}/evmtest_coverage/coverage:/tests
           run: /check.sh


### PR DESCRIPTION
## 🗒️ Description
Replaces [this coverage script](https://hub.docker.com/r/winsvega/evmone-coverage-script/tags) with the clone [located here](https://hub.docker.com/r/felix314159/evmone-coverage-script/tags). You can see that the hash is identical, but we still have to replace our `secrets.DOCKERHUB_PASSWORD` with my PAT (public read only). DM me for this, it can be done via GitHub GUI (GitHub repo → Settings → Secrets and variables → Actions).

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] ~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
