### PR TITLE
feat(tests): Additional EIP-7934 test cases

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -114,6 +114,7 @@ Users can select any of the artifacts depending on their testing needs for their
 - ✨ Opcode classes now validate keyword arguments and raise `ValueError` with clear error messages ([#1739](https://github.com/ethereum/execution-spec-tests/pull/1739), [#1856](https://github.com/ethereum/execution-spec-tests/pull/1856)).
 - ✨ All commands (`fill`, `consume`, `execute`) now work without having to clone the repository, e.g. `uv run --with git+https://github.com/ethereum/execution-spec-tests.git consume` now works from any folder ([#1863](https://github.com/ethereum/execution-spec-tests/pull/1863)).
 - 🔀 Move Prague to stable and Osaka to develop ([#1573](https://github.com/ethereum/execution-spec-tests/pull/1573)).
+- ✨ Add a `pytest.mark.with_all_typed_transactions` marker that creates default typed transactions for each `tx_type` supported by the current `fork` ([#1890](https://github.com/ethereum/execution-spec-tests/pull/1890)).
 
 ### 🧪 Test Cases
 
@@ -128,6 +129,7 @@ Users can select any of the artifacts depending on their testing needs for their
 - ✨ [EIP-7934](https://eips.ethereum.org/EIPS/eip-7934): Add test cases for the block RLP max limit of 10MiB ([#1730](https://github.com/ethereum/execution-spec-tests/pull/1730)).
 - ✨ [EIP-7939](https://eips.ethereum.org/EIPS/eip-7939) Add count leading zeros (CLZ) opcode tests for Osaka ([#1733](https://github.com/ethereum/execution-spec-tests/pull/1733)).
 - ✨ [EIP-7918](https://eips.ethereum.org/EIPS/eip-7918): Blob base fee bounded by execution cost test cases (initial), includes some adjustments to [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844) tests ([#1685](https://github.com/ethereum/execution-spec-tests/pull/1685)). Update the blob_base_cost ([#1915](https://github.com/ethereum/EIPs/pull/1915)).
+- ✨ [EIP-7934](https://eips.ethereum.org/EIPS/eip-7934): Add additional test cases for block RLP max limit with all typed transactions and for a log-creating transactions ([#1890](https://github.com/ethereum/execution-spec-tests/pull/1890)).
 
 ## [v4.5.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v4.5.0) - 2025-05-14
 

--- a/src/cli/pytest_commands/pytest_ini_files/pytest-check-eip-versions.ini
+++ b/src/cli/pytest_commands/pytest_ini_files/pytest-check-eip-versions.ini
@@ -13,6 +13,7 @@ addopts =
     -p pytest_plugins.filler.pre_alloc
     -p pytest_plugins.filler.filler
     -p pytest_plugins.shared.execute_fill
+    -p pytest_plugins.shared.transaction_fixtures
     -p pytest_plugins.forks.forks
     -p pytest_plugins.help.help
     -m eip_version_check

--- a/src/cli/pytest_commands/pytest_ini_files/pytest-execute-hive.ini
+++ b/src/cli/pytest_commands/pytest_ini_files/pytest-execute-hive.ini
@@ -14,6 +14,7 @@ addopts =
     -p pytest_plugins.execute.rpc.hive
     -p pytest_plugins.execute.execute
     -p pytest_plugins.shared.execute_fill
+    -p pytest_plugins.shared.transaction_fixtures
     -p pytest_plugins.forks.forks
     -p pytest_plugins.pytest_hive.pytest_hive
     -p pytest_plugins.help.help

--- a/src/cli/pytest_commands/pytest_ini_files/pytest-execute.ini
+++ b/src/cli/pytest_commands/pytest_ini_files/pytest-execute.ini
@@ -14,10 +14,10 @@ addopts =
     -p pytest_plugins.execute.pre_alloc
     -p pytest_plugins.execute.execute
     -p pytest_plugins.shared.execute_fill
+    -p pytest_plugins.shared.transaction_fixtures
     -p pytest_plugins.execute.rpc.remote_seed_sender
     -p pytest_plugins.execute.rpc.remote
     -p pytest_plugins.forks.forks
-    -p pytest_plugins.pytest_fixtures.transaction_fixtures
     -p pytest_plugins.help.help
     --tb short
     --dist loadscope

--- a/src/cli/pytest_commands/pytest_ini_files/pytest-execute.ini
+++ b/src/cli/pytest_commands/pytest_ini_files/pytest-execute.ini
@@ -17,6 +17,7 @@ addopts =
     -p pytest_plugins.execute.rpc.remote_seed_sender
     -p pytest_plugins.execute.rpc.remote
     -p pytest_plugins.forks.forks
+    -p pytest_plugins.pytest_fixtures.transaction_fixtures
     -p pytest_plugins.help.help
     --tb short
     --dist loadscope

--- a/src/cli/pytest_commands/pytest_ini_files/pytest-fill.ini
+++ b/src/cli/pytest_commands/pytest_ini_files/pytest-fill.ini
@@ -15,6 +15,7 @@ addopts =
     -p pytest_plugins.filler.ported_tests
     -p pytest_plugins.filler.static_filler
     -p pytest_plugins.shared.execute_fill
+    -p pytest_plugins.shared.transaction_fixtures
     -p pytest_plugins.forks.forks
     -p pytest_plugins.eels_resolver
     -p pytest_plugins.help.help

--- a/src/pytest_plugins/forks/forks.py
+++ b/src/pytest_plugins/forks/forks.py
@@ -25,15 +25,6 @@ from ethereum_test_forks import (
     transition_fork_to,
 )
 
-from ..shared.transaction_fixtures import (  # noqa: F401
-    type_0_default_transaction,
-    type_1_default_transaction,
-    type_2_default_transaction,
-    type_3_default_transaction,
-    type_4_default_transaction,
-    typed_transaction,
-)
-
 
 def pytest_addoption(parser):
     """Add command-line options to pytest."""

--- a/src/pytest_plugins/forks/tests/test_covariant_markers.py
+++ b/src/pytest_plugins/forks/tests/test_covariant_markers.py
@@ -266,11 +266,11 @@ import pytest
             """
             import pytest
             from ethereum_test_tools import Transaction
-            @pytest.mark.with_all_typed_transactions()
+            @pytest.mark.with_all_typed_transactions
             @pytest.mark.valid_from("Berlin")
             @pytest.mark.valid_until("Berlin")
             @pytest.mark.state_test_only
-            def test_case(state_test, typed_transaction, pre):
+            def test_case(state_test, typed_transaction):
                 assert isinstance(typed_transaction, Transaction)
                 assert typed_transaction.ty in [0, 1]  # Berlin supports types 0 and 1
             """,
@@ -293,24 +293,6 @@ import pytest
             {"passed": 3, "failed": 0, "skipped": 0, "errors": 0},
             None,
             id="with_all_typed_transactions_london",
-        ),
-        pytest.param(
-            """
-            import pytest
-            from ethereum_test_tools import Transaction
-            @pytest.mark.with_all_typed_transactions()
-            @pytest.mark.valid_from("London")
-            @pytest.mark.valid_until("London")
-            @pytest.mark.state_test_only
-            def test_case(state_test, typed_transaction, pre):
-                assert isinstance(typed_transaction, Transaction)
-                # Test with marks to skip type 0
-                if typed_transaction.ty == 0:
-                    pytest.skip("Testing skip functionality")
-            """,
-            {"passed": 2, "failed": 0, "skipped": 1, "errors": 0},
-            None,
-            id="with_all_typed_transactions_with_skip",
         ),
         pytest.param(
             """

--- a/src/pytest_plugins/forks/tests/test_covariant_markers.py
+++ b/src/pytest_plugins/forks/tests/test_covariant_markers.py
@@ -265,6 +265,97 @@ import pytest
         pytest.param(
             """
             import pytest
+            from ethereum_test_tools import Transaction
+            @pytest.mark.with_all_typed_transactions()
+            @pytest.mark.valid_from("Berlin")
+            @pytest.mark.valid_until("Berlin")
+            @pytest.mark.state_test_only
+            def test_case(state_test, typed_transaction, pre):
+                assert isinstance(typed_transaction, Transaction)
+                assert typed_transaction.ty in [0, 1]  # Berlin supports types 0 and 1
+            """,
+            {"passed": 2, "failed": 0, "skipped": 0, "errors": 0},
+            None,
+            id="with_all_typed_transactions_berlin",
+        ),
+        pytest.param(
+            """
+            import pytest
+            from ethereum_test_tools import Transaction
+            @pytest.mark.with_all_typed_transactions()
+            @pytest.mark.valid_from("London")
+            @pytest.mark.valid_until("London")
+            @pytest.mark.state_test_only
+            def test_case(state_test, typed_transaction, pre):
+                assert isinstance(typed_transaction, Transaction)
+                assert typed_transaction.ty in [0, 1, 2]  # London supports types 0, 1, 2
+            """,
+            {"passed": 3, "failed": 0, "skipped": 0, "errors": 0},
+            None,
+            id="with_all_typed_transactions_london",
+        ),
+        pytest.param(
+            """
+            import pytest
+            from ethereum_test_tools import Transaction
+            @pytest.mark.with_all_typed_transactions()
+            @pytest.mark.valid_from("London")
+            @pytest.mark.valid_until("London")
+            @pytest.mark.state_test_only
+            def test_case(state_test, typed_transaction, pre):
+                assert isinstance(typed_transaction, Transaction)
+                # Test with marks to skip type 0
+                if typed_transaction.ty == 0:
+                    pytest.skip("Testing skip functionality")
+            """,
+            {"passed": 2, "failed": 0, "skipped": 1, "errors": 0},
+            None,
+            id="with_all_typed_transactions_with_skip",
+        ),
+        pytest.param(
+            """
+            import pytest
+            from ethereum_test_tools import Transaction
+            from ethereum_test_base_types import AccessList
+
+            # Override the type 3 transaction fixture
+            @pytest.fixture
+            def type_3_default_transaction(pre):
+                sender = pre.fund_eoa()
+
+                return Transaction(
+                    ty=3,
+                    sender=sender,
+                    max_fee_per_gas=10**10,
+                    max_priority_fee_per_gas=10**9,
+                    max_fee_per_blob_gas=10**8,
+                    gas_limit=300_000,
+                    data=b"\\xFF" * 50,
+                    access_list=[
+                        AccessList(address=0x1111, storage_keys=[10, 20]),
+                    ],
+                    blob_versioned_hashes=[
+                        0x0111111111111111111111111111111111111111111111111111111111111111,
+                    ],
+                )
+
+            @pytest.mark.with_all_typed_transactions()
+            @pytest.mark.valid_at("Cancun")
+            @pytest.mark.state_test_only
+            def test_case(state_test, typed_transaction, pre):
+                assert isinstance(typed_transaction, Transaction)
+                if typed_transaction.ty == 3:
+                    # Verify our override worked
+                    assert typed_transaction.data == b"\\xFF" * 50
+                    assert len(typed_transaction.blob_versioned_hashes) == 1
+            """,
+            {"passed": 4, "failed": 0, "skipped": 0, "errors": 0},
+            None,
+            id="with_all_typed_transactions_with_override",
+        ),
+        pytest.param(
+            """
+            import pytest
             @pytest.mark.with_all_tx_types(invalid_parameter="invalid")
             @pytest.mark.valid_from("Paris")
             @pytest.mark.valid_until("Paris")

--- a/src/pytest_plugins/forks/transaction_fixtures.py
+++ b/src/pytest_plugins/forks/transaction_fixtures.py
@@ -1,0 +1,166 @@
+"""
+Pytest plugin providing default transaction fixtures for each transaction type.
+
+Each fixture can be overridden in test files to customize transaction behavior.
+"""
+
+import pytest
+
+from ethereum_test_base_types import AccessList
+from ethereum_test_tools import Opcodes as Op
+from ethereum_test_types import AuthorizationTuple, Transaction, add_kzg_version
+
+
+@pytest.fixture
+def type_0_default_transaction(pre):
+    """Type 0 (legacy) default transaction available in all forks."""
+    sender = pre.fund_eoa()
+    return Transaction(
+        ty=0,
+        sender=sender,
+        gas_price=10**9,
+        gas_limit=100_000,
+        data=b"\x00" * 100,
+    )
+
+
+@pytest.fixture
+def type_1_default_transaction(pre):
+    """Type 1 (access list) default transaction introduced in Berlin fork."""
+    sender = pre.fund_eoa()
+    return Transaction(
+        ty=1,
+        sender=sender,
+        gas_price=10**9,
+        gas_limit=100_000,
+        data=b"\x00" * 100,
+        access_list=[
+            AccessList(address=0x1234, storage_keys=[0, 1, 2]),
+            AccessList(address=0x5678, storage_keys=[3, 4, 5]),
+            AccessList(address=0x9ABC, storage_keys=[]),
+        ],
+    )
+
+
+@pytest.fixture
+def type_2_default_transaction(pre):
+    """Type 2 (dynamic fee) default transaction introduced in London fork."""
+    sender = pre.fund_eoa()
+    return Transaction(
+        ty=2,
+        sender=sender,
+        max_fee_per_gas=10**10,
+        max_priority_fee_per_gas=10**9,
+        gas_limit=100_000,
+        data=b"\x00" * 200,
+        access_list=[
+            AccessList(address=0x2468, storage_keys=[10, 20, 30]),
+            AccessList(address=0xACE0, storage_keys=[40, 50]),
+        ],
+    )
+
+
+@pytest.fixture
+def type_3_default_transaction(pre):
+    """Type 3 (blob) default transaction introduced in Cancun fork."""
+    sender = pre.fund_eoa()
+    return Transaction(
+        ty=3,
+        sender=sender,
+        max_fee_per_gas=10**10,
+        max_priority_fee_per_gas=10**9,
+        max_fee_per_blob_gas=10**9,
+        gas_limit=100_000,
+        data=b"\x00" * 150,
+        access_list=[
+            AccessList(address=0x3690, storage_keys=[100, 200]),
+            AccessList(address=0xBEEF, storage_keys=[300]),
+        ],
+        blob_versioned_hashes=add_kzg_version(
+            [
+                0x1111111111111111111111111111111111111111111111111111111111111111,
+                0x2222222222222222222222222222222222222222222222222222222222222222,
+            ],
+            0x01,
+        ),
+    )
+
+
+@pytest.fixture
+def type_4_default_transaction(pre):
+    """Type 4 (set code) default transaction introduced in Prague fork."""
+    sender = pre.fund_eoa()
+
+    # Create authorized accounts with funds
+    auth_signer1 = pre.fund_eoa(amount=10**18)
+    auth_signer2 = pre.fund_eoa(amount=10**18)
+
+    # Create target addresses that will be authorized
+    target1 = pre.deploy_contract(Op.SSTORE(0, 1))
+    target2 = pre.deploy_contract(Op.SSTORE(0, 1))
+
+    return Transaction(
+        ty=4,
+        sender=sender,
+        max_fee_per_gas=10**10,
+        max_priority_fee_per_gas=10**9,
+        gas_limit=150_000,
+        data=b"\x00" * 200,
+        access_list=[
+            AccessList(address=0x4567, storage_keys=[1000, 2000, 3000]),
+            AccessList(address=0xCDEF, storage_keys=[4000, 5000]),
+        ],
+        authorization_list=[
+            AuthorizationTuple(
+                chain_id=1,
+                address=target1,
+                nonce=0,
+                signer=auth_signer1,
+            ),
+            AuthorizationTuple(
+                chain_id=1,
+                address=target2,
+                nonce=0,
+                signer=auth_signer2,
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+def typed_transaction(request, fork):
+    """
+    Fixture that provides a Transaction object based on the parametrized tx type.
+
+    This fixture works with the @pytest.mark.with_all_typed_transactions marker,
+    which parametrizes the test with all transaction types supported by the fork.
+
+    The actual transaction type value comes from the marker's parametrization.
+    """
+    # The marker parametrizes 'typed_transaction' with tx type integers
+    # Get the parametrized tx_type value
+    if hasattr(request, "param"):
+        # When parametrized by the marker, request.param contains the tx type
+        tx_type = request.param
+    else:
+        raise ValueError(
+            "`typed_transaction` fixture must be used with "
+            "`@pytest.mark.with_all_typed_transactions` marker"
+        )
+
+    fixture_name = f"type_{tx_type}_default_transaction"
+
+    # Check if fixture exists - try to get it first
+    try:
+        # This will find fixtures defined in the test file or plugin
+        return request.getfixturevalue(fixture_name)
+    except pytest.FixtureLookupError as e:
+        # Get all supported tx types for better error message
+        supported_types = fork.tx_types()
+        raise NotImplementedError(
+            f"Fork {fork} supports transaction type {tx_type} but "
+            f"fixture '{fixture_name}' is not implemented!\n"
+            f"Fork {fork} supports transaction types: {supported_types}\n"
+            f"Please add the missing fixture to "
+            f"src/pytest_plugins/pytest_fixtures/transaction_fixtures.py"
+        ) from e

--- a/src/pytest_plugins/shared/execute_fill.py
+++ b/src/pytest_plugins/shared/execute_fill.py
@@ -7,6 +7,7 @@ import pytest
 from ethereum_test_execution import BaseExecute, LabeledExecuteFormat
 from ethereum_test_fixtures import BaseFixture, LabeledFixtureFormat
 from ethereum_test_specs import BaseTest
+from ethereum_test_types import EOA, Alloc
 from pytest_plugins.spec_version_checker.spec_version_checker import EIPSpecTestItem
 
 
@@ -148,6 +149,13 @@ def pytest_runtest_call(item: pytest.Item):
             + "properly generate a test: "
             + ", ".join(SPEC_TYPES_PARAMETERS)
         )
+
+
+# Global `sender` fixture that can be overridden by tests.
+@pytest.fixture
+def sender(pre: Alloc) -> EOA:
+    """Fund an EOA from pre-alloc."""
+    return pre.fund_eoa()
 
 
 def pytest_addoption(parser: pytest.Parser):

--- a/src/pytest_plugins/shared/transaction_fixtures.py
+++ b/src/pytest_plugins/shared/transaction_fixtures.py
@@ -12,9 +12,8 @@ from ethereum_test_types import AuthorizationTuple, Transaction, add_kzg_version
 
 
 @pytest.fixture
-def type_0_default_transaction(pre):
+def type_0_default_transaction(sender):
     """Type 0 (legacy) default transaction available in all forks."""
-    sender = pre.fund_eoa()
     return Transaction(
         ty=0,
         sender=sender,
@@ -25,9 +24,8 @@ def type_0_default_transaction(pre):
 
 
 @pytest.fixture
-def type_1_default_transaction(pre):
+def type_1_default_transaction(sender):
     """Type 1 (access list) default transaction introduced in Berlin fork."""
-    sender = pre.fund_eoa()
     return Transaction(
         ty=1,
         sender=sender,
@@ -43,9 +41,8 @@ def type_1_default_transaction(pre):
 
 
 @pytest.fixture
-def type_2_default_transaction(pre):
+def type_2_default_transaction(sender):
     """Type 2 (dynamic fee) default transaction introduced in London fork."""
-    sender = pre.fund_eoa()
     return Transaction(
         ty=2,
         sender=sender,
@@ -61,9 +58,8 @@ def type_2_default_transaction(pre):
 
 
 @pytest.fixture
-def type_3_default_transaction(pre):
+def type_3_default_transaction(sender):
     """Type 3 (blob) default transaction introduced in Cancun fork."""
-    sender = pre.fund_eoa()
     return Transaction(
         ty=3,
         sender=sender,
@@ -87,10 +83,8 @@ def type_3_default_transaction(pre):
 
 
 @pytest.fixture
-def type_4_default_transaction(pre):
+def type_4_default_transaction(sender, pre):
     """Type 4 (set code) default transaction introduced in Prague fork."""
-    sender = pre.fund_eoa()
-
     # Create authorized accounts with funds
     auth_signer1 = pre.fund_eoa(amount=10**18)
     auth_signer2 = pre.fund_eoa(amount=10**18)

--- a/src/pytest_plugins/shared/transaction_fixtures.py
+++ b/src/pytest_plugins/shared/transaction_fixtures.py
@@ -156,5 +156,5 @@ def typed_transaction(request, fork):
             f"fixture '{fixture_name}' is not implemented!\n"
             f"Fork {fork} supports transaction types: {supported_types}\n"
             f"Please add the missing fixture to "
-            f"src/pytest_plugins/pytest_fixtures/transaction_fixtures.py"
+            f"src/pytest_plugins/shared/transaction_fixtures.py"
         ) from e

--- a/tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py
+++ b/tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py
@@ -48,12 +48,6 @@ def pre_fork_blobs_per_block(fork: Fork) -> int:
 
 
 @pytest.fixture
-def sender(pre: Alloc) -> EOA:
-    """Sender account."""
-    return pre.fund_eoa()
-
-
-@pytest.fixture
 def pre_fork_blocks(
     pre_fork_blobs_per_block: int,
     destination_account: Address,

--- a/tests/cancun/eip4844_blobs/test_point_evaluation_precompile.py
+++ b/tests/cancun/eip4844_blobs/test_point_evaluation_precompile.py
@@ -190,12 +190,6 @@ def precompile_caller_address(
 
 
 @pytest.fixture
-def sender(pre: Alloc) -> EOA:
-    """Return sender account."""
-    return pre.fund_eoa()
-
-
-@pytest.fixture
 def tx(
     precompile_caller_address: Address,
     precompile_input: bytes,

--- a/tests/cancun/eip5656_mcopy/test_mcopy_memory_expansion.py
+++ b/tests/cancun/eip5656_mcopy/test_mcopy_memory_expansion.py
@@ -141,11 +141,6 @@ def caller_address(pre: Alloc, callee_bytecode: bytes) -> Address:  # noqa: D103
 
 
 @pytest.fixture
-def sender(pre: Alloc) -> Address:  # noqa: D103
-    return pre.fund_eoa()
-
-
-@pytest.fixture
 def tx(  # noqa: D103
     sender: Address,
     caller_address: Address,

--- a/tests/cancun/eip6780_selfdestruct/conftest.py
+++ b/tests/cancun/eip6780_selfdestruct/conftest.py
@@ -2,13 +2,7 @@
 
 import pytest
 
-from ethereum_test_tools import EOA, Address, Alloc, Environment
-
-
-@pytest.fixture
-def sender(pre: Alloc) -> EOA:
-    """EOA that will be used to send transactions."""
-    return pre.fund_eoa()
+from ethereum_test_tools import Address, Alloc, Environment
 
 
 @pytest.fixture

--- a/tests/cancun/eip6780_selfdestruct/test_selfdestruct.py
+++ b/tests/cancun/eip6780_selfdestruct/test_selfdestruct.py
@@ -125,12 +125,6 @@ def selfdestruct_code(
     return selfdestruct_code_preset(sendall_recipient_addresses=sendall_recipient_addresses)
 
 
-@pytest.fixture
-def sender(pre: Alloc) -> EOA:
-    """EOA that will be used to send transactions."""
-    return pre.fund_eoa()
-
-
 @pytest.mark.parametrize("create_opcode", [Op.CREATE, Op.CREATE2])
 @pytest.mark.parametrize(
     "call_times,sendall_recipient_addresses",

--- a/tests/osaka/eip7934_block_rlp_limit/conftest.py
+++ b/tests/osaka/eip7934_block_rlp_limit/conftest.py
@@ -3,7 +3,6 @@
 import pytest
 
 from ethereum_test_tools import (
-    EOA,
     Address,
     Alloc,
 )
@@ -21,12 +20,6 @@ def post() -> Alloc:
 def env() -> Environment:
     """Environment fixture with a specified gas limit."""
     return Environment(gas_limit=100_000_000)
-
-
-@pytest.fixture
-def sender(pre: Alloc) -> EOA:
-    """Funded EOA fixture used for sending transactions."""
-    return pre.fund_eoa()
 
 
 @pytest.fixture

--- a/tests/osaka/eip7934_block_rlp_limit/spec.py
+++ b/tests/osaka/eip7934_block_rlp_limit/spec.py
@@ -24,6 +24,7 @@ class Spec:
     MAX_BLOCK_SIZE = 10_485_760  # 10 MiB
     SAFETY_MARGIN = 2_097_152  # 2 MiB
     MAX_RLP_BLOCK_SIZE = MAX_BLOCK_SIZE - SAFETY_MARGIN  # 8_388_608 bytes
+    BLOB_COMMITMENT_VERSION_KZG = 1
 
     @staticmethod
     def exceed_max_rlp_block_size(rlp_encoded_block: bytes) -> bool:

--- a/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
+++ b/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
@@ -4,7 +4,7 @@ abstract: Test [EIP-7934: RLP Execution Block Size Limit](https://eips.ethereum.
 """
 
 from functools import lru_cache
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 
 import pytest
 
@@ -107,9 +107,9 @@ def exact_size_transactions(
     sender: EOA,
     block_size_limit: int,
     fork: Fork,
-    pre: Optional[Alloc],
+    pre: Alloc,
     emit_logs: bool = False,
-    specific_transaction_to_include: Optional[Transaction] = None,
+    specific_transaction_to_include: Transaction | None = None,
 ) -> Tuple[List[Transaction], int]:
     """
     Generate transactions that fill a block to exactly the RLP size limit.
@@ -180,7 +180,7 @@ def exact_size_transactions(
 def _exact_size_transactions_cached(
     block_size_limit: int,
     fork: Fork,
-    emit_logs_contract: Optional[Address] = None,
+    emit_logs_contract: Address | None = None,
 ) -> Tuple[List[Transaction], int]:
     """
     Generate transactions that fill a block to exactly the RLP size limit. Abstracted
@@ -192,8 +192,8 @@ def _exact_size_transactions_cached(
 def _exact_size_transactions_impl(
     block_size_limit: int,
     fork: Fork,
-    specific_transaction_to_include: Optional[Transaction] = None,
-    emit_logs_contract: Optional[Address] = None,
+    specific_transaction_to_include: Transaction | None = None,
+    emit_logs_contract: Address | None = None,
 ) -> Tuple[List[Transaction], int]:
     """
     Calculate the exact size of transactions to be included. Shared by both cached and

--- a/tests/osaka/eip7951_p256verify_precompiles/conftest.py
+++ b/tests/osaka/eip7951_p256verify_precompiles/conftest.py
@@ -119,12 +119,6 @@ def call_contract_address(pre: Alloc, call_contract_code: Bytecode) -> Address:
 
 
 @pytest.fixture
-def sender(pre: Alloc) -> EOA:
-    """Sender of the transaction."""
-    return pre.fund_eoa()
-
-
-@pytest.fixture
 def post(call_contract_address: Address, call_contract_post_storage: Storage):
     """Test expected post outcome."""
     return {

--- a/tests/prague/eip7623_increase_calldata_cost/conftest.py
+++ b/tests/prague/eip7623_increase_calldata_cost/conftest.py
@@ -25,12 +25,6 @@ from .helpers import DataTestType, find_floor_cost_threshold
 
 
 @pytest.fixture
-def sender(pre: Alloc) -> EOA:
-    """Create the sender account."""
-    return pre.fund_eoa()
-
-
-@pytest.fixture
 def to(
     request: pytest.FixtureRequest,
     pre: Alloc,

--- a/tests/prague/eip7702_set_code_tx/test_calls.py
+++ b/tests/prague/eip7702_set_code_tx/test_calls.py
@@ -6,7 +6,6 @@ from enum import Enum, auto, unique
 import pytest
 
 from ethereum_test_tools import (
-    EOA,
     Account,
     Address,
     Alloc,
@@ -51,12 +50,6 @@ class TargetAccountType(Enum):
     def __str__(self) -> str:
         """Return string representation of the enum."""
         return f"{self.name}"
-
-
-@pytest.fixture
-def sender(pre: Alloc) -> EOA:
-    """Sender of the transaction."""
-    return pre.fund_eoa()
 
 
 @pytest.fixture

--- a/tests/shanghai/eip3651_warm_coinbase/conftest.py
+++ b/tests/shanghai/eip3651_warm_coinbase/conftest.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from ethereum_test_tools import EOA, Alloc, Environment
+from ethereum_test_tools import Alloc, Environment
 
 
 @pytest.fixture
@@ -15,9 +15,3 @@ def env() -> Environment:
 def post() -> Alloc:
     """Post state fixture."""
     return Alloc()
-
-
-@pytest.fixture
-def sender(pre: Alloc) -> EOA:
-    """Funded EOA used for sending transactions."""
-    return pre.fund_eoa()

--- a/tests/shanghai/eip3855_push0/conftest.py
+++ b/tests/shanghai/eip3855_push0/conftest.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from ethereum_test_tools import EOA, Alloc, Environment
+from ethereum_test_tools import Alloc, Environment
 
 
 @pytest.fixture
@@ -15,9 +15,3 @@ def env() -> Environment:
 def post() -> Alloc:
     """Post state fixture."""
     return Alloc()
-
-
-@pytest.fixture
-def sender(pre: Alloc) -> EOA:
-    """Funded EOA used for sending transactions."""
-    return pre.fund_eoa()

--- a/tests/shanghai/eip3860_initcode/conftest.py
+++ b/tests/shanghai/eip3860_initcode/conftest.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from ethereum_test_tools import EOA, Alloc, Environment
+from ethereum_test_tools import Alloc, Environment
 
 
 @pytest.fixture
@@ -15,9 +15,3 @@ def env() -> Environment:
 def post() -> Alloc:
     """Post state fixture."""
     return Alloc()
-
-
-@pytest.fixture
-def sender(pre: Alloc) -> EOA:
-    """Funded EOA used for sending transactions."""
-    return pre.fund_eoa()

--- a/tests/shanghai/eip4895_withdrawals/conftest.py
+++ b/tests/shanghai/eip4895_withdrawals/conftest.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from ethereum_test_tools import EOA, Alloc, Environment
+from ethereum_test_tools import Alloc, Environment
 
 
 @pytest.fixture
@@ -15,9 +15,3 @@ def env() -> Environment:
 def post() -> Alloc:
     """Post state fixture."""
     return Alloc()
-
-
-@pytest.fixture
-def sender(pre: Alloc) -> EOA:
-    """Funded EOA used for sending transactions."""
-    return pre.fund_eoa()

--- a/tests/unscheduled/eip7692_eof_v1/eip7069_extcall/test_calls.py
+++ b/tests/unscheduled/eip7692_eof_v1/eip7069_extcall/test_calls.py
@@ -79,12 +79,6 @@ class TargetAccountType(Enum):
 
 
 @pytest.fixture
-def sender(pre: Alloc) -> EOA:
-    """Sender of the transaction."""
-    return pre.fund_eoa()
-
-
-@pytest.fixture
 def target_address(pre: Alloc, target_account_type: TargetAccountType) -> Address:
     """Target address of the call depending on required type of account."""
     match target_account_type:


### PR DESCRIPTION
## 🗒️ Description

- Add test case for RLP block size at limit with all transaction types, including blobs, access lists, and authorizations
- Add test case for RLP block size at limit with logs emitted

## 🔗 Related Issues or PRs

Related to #1772 

## TODO:

- [x] Refactor built transactions for `with_all_tx_types` into something that can be more useful across the board. I'm thinking default transactions that each fork can define if it includes a new tx type and tests can automatically use these transactions, override them as fixtures, or some other more useful flow than re-building every time.
    - This was done via `with_all_typed_transactions` indirect (new feature) marker

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [x] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
