### PR TITLE
chore(ci): Add self hosted runner to Ubuntu tests_deployed Github workflow

### DIFF
--- a/.github/workflows/tox_verify.yaml
+++ b/.github/workflows/tox_verify.yaml
@@ -139,14 +139,16 @@ jobs:
         run: uvx --with=tox-uv tox -e pytest
 
   tests_deployed:
-    name: Fill tests, deployed, ${{ matrix.os }}, ${{ matrix.python }}
+    name: Fill tests, deployed, ${{ matrix.name }}, ${{ matrix.python }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: [self-hosted-ghr, size-xl-x64]
+            name: self-hosted-ghr-xl-x64
             python: "3.11"
           - os: macos-latest
+            name: macos-latest
             python: "3.12"
     steps:
       - name: Checkout ethereum/execution-spec-tests


### PR DESCRIPTION
## 🗒️ Description

Added a self hosted runner to the longest running test: `Fill tests, deployed, ubuntu-latest, 3.11`. It looks like we can just specify a self-hosted runner and it will spin one up on demand. Explored adding a self-hosted runner to both unit tests and the zkevm tests, but neither one made a difference. This optimization saves ~5 minutes every run.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
    
Does this warrant an entry into the CHANGELOG?

- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).



