### PR TITLE
chore(ci): Remove deprecated macos-latest in favor of macos-15

### DIFF
--- a/.github/workflows/tox_verify.yaml
+++ b/.github/workflows/tox_verify.yaml
@@ -111,7 +111,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-latest
+          - os: macos-15
             python: "3.11"
           - os: ubuntu-latest
             python: "3.12"
@@ -155,8 +155,8 @@ jobs:
           - os: [self-hosted-ghr, size-xl-x64]
             name: self-hosted-ghr-xl-x64
             python: "3.11"
-          - os: macos-latest
-            name: macos-latest
+          - os: macos-15
+            name: macos-15
             python: "3.12"
     steps:
       - name: Checkout ethereum/execution-spec-tests
@@ -190,7 +190,7 @@ jobs:
         include:
           - os: ubuntu-latest
             python: "3.11"
-          - os: macos-latest
+          - os: macos-15
             python: "3.12"
     steps:
       - name: Checkout ethereum/execution-spec-tests


### PR DESCRIPTION
## 🗒️ Description
There is a github actions warning that says macos-latest will become macos-15 on August 4. Updated our CI.

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).