### PR TITLE
chore(ci/benchmark): add current mainnet gas limit

### DIFF
--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -13,7 +13,7 @@ static:
   solc: 0.8.21
 benchmark_test:
   evm-type: benchmark
-  fill-params: --from=Cancun --until=Prague --gas-benchmark-values 1,10,30,60,90,120 -m benchmark --generate-all-formats ./tests
+  fill-params: --from=Cancun --until=Prague --gas-benchmark-values 1,10,30,45,60,90,120 -m benchmark --generate-all-formats ./tests
   solc: 0.8.21
   feature_only: true
 eip7692:


### PR DESCRIPTION
## 🗒️ Description

From the zkEVM benchmark perspective, we are close to start running the full benchmark suite across multiple zkVMs. Thinking with @kevaundray around which gas limit to use, we think using the current mainnet gas limit would be ideal.

While proving times should be linear with the gas limit, publishing results with 30M gas makes the interpretation of numbers a bit harder. Also, not only are proving times important, but also "memory usage" inside the zkVMs -- and many zkVMs have tight max memory limits which we might not reach with 30M, but we might with 45M (current gas limit), so we might not catch a crash.

This PR proposes adding 45M to the list and modifying it over time to always represent the current gas limit on mainnet.

cc @marioevz 