### PR TITLE
chore(tests): update gas cost configuration for clz

### DIFF
--- a/tests/osaka/eip7939_count_leading_zeros/test_count_leading_zeros.py
+++ b/tests/osaka/eip7939_count_leading_zeros/test_count_leading_zeros.py
@@ -116,7 +116,7 @@ def test_clz_gas_cost(state_test: StateTestFiller, pre: Alloc, fork: Fork):
             CodeGasMeasure(
                 code=Op.CLZ(Op.PUSH1(1)),
                 extra_stack_items=1,
-                overhead_cost=fork.gas_costs().G_LOW,
+                overhead_cost=fork.gas_costs().G_VERY_LOW,
             ),
         ),
         storage={"0x00": "0xdeadbeef"},
@@ -125,7 +125,7 @@ def test_clz_gas_cost(state_test: StateTestFiller, pre: Alloc, fork: Fork):
     tx = Transaction(to=contract_address, sender=sender, gas_limit=200_000)
     post = {
         contract_address: Account(  # Cost measured is CLZ + PUSH1
-            storage={"0x00": fork.gas_costs().G_VERY_LOW}
+            storage={"0x00": fork.gas_costs().G_LOW}
         ),
     }
     state_test(pre=pre, post=post, tx=tx)


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

During the ACDT meeting, we decided to increase the gas cost of CLZ from 3 to 5. This change has been updated in the [PR](https://github.com/ethereum/execution-spec-tests/pull/1879). However, it breaks some existing test cases, which are addressed and fixed in this PR. Additional details are provided below.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->

PR for EEST: https://github.com/ethereum/execution-spec-tests/pull/1879
PR for EIP: https://github.com/ethereum/EIPs/pull/9987
PR for EELS: https://github.com/ethereum/execution-specs/pull/1314

Fill with this Osaka in `eels_resolutions.json`:
```json
    "Osaka": {
        "git_url": "https://github.com/spencer-tb/execution-specs.git",
        "branch": "forks/osaka",
        "commit": "bff77defcfa5be8130cdc6c4ec8200104e22dd8f"
    }
```

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
