### PR TITLE
style(tools): convert absolute to relative imports across codebase

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -90,6 +90,7 @@ Users can select any of the artifacts depending on their testing needs for their
 ### 📋 Misc
 
 - 🔀 Use only relative imports in `tests/` directory ([#1848](https://github.com/ethereum/execution-spec-tests/pull/1848)).
+- 🔀 Convert absolute imports to relative imports in `src/` directory for better code maintainability ([#1907](https://github.com/ethereum/execution-spec-tests/pull/1907)).
 - 🔀 Misc. doc updates, including a navigation footer ([#1846](https://github.com/ethereum/execution-spec-tests/pull/1846)).
 - 🔀 Remove Python 3.10 support ([#1808](https://github.com/ethereum/execution-spec-tests/pull/1808)).
 - 🔀 Modernize codebase with Python 3.11 language features ([#1812](https://github.com/ethereum/execution-spec-tests/pull/1812)).

--- a/src/cli/eest/cli.py
+++ b/src/cli/eest/cli.py
@@ -5,8 +5,8 @@ Invoke using `uv run eest`.
 
 import click
 
-from cli.eest.commands import clean, info
-from cli.eest.make.cli import make
+from .commands import clean, info
+from .make.cli import make
 
 
 @click.group(context_settings={"help_option_names": ["-h", "--help"], "max_content_width": 120})

--- a/src/cli/eest/make/cli.py
+++ b/src/cli/eest/make/cli.py
@@ -10,9 +10,7 @@ is present, it shows a list of valid subcommands to choose from.
 
 import click
 
-from cli.eest.make.commands import create_default_env
-
-from .commands import test
+from .commands import create_default_env, test
 
 
 @click.group(short_help="Generate project files.")

--- a/src/cli/eest/make/commands/env.py
+++ b/src/cli/eest/make/commands/env.py
@@ -3,8 +3,9 @@
 import click
 from jinja2 import Environment, PackageLoader
 
-from cli.eest.quotes import get_quote
 from config.env import ENV_PATH, Config
+
+from ...quotes import get_quote
 
 
 @click.command(short_help="Generate the default environment file (env.yaml).", name="env")

--- a/src/cli/eest/make/commands/test.py
+++ b/src/cli/eest/make/commands/test.py
@@ -13,9 +13,10 @@ from pathlib import Path
 import click
 import jinja2
 
-from cli.input import input_select, input_text
 from config.docs import DocsConfig
 from ethereum_test_forks import get_development_forks, get_forks
+
+from ....input import input_select, input_text
 
 template_loader = jinja2.PackageLoader("cli.eest.make")
 template_env = jinja2.Environment(

--- a/src/cli/eofwrap.py
+++ b/src/cli/eofwrap.py
@@ -19,7 +19,6 @@ from typing import Any, Dict, no_type_check
 
 import click
 
-from cli.evm_bytes import OpcodeWithOperands, process_evm_bytes
 from ethereum_clis import CLINotFoundInPathError
 from ethereum_clis.clis.evmone import EvmOneTransitionTool
 from ethereum_test_base_types import Bytes, EthereumTestRootModel
@@ -35,6 +34,8 @@ from ethereum_test_types import Transaction
 from ethereum_test_types.block_types import Environment
 from ethereum_test_types.eof.v1 import Container
 from ethereum_test_vm.bytecode import Bytecode
+
+from .evm_bytes import OpcodeWithOperands, process_evm_bytes
 
 
 @click.command()

--- a/src/cli/gentest/tests/test_cli.py
+++ b/src/cli/gentest/tests/test_cli.py
@@ -3,10 +3,11 @@
 import pytest
 from click.testing import CliRunner
 
-from cli.gentest.cli import generate
-from cli.gentest.test_context_providers import StateTestProvider
 from ethereum_test_base_types import Account
 from ethereum_test_tools import Environment, Storage, Transaction
+
+from ..cli import generate
+from ..test_context_providers import StateTestProvider
 
 transactions_by_type = {
     0: {

--- a/src/pytest_plugins/consume/simulators/base.py
+++ b/src/pytest_plugins/consume/simulators/base.py
@@ -12,7 +12,8 @@ from ethereum_test_fixtures import (
 from ethereum_test_fixtures.consume import TestCaseIndexFile, TestCaseStream
 from ethereum_test_fixtures.file import Fixtures
 from ethereum_test_rpc import EthRPC
-from pytest_plugins.consume.consume import FixturesSource
+
+from ..consume import FixturesSource
 
 
 @pytest.fixture(scope="function")

--- a/src/pytest_plugins/consume/simulators/simulator_logic/test_via_engine.py
+++ b/src/pytest_plugins/consume/simulators/simulator_logic/test_via_engine.py
@@ -11,9 +11,9 @@ from ethereum_test_exceptions import UndefinedException
 from ethereum_test_fixtures import BlockchainEngineFixture
 from ethereum_test_rpc import EngineRPC, EthRPC
 from ethereum_test_rpc.types import ForkchoiceState, JSONRPCError, PayloadStatusEnum
-from pytest_plugins.consume.simulators.helpers.exceptions import GenesisBlockMismatchExceptionError
-from pytest_plugins.logging import get_logger
 
+from ....logging import get_logger
+from ..helpers.exceptions import GenesisBlockMismatchExceptionError
 from ..helpers.timing import TimingData
 
 logger = get_logger(__name__)

--- a/src/pytest_plugins/consume/simulators/simulator_logic/test_via_rlp.py
+++ b/src/pytest_plugins/consume/simulators/simulator_logic/test_via_rlp.py
@@ -9,8 +9,8 @@ import logging
 
 from ethereum_test_fixtures import BlockchainFixture
 from ethereum_test_rpc import EthRPC
-from pytest_plugins.consume.simulators.helpers.exceptions import GenesisBlockMismatchExceptionError
 
+from ..helpers.exceptions import GenesisBlockMismatchExceptionError
 from ..helpers.timing import TimingData
 
 logger = logging.getLogger(__name__)

--- a/src/pytest_plugins/consume/simulators/single_test_client.py
+++ b/src/pytest_plugins/consume/simulators/single_test_client.py
@@ -12,10 +12,10 @@ from hive.testing import HiveTest
 from ethereum_test_base_types import Number, to_json
 from ethereum_test_fixtures import BlockchainFixtureCommon
 from ethereum_test_fixtures.blockchain import FixtureHeader
-from pytest_plugins.consume.simulators.helpers.ruleset import (
+
+from .helpers.ruleset import (
     ruleset,  # TODO: generate dynamically
 )
-
 from .helpers.timing import TimingData
 
 logger = logging.getLogger(__name__)

--- a/src/pytest_plugins/consume/simulators/test_case_description.py
+++ b/src/pytest_plugins/consume/simulators/test_case_description.py
@@ -11,7 +11,8 @@ from hive.client import ClientType
 
 from ethereum_test_fixtures import BaseFixture
 from ethereum_test_fixtures.consume import TestCaseIndexFile, TestCaseStream
-from pytest_plugins.pytest_hive.hive_info import ClientFile, HiveInfo
+
+from ...pytest_hive.hive_info import ClientFile, HiveInfo
 
 logger = logging.getLogger(__name__)
 

--- a/src/pytest_plugins/consume/tests/test_fixtures_source_input_types.py
+++ b/src/pytest_plugins/consume/tests/test_fixtures_source_input_types.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from pytest_plugins.consume.consume import CACHED_DOWNLOADS_DIRECTORY, FixturesSource
+from ..consume import CACHED_DOWNLOADS_DIRECTORY, FixturesSource
 
 
 class TestSimplifiedConsumeBehavior:

--- a/src/pytest_plugins/execute/execute.py
+++ b/src/pytest_plugins/execute/execute.py
@@ -12,13 +12,13 @@ from ethereum_test_forks import Fork
 from ethereum_test_rpc import EngineRPC, EthRPC
 from ethereum_test_tools import BaseTest
 from ethereum_test_types import EnvironmentDefaults, TransactionDefaults
-from pytest_plugins.spec_version_checker.spec_version_checker import EIPSpecTestItem
 
 from ..shared.helpers import (
     get_spec_format_for_item,
     is_help_or_collectonly_mode,
     labeled_format_parameter_set,
 )
+from ..spec_version_checker.spec_version_checker import EIPSpecTestItem
 from .pre_alloc import Alloc
 
 

--- a/src/pytest_plugins/execute/rpc/hive.py
+++ b/src/pytest_plugins/execute/rpc/hive.py
@@ -39,7 +39,8 @@ from ethereum_test_tools import (
 )
 from ethereum_test_types import Requests
 from ethereum_test_types.trie import keccak256
-from pytest_plugins.consume.simulators.helpers.ruleset import ruleset
+
+from ...consume.simulators.helpers.ruleset import ruleset
 
 
 class HashList(RootModel[List[Hash]]):

--- a/src/pytest_plugins/filler/tests/test_filler.py
+++ b/src/pytest_plugins/filler/tests/test_filler.py
@@ -13,7 +13,7 @@ import pytest
 
 from ethereum_test_tools import Environment
 from ethereum_clis import ExecutionSpecsTransitionTool, TransitionTool
-from pytest_plugins.filler.filler import default_output_directory
+from ..filler import default_output_directory
 
 
 # flake8: noqa

--- a/src/pytest_plugins/filler/tests/test_output_directory.py
+++ b/src/pytest_plugins/filler/tests/test_output_directory.py
@@ -7,7 +7,8 @@ import pytest
 from pytest import TempPathFactory
 
 from ethereum_clis import TransitionTool
-from pytest_plugins.filler.fixture_output import FixtureOutput
+
+from ..fixture_output import FixtureOutput
 
 
 @pytest.fixture(scope="module")

--- a/src/pytest_plugins/shared/execute_fill.py
+++ b/src/pytest_plugins/shared/execute_fill.py
@@ -8,7 +8,8 @@ from ethereum_test_execution import BaseExecute, LabeledExecuteFormat
 from ethereum_test_fixtures import BaseFixture, LabeledFixtureFormat
 from ethereum_test_specs import BaseTest
 from ethereum_test_types import EOA, Alloc
-from pytest_plugins.spec_version_checker.spec_version_checker import EIPSpecTestItem
+
+from ..spec_version_checker.spec_version_checker import EIPSpecTestItem
 
 
 @pytest.hookimpl(tryfirst=True)


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Convert absolute imports to relative imports within the same package

Changes affect:

* CLI components (eest, eofwrap)
* Test files across all packages
* Pytest plugin components (consume, execute, filler)
* Framework utility modules

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

Related to #1844 #1848

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
