### PR TITLE
bug(tests): enforce transaction gas limit in Osaka

### DIFF
--- a/tests/cancun/eip5656_mcopy/test_mcopy_memory_expansion.py
+++ b/tests/cancun/eip5656_mcopy/test_mcopy_memory_expansion.py
@@ -115,11 +115,17 @@ def block_gas_limit() -> int:  # noqa: D103
 
 @pytest.fixture
 def tx_gas_limit(  # noqa: D103
+    fork: Fork,
     call_exact_cost: int,
     block_gas_limit: int,
     successful: bool,
 ) -> int:
-    return min(call_exact_cost - (0 if successful else 1), block_gas_limit)
+    return min(
+        call_exact_cost - (0 if successful else 1),
+        # If the transaction gas limit cap is not set (pre-osaka),
+        # use the block gas limit
+        fork.transaction_gas_limit_cap() or block_gas_limit,
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
## 🗒️ Description
`test_mcopy_memory_expansion.py` tests assumes that there is not explicit transaction gas limit and that the transaction gas limit is just the same as the block gas limit. The osaka fork introduces an explicit transaction gas limit.

## 🔗 Related Issues or PRs
#1828

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).