### PR TITLE
feat(benchmark): add coverage for CREATE and CREATE2

### DIFF
--- a/tests/benchmark/test_worst_bytecode.py
+++ b/tests/benchmark/test_worst_bytecode.py
@@ -427,7 +427,7 @@ def test_worst_create(
 
     tx = Transaction(
         # Set enough balance in the pre-alloc for `value > 0` configurations.
-        to=pre.deploy_contract(code=code, balance=1_000_000_000),
+        to=pre.deploy_contract(code=code, balance=1_000_000_000 if value > 0 else 0),
         gas_limit=env.gas_limit,
         sender=pre.fund_eoa(),
     )

--- a/tests/benchmark/test_worst_bytecode.py
+++ b/tests/benchmark/test_worst_bytecode.py
@@ -445,7 +445,7 @@ def test_worst_create(
     "opcode",
     [
         Op.CREATE,
-        Op.CREATE2,
+        # Op.CREATE2,
     ],
 )
 def test_worst_creates_collisions(
@@ -468,7 +468,7 @@ def test_worst_creates_collisions(
     padded_init_code = init_code + b"\x00" * (32 - init_code_size)
     # The proxy contract basically does a quick MSTORE to configure the init code and
     # calls CREATE2 with such init code. The current call frame gas will be exhausted because of
-    # the collission. For this reason the caller will carefully give us the minimal gas necessary
+    # the collision. For this reason the caller will carefully give us the minimal gas necessary
     # to execute the CREATE2 and not waste any extra gas in the CREATE2-failure.
     proxy_contract = pre.deploy_contract(
         code=Op.MSTORE(0, Bytes(padded_init_code))

--- a/tests/benchmark/test_worst_bytecode.py
+++ b/tests/benchmark/test_worst_bytecode.py
@@ -9,7 +9,6 @@ import math
 
 import pytest
 
-from ethereum_test_base_types.base_types import Bytes
 from ethereum_test_forks import Fork
 from ethereum_test_tools import (
     Account,
@@ -453,9 +452,9 @@ def test_worst_creates_collisions(
     # consume all the available gas. If we try to execute the CREATE(2) directly without being
     # wrapped **and capped in gas** in a previous CALL, we would run out of gas very fast!
     #
-    # The proxy contract calls CREATE(2) with empty initcode. The current call frame gas will 
-    # be exhausted because of the collision. For this reason the caller will carefully give us 
-    # the minimal gas necessary to execute the CREATE(2) and not waste any extra gas in the 
+    # The proxy contract calls CREATE(2) with empty initcode. The current call frame gas will
+    # be exhausted because of the collision. For this reason the caller will carefully give us
+    # the minimal gas necessary to execute the CREATE(2) and not waste any extra gas in the
     # CREATE(2)-failure.
     #
     # Note that these CREATE(2) calls will fail because in (**) below we pre-alloc contracts
@@ -475,7 +474,7 @@ def test_worst_creates_collisions(
         # DUP7 refers to the PUSH3 above.
         # DUP7 refers to the proxy contract address.
         Op.CALL(gas=Op.DUP7, address=Op.DUP7)
-    )  
+    )
     code = code_loop_precompile_call(code_prefix, attack_block, fork)
     tx_target = pre.deploy_contract(code=code)
 

--- a/tests/benchmark/test_worst_bytecode.py
+++ b/tests/benchmark/test_worst_bytecode.py
@@ -445,7 +445,7 @@ def test_worst_create(
     "opcode",
     [
         Op.CREATE,
-        # Op.CREATE2,
+        Op.CREATE2,
     ],
 )
 def test_worst_creates_collisions(


### PR DESCRIPTION
## 🗒️ Description
This PR adds coverage for opcodes `CREATE` and `CREATE2`. This includes both successful executions and collision failures.

Cycles:
```
test_worst_bytecode.py::test_worst_create[fork_Cancun-blockchain_test_from_state_test-max code size with zero data-opcode_CREATE]-1     3323528
test_worst_bytecode.py::test_worst_create[fork_Cancun-blockchain_test_from_state_test-0.75x max code size with zero data-opcode_CREATE]-1       3337862
test_worst_bytecode.py::test_worst_create[fork_Cancun-blockchain_test_from_state_test-max code size with zero data-opcode_CREATE2]-1    3376118
test_worst_bytecode.py::test_worst_create[fork_Cancun-blockchain_test_from_state_test-0.75x max code size with zero data-opcode_CREATE2]-1      3377367
test_worst_bytecode.py::test_worst_create[fork_Cancun-blockchain_test_from_state_test-0.50x max code size with zero data-opcode_CREATE]-1       3492970
test_worst_bytecode.py::test_worst_create[fork_Cancun-blockchain_test_from_state_test-0.50x max code size with zero data-opcode_CREATE2]-1      3520195
test_worst_bytecode.py::test_worst_create[fork_Cancun-blockchain_test_from_state_test-max code size with non-zero data-opcode_CREATE]-1 3668296
test_worst_bytecode.py::test_worst_create[fork_Cancun-blockchain_test_from_state_test-0.75x max code size with non-zero data-opcode_CREATE]-1   3673238
test_worst_bytecode.py::test_worst_create[fork_Cancun-blockchain_test_from_state_test-max code size with non-zero data-opcode_CREATE2]-1        3706400
test_worst_bytecode.py::test_worst_create[fork_Cancun-blockchain_test_from_state_test-0.75x max code size with non-zero data-opcode_CREATE2]-1  3750360
test_worst_bytecode.py::test_worst_create[fork_Cancun-blockchain_test_from_state_test-0.25x max code size with zero data-opcode_CREATE]-1       3815778
test_worst_bytecode.py::test_worst_create[fork_Cancun-blockchain_test_from_state_test-0.50x max code size with non-zero data-opcode_CREATE]-1   3836720
test_worst_bytecode.py::test_worst_create[fork_Cancun-blockchain_test_from_state_test-0.25x max code size with zero data-opcode_CREATE2]-1      3863527
test_worst_bytecode.py::test_worst_create[fork_Cancun-blockchain_test_from_state_test-0.50x max code size with non-zero data-opcode_CREATE2]-1  3882151
test_worst_bytecode.py::test_worst_create[fork_Cancun-blockchain_test_from_state_test-0.25x max code size with non-zero data-opcode_CREATE]-1   4180398
test_worst_bytecode.py::test_worst_create[fork_Cancun-blockchain_test_from_state_test-0.25x max code size with non-zero data-opcode_CREATE2]-1  4242967
test_worst_bytecode.py::test_worst_creates_collisions[fork_Cancun-blockchain_test_from_state_test-opcode_CREATE2]-1     20350067
test_worst_bytecode.py::test_worst_create[fork_Cancun-blockchain_test_from_state_test-0 bytes without value-opcode_CREATE]-1    25581781
test_worst_bytecode.py::test_worst_create[fork_Cancun-blockchain_test_from_state_test-0 bytes with value-opcode_CREATE]-1       25600400
test_worst_bytecode.py::test_worst_create[fork_Cancun-blockchain_test_from_state_test-0 bytes without value-opcode_CREATE2]-1   26995607
test_worst_bytecode.py::test_worst_create[fork_Cancun-blockchain_test_from_state_test-0 bytes with value-opcode_CREATE2]-1      27014351
test_worst_bytecode.py::test_worst_creates_collisions[fork_Cancun-blockchain_test_from_state_test-opcode_CREATE]-1      49330692
```

## 🔗 Related Issues or PRs
#1689
