### PR TITLE
chore(consume): retry logic for initial consume engine fcu

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -45,6 +45,7 @@ Users can select any of the artifacts depending on their testing needs for their
 
 - 🔀 `consume` now automatically avoids GitHub API calls when using direct release URLs (better for CI environments), while release specifiers like `stable@latest` continue to use the API for version resolution ([#1788](https://github.com/ethereum/execution-spec-tests/pull/1788)).
 - 🔀 Refactor consume simulator architecture to use explicit pytest plugin structure with forward-looking architecture ([#1801](https://github.com/ethereum/execution-spec-tests/pull/1801)).
+- 🔀 Add exponential retry logic to initial fcu within consume engine ([#1815](https://github.com/ethereum/execution-spec-tests/pull/1815)).
 
 #### `execute`
 

--- a/src/pytest_plugins/consume/simulators/hive_tests/test_via_engine.py
+++ b/src/pytest_plugins/consume/simulators/hive_tests/test_via_engine.py
@@ -5,6 +5,8 @@ from the Engine API. The simulator uses the `BlockchainEngineFixtures` to test a
 Each `engine_newPayloadVX` is verified against the appropriate VALID/INVALID responses.
 """
 
+import time
+
 from ethereum_test_exceptions import UndefinedException
 from ethereum_test_fixtures import BlockchainEngineFixture
 from ethereum_test_rpc import EngineRPC, EthRPC
@@ -42,16 +44,28 @@ def test_blockchain_via_engine(
     # Send a initial forkchoice update
     with timing_data.time("Initial forkchoice update"):
         logger.info("Sending initial forkchoice update to genesis block...")
-        forkchoice_response = engine_rpc.forkchoice_updated(
-            forkchoice_state=ForkchoiceState(
-                head_block_hash=fixture.genesis.block_hash,
-            ),
-            payload_attributes=None,
-            version=fixture.payloads[0].forkchoice_updated_version,
-        )
-        status = forkchoice_response.payload_status.status
-        logger.info(f"Initial forkchoice update response: {status}")
+        delay = 0.5
+        for attempt in range(3):
+            forkchoice_response = engine_rpc.forkchoice_updated(
+                forkchoice_state=ForkchoiceState(
+                    head_block_hash=fixture.genesis.block_hash,
+                ),
+                payload_attributes=None,
+                version=fixture.payloads[0].forkchoice_updated_version,
+            )
+            status = forkchoice_response.payload_status.status
+            logger.info(f"Initial forkchoice update response attempt {attempt + 1}: {status}")
+            if status != PayloadStatusEnum.SYNCING:
+                break
+            if attempt < 2:
+                time.sleep(delay)
+                delay *= 2
+
         if forkchoice_response.payload_status.status != PayloadStatusEnum.VALID:
+            logger.error(
+                f"Client failed to initialize properly after 3 attempts, "
+                f"final status: {forkchoice_response.payload_status.status}"
+            )
             raise LoggedError(
                 f"unexpected status on forkchoice updated to genesis: {forkchoice_response}"
             )


### PR DESCRIPTION
## 🗒️ Description

Adds a simple exponential retry for the initial fcu within consume engine.

Using generic retry logic on all RPC calls were considered via #1532, however, this case specifically requires us keep calling the initial fcu until the client is no longer syncing. There may be cases in the future where we want to check syncing in other scenarios.

Following a comment from @danceratopz:
> Hive allows the simulator to define a "check live port" which is used to verify that the client has finished starting up: 
> https://github.com/ethereum/execution-spec-tests/blob/851f9f5bc88d25f869a7fcd7798b10b9c5bceb7e/src/pytest_plugins/consume/simulators/single_test_client.py#L34-L47
> For the engine simulator it's 8551, for example:
> https://github.com/ethereum/execution-spec-tests/blob/851f9f5bc88d25f869a7fcd7798b10b9c5bceb7e/src/pytest_plugins/consume/simulators/base.py#L24-L33

A clients engine port can be live after start up, but does not necessarily mean they are ready to accept all engine requests "properly". In the case for Erigon who prompted the latter, they have an occasional flakey test where their engine port is live, but the client needs some more time to finish syncing.

This retry logic should fix the issue with the Erigon flakey test issues, as now we wait for the client to finish syncing after start up. Note this won't be an issue in consume enginex or consume rlp.


## 🔗 Related Issues or PRs

#1532

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).