### PR TITLE
fix typo in test_vm.py

### DIFF
--- a/src/ethereum_test_vm/tests/test_vm.py
+++ b/src/ethereum_test_vm/tests/test_vm.py
@@ -451,11 +451,11 @@ def test_opcode_kwargs_validation():
         Op.MSTORE(offset=0, value=1, wrong_arg=2)
 
     with pytest.raises(
-        ValueError, match=r"Invalid keyword argument\(s\) \['addres'\] for opcode CALL"
+        ValueError, match=r"Invalid keyword argument\(s\) \['address'\] for opcode CALL"
     ):
         Op.CALL(
             gas=1,
-            addres=2,  # codespell:ignore
+            address=2,  # codespell:ignore
             value=3,
             args_offset=4,
             args_size=5,


### PR DESCRIPTION

---


**Description:**  
This PR corrects a minor typo in the `test_opcode_kwargs_validation` test:
- Replaces the incorrect keyword argument `'addres'` with `'address'`.


---