### PR TITLE
chore(cli): show sub-command help string in `execute --help` output

### DIFF
--- a/src/cli/pytest_commands/execute.py
+++ b/src/cli/pytest_commands/execute.py
@@ -31,7 +31,7 @@ def _create_execute_subcommand(
         context_settings={"ignore_unknown_options": True},
     )
     @common_pytest_options
-    def command(pytest_args: List[str], **kwargs) -> None:
+    def command(pytest_args: List[str], **_kwargs) -> None:
         pytest_command = PytestCommand(
             config_file=config_file,
             argument_processors=[HelpFlagsProcessor(f"execute-{command_name}")],

--- a/src/cli/pytest_commands/execute.py
+++ b/src/cli/pytest_commands/execute.py
@@ -46,10 +46,7 @@ def _create_execute_subcommand(
 hive = _create_execute_subcommand(
     "hive",
     "pytest-execute-hive.ini",
-    (
-        "Execute tests using hive in dev-mode as backend, requires hive to be running "
-        "(using command: `./hive --dev`)."
-    ),
+    "Execute tests using hive as a backend (`./hive --dev`).",
 )
 
 remote = _create_execute_subcommand(
@@ -61,5 +58,5 @@ remote = _create_execute_subcommand(
 recover = _create_execute_subcommand(
     "recover",
     "pytest-execute-recover.ini",
-    "Recover funds from a failed test execution using a remote RPC endpoint.",
+    "Recover funds from test executions using a remote RPC endpoint.",
 )

--- a/src/cli/pytest_commands/execute.py
+++ b/src/cli/pytest_commands/execute.py
@@ -27,6 +27,7 @@ def _create_execute_subcommand(
 
     @execute.command(
         name=command_name,
+        help=help_text,
         context_settings={"ignore_unknown_options": True},
     )
     @common_pytest_options

--- a/src/cli/tests/test_pytest_execute_command.py
+++ b/src/cli/tests/test_pytest_execute_command.py
@@ -1,0 +1,43 @@
+"""Tests for execute command click CLI."""
+
+import pytest
+from click.testing import CliRunner
+
+from ..pytest_commands.execute import execute
+
+
+@pytest.fixture
+def runner():
+    """Provide a Click CliRunner for invoking command-line interfaces."""
+    return CliRunner()
+
+
+def test_execute_help_shows_subcommand_docstrings(runner):
+    """Test that execute --help shows sub-command docstrings."""
+    result = runner.invoke(execute, ["--help"])
+    assert result.exit_code == 0
+
+    # Check that all sub-commands are shown with their help text
+    assert "hive" in result.output
+    assert "Execute tests using hive as a backend" in result.output
+
+    assert "remote" in result.output
+    assert "Execute tests using a remote RPC endpoint" in result.output
+
+    assert "recover" in result.output
+    assert "Recover funds from test executions" in result.output
+
+
+def test_execute_subcommands_have_help_text(runner):
+    """Test that execute sub-commands have proper help text defined."""
+    from ..pytest_commands.execute import hive, recover, remote
+
+    # Test that each sub-command has a docstring
+    assert hive.__doc__ is not None
+    assert "hive" in hive.__doc__.lower()
+
+    assert remote.__doc__ is not None
+    assert "remote" in remote.__doc__.lower()
+
+    assert recover.__doc__ is not None
+    assert "recover" in recover.__doc__.lower()


### PR DESCRIPTION
## 🗒️ Description
Fixes the missing `execute` sub-command help strings and makes them good one-liners, so that they don't get abbreviated.

Previously:
```
Commands:
  hive     Execute tests using hive in dev-mode as backend, requires hive...
  recover  Recover funds from a failed test execution using a remote RPC...
  remote   Execute tests using a remote RPC endpoint.
```

Now:
```
Commands:
  hive     Execute tests using hive dev-mode as a backend (`./hive --dev`).
  recover  Recover funds from test executions using a remote RPC endpoint.
  remote   Execute tests using a remote RPC endpoint.
```

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] ~~All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~ skipped
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
