### PR TITLE
feat(tooling): log RLP errors to file + shorten RLP errors in console

### DIFF
--- a/pytest-execute-hive.ini
+++ b/pytest-execute-hive.ini
@@ -14,6 +14,7 @@ addopts =
     -p pytest_plugins.solc.solc
     -p pytest_plugins.execute.rpc.hive
     -p pytest_plugins.execute.execute
+    -p pytest_plugins.logging.logging
     -p pytest_plugins.shared.execute_fill
     -p pytest_plugins.forks.forks
     -p pytest_plugins.pytest_hive.pytest_hive

--- a/pytest-execute.ini
+++ b/pytest-execute.ini
@@ -14,6 +14,7 @@ addopts =
     -p pytest_plugins.execute.pre_alloc
     -p pytest_plugins.solc.solc
     -p pytest_plugins.execute.execute
+    -p pytest_plugins.logging.logging
     -p pytest_plugins.shared.execute_fill
     -p pytest_plugins.execute.rpc.remote_seed_sender
     -p pytest_plugins.execute.rpc.remote

--- a/pytest.ini
+++ b/pytest.ini
@@ -15,6 +15,7 @@ addopts =
     -p pytest_plugins.filler.filler
     -p pytest_plugins.filler.static_filler
     -p pytest_plugins.filler.ported_tests
+    -p pytest_plugins.logging.logging
     -p pytest_plugins.shared.execute_fill
     -p pytest_plugins.forks.forks
     -p pytest_plugins.eels_resolver


### PR DESCRIPTION
## 🗒️ Description
This change was originally part of #1614 but was split out into a separate PR. Rationale: When using real blobs logging the entire RLP on error into console is not feasible, so this PR shortens the logged error to 50 chars in these cases. Also logs entire RLP to file (only when error is encountered).

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
