### PR TITLE
chores(mypy): mypy ignore comments added to silence errors

### DIFF
--- a/src/pytest_plugins/filler/filler.py
+++ b/src/pytest_plugins/filler/filler.py
@@ -906,7 +906,7 @@ def base_test_parametrizer(cls: Type[BaseTest]):
                             "Make sure phase 1 (--generate-pre-alloc-groups) was run "
                             "before phase 2."
                         )
-                    group: PreAllocGroup = request.config.pre_alloc_groups[pre_alloc_hash]
+                    group: PreAllocGroup = request.config.pre_alloc_groups[pre_alloc_hash]  # type: ignore[annotation-unchecked]
                     self.pre = group.pre
 
                 fixture = self.generate(

--- a/src/pytest_plugins/filler/gen_test_doc/gen_test_doc.py
+++ b/src/pytest_plugins/filler/gen_test_doc/gen_test_doc.py
@@ -596,4 +596,4 @@ class TestDocsGenerator:
     def write_pages(self) -> None:
         """Write all pages to the target directory."""
         for page in self.page_props.values():
-            page.write_page(mkdocs_gen_files, self.jinja2_env)
+            page.write_page(mkdocs_gen_files, self.jinja2_env)  # type: ignore[arg-type]


### PR DESCRIPTION
## 🗒️ Description
As I commented [here](https://github.com/ethereum/execution-spec-tests/commit/d71dcc07c0bc6d5cd567171ac1c38a74044d684f#r159928912) I get 1 mypy `annotation-unchecked` warning and 4 `arg-type` errors. Since no one else complained and I do not know a fix for now we can silence those. However, generally we should try to fix these issues instead of silencing them. But I do think that reducing the amount of open issues and PRs in our repo is higher prio than removing usage of these silencer comments.

Mypy output before this PR:
```
uv run mypy
      Built ethereum-execution-spec-tests @ file:///home/user/Documents/execution-spec-tests
Uninstalled 1 package in 0.80ms
Installed 1 package in 1ms
src/pytest_plugins/filler/filler.py:909: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
src/pytest_plugins/filler/gen_test_doc/gen_test_doc.py:599: error: Argument 1 to "write_page" of "PagePropsBase" has incompatible type Module; expected "FileOpener"  [arg-type]
src/pytest_plugins/filler/gen_test_doc/gen_test_doc.py:599: error: Argument 1 to "write_page" of "FunctionPageProps" has incompatible type Module; expected "FileOpener"  [arg-type]
src/pytest_plugins/filler/gen_test_doc/gen_test_doc.py:599: error: Argument 1 to "write_page" of "MarkdownPageProps" has incompatible type Module; expected "FileOpener"  [arg-type]
src/pytest_plugins/filler/gen_test_doc/gen_test_doc.py:599: error: Argument 1 to "write_page" of "EipChecklistPageProps" has incompatible type Module; expected "FileOpener"  [arg-type]
Found 4 errors in 1 file (checked 670 source files)
```

Mypy output after this PR:
```
Success: no issues found in 670 source files
```

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
