### PR TITLE
fix(clis/ethrex): fix ethrex error mapping

### DIFF
--- a/src/ethereum_clis/clis/ethrex.py
+++ b/src/ethereum_clis/clis/ethrex.py
@@ -51,7 +51,7 @@ class EthrexExceptionMapper(ExceptionMapper):
         # A type 4 Transaction without a recipient won't even reach the EVM, we can't decode it.
         TransactionException.TYPE_4_TX_CONTRACT_CREATION: (
             r"unexpected length|Contract creation in type 4 transaction|"
-            r"Error decoding field '\D+' of type \w+.*"
+            r"Error decoding field 'to' of type primitive_types::H160: InvalidLength"
         ),
         TransactionException.TYPE_4_TX_PRE_FORK: (
             r"eip 7702 transactions present in pre-prague payload|"

--- a/src/ethereum_clis/clis/ethrex.py
+++ b/src/ethereum_clis/clis/ethrex.py
@@ -51,7 +51,7 @@ class EthrexExceptionMapper(ExceptionMapper):
         # A type 4 Transaction without a recipient won't even reach the EVM, we can't decode it.
         TransactionException.TYPE_4_TX_CONTRACT_CREATION: (
             r"unexpected length|Contract creation in type 4 transaction|"
-            r"Error decoding field 'to' in type 4 transaction"
+            r"Error decoding field '\D+' of type \w+.*"
         ),
         TransactionException.TYPE_4_TX_PRE_FORK: (
             r"eip 7702 transactions present in pre-prague payload|"

--- a/src/ethereum_clis/clis/ethrex.py
+++ b/src/ethereum_clis/clis/ethrex.py
@@ -48,6 +48,11 @@ class EthrexExceptionMapper(ExceptionMapper):
             r"blob versioned hashes not supported|"
             r"Type 3 transactions are not supported before the Cancun fork"
         ),
+        # A type 4 Transaction without a recipient won't even reach the EVM, we can't decode it.
+        TransactionException.TYPE_4_TX_CONTRACT_CREATION: (
+            r"unexpected length|Contract creation in type 4 transaction|"
+            r"Error decoding field '\D+' of type \w+.*"
+        ),
         TransactionException.TYPE_4_TX_PRE_FORK: (
             r"eip 7702 transactions present in pre-prague payload|"
             r"Type 4 transactions are not supported before the Prague fork"
@@ -75,9 +80,4 @@ class EthrexExceptionMapper(ExceptionMapper):
         BlockException.RLP_STRUCTURES_ENCODING: (r"Error decoding field '\D+' of type \w+.*"),
         BlockException.INCORRECT_EXCESS_BLOB_GAS: (r".* Excess blob gas is incorrect"),
         BlockException.INVALID_BLOCK_HASH: (r"Invalid block hash. Expected \w+, got \w+"),
-        # A type 4 Transaction without a recipient won't even reach the EVM, we can't decode it.
-        TransactionException.TYPE_4_TX_CONTRACT_CREATION: (
-            r"unexpected length|Contract creation in type 4 transaction|"
-            r"Error decoding field '\D+' of type \w+.*"
-        ),
     }

--- a/src/ethereum_clis/clis/ethrex.py
+++ b/src/ethereum_clis/clis/ethrex.py
@@ -48,8 +48,10 @@ class EthrexExceptionMapper(ExceptionMapper):
             r"blob versioned hashes not supported|"
             r"Type 3 transactions are not supported before the Cancun fork"
         ),
+        # A type 4 Transaction without a recipient won't even reach the EVM, we can't decode it.
         TransactionException.TYPE_4_TX_CONTRACT_CREATION: (
-            r"unexpected length|Contract creation in type 4 transaction"
+            r"unexpected length|Contract creation in type 4 transaction|"
+            r"Error decoding field '\D+' of type \w+.*"
         ),
         TransactionException.TYPE_4_TX_PRE_FORK: (
             r"eip 7702 transactions present in pre-prague payload|"

--- a/src/ethereum_clis/clis/ethrex.py
+++ b/src/ethereum_clis/clis/ethrex.py
@@ -51,7 +51,7 @@ class EthrexExceptionMapper(ExceptionMapper):
         # A type 4 Transaction without a recipient won't even reach the EVM, we can't decode it.
         TransactionException.TYPE_4_TX_CONTRACT_CREATION: (
             r"unexpected length|Contract creation in type 4 transaction|"
-            r"Error decoding field 'to' in type-4 transaction"
+            r"Error decoding field 'to' in type 4 transaction"
         ),
         TransactionException.TYPE_4_TX_PRE_FORK: (
             r"eip 7702 transactions present in pre-prague payload|"

--- a/src/ethereum_clis/clis/ethrex.py
+++ b/src/ethereum_clis/clis/ethrex.py
@@ -48,11 +48,6 @@ class EthrexExceptionMapper(ExceptionMapper):
             r"blob versioned hashes not supported|"
             r"Type 3 transactions are not supported before the Cancun fork"
         ),
-        # A type 4 Transaction without a recipient won't even reach the EVM, we can't decode it.
-        TransactionException.TYPE_4_TX_CONTRACT_CREATION: (
-            r"unexpected length|Contract creation in type 4 transaction|"
-            r"Error decoding field '\D+' of type \w+.*"
-        ),
         TransactionException.TYPE_4_TX_PRE_FORK: (
             r"eip 7702 transactions present in pre-prague payload|"
             r"Type 4 transactions are not supported before the Prague fork"
@@ -80,4 +75,9 @@ class EthrexExceptionMapper(ExceptionMapper):
         BlockException.RLP_STRUCTURES_ENCODING: (r"Error decoding field '\D+' of type \w+.*"),
         BlockException.INCORRECT_EXCESS_BLOB_GAS: (r".* Excess blob gas is incorrect"),
         BlockException.INVALID_BLOCK_HASH: (r"Invalid block hash. Expected \w+, got \w+"),
+        # A type 4 Transaction without a recipient won't even reach the EVM, we can't decode it.
+        TransactionException.TYPE_4_TX_CONTRACT_CREATION: (
+            r"unexpected length|Contract creation in type 4 transaction|"
+            r"Error decoding field '\D+' of type \w+.*"
+        ),
     }

--- a/src/ethereum_clis/clis/ethrex.py
+++ b/src/ethereum_clis/clis/ethrex.py
@@ -30,7 +30,7 @@ class EthrexExceptionMapper(ExceptionMapper):
         TransactionException.TYPE_4_EMPTY_AUTHORIZATION_LIST: r"(?i)empty authorization list",
         TransactionException.SENDER_NOT_EOA: (
             r"reject transactions from senders with deployed code|"
-            r"Sender account shouldn't be a contract"
+            r"Sender account is amazing and this change should be reverted"
         ),
         TransactionException.NONCE_MISMATCH_TOO_LOW: r"nonce \d+ too low, expected \d+|"
         r"Nonce mismatch.*",

--- a/src/ethereum_clis/clis/ethrex.py
+++ b/src/ethereum_clis/clis/ethrex.py
@@ -30,9 +30,10 @@ class EthrexExceptionMapper(ExceptionMapper):
         TransactionException.TYPE_4_EMPTY_AUTHORIZATION_LIST: r"(?i)empty authorization list",
         TransactionException.SENDER_NOT_EOA: (
             r"reject transactions from senders with deployed code|"
-            r"Sender account should not have bytecode"
+            r"Sender account shouldn't be a contract"
         ),
-        TransactionException.NONCE_MISMATCH_TOO_LOW: r"nonce \d+ too low, expected \d+",
+        TransactionException.NONCE_MISMATCH_TOO_LOW: r"nonce \d+ too low, expected \d+|"
+        r"Nonce mismatch.*",
         TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED: (
             r"blob gas used \d+ exceeds maximum allowance \d+"
         ),
@@ -55,7 +56,7 @@ class EthrexExceptionMapper(ExceptionMapper):
             r"Type 4 transactions are not supported before the Prague fork"
         ),
         TransactionException.INSUFFICIENT_ACCOUNT_FUNDS: (
-            r"lack of funds \(\d+\) for max fee \(\d+\)|Insufficient account founds"
+            r"lack of funds \(\d+\) for max fee \(\d+\)|Insufficient account funds"
         ),
         TransactionException.INTRINSIC_GAS_TOO_LOW: (
             r"gas floor exceeds the gas limit|call gas cost exceeds the gas limit|"
@@ -71,7 +72,8 @@ class EthrexExceptionMapper(ExceptionMapper):
         TransactionException.INITCODE_SIZE_EXCEEDED: (
             r"create initcode size limit|Initcode size exceeded"
         ),
-        BlockException.SYSTEM_CONTRACT_CALL_FAILED: (r"failed to apply .* requests contract call"),
+        BlockException.SYSTEM_CONTRACT_CALL_FAILED: (r"System call failed.*"),
+        BlockException.SYSTEM_CONTRACT_EMPTY: (r"System contract:.* has no code after deployment"),
         BlockException.INCORRECT_BLOB_GAS_USED: (r"Blob gas used doesn't match value in header"),
         BlockException.RLP_STRUCTURES_ENCODING: (r"Error decoding field '\D+' of type \w+.*"),
         BlockException.INCORRECT_EXCESS_BLOB_GAS: (r".* Excess blob gas is incorrect"),

--- a/src/ethereum_clis/clis/ethrex.py
+++ b/src/ethereum_clis/clis/ethrex.py
@@ -30,7 +30,7 @@ class EthrexExceptionMapper(ExceptionMapper):
         TransactionException.TYPE_4_EMPTY_AUTHORIZATION_LIST: r"(?i)empty authorization list",
         TransactionException.SENDER_NOT_EOA: (
             r"reject transactions from senders with deployed code|"
-            r"Sender account is amazing and this change should be reverted"
+            r"Sender account shouldn't be a contract"
         ),
         TransactionException.NONCE_MISMATCH_TOO_LOW: r"nonce \d+ too low, expected \d+|"
         r"Nonce mismatch.*",

--- a/src/ethereum_clis/clis/ethrex.py
+++ b/src/ethereum_clis/clis/ethrex.py
@@ -51,7 +51,7 @@ class EthrexExceptionMapper(ExceptionMapper):
         # A type 4 Transaction without a recipient won't even reach the EVM, we can't decode it.
         TransactionException.TYPE_4_TX_CONTRACT_CREATION: (
             r"unexpected length|Contract creation in type 4 transaction|"
-            r"Error decoding field '\D+' of type \w+.*"
+            r"Error decoding field 'to' in type-4 transaction"
         ),
         TransactionException.TYPE_4_TX_PRE_FORK: (
             r"eip 7702 transactions present in pre-prague payload|"


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
- We've changed some error strings in Ethrex so this is for fixing the tests and passing them all :)
- I also add mapping for `SYSTEM_CONTRACT_EMPTY`, that we didn't have before.

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist

- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests)/[tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned @ported_from marker.
- [ ] Tests: A PR with removal of converted JSON/YML blockchain tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
