### PR TITLE
chore(forks|tests): fork agnostic blob tx wrapper version

### DIFF
--- a/src/ethereum_test_forks/base_fork.py
+++ b/src/ethereum_test_forks/base_fork.py
@@ -331,6 +331,12 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
         pass
 
     @classmethod
+    @abstractmethod
+    def full_blob_tx_wrapper_version(cls, block_number: int = 0, timestamp: int = 0) -> int | None:
+        """Return the version of the full blob transaction wrapper at a given fork."""
+        pass
+
+    @classmethod
     @prefer_transition_to_method
     @abstractmethod
     def blob_schedule(cls, block_number: int = 0, timestamp: int = 0) -> BlobSchedule | None:

--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -251,6 +251,13 @@ class Frontier(BaseFork, solc_name="homestead"):
         raise NotImplementedError(f"Max blobs per block is not supported in {cls.name()}")
 
     @classmethod
+    def full_blob_tx_wrapper_version(cls, block_number: int = 0, timestamp: int = 0) -> int | None:
+        """Return the version of the full blob transaction wrapper."""
+        raise NotImplementedError(
+            f"Full blob transaction wrapper version is not supported in {cls.name()}"
+        )
+
+    @classmethod
     def blob_schedule(cls, block_number: int = 0, timestamp: int = 0) -> BlobSchedule | None:
         """At genesis, no blob schedule is used."""
         return None
@@ -1015,6 +1022,11 @@ class Cancun(Shanghai):
         return 6
 
     @classmethod
+    def full_blob_tx_wrapper_version(cls, block_number: int = 0, timestamp: int = 0) -> int | None:
+        """Pre-Osaka forks don't use tx wrapper versions for full blob transactions."""
+        return None
+
+    @classmethod
     def blob_schedule(cls, block_number: int = 0, timestamp: int = 0) -> BlobSchedule | None:
         """
         At Cancun, the fork object runs this routine to get the updated blob
@@ -1374,6 +1386,11 @@ class Osaka(Prague, solc_name="cancun"):
     def engine_get_blobs_version(cls, block_number: int = 0, timestamp: int = 0) -> Optional[int]:
         """At Osaka, the engine get blobs version is 2."""
         return 2
+
+    @classmethod
+    def full_blob_tx_wrapper_version(cls, block_number=0, timestamp=0) -> int | None:
+        """At Osaka, the full blob transaction wrapper version is defined."""
+        return 1
 
     @classmethod
     def transaction_gas_limit_cap(cls, block_number: int = 0, timestamp: int = 0) -> int | None:

--- a/tests/cancun/eip4844_blobs/test_blob_txs_full.py
+++ b/tests/cancun/eip4844_blobs/test_blob_txs_full.py
@@ -157,6 +157,7 @@ def txs(  # noqa: D103
     tx_error: Optional[TransactionException],
     txs_blobs: List[List[Blob]],
     txs_wrapped_blobs: List[bool],
+    fork: Fork,
 ) -> List[Transaction]:
     """Prepare the list of transactions that are sent during the test."""
     if len(txs_blobs) != len(txs_versioned_hashes) or len(txs_blobs) != len(txs_wrapped_blobs):
@@ -182,7 +183,11 @@ def txs(  # noqa: D103
             wrapped_blob_transaction=tx_wrapped_blobs,
         )
         if tx_wrapped_blobs:
-            network_wrapped_tx = NetworkWrappedTransaction(tx=tx, blob_objects=tx_blobs)
+            network_wrapped_tx = NetworkWrappedTransaction(
+                tx=tx,
+                blob_objects=tx_blobs,
+                wrapper_version=fork.full_blob_tx_wrapper_version(),
+            )
             tx.rlp_override = network_wrapped_tx.rlp()
         txs.append(tx)
     return txs

--- a/tests/osaka/eip7594_peerdas/test_get_blobs.py
+++ b/tests/osaka/eip7594_peerdas/test_get_blobs.py
@@ -155,12 +155,6 @@ def tx_error() -> Optional[TransactionException]:
     return None
 
 
-@pytest.fixture
-def tx_wrapper_version() -> int | None:
-    """Return wrapper version used for the transactions sent during test."""
-    return 1
-
-
 @pytest.fixture(autouse=True)
 def txs(  # noqa: D103
     pre: Alloc,
@@ -172,7 +166,7 @@ def txs(  # noqa: D103
     txs_versioned_hashes: List[List[bytes]],
     tx_error: Optional[TransactionException],
     txs_blobs: List[List[Blob]],
-    tx_wrapper_version: int | None,
+    fork: Fork,
 ) -> List[NetworkWrappedTransaction | Transaction]:
     """Prepare the list of transactions that are sent during the test."""
     if len(txs_blobs) != len(txs_versioned_hashes):
@@ -193,8 +187,8 @@ def txs(  # noqa: D103
         )
         network_wrapped_tx = NetworkWrappedTransaction(
             tx=tx,
-            wrapper_version=tx_wrapper_version,
             blob_objects=tx_blobs,
+            wrapper_version=fork.full_blob_tx_wrapper_version(),
         )
         txs.append(network_wrapped_tx)
     return txs


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

This PR makes the blob tx wrapper version fork agnostic. PeerDAS introduced the wrapper version field where:
```
< Osaka: rlp([tx_payload_body, blobs, commitments, proofs])
>= Osaka: rlp([tx_payload_body, wrapper_version,  blobs, commitments, cell_proofs])
```

Following the latter we have updated the existing PeerDAS get blobs tests to use the fork agnostic wrapper version. It additionally fixes the filling of `test_blob_full_txs.py` tests for Osaka by introducing this field.

Assuming the version updates again in the future we will only need to add a new fork method with the new version.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Blocker for #1884.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
