### PR TITLE
fix(tests): fix invalid log opcode keyword 7702 fails

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,11 +27,6 @@ Users can select any of the artifacts depending on their testing needs for their
 
 ### 🛠️ Framework
 
-#### 🔀 Refactoring
-
-- 🔀 Move `TransactionType` enum from test file to proper module location in `ethereum_test_types.transaction_types` for better code organization and reusability.
-- ✨ Opcode classes now validate keyword arguments and raise `ValueError` with clear error messages.
-
 #### `fill`
 
 - ✨ Add the `ported_from` test marker to track Python test cases that were converted from static fillers in [ethereum/tests](https://github.com/ethereum/tests) repository ([#1590](https://github.com/ethereum/execution-spec-tests/pull/1590)).
@@ -79,6 +74,8 @@ Users can select any of the artifacts depending on their testing needs for their
 - 🔀 Refactor and clean up of exceptions including EOF exceptions within client specific mappers [#1803](https://github.com/ethereum/execution-spec-tests/pull/1803).
 - 🔀 Rename `tests/zkevm/` to `tests/benchmark/` and replace the `zkevm` pytest mark with `benchmark` [#1804](https://github.com/ethereum/execution-spec-tests/pull/1804).
 - 🔀 Add fixture comparison check to optimize coverage workflow in CI ([#1833](https://github.com/ethereum/execution-spec-tests/pull/1833)).
+- 🔀 Move `TransactionType` enum from test file to proper module location in `ethereum_test_types.transaction_types` for better code organization and reusability ([#1763](https://github.com/ethereum/execution-spec-tests/pull/1673)).
+- ✨ Opcode classes now validate keyword arguments and raise `ValueError` with clear error messages ([#1739](https://github.com/ethereum/execution-spec-tests/pull/1739), [#1856](https://github.com/ethereum/execution-spec-tests/pull/1856)).
 
 ### 🧪 Test Cases
 

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -2496,9 +2496,9 @@ def test_set_code_to_log(
     sender = pre.fund_eoa()
 
     log_kwargs = {}
-    if "topic_1" not in log_opcode.kwargs:
+    if "topic_1" in log_opcode.kwargs:
         log_kwargs["topic_1"] = 1
-    if "topic_2" not in log_opcode.kwargs:
+    if "topic_2" in log_opcode.kwargs:
         log_kwargs["topic_2"] = 2
     if "topic_3" in log_opcode.kwargs:
         log_kwargs["topic_3"] = 3


### PR DESCRIPTION
## 🗒️ Description

- Fix fails while filling due to invalid LOG opcode kw arg fails.
- Fix-up changelog: Add missing links to the PR; Remove "Refactoring" subsection. Both Claude hiccups.

@marioevz @spencer-tb we need bump Prague to deployed and fill Prague in CI :cry: 

## 🔗 Related Issues or PRs
Small fix-up to:
- #1739

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

