### PR TITLE
refactor(tests): double P256VERIFY gas constant

### DIFF
--- a/tests/osaka/eip7951_p256verify_precompiles/spec.py
+++ b/tests/osaka/eip7951_p256verify_precompiles/spec.py
@@ -91,7 +91,7 @@ class Spec:
     P256VERIFY = 0x100
 
     # Gas constants
-    P256VERIFY_GAS = 3450
+    P256VERIFY_GAS = 6900
 
     # Curve Parameters
     P = 0xFFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFF  ## Base field modulus


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Follow up ACDE#215 meeting, the gas cost of the `P256VERIFY` double down from 3450 to 6900.

Notes from ETH Magician: https://ethereum-magicians.org/t/allcoredevs-execution-acde-215-july-3-2025/24701/4?u=timbeiko

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->

EIP update PR: https://github.com/ethereum/EIPs/pull/9978/files

Execution Spec PR: https://github.com/ethereum/execution-specs/pull/1304

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

