### PR TITLE
bug(forks): add valid opcodes for Osaka

### DIFF
--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -1376,6 +1376,15 @@ class Osaka(Prague, solc_name="cancun"):
         return False
 
     @classmethod
+    def valid_opcodes(
+        cls,
+    ) -> List[Opcodes]:
+        """Return list of Opcodes that are valid to work on this fork."""
+        return [
+            Opcodes.CLZ,
+        ] + super(Prague, cls).valid_opcodes()
+
+    @classmethod
     def solc_min_version(cls) -> Version:
         """Return minimum version of solc that supports this fork."""
         return Version.parse("1.0.0")  # set a high version; currently unknown


### PR DESCRIPTION
## 🗒️ Description
The Osaka fork introduced the new CLZ opcode. `valid_opcodes` in the fork need to be updated to reflect this.

## 🔗 Related Issues
#1826

## ✅ Checklist

- [x] All: Set appropriate labels for the changes.
- [x] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.