### PR TITLE
feat(tests): add jump operation test case for CLZ

### DIFF
--- a/tests/osaka/eip7939_count_leading_zeros/test_count_leading_zeros.py
+++ b/tests/osaka/eip7939_count_leading_zeros/test_count_leading_zeros.py
@@ -222,3 +222,50 @@ def test_clz_fork_transition(blockchain_test: BlockchainTestFiller, pre: Alloc):
             ),
         },
     )
+
+
+@pytest.mark.valid_from("Osaka")
+@pytest.mark.parametrize("cond_jump", [True, False])
+@pytest.mark.parametrize("success", [True, False])
+@pytest.mark.parametrize("bits", [0, 16, 64, 128, 255])
+def test_clz_jump_operation(
+    state_test: StateTestFiller, pre: Alloc, cond_jump: bool, success: bool, bits: int
+):
+    """Test CLZ opcode with valid and invalid jump."""
+    opcode = Op.JUMPI if cond_jump else Op.JUMP
+
+    code = Op.PUSH32(1 << bits)
+
+    if cond_jump:
+        code += Op.PUSH1(1)
+
+    code += Op.PUSH1(len(code) + 3) + opcode
+
+    if success:
+        code += Op.JUMPDEST
+
+    code += Op.CLZ + Op.PUSH0 + Op.SSTORE + Op.RETURN(0, 0)
+
+    callee_address = pre.deploy_contract(code=code)
+
+    caller_address = pre.deploy_contract(
+        code=Op.SSTORE(0, Op.CALL(gas=0xFFFF, address=callee_address)),
+        storage={"0x00": "0xdeadbeef"},
+    )
+
+    tx = Transaction(
+        to=caller_address,
+        sender=pre.fund_eoa(),
+        gas_limit=200_000,
+    )
+
+    expected_clz = 255 - bits
+
+    post = {
+        caller_address: Account(storage={"0x00": 1 if success else 0}),
+    }
+
+    if success:
+        post[callee_address] = Account(storage={"0x00": expected_clz})
+
+    state_test(pre=pre, post=post, tx=tx)

--- a/tests/osaka/eip7939_count_leading_zeros/test_count_leading_zeros.py
+++ b/tests/osaka/eip7939_count_leading_zeros/test_count_leading_zeros.py
@@ -225,18 +225,16 @@ def test_clz_fork_transition(blockchain_test: BlockchainTestFiller, pre: Alloc):
 
 
 @pytest.mark.valid_from("Osaka")
-@pytest.mark.parametrize("cond_jump", [True, False])
+@pytest.mark.parametrize("opcode", [Op.JUMPI, Op.JUMP])
 @pytest.mark.parametrize("success", [True, False])
 @pytest.mark.parametrize("bits", [0, 16, 64, 128, 255])
 def test_clz_jump_operation(
-    state_test: StateTestFiller, pre: Alloc, cond_jump: bool, success: bool, bits: int
+    state_test: StateTestFiller, pre: Alloc, opcode: Op, success: bool, bits: int
 ):
     """Test CLZ opcode with valid and invalid jump."""
-    opcode = Op.JUMPI if cond_jump else Op.JUMP
-
     code = Op.PUSH32(1 << bits)
 
-    if cond_jump:
+    if opcode == Op.JUMPI:
         code += Op.PUSH1(1)
 
     code += Op.PUSH1(len(code) + 3) + opcode

--- a/tests/osaka/eip7939_count_leading_zeros/test_count_leading_zeros.py
+++ b/tests/osaka/eip7939_count_leading_zeros/test_count_leading_zeros.py
@@ -226,20 +226,29 @@ def test_clz_fork_transition(blockchain_test: BlockchainTestFiller, pre: Alloc):
 
 @pytest.mark.valid_from("Osaka")
 @pytest.mark.parametrize("opcode", [Op.JUMPI, Op.JUMP])
-@pytest.mark.parametrize("success", [True, False])
+@pytest.mark.parametrize("valid_jump", [True, False])
+@pytest.mark.parametrize("jumpi_condition", [True, False])
 @pytest.mark.parametrize("bits", [0, 16, 64, 128, 255])
 def test_clz_jump_operation(
-    state_test: StateTestFiller, pre: Alloc, opcode: Op, success: bool, bits: int
+    state_test: StateTestFiller,
+    pre: Alloc,
+    opcode: Op,
+    valid_jump: bool,
+    jumpi_condition: bool,
+    bits: int,
 ):
     """Test CLZ opcode with valid and invalid jump."""
+    if opcode == Op.JUMP and not jumpi_condition:
+        pytest.skip("Duplicate case for JUMP.")
+
     code = Op.PUSH32(1 << bits)
 
     if opcode == Op.JUMPI:
-        code += Op.PUSH1(1)
+        code += Op.PUSH1(jumpi_condition)
 
     code += Op.PUSH1(len(code) + 3) + opcode
 
-    if success:
+    if valid_jump:
         code += Op.JUMPDEST
 
     code += Op.CLZ + Op.PUSH0 + Op.SSTORE + Op.RETURN(0, 0)
@@ -260,10 +269,10 @@ def test_clz_jump_operation(
     expected_clz = 255 - bits
 
     post = {
-        caller_address: Account(storage={"0x00": 1 if success else 0}),
+        caller_address: Account(storage={"0x00": 1 if valid_jump or not jumpi_condition else 0}),
     }
 
-    if success:
+    if valid_jump or not jumpi_condition:
         post[callee_address] = Account(storage={"0x00": expected_clz})
 
     state_test(pre=pre, post=post, tx=tx)


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Add two extra scenario:

1. JUMP and JUMPI operation
2. If the jump operation jumps to valid/invalid desitnation -> valid: `JUMPDEST`, invalid: `CLZ`

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->

Issue https://github.com/ethereum/execution-spec-tests/issues/1795

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
