### PR TITLE
fix(consume): fix consume cache's --cache-folder flag

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -46,6 +46,7 @@ Users can select any of the artifacts depending on their testing needs for their
 
 #### `consume`
 
+- 🐞 Fix `consume cache --cache-folder` parameter being ignored, now properly caches fixtures in the specified directory instead of always using the default system cache location.
 - 🔀 `consume` now automatically avoids GitHub API calls when using direct release URLs (better for CI environments), while release specifiers like `stable@latest` continue to use the API for version resolution ([#1788](https://github.com/ethereum/execution-spec-tests/pull/1788)).
 - 🔀 Refactor consume simulator architecture to use explicit pytest plugin structure with forward-looking architecture ([#1801](https://github.com/ethereum/execution-spec-tests/pull/1801)).
 - 🔀 Add exponential retry logic to initial fcu within consume engine ([#1815](https://github.com/ethereum/execution-spec-tests/pull/1815)).

--- a/src/pytest_plugins/consume/tests/test_fixtures_source_input_types.py
+++ b/src/pytest_plugins/consume/tests/test_fixtures_source_input_types.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from pytest_plugins.consume.consume import FixturesSource
+from pytest_plugins.consume.consume import CACHED_DOWNLOADS_DIRECTORY, FixturesSource
 
 
 class TestSimplifiedConsumeBehavior:
@@ -141,7 +141,7 @@ class TestFixturesSourceFromInput:
 
             FixturesSource.from_input(test_url)
 
-            mock_from_release_url.assert_called_once_with(test_url)
+            mock_from_release_url.assert_called_once_with(test_url, CACHED_DOWNLOADS_DIRECTORY)
 
     def test_from_input_handles_release_spec(self):
         """Test that from_input properly handles release specs."""
@@ -152,7 +152,7 @@ class TestFixturesSourceFromInput:
 
             FixturesSource.from_input(test_spec)
 
-            mock_from_release_spec.assert_called_once_with(test_spec)
+            mock_from_release_spec.assert_called_once_with(test_spec, CACHED_DOWNLOADS_DIRECTORY)
 
     def test_from_input_handles_regular_url(self):
         """Test that from_input properly handles regular URLs."""
@@ -163,4 +163,4 @@ class TestFixturesSourceFromInput:
 
             FixturesSource.from_input(test_url)
 
-            mock_from_url.assert_called_once_with(test_url)
+            mock_from_url.assert_called_once_with(test_url, CACHED_DOWNLOADS_DIRECTORY)


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
* Adds cache_folder parameter to all FixturesSource.from_* methods
* Updates pytest_configure to pass the user-provided cache folder
* Updates existing tests to work with the new parameter signature

## 🔗 Related Issues or PRs
Fixes #1834

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
