### PR TITLE
chore(benchmark): don't fill benchmark tests by default

### DIFF
--- a/src/cli/pytest_commands/pytest_ini_files/pytest-fill.ini
+++ b/src/cli/pytest_commands/pytest_ini_files/pytest-fill.ini
@@ -9,7 +9,6 @@ markers =
     ported_from
     pre_alloc_group: Control shared pre-allocation grouping (use "separate" for isolated group or custom string for named groups)
 addopts = 
-    -m "not benchmark"
     -p pytest_plugins.concurrency
     -p pytest_plugins.filler.pre_alloc
     -p pytest_plugins.filler.filler

--- a/src/cli/pytest_commands/pytest_ini_files/pytest-fill.ini
+++ b/src/cli/pytest_commands/pytest_ini_files/pytest-fill.ini
@@ -9,6 +9,7 @@ markers =
     ported_from
     pre_alloc_group: Control shared pre-allocation grouping (use "separate" for isolated group or custom string for named groups)
 addopts = 
+    -m "not benchmark"
     -p pytest_plugins.concurrency
     -p pytest_plugins.filler.pre_alloc
     -p pytest_plugins.filler.filler

--- a/tests/benchmark/conftest.py
+++ b/tests/benchmark/conftest.py
@@ -12,22 +12,18 @@ def pytest_collection_modifyitems(config, items):
     run_benchmarks = marker_expr and (
         "benchmark" in marker_expr and "not benchmark" not in marker_expr
     )
-
     if gas_benchmark_values:
         run_benchmarks = True
-
     items_for_removal = []
     for i, item in enumerate(items):
-        is_benchmark_test = Path(__file__).parent in Path(item.fspath).parents
-
+        is_in_benchmark_dir = Path(__file__).parent in Path(item.fspath).parents
+        has_benchmark_marker = item.get_closest_marker("benchmark") is not None
+        is_benchmark_test = is_in_benchmark_dir or has_benchmark_marker
         if is_benchmark_test:
-            benchmark_marker = pytest.mark.benchmark
+            if is_in_benchmark_dir and not has_benchmark_marker:
+                benchmark_marker = pytest.mark.benchmark
 
-            if gas_benchmark_values:
-                gas_values = [int(v.strip()) for v in gas_benchmark_values.split(",")]
-                benchmark_marker = pytest.mark.benchmark(gas_values=gas_values)
-
-            item.add_marker(benchmark_marker)
+                item.add_marker(benchmark_marker)
             if not run_benchmarks:
                 items_for_removal.append(i)
 

--- a/tests/benchmark/conftest.py
+++ b/tests/benchmark/conftest.py
@@ -7,6 +7,17 @@ import pytest
 
 def pytest_collection_modifyitems(config, items):
     """Add the `benchmark` marker to all tests under `./tests/benchmark`."""
+    marker_expr = config.getoption("-m", default="")
+    run_benchmarks = marker_expr and (
+        "benchmark" in marker_expr and "not benchmark" not in marker_expr
+    )
+
     for item in items:
         if Path(__file__).parent in Path(item.fspath).parents:
             item.add_marker(pytest.mark.benchmark)
+            if not run_benchmarks:
+                item.add_marker(
+                    pytest.mark.skip(
+                        reason="Benchmark tests skipped by default. Use -m benchmark to run them."
+                    )
+                )

--- a/tests/benchmark/conftest.py
+++ b/tests/benchmark/conftest.py
@@ -8,16 +8,31 @@ import pytest
 def pytest_collection_modifyitems(config, items):
     """Add the `benchmark` marker to all tests under `./tests/benchmark`."""
     marker_expr = config.getoption("-m", default="")
+    gas_benchmark_values = config.getoption("--gas-benchmark-values", default=None)
     run_benchmarks = marker_expr and (
         "benchmark" in marker_expr and "not benchmark" not in marker_expr
     )
 
-    items_to_remove = []
-    for item in items:
-        if Path(__file__).parent in Path(item.fspath).parents:
-            item.add_marker(pytest.mark.benchmark)
-            if not run_benchmarks:
-                items_to_remove.append(item)
+    if gas_benchmark_values:
+        run_benchmarks = True
 
-    for item in items_to_remove:
-        items.remove(item)
+    items_for_removal = []
+    for i, item in enumerate(items):
+        is_benchmark_test = Path(__file__).parent in Path(item.fspath).parents
+
+        if is_benchmark_test:
+            benchmark_marker = pytest.mark.benchmark
+
+            if gas_benchmark_values:
+                gas_values = [int(v.strip()) for v in gas_benchmark_values.split(",")]
+                benchmark_marker = pytest.mark.benchmark(gas_values=gas_values)
+
+            item.add_marker(benchmark_marker)
+            if not run_benchmarks:
+                items_for_removal.append(i)
+
+        elif run_benchmarks:
+            items_for_removal.append(i)
+
+    for i in reversed(items_for_removal):
+        items.pop(i)

--- a/tests/benchmark/conftest.py
+++ b/tests/benchmark/conftest.py
@@ -12,12 +12,12 @@ def pytest_collection_modifyitems(config, items):
         "benchmark" in marker_expr and "not benchmark" not in marker_expr
     )
 
+    items_to_remove = []
     for item in items:
         if Path(__file__).parent in Path(item.fspath).parents:
             item.add_marker(pytest.mark.benchmark)
             if not run_benchmarks:
-                item.add_marker(
-                    pytest.mark.skip(
-                        reason="Benchmark tests skipped by default. Use -m benchmark to run them."
-                    )
-                )
+                items_to_remove.append(item)
+
+    for item in items_to_remove:
+        items.remove(item)

--- a/tox.ini
+++ b/tox.ini
@@ -83,7 +83,7 @@ description = Fill test cases in ./tests/ for deployed mainnet forks, except for
 setenv =
     # Use custom EELS_RESOLUTIONS_FILE if it is set via the environment (eg, in CI)
     EELS_RESOLUTIONS_FILE = {env:EELS_RESOLUTIONS_FILE:}
-commands = fill -n auto -m "not slow and not benchmark" --output=/tmp/fixtures-tox --clean
+commands = fill -n auto -m "not slow" --output=/tmp/fixtures-tox --clean
 
 [testenv:tests-deployed-benchmark]
 description = Fill benchmarking test cases in ./tests/ for deployed mainnet forks, using evmone-t8n.
@@ -94,7 +94,7 @@ description = Fill test cases in ./tests/ for deployed and development mainnet f
 setenv =
     # Use custom EELS_RESOLUTIONS_FILE if it is set via the environment (eg, in CI)
     EELS_RESOLUTIONS_FILE = {env:EELS_RESOLUTIONS_FILE:}
-commands = fill -n auto --until={[forks]develop} -k "not slow and not benchmark" --output=/tmp/fixtures-tox --clean
+commands = fill -n auto --until={[forks]develop} -k "not slow" --output=/tmp/fixtures-tox --clean
 
 # ----------------------------------------------------------------------------------------------
 # ALIAS ENVIRONMENTS


### PR DESCRIPTION
## 🗒️ Description

Updates EEST to not fill benchmark tests by default.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
#1919 

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).