### PR TITLE
feat(packaging,types): add kzg setup to package-data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ ethereum_test_forks = ["forks/contracts/*.bin"]
 "pytest_plugins" = ["eels_resolutions.json"]
 "cli.eest.make" = ["templates/*.j2"]
 "cli.pytest_commands" = ["pytest_ini_files/*.ini"]
+"ethereum_test_types" = ["kzg_trusted_setup.txt"]
 
 [tool.ruff]
 line-length = 99


### PR DESCRIPTION
## 🗒️ Description
The kzg setup file needs to be specified in the `*.toml` file. This is important while installing eest as a library.


## ✅ Checklist

- [X] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [X] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] ~~All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~ skipped
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
