### PR TITLE
feat(osaka): Update EIP-7939 - update CLZ gas cost

### DIFF
--- a/tests/osaka/eip7939_count_leading_zeros/spec.py
+++ b/tests/osaka/eip7939_count_leading_zeros/spec.py
@@ -18,7 +18,7 @@ ref_spec_7939 = ReferenceSpec("EIPS/eip-7939.md", "c8321494fdfbfda52ad46c3515a7c
 class Spec:
     """Constants and helpers for the CLZ opcode."""
 
-    CLZ_GAS_COST = 3
+    CLZ_GAS_COST = 5
 
     @classmethod
     def calculate_clz(cls, value: int) -> int:

--- a/tests/osaka/eip7939_count_leading_zeros/test_count_leading_zeros.py
+++ b/tests/osaka/eip7939_count_leading_zeros/test_count_leading_zeros.py
@@ -116,7 +116,7 @@ def test_clz_gas_cost(state_test: StateTestFiller, pre: Alloc, fork: Fork):
             CodeGasMeasure(
                 code=Op.CLZ(Op.PUSH1(1)),
                 extra_stack_items=1,
-                overhead_cost=fork.gas_costs().G_VERY_LOW,
+                overhead_cost=fork.gas_costs().G_LOW,
             ),
         ),
         storage={"0x00": "0xdeadbeef"},


### PR DESCRIPTION
## 🗒️ Description
Update the gas cost of the CLZ opcode according to this update

- ethereum/EIPs#9987

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [X] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [X] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
