### PR TITLE
fix(ci): eliminate duplicate CI runs in tox workflow

### DIFF
--- a/.github/workflows/tox_verify.yaml
+++ b/.github/workflows/tox_verify.yaml
@@ -1,6 +1,14 @@
 name: Tox
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   lint:


### PR DESCRIPTION
## 🗒️ Description

This PR tries to eliminate the most obvious inefficiency in our current CI: Duplicated tox_verify runs, e.g.
![image](https://github.com/user-attachments/assets/1c88a908-7236-49ca-9377-ab954ae442e5)

It won't make individual jobs quicker, but it will stop jobs getting queued up and delaying CI for a PR. 

It eliminates redundant CI executions by:
- Limiting 'push' triggers to only the 'main' branch for post-merge verification.
- Using 'pull_request' for PR validation to run exactly once per commit.
- Adding concurrency control to cancel in-progress runs when new commits are pushed.

###  Before the change:

- Push to any branch → CI runs.
- Open/update PR → CI runs.
- Push to PR branch → CI runs twice (push + pull_request events).

### After the change:

- Push to main only → CI runs
- Push to any other branch without PR → No CI runs
- Open/update PR → CI runs once (pull_request event only)

###  Key differences:

1. ✅ Push to main: Still triggers CI (for post-merge verification)
2. ❌ Push to feature branch without PR: No longer triggers CI
3. ✅ PR commits: Triggers CI exactly once instead of twice
4. ✅ Merging branch into branch: Still works (via pull_request event)

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] ~~All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~ skipped
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

