### PR TITLE
feat(github): add benchmarks releases for 1M and 10M gas limit

### DIFF
--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -11,6 +11,16 @@ static:
   evm-type: static
   fill-params: --until=Prague --fill-static-tests ./tests/static
   solc: 0.8.21
+benchmark_1M:
+  evm-type: benchmark
+  fill-params: --from=Cancun --until=Prague --block-gas-limit 1000000 -m benchmark ./tests
+  solc: 0.8.21
+  feature_only: true
+benchmark_10M:
+  evm-type: benchmark
+  fill-params: --from=Cancun --until=Prague --block-gas-limit 10000000 -m benchmark ./tests
+  solc: 0.8.21
+  feature_only: true
 benchmark_30M:
   evm-type: benchmark
   fill-params: --from=Cancun --until=Prague --block-gas-limit 30000000 -m benchmark ./tests

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,7 +26,7 @@ The output behavior of `fill` has changed ([#1608](https://github.com/ethereum/e
 
 Due to the crossover between `zkevm` and `benchmark` tests, all instances of the former have been replaced with the latter nomenclature. Repository PR labels and titles are additionally updated to reflect this change.
 
-This update renames the `zkevm` feature release to `benchmark_30M` and further expands the latter for 60M, 90M, and 120M block gas limits in `fixtures_benchmark_30M.tar.gz`, `fixtures_benchmark_60M.tar.gz`, `fixtures_benchmark_90M.tar.gz`, and `fixtures_benchmark_120M.tar.gz` respectively.
+This update renames the `zkevm` feature release to `benchmark_30M` and further expands the latter for 1M, 10M, 60M, 90M, and 120M block gas limits in `fixtures_benchmark_1M.tar.gz`, `fixtures_benchmark_10M.tar.gz`, `fixtures_benchmark_30M.tar.gz`, `fixtures_benchmark_60M.tar.gz`, `fixtures_benchmark_90M.tar.gz`, and `fixtures_benchmark_120M.tar.gz` respectively.
 
 Users can select any of the artifacts depending on their testing needs for their provers.
 


### PR DESCRIPTION
## 🗒️ Description
This PR proposes adding two extra "low gas" cases for being included in benchmark releases.

The motivation is that for zkEVMs using the benchmarks, it is helpful to have low gas cases to:
- Be able to have CI pipelines that don't take so much time.
- We're validating the assumption that proving times are linearly related to gas costs. If this is the case, it would be acceptable to run experiments with gas cost changes on lower gas and obtain results faster (e.g., 1M or 10M, depending on whether it is a single GPU or multi-GPU prover).

I think 1M and 10M are reasonable. I was tempted to include a 500k but I think we can avoid it for now, and let reality tell us better (e.g., maybe in the future is better to change 1M to 500k instead of adding 500k, etc).

cc @kevaundray 