### PR TITLE
chore(fw): get weld-ready w/minor fixes to remove dead code 

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,7 @@ Users can select any of the artifacts depending on their testing needs for their
 
 - 🔀 Move `TransactionType` enum from test file to proper module location in `ethereum_test_types.transaction_types` for better code organization and reusability.
 - ✨ Opcode classes now validate keyword arguments and raise `ValueError` with clear error messages.
+- 🐞 Clean up unused parameters in various functions
 
 #### `fill`
 

--- a/src/ethereum_test_checklists/tests/test_checklist_template_consistency.py
+++ b/src/ethereum_test_checklists/tests/test_checklist_template_consistency.py
@@ -32,7 +32,7 @@ def extract_markdown_ids(markdown_content: str) -> Set[str]:
     return ids
 
 
-def get_all_checklist_ids(obj, current_path="") -> Set[str]:
+def get_all_checklist_ids(obj) -> Set[str]:
     """Recursively extract all checklist IDs from EIPChecklist and its children."""
     ids = set()
 

--- a/src/pytest_plugins/consume/tests/test_consume_args.py
+++ b/src/pytest_plugins/consume/tests/test_consume_args.py
@@ -75,7 +75,7 @@ def fill_tests(
 
 
 @pytest.fixture(autouse=True, scope="function")
-def test_fixtures(pytester: Pytester, fixtures_dir: Path, fill_tests: None) -> List[Path]:
+def test_fixtures(pytester: Pytester, fixtures_dir: Path) -> List[Path]:
     """
     Copy test fixtures from the regular temp path to the pytester temporary dir.
 

--- a/src/pytest_plugins/eels_resolver.py
+++ b/src/pytest_plugins/eels_resolver.py
@@ -59,7 +59,7 @@ def pytest_configure(config: pytest.Config) -> None:
     config._eels_resolutions_file = eels_resolutions_file  # type: ignore
 
 
-def pytest_report_header(config: pytest.Config, startdir: Path) -> str:
+def pytest_report_header(config: pytest.Config) -> str:
     """
     Report the EELS_RESOLUTIONS_FILE path to the pytest report header.
 


### PR DESCRIPTION
## 🗒️ Description
Remove some method params which were not being used. 

## 🔗 Related Issues or PRs
Related to The Weld, testing the waters for applying Vulture to EEST.

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).