### PR TITLE
Fix dead links in navigation and documentation

### DIFF
--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -4,8 +4,8 @@
   * Getting Started
       * [Installation](getting_started/installation.md)
       * [Installation Troubleshooting](getting_started/installation_troubleshooting.md)
-      * [Contributing](getting_started/contributing.md)
-      * [Security Policy](getting_started/security.md)
+      * [Contributing](../CONTRIBUTING.md)
+      * [Security Policy](../SECURITY.md)
       * [Code Standards](getting_started/code_standards.md)
       * [Detailed Code Standards](getting_started/code_standards_details.md)
       * [VS Code Setup](getting_started/setup_vs_code.md)


### PR DESCRIPTION






**Description:**
- Updated links to `CONTRIBUTING.md` and `SECURITY.md` in `docs/navigation.md` to point to the correct files.


