### PR TITLE
feat(tests): extra stack operation test for CLZ opcode

### DIFF
--- a/tests/osaka/eip7939_count_leading_zeros/test_count_leading_zeros.py
+++ b/tests/osaka/eip7939_count_leading_zeros/test_count_leading_zeros.py
@@ -202,6 +202,32 @@ def test_clz_stack_underflow(state_test: StateTestFiller, pre: Alloc):
     state_test(pre=pre, post=post, tx=tx)
 
 
+@pytest.mark.valid_from("Osaka")
+def test_clz_stack_not_overflow(state_test: StateTestFiller, pre: Alloc, fork: Fork):
+    """Test CLZ opcode never causes stack overflow."""
+    max_stack_items = fork.max_stack_height()
+
+    code = Bytecode()
+    post = {}
+
+    code += Op.PUSH0 * (max_stack_items - 2)
+
+    for i in range(256):
+        code += Op.PUSH1(i) + Op.CLZ(1 << i) + Op.SWAP1 + Op.SSTORE
+
+    code_address = pre.deploy_contract(code=code)
+
+    post[code_address] = Account(storage={i: 255 - i for i in range(256)})
+
+    tx = Transaction(
+        to=code_address,
+        sender=pre.fund_eoa(),
+        gas_limit=6_000_000,
+    )
+
+    state_test(pre=pre, post=post, tx=tx)
+
+
 @pytest.mark.valid_at_transition_to("Osaka", subsequent_forks=True)
 def test_clz_fork_transition(blockchain_test: BlockchainTestFiller, pre: Alloc):
     """Test CLZ opcode behavior at fork transition."""

--- a/tests/osaka/eip7939_count_leading_zeros/test_count_leading_zeros.py
+++ b/tests/osaka/eip7939_count_leading_zeros/test_count_leading_zeros.py
@@ -228,26 +228,33 @@ def test_clz_stack_not_overflow(state_test: StateTestFiller, pre: Alloc, fork: F
     state_test(pre=pre, post=post, tx=tx)
 
 
-@pytest.mark.parametrize("bit", list(range(1, 33)))
 @pytest.mark.valid_from("Osaka")
-def test_clz_push_operation_same_value(state_test: StateTestFiller, pre: Alloc, bit: int):
+def test_clz_push_operation_same_value(state_test: StateTestFiller, pre: Alloc):
     """Test CLZ opcode returns the same value via different push operations."""
     code = Bytecode()
+    post = {}
 
-    for i in range(bit, 32):
-        op = getattr(Op, f"PUSH{i}")
-        code += Op.SSTORE(op[i], Op.CLZ(1 << bit))
+    for bit in range(1, 33):  # PUSH value
+        for push_n in range(bit, 33):  # PUSHn opcode
+            op = getattr(Op, f"PUSH{push_n}")
+            key = 100 * bit + push_n
+            code += Op.SSTORE(key, Op.CLZ(op[1 << bit]))
 
     code_address = pre.deploy_contract(code=code)
 
     tx = Transaction(
         to=code_address,
         sender=pre.fund_eoa(),
-        gas_limit=6_000_000,
+        gas_limit=30_000_000,
     )
 
-    post = {}
-    post[code_address] = Account(storage={i: 255 - bit for i in range(bit, 32)})
+    post = {
+        code_address: Account(
+            storage={
+                bit * 100 + push_n: 255 - bit for bit in range(1, 33) for push_n in range(bit, 33)
+            }
+        )
+    }
 
     state_test(pre=pre, post=post, tx=tx)
 


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

**Hardening Fusaka for EIP-7939**

Add two additional test cases for stack manipulation related to the CLZ (Count Leading Zeros) opcode:
1. No Stack Overflow
The CLZ operation must never cause a stack overflow, as it does not increase the number of items on the stack.
Test: Push 1022 items onto the stack, then execute CLZ 256 times while storing the result after each call. Ensure that no stack overflow occurs during this process.
2. Consistency Across Equivalent PUSH Operations
For the same numeric value pushed onto the stack, the CLZ opcode should yield the same result, regardless of which PUSH variant (PUSH1 to PUSH32) was used.
Examples:
- Pushing the value 0x01 using any PUSH1–PUSH32 should result in the same CLZ output.
- Pushing the value 0x0A000000 (10 00 00 00 in hex) using any PUSH4–PUSH32 should also produce a consistent result.


## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->

Issue https://github.com/ethereum/execution-spec-tests/issues/1795

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
