### PR TITLE
chore(cli): add block rlp size limit exceptions

### DIFF
--- a/src/ethereum_clis/clis/besu.py
+++ b/src/ethereum_clis/clis/besu.py
@@ -262,10 +262,6 @@ class BesuExceptionMapper(ExceptionMapper):
             "Payload BlobGasUsed does not match calculated BlobGasUsed"
         ),
         BlockException.INVALID_GAS_USED_ABOVE_LIMIT: "Header validation failed (FULL)",
-        BlockException.RLP_BLOCK_LIMIT_EXCEEDED: (
-            # TODO:
-            ""
-        ),
         # TODO EVMONE needs to differentiate when the section is missing in the header or body
         EOFException.MISSING_STOP_OPCODE: "err: no_terminating_instruction",
         EOFException.MISSING_CODE_HEADER: "err: code_section_missing",
@@ -325,6 +321,9 @@ class BesuExceptionMapper(ExceptionMapper):
             r"Invalid (amount|index|pubKey|signature|withdrawalCred) (offset|size): "
             r"expected (\d+), but got (-?\d+)|"
             r"Invalid deposit log length\. Must be \d+ bytes, but is \d+ bytes"
+        ),
+        BlockException.RLP_BLOCK_LIMIT_EXCEEDED: (
+            r"Block size of \d+ bytes exceeds limit of \d+ bytes"
         ),
         TransactionException.INITCODE_SIZE_EXCEEDED: (
             r"transaction invalid Initcode size of \d+ exceeds maximum size of \d+"

--- a/src/ethereum_clis/clis/erigon.py
+++ b/src/ethereum_clis/clis/erigon.py
@@ -40,10 +40,7 @@ class ErigonExceptionMapper(ExceptionMapper):
         BlockException.SYSTEM_CONTRACT_CALL_FAILED: "Unprecedented Syscall failure",
         BlockException.INVALID_REQUESTS: "invalid requests root hash in header",
         BlockException.INVALID_BLOCK_HASH: "invalid block hash",
-        BlockException.RLP_BLOCK_LIMIT_EXCEEDED: (
-            # TODO:
-            ""
-        ),
+        BlockException.RLP_BLOCK_LIMIT_EXCEEDED: "block exceeds max rlp size",
     }
     mapping_regex = {
         TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM: (

--- a/src/ethereum_clis/clis/geth.py
+++ b/src/ethereum_clis/clis/geth.py
@@ -67,9 +67,7 @@ class GethExceptionMapper(ExceptionMapper):
         TransactionException.TYPE_4_TX_CONTRACT_CREATION: (
             "input string too short for common.Address, decoding into (types.SetCodeTx).To"
         ),
-        TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM: (
-            "transaction exceeds maximum allowed gas limit"
-        ),
+        TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM: "transaction gas limit too high",
         TransactionException.TYPE_4_TX_PRE_FORK: ("transaction type not supported"),
         TransactionException.INITCODE_SIZE_EXCEEDED: "max initcode size exceeded",
         TransactionException.NONCE_MISMATCH_TOO_LOW: "nonce too low",
@@ -80,10 +78,7 @@ class GethExceptionMapper(ExceptionMapper):
         BlockException.INVALID_REQUESTS: "invalid requests hash",
         BlockException.SYSTEM_CONTRACT_CALL_FAILED: "system call failed to execute:",
         BlockException.INVALID_BLOCK_HASH: "blockhash mismatch",
-        BlockException.RLP_BLOCK_LIMIT_EXCEEDED: (
-            # TODO:
-            ""
-        ),
+        BlockException.RLP_BLOCK_LIMIT_EXCEEDED: "block RLP-encoded size exceeds maximum",
         # TODO EVMONE needs to differentiate when the section is missing in the header or body
         EOFException.MISSING_STOP_OPCODE: "err: no_terminating_instruction",
         EOFException.MISSING_CODE_HEADER: "err: code_section_missing",

--- a/src/ethereum_clis/clis/nethermind.py
+++ b/src/ethereum_clis/clis/nethermind.py
@@ -361,8 +361,7 @@ class NethermindExceptionMapper(ExceptionMapper):
             "ExceededGasLimit: Gas used exceeds gas limit."
         ),
         BlockException.RLP_BLOCK_LIMIT_EXCEEDED: (
-            # TODO:
-            ""
+            "ExceededBlockSizeLimit: Exceeded block size limit"
         ),
         BlockException.INVALID_DEPOSIT_EVENT_LAYOUT: (
             "DepositsInvalid: Invalid deposit event layout:"

--- a/src/ethereum_clis/clis/nimbus.py
+++ b/src/ethereum_clis/clis/nimbus.py
@@ -87,17 +87,14 @@ class NimbusExceptionMapper(ExceptionMapper):
             "invalid tx: one of blobVersionedHash has invalid version"
         ),
         # TODO: temp solution until mapper for nimbus is fixed
-        TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM: ("zero gasUsed but transactions present"),
+        TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM: "zero gasUsed but transactions present",
         # This message is the same as TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED
         TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED: "exceeds maximum allowance",
         TransactionException.TYPE_3_TX_ZERO_BLOBS: "blob transaction missing blob hashes",
-        TransactionException.INTRINSIC_GAS_TOO_LOW: "intrinsic gas too low",
+        TransactionException.INTRINSIC_GAS_TOO_LOW: "zero gasUsed but transactions present",
         TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST: "intrinsic gas too low",
-        TransactionException.INITCODE_SIZE_EXCEEDED: "max initcode size exceeded",
-        BlockException.RLP_BLOCK_LIMIT_EXCEEDED: (
-            # TODO:
-            ""
-        ),
+        TransactionException.INITCODE_SIZE_EXCEEDED: "zero gasUsed but transactions present",
+        BlockException.RLP_BLOCK_LIMIT_EXCEEDED: "zero gasUsed but transactions present",
         # TODO EVMONE needs to differentiate when the section is missing in the header or body
         EOFException.MISSING_STOP_OPCODE: "err: no_terminating_instruction",
         EOFException.MISSING_CODE_HEADER: "err: code_section_missing",

--- a/src/ethereum_clis/clis/reth.py
+++ b/src/ethereum_clis/clis/reth.py
@@ -37,10 +37,7 @@ class RethExceptionMapper(ExceptionMapper):
         BlockException.INVALID_STATE_ROOT: "mismatched block state root",
         BlockException.INVALID_BLOCK_HASH: "block hash mismatch",
         BlockException.INVALID_GAS_USED: "block gas used mismatch",
-        BlockException.RLP_BLOCK_LIMIT_EXCEEDED: (
-            # TODO:
-            ""
-        ),
+        BlockException.RLP_BLOCK_LIMIT_EXCEEDED: "block is too large: ",
     }
     mapping_regex = {
         TransactionException.NONCE_MISMATCH_TOO_LOW: r"nonce \d+ too low, expected \d+",


### PR DESCRIPTION
## 🗒️ Description
Updates the exception mapper for EIP-7934. Note a temporary error is added to Nimbus for now.

## 🔗 Related Issues
#1730 

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [x] ~All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
