### PR TITLE
fix(github): Coverage check for modified files

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -133,7 +133,7 @@ jobs:
           ./.github/scripts/fill_introduced_tests.sh "$CHANGED_TEST_FILES" "${{ github.workspace }}/evmtest_coverage/coverage/PATCH_TESTS" "${{ env.BLOCK_GAS_LIMIT }}" "${{ env.FILL_UNTIL }}"
 
       - name: Parse and fill introduced test sources from before the PR
-        if: ${{ (steps.changed-tests.outputs.tests_any_modified == 'true' || steps.changed-tests.outputs.tests_any_deleted == 'true') && steps.ported-from.outputs.any_ported == 'false' }}
+        if: ${{ (steps.changed-tests.outputs.tests_modified_files_count != '0' || steps.changed-tests.outputs.tests_deleted_files_count != '0') && steps.ported-from.outputs.any_ported == 'false' }}
         id: pre-patch-fill
         env:
           MODIFIED_TEST_FILES: ${{ steps.changed-tests.outputs.tests_modified_files }}


### PR DESCRIPTION
## 🗒️ Description
Fixes the check for modified/deleted files when deciding whether to fill pre-patched tests

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).