### PR TITLE
chore(tooling): change `ruff format`'s flag from `--diff` to `--check` in `tox.ini`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -58,7 +58,7 @@ setenv =
     DYLD_FALLBACK_LIBRARY_PATH = /opt/homebrew/lib
 commands = 
     ruff check --no-fix --show-fixes docs/scripts
-    ruff format --diff docs/scripts
+    ruff format --check docs/scripts
     mkdocs build --strict
 
 [testenv:pytest]


### PR DESCRIPTION
## 🗒️ Description
This PR replaces --diff with --check so that resulting print when everything is fine is not danger-red colored

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] ~~All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~ skipped
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

