### PR TITLE
feat(tests): add call operation test case for CLZ

### DIFF
--- a/tests/osaka/eip7939_count_leading_zeros/test_count_leading_zeros.py
+++ b/tests/osaka/eip7939_count_leading_zeros/test_count_leading_zeros.py
@@ -566,17 +566,16 @@ def test_clz_call_operation(
     state_test: StateTestFiller, pre: Alloc, opcode: Op, context: CallingContext, bits: int
 ):
     """Test CLZ opcode with call operation."""
-    callee_code = Op.PUSH32(1 << bits) + Op.DUP1
+    callee_code = Op.PUSH32(1 << bits) + Op.CLZ
 
     if context != CallingContext.no_context:
-        callee_code += Op.CLZ + Op.PUSH0 + Op.SSTORE
+        callee_code += Op.DUP1 + Op.PUSH0 + Op.SSTORE
 
-    callee_code += Op.CLZ + Op.PUSH0 + Op.MSTORE + Op.RETURN(0, 32)
+    callee_code += Op.PUSH0 + Op.MSTORE + Op.RETURN(0, 32)
 
     callee_address = pre.deploy_contract(code=callee_code)
 
     caller_code = opcode(gas=0xFFFF, address=callee_address, ret_offset=0, ret_size=0x20)
-    caller_code += Op.RETURNDATACOPY(dest=0, offset=0, size=Op.RETURNDATASIZE)
     caller_code += Op.SSTORE(key=1, value=Op.MLOAD(0))
 
     caller_address = pre.deploy_contract(code=caller_code)


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Add `CALL`/`DELEGATECALL`/`STATICCALL`/`CODECALL` opcode interaction with CLZ

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->

Issue https://github.com/ethereum/execution-spec-tests/issues/1795

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
