### PR TITLE
refactor(benchmark): don't mark the BLS12-381 tests for benchmarking

### DIFF
--- a/tests/prague/eip2537_bls_12_381_precompiles/conftest.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/conftest.py
@@ -1,6 +1,5 @@
 """Shared pytest definitions local to EIP-2537 tests."""
 
-from pathlib import Path
 from typing import SupportsBytes
 
 import pytest
@@ -11,13 +10,6 @@ from ethereum_test_tools import Opcodes as Op
 
 from .helpers import BLSPointGenerator
 from .spec import GAS_CALCULATION_FUNCTION_MAP
-
-
-def pytest_collection_modifyitems(config, items):
-    """Add the `zkevm` marker to all tests in `./tests/prague/eip2537_bls_12_381_precompiles`."""
-    for item in items:
-        if Path(__file__).parent in Path(item.fspath).parents:
-            item.add_marker(pytest.mark.zkevm)
 
 
 @pytest.fixture


### PR DESCRIPTION
## 🗒️ Description
This PR removes the automatic `zkevm` marker to `tests/prague/eip2537_bls_12_381_precompiles`.

We talked with @kevaundray, and these tests were an initial experiment for the zkEVM efforts, which later got more formalized in the `zkevm` folder. We propose removing them since BLS12381 precompiles are already more formally covered.

@danceratopz, please take a look, as I'm reverting the part of your PR that **I think** achieves what we want. :smile: 

## 🔗 Related Issues or PRs
- [Original PR that added them](https://github.com/ethereum/execution-spec-tests/pull/1514)
- [Later automatic marking](https://github.com/ethereum/execution-spec-tests/pull/1534)
