### PR TITLE
feat(tests): add codecopy and extcodecopy for clz opcode

### DIFF
--- a/tests/osaka/eip7939_count_leading_zeros/spec.py
+++ b/tests/osaka/eip7939_count_leading_zeros/spec.py
@@ -18,6 +18,7 @@ ref_spec_7939 = ReferenceSpec("EIPS/eip-7939.md", "c8321494fdfbfda52ad46c3515a7c
 class Spec:
     """Constants and helpers for the CLZ opcode."""
 
+    CLZ = 0x1E
     CLZ_GAS_COST = 5
 
     @classmethod

--- a/tests/osaka/eip7939_count_leading_zeros/test_count_leading_zeros.py
+++ b/tests/osaka/eip7939_count_leading_zeros/test_count_leading_zeros.py
@@ -357,3 +357,53 @@ def test_clz_code_copy_operation(state_test: StateTestFiller, pre: Alloc, bits: 
     )
 
     state_test(pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.valid_from("Osaka")
+@pytest.mark.parametrize("bits", [0, 16, 64, 128, 255])
+@pytest.mark.parametrize("opcode", [Op.CODECOPY, Op.EXTCODECOPY])
+def test_clz_with_memory_operation(state_test: StateTestFiller, pre: Alloc, bits: int, opcode: Op):
+    """Test CLZ opcode with memory operation."""
+    storage = Storage()
+
+    expected_value = 255 - bits
+
+    # Target code pattern:
+    #   PUSH32 (1 << bits)
+    #   PUSH0
+    #   MSTORE
+    #
+    # This sequence stores a 32-byte value in memory.
+    # Later, we copy the immediate value from the PUSH32 instruction into memory
+    # using CODECOPY or EXTCODECOPY, and then load it with MLOAD for the CLZ test.
+    target_code = Op.MSTORE(0, Op.PUSH32(1 << bits))
+    offset = 1
+
+    target_address = pre.deploy_contract(code=target_code)
+
+    clz_contract_address = pre.deploy_contract(
+        code=(
+            target_code
+            + Op.SSTORE(storage.store_next(expected_value), expected_value)  # Store CLZ result
+            + (
+                Op.CODECOPY(dest_offset=0, offset=offset, size=0x20)
+                if opcode == Op.CODECOPY
+                else Op.EXTCODECOPY(
+                    address=target_address, dest_offset=0, offset=offset, size=0x20
+                )
+            )
+            + Op.SSTORE(storage.store_next(expected_value), Op.CLZ(Op.MLOAD(0)))
+        )
+    )
+
+    post = {
+        clz_contract_address: Account(storage={"0x00": expected_value, "0x01": expected_value}),
+    }
+
+    tx = Transaction(
+        to=clz_contract_address,
+        sender=pre.fund_eoa(),
+        gas_limit=200_000,
+    )
+
+    state_test(pre=pre, post=post, tx=tx)

--- a/tests/osaka/eip7939_count_leading_zeros/test_count_leading_zeros.py
+++ b/tests/osaka/eip7939_count_leading_zeros/test_count_leading_zeros.py
@@ -314,60 +314,6 @@ def test_clz_jump_operation(
 
 
 @pytest.mark.valid_from("Osaka")
-@pytest.mark.parametrize("opcode", [Op.JUMPI, Op.JUMP])
-@pytest.mark.parametrize("valid_jump", [True, False])
-@pytest.mark.parametrize("jumpi_condition", [True, False])
-@pytest.mark.parametrize("bits", [0, 16, 64, 128, 255])
-def test_clz_jump_operation(
-    state_test: StateTestFiller,
-    pre: Alloc,
-    opcode: Op,
-    valid_jump: bool,
-    jumpi_condition: bool,
-    bits: int,
-):
-    """Test CLZ opcode with valid and invalid jump."""
-    if opcode == Op.JUMP and not jumpi_condition:
-        pytest.skip("Duplicate case for JUMP.")
-
-    code = Op.PUSH32(1 << bits)
-
-    if opcode == Op.JUMPI:
-        code += Op.PUSH1(jumpi_condition)
-
-    code += Op.PUSH1(len(code) + 3) + opcode
-
-    if valid_jump:
-        code += Op.JUMPDEST
-
-    code += Op.CLZ + Op.PUSH0 + Op.SSTORE + Op.RETURN(0, 0)
-
-    callee_address = pre.deploy_contract(code=code)
-
-    caller_address = pre.deploy_contract(
-        code=Op.SSTORE(0, Op.CALL(gas=0xFFFF, address=callee_address)),
-        storage={"0x00": "0xdeadbeef"},
-    )
-
-    tx = Transaction(
-        to=caller_address,
-        sender=pre.fund_eoa(),
-        gas_limit=200_000,
-    )
-
-    expected_clz = 255 - bits
-
-    post = {
-        caller_address: Account(storage={"0x00": 1 if valid_jump or not jumpi_condition else 0}),
-    }
-
-    if valid_jump or not jumpi_condition:
-        post[callee_address] = Account(storage={"0x00": expected_clz})
-
-    state_test(pre=pre, post=post, tx=tx)
-
-
-@pytest.mark.valid_from("Osaka")
 @pytest.mark.parametrize("bits", [0, 64, 255])
 @pytest.mark.parametrize("opcode", [Op.CODECOPY, Op.EXTCODECOPY])
 def test_clz_code_copy_operation(state_test: StateTestFiller, pre: Alloc, bits: int, opcode: Op):

--- a/tests/osaka/eip7939_count_leading_zeros/test_count_leading_zeros.py
+++ b/tests/osaka/eip7939_count_leading_zeros/test_count_leading_zeros.py
@@ -339,7 +339,8 @@ def test_clz_code_copy_operation(state_test: StateTestFiller, pre: Alloc, bits: 
                 )
             )
             + Op.SSTORE(storage.store_next(mload_value), Op.MLOAD(0))  # Store loaded CLZ byte
-        )
+        ),
+        storage={"0x00": "0xdeadbeef"},
     )
 
     post = {
@@ -393,7 +394,8 @@ def test_clz_with_memory_operation(state_test: StateTestFiller, pre: Alloc, bits
                 )
             )
             + Op.SSTORE(storage.store_next(expected_value), Op.CLZ(Op.MLOAD(0)))
-        )
+        ),
+        storage={"0x00": "0xdeadbeef"},
     )
 
     post = {


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Add CODECOPY / EXTCODECOPY for CLZ opcode

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

Issue https://github.com/ethereum/execution-spec-tests/issues/1795

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).