### PR TITLE
feat(benchmark): add RETURN and REVERT coverage

### DIFF
--- a/tests/benchmark/test_worst_compute.py
+++ b/tests/benchmark/test_worst_compute.py
@@ -2290,7 +2290,8 @@ def test_worst_return_revert(
     # <Fill with INVALID opcodes up to the max contract size>
     # ```
     # Filling the contract up to the max size is a cheap way of leveraging CODECOPY to return
-    # non-zero bytes if requested.
+    # non-zero bytes if requested. Note that since this is a pre-deploy this cost isn't 
+    # relevant for the benchmark.
     mem_preparation = Bytecode() if not return_non_zero_data else Op.CODECOPY(size=return_size)
     executable_code = mem_preparation + opcode(size=return_size)
     code = executable_code + Op.INVALID * (max_code_size - len(executable_code))

--- a/tests/benchmark/test_worst_compute.py
+++ b/tests/benchmark/test_worst_compute.py
@@ -2292,7 +2292,7 @@ def test_worst_return_revert(
     # Filling the contract up to the max size is a cheap way of leveraging CODECOPY to return
     # non-zero bytes if requested. Note that since this is a pre-deploy this cost isn't 
     # relevant for the benchmark.
-    mem_preparation = Bytecode() if not return_non_zero_data else Op.CODECOPY(size=return_size)
+    mem_preparation = Op.CODECOPY(size=return_size) if return_non_zero_data else Bytecode() 
     executable_code = mem_preparation + opcode(size=return_size)
     code = executable_code + Op.INVALID * (max_code_size - len(executable_code))
     target_contract_address = pre.deploy_contract(code=code)

--- a/tests/benchmark/test_worst_compute.py
+++ b/tests/benchmark/test_worst_compute.py
@@ -2258,7 +2258,7 @@ def test_worst_push(
 
 @pytest.mark.parametrize(
     "opcode",
-    [ Op.RETURN, Op.REVERT],
+    [Op.RETURN, Op.REVERT],
 )
 @pytest.mark.parametrize(
     "return_size, return_non_zero_data",
@@ -2287,11 +2287,11 @@ def test_worst_return_revert(
     # ```
     # [CODECOPY(returned_size) -- Conditional if return_non_zero_data]
     # opcode(returned_size)
-    # <Fill with INVALID opcodes up to the max contract size> 
+    # <Fill with INVALID opcodes up to the max contract size>
     # ```
     # Filling the contract up to the max size is a cheap way of leveraging CODECOPY to return
     # non-zero bytes if requested.
-    mem_preparation = Bytecode() if not return_non_zero_data else Op.CODECOPY(size=return_size) 
+    mem_preparation = Bytecode() if not return_non_zero_data else Op.CODECOPY(size=return_size)
     executable_code = mem_preparation + opcode(size=return_size)
     code = executable_code + Op.INVALID * (max_code_size - len(executable_code))
     target_contract_address = pre.deploy_contract(code=code)

--- a/tests/benchmark/test_worst_compute.py
+++ b/tests/benchmark/test_worst_compute.py
@@ -2274,7 +2274,7 @@ def test_worst_return_revert(
     state_test: StateTestFiller,
     pre: Alloc,
     fork: Fork,
-    opcode : Op,
+    opcode: Op,
     return_size: int,
     return_non_zero_data: bool,
 ):
@@ -2294,7 +2294,9 @@ def test_worst_return_revert(
     # relevant for the benchmark.
     mem_preparation = Op.CODECOPY(size=return_size) if return_non_zero_data else Bytecode()
     executable_code = mem_preparation + opcode(size=return_size)
-    code = executable_code + Op.INVALID * (max_code_size - len(executable_code))
+    code = executable_code
+    if return_non_zero_data:
+        code += Op.INVALID * (max_code_size - len(executable_code))
     target_contract_address = pre.deploy_contract(code=code)
 
     calldata = Bytecode()

--- a/tests/benchmark/test_worst_compute.py
+++ b/tests/benchmark/test_worst_compute.py
@@ -2290,9 +2290,9 @@ def test_worst_return_revert(
     # <Fill with INVALID opcodes up to the max contract size>
     # ```
     # Filling the contract up to the max size is a cheap way of leveraging CODECOPY to return
-    # non-zero bytes if requested. Note that since this is a pre-deploy this cost isn't 
+    # non-zero bytes if requested. Note that since this is a pre-deploy this cost isn't
     # relevant for the benchmark.
-    mem_preparation = Op.CODECOPY(size=return_size) if return_non_zero_data else Bytecode() 
+    mem_preparation = Op.CODECOPY(size=return_size) if return_non_zero_data else Bytecode()
     executable_code = mem_preparation + opcode(size=return_size)
     code = executable_code + Op.INVALID * (max_code_size - len(executable_code))
     target_contract_address = pre.deploy_contract(code=code)

--- a/tests/benchmark/test_worst_compute.py
+++ b/tests/benchmark/test_worst_compute.py
@@ -2255,3 +2255,62 @@ def test_worst_push(
         post={},
         tx=tx,
     )
+
+@pytest.mark.parametrize(
+    "opcode",
+    [ Op.RETURN, Op.REVERT],
+)
+@pytest.mark.parametrize(
+    "return_size, return_non_zero_data",
+    [
+        pytest.param(0, False, id="empty"),
+        pytest.param(1024, True, id="1KiB of non-zero data"),
+        pytest.param(1024, False, id="1KiB of zero data"),
+        pytest.param(1024 * 1024, True, id="1MiB of non-zero data"),
+        pytest.param(1024 * 1024, False, id="1MiB of zero data"),
+    ],
+)
+def test_worst_return_revert(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    opcode : Op,
+    return_size: int,
+    return_non_zero_data: bool,
+):
+    """Test running a block with as many RETURN or REVERT as possible."""
+    env = Environment()
+    max_code_size = fork.max_code_size()
+
+    # Create the contract that will be called repeatedly.
+    # The bytecode of the contract is:
+    # ```
+    # [CODECOPY(returned_size) -- Conditional if return_non_zero_data]
+    # opcode(returned_size)
+    # <Fill with INVALID opcodes up to the max contract size> 
+    # ```
+    # Filling the contract up to the max size is a cheap way of leveraging CODECOPY to return
+    # non-zero bytes if requested.
+    mem_preparation = Bytecode() if not return_non_zero_data else Op.CODECOPY(size=return_size) 
+    executable_code = mem_preparation + opcode(size=return_size)
+    code = executable_code + Op.INVALID * (max_code_size - len(executable_code))
+    target_contract_address = pre.deploy_contract(code=code)
+
+    calldata = Bytecode()
+    attack_block = Op.POP(Op.STATICCALL(address=target_contract_address))
+    code = code_loop_precompile_call(calldata, attack_block, fork)
+    code_address = pre.deploy_contract(code=code)
+
+    tx = Transaction(
+        to=code_address,
+        gas_limit=env.gas_limit,
+        sender=pre.fund_eoa(),
+    )
+
+    state_test(
+        env=env,
+        pre=pre,
+        post={},
+        tx=tx,
+    )
+

--- a/tests/benchmark/test_worst_compute.py
+++ b/tests/benchmark/test_worst_compute.py
@@ -2256,6 +2256,7 @@ def test_worst_push(
         tx=tx,
     )
 
+
 @pytest.mark.parametrize(
     "opcode",
     [Op.RETURN, Op.REVERT],
@@ -2316,4 +2317,3 @@ def test_worst_return_revert(
         post={},
         tx=tx,
     )
-


### PR DESCRIPTION
## 🗒️ Description
This PR adds coverage for `RETURN` and `REVERT`.

Cycles:
```
test_worst_compute.py::test_worst_return_revert[fork_Cancun-blockchain_test_from_state_test-1MiB of zero data-opcode_REVERT]-1  19759096
test_worst_compute.py::test_worst_return_revert[fork_Cancun-blockchain_test_from_state_test-1MiB of zero data-opcode_RETURN]-1  19779138
test_worst_compute.py::test_worst_return_revert[fork_Cancun-blockchain_test_from_state_test-1MiB of non-zero data-opcode_RETURN]-1      24151658
test_worst_compute.py::test_worst_return_revert[fork_Cancun-blockchain_test_from_state_test-1MiB of non-zero data-opcode_REVERT]-1      24167501
test_worst_compute.py::test_worst_return_revert[fork_Cancun-blockchain_test_from_state_test-1KiB of non-zero data-opcode_RETURN]-1      1422016887
test_worst_compute.py::test_worst_return_revert[fork_Cancun-blockchain_test_from_state_test-1KiB of non-zero data-opcode_REVERT]-1      1523965132
test_worst_compute.py::test_worst_return_revert[fork_Cancun-blockchain_test_from_state_test-1KiB of zero data-opcode_RETURN]-1  1772597661
test_worst_compute.py::test_worst_return_revert[fork_Cancun-blockchain_test_from_state_test-1KiB of zero data-opcode_REVERT]-1  1923938441
test_worst_compute.py::test_worst_return_revert[fork_Cancun-blockchain_test_from_state_test-empty-opcode_RETURN]-1      2506531667
test_worst_compute.py::test_worst_return_revert[fork_Cancun-blockchain_test_from_state_test-empty-opcode_REVERT]-1      2776483689
```

## 🔗 Related Issues or PRs
#1689 
