### PR TITLE
tooling(fix): ruff autofix on save + filter static and unscheduled tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -61,6 +61,6 @@
       "tests/static": true
     },
     "files.watcherExclude": {
-      "tests/static": true,
+      "tests/static": true
     }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -58,7 +58,7 @@
     "ruff.logLevel": "error",
     "extensions.ignoreRecommendations": false,
     "search.exclude": {
-      "tests/static": true,
+      "tests/static": true
     },
     "files.watcherExclude": {
       "tests/static": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -59,10 +59,8 @@
     "extensions.ignoreRecommendations": false,
     "search.exclude": {
       "tests/static": true,
-      "tests/unscheduled": true,
     },
     "files.watcherExclude": {
       "tests/static": true,
-      "tests/unscheduled": true,
     }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,7 +18,8 @@
         "editor.formatOnSave": true,
         "editor.defaultFormatter": "charliermarsh.ruff",
         "editor.codeActionsOnSave": {
-            "source.organizeImports": "explicit"
+            "source.organizeImports": "explicit",
+            "source.fixAll.ruff": "explicit",
         },
     },
     "python.analysis.autoFormatStrings": true,
@@ -57,9 +58,11 @@
     "ruff.logLevel": "error",
     "extensions.ignoreRecommendations": false,
     "search.exclude": {
-      "tests/legacy": true
+      "tests/static": true,
+      "tests/unscheduled": true,
     },
     "files.watcherExclude": {
-      "tests/legacy": true
+      "tests/static": true,
+      "tests/unscheduled": true,
     }
 }


### PR DESCRIPTION
## 🗒️ Description
Yesterday I wasted CI resources because I forgot to manually remove an unused import even though I had saved the file. With this change ruff with autofix (includes removing unused imports) on save, so this should not happen again. 

This PR includes a second change, the folder `tests/legacy` does not exist anymore so we should instead skip the folders `tests/static` and `tests/unscheduled` 

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
