### PR TITLE
feat(specs,tests): Update all benchmark tests to use `gas_benchmark_value`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -47,7 +47,11 @@ Additionally, writing debugging information to the EVM "dump directory" by defau
 
 Due to the crossover between `zkevm` and `benchmark` tests, all instances of the former have been replaced with the latter nomenclature. Repository PR labels and titles are additionally updated to reflect this change.
 
-This update renames the `zkevm` feature release to `benchmark_30M` and further expands the latter for 1M, 10M, 60M, 90M, and 120M block gas limits in `fixtures_benchmark_1M.tar.gz`, `fixtures_benchmark_10M.tar.gz`, `fixtures_benchmark_30M.tar.gz`, `fixtures_benchmark_60M.tar.gz`, `fixtures_benchmark_90M.tar.gz`, and `fixtures_benchmark_120M.tar.gz` respectively.
+This update renames the `zkevm` feature release to `benchmark` and further expands the latter for 1M, 10M, 30M, 45M, 60M, 90M, and 120M block gas limits in `fixtures_benchmark.tar.gz`.
+
+To select a test for a given gas limit, the IDs of the tests have been expanded to contain `benchmark-gas-value_XM`, where `X` can be any of the aforementioned values.
+
+The benchmark release also now includes BlockchainEngineX format that combines most of the tests into a minimal amount of genesis files. For more info see [Blockchain Engine X Tests](https://eest.ethereum.org/main/running_tests/test_formats/blockchain_test_engine_x/) in the EEST documentation.
 
 Users can select any of the artifacts depending on their testing needs for their provers.
 

--- a/src/ethereum_test_specs/blockchain.py
+++ b/src/ethereum_test_specs/blockchain.py
@@ -780,6 +780,7 @@ class BlockchainTest(BaseTest):
                 block=Block(),
                 previous_env=env,
                 previous_alloc=alloc,
+                last_block=False,
             )
             sync_payload = sync_built_block.get_fixture_engine_new_payload()
 

--- a/src/ethereum_test_specs/blockchain.py
+++ b/src/ethereum_test_specs/blockchain.py
@@ -53,7 +53,7 @@ from ethereum_test_fixtures.common import FixtureBlobSchedule
 from ethereum_test_forks import Fork
 from ethereum_test_types import Alloc, Environment, Removable, Requests, Transaction, Withdrawal
 
-from .base import BaseTest, verify_result
+from .base import BaseTest, OpMode, verify_result
 from .debugging import print_traces
 from .helpers import verify_block, verify_transactions
 
@@ -489,6 +489,7 @@ class BlockchainTest(BaseTest):
         block: Block,
         previous_env: Environment,
         previous_alloc: Alloc,
+        last_block: bool,
     ) -> BuiltBlock:
         """Generate common block data for both make_fixture and make_hive_fixture."""
         env = block.set_environment(previous_env)
@@ -553,6 +554,18 @@ class BlockchainTest(BaseTest):
         if block.header_verify is not None:
             # Verify the header after transition tool processing.
             block.header_verify.verify(header)
+
+        if last_block and self._operation_mode == OpMode.BENCHMARKING:
+            expected_benchmark_gas_used = self.expected_benchmark_gas_used
+            assert expected_benchmark_gas_used is not None, (
+                "expected_benchmark_gas_used is not set"
+            )
+            gas_used = int(transition_tool_output.result.gas_used)
+            assert gas_used == expected_benchmark_gas_used, (
+                f"gas_used ({gas_used}) does not match expected_benchmark_gas_used "
+                f"({expected_benchmark_gas_used})"
+                f", difference: {gas_used - expected_benchmark_gas_used}"
+            )
 
         requests_list: List[Bytes] | None = None
         if fork.header_requests_required(header.number, header.timestamp):
@@ -659,7 +672,7 @@ class BlockchainTest(BaseTest):
         env = environment_from_parent_header(genesis.header)
         head = genesis.header.block_hash
         invalid_blocks = 0
-        for block in self.blocks:
+        for i, block in enumerate(self.blocks):
             # This is the most common case, the RLP needs to be constructed
             # based on the transactions to be included in the block.
             # Set the environment according to the block to execute.
@@ -669,6 +682,7 @@ class BlockchainTest(BaseTest):
                 block=block,
                 previous_env=env,
                 previous_alloc=alloc,
+                last_block=i == len(self.blocks) - 1,
             )
             fixture_blocks.append(built_block.get_fixture_block())
             if block.exception is None:
@@ -718,13 +732,14 @@ class BlockchainTest(BaseTest):
         env = environment_from_parent_header(genesis.header)
         head_hash = genesis.header.block_hash
         invalid_blocks = 0
-        for block in self.blocks:
+        for i, block in enumerate(self.blocks):
             built_block = self.generate_block_data(
                 t8n=t8n,
                 fork=fork,
                 block=block,
                 previous_env=env,
                 previous_alloc=alloc,
+                last_block=i == len(self.blocks) - 1,
             )
             fixture_payloads.append(built_block.get_fixture_engine_new_payload())
             if block.exception is None:

--- a/src/ethereum_test_specs/state.py
+++ b/src/ethereum_test_specs/state.py
@@ -32,7 +32,7 @@ from ethereum_test_fixtures.state import (
 from ethereum_test_forks import Fork
 from ethereum_test_types import Alloc, Environment, Transaction
 
-from .base import BaseTest
+from .base import BaseTest, OpMode
 from .blockchain import Block, BlockchainTest, Header
 from .debugging import print_traces
 from .helpers import verify_transactions
@@ -218,6 +218,18 @@ class StateTest(BaseTest):
             pprint(transition_tool_output.result)
             pprint(transition_tool_output.alloc)
             raise e
+
+        if self._operation_mode == OpMode.BENCHMARKING:
+            expected_benchmark_gas_used = self.expected_benchmark_gas_used
+            gas_used = int(transition_tool_output.result.gas_used)
+            assert expected_benchmark_gas_used is not None, (
+                "expected_benchmark_gas_used is not set"
+            )
+            assert gas_used == expected_benchmark_gas_used, (
+                f"gas_used ({gas_used}) does not match expected_benchmark_gas_used "
+                f"({expected_benchmark_gas_used})"
+                f", difference: {gas_used - expected_benchmark_gas_used}"
+            )
 
         return StateFixture(
             env=FixtureEnvironment(**env.model_dump(exclude_none=True)),

--- a/src/pytest_plugins/filler/filler.py
+++ b/src/pytest_plugins/filler/filler.py
@@ -889,6 +889,7 @@ def base_test_parametrizer(cls: Type[BaseTest]):
         fixture_collector: FixtureCollector,
         test_case_description: str,
         fixture_source_url: str,
+        gas_benchmark_value: int,
     ):
         """
         Fixture used to instantiate an auto-fillable BaseTest object from within
@@ -914,8 +915,11 @@ def base_test_parametrizer(cls: Type[BaseTest]):
                 kwargs["t8n_dump_dir"] = dump_dir_parameter_level
                 if "pre" not in kwargs:
                     kwargs["pre"] = pre
+                if "expected_benchmark_gas_used" not in kwargs:
+                    kwargs["expected_benchmark_gas_used"] = gas_benchmark_value
                 super(BaseTestWrapper, self).__init__(*args, **kwargs)
                 self._request = request
+                self._operation_mode = request.config.op_mode
 
                 # Phase 1: Generate pre-allocation groups
                 if fixture_format is BlockchainEngineXFixture and request.config.getoption(

--- a/src/pytest_plugins/shared/benchmarking.py
+++ b/src/pytest_plugins/shared/benchmarking.py
@@ -56,6 +56,6 @@ BENCHMARKING_MAX_GAS = 500_000_000_000
 @pytest.fixture
 def env(request: pytest.FixtureRequest) -> Environment:  # noqa: D103
     """Return an Environment instance with appropriate gas limit based on operation mode."""
-    if request.config.op_mode == OpMode.BENCHMARKING:  # type: ignore[attr-defined]
+    if request.node.get_closest_marker("benchmark") is not None:
         return Environment(gas_limit=BENCHMARKING_MAX_GAS)
     return Environment()

--- a/src/pytest_plugins/shared/benchmarking.py
+++ b/src/pytest_plugins/shared/benchmarking.py
@@ -50,7 +50,7 @@ def gas_benchmark_value(request: pytest.FixtureRequest) -> int:
     return EnvironmentDefaults.gas_limit
 
 
-BENCHMARKING_MAX_GAS = 100_000_000_000
+BENCHMARKING_MAX_GAS = 500_000_000_000
 
 
 @pytest.fixture

--- a/src/pytest_plugins/shared/benchmarking.py
+++ b/src/pytest_plugins/shared/benchmarking.py
@@ -54,8 +54,16 @@ BENCHMARKING_MAX_GAS = 500_000_000_000
 
 
 @pytest.fixture
+def genesis_environment(request: pytest.FixtureRequest) -> Environment:  # noqa: D103
+    """Return an Environment instance with appropriate gas limit based on test type."""
+    if request.node.get_closest_marker("benchmark") is not None:
+        return Environment(gas_limit=BENCHMARKING_MAX_GAS)
+    return Environment()
+
+
+@pytest.fixture
 def env(request: pytest.FixtureRequest) -> Environment:  # noqa: D103
-    """Return an Environment instance with appropriate gas limit based on operation mode."""
+    """Return an Environment instance with appropriate gas limit based on test type."""
     if request.node.get_closest_marker("benchmark") is not None:
         return Environment(gas_limit=BENCHMARKING_MAX_GAS)
     return Environment()

--- a/src/pytest_plugins/shared/benchmarking.py
+++ b/src/pytest_plugins/shared/benchmarking.py
@@ -50,12 +50,12 @@ def gas_benchmark_value(request: pytest.FixtureRequest) -> int:
     return EnvironmentDefaults.gas_limit
 
 
-GIGA_GAS = 1_000_000_000
+BENCHMARKING_MAX_GAS = 100_000_000_000
 
 
 @pytest.fixture
 def env(request: pytest.FixtureRequest) -> Environment:  # noqa: D103
     """Return an Environment instance with appropriate gas limit based on operation mode."""
     if request.config.op_mode == OpMode.BENCHMARKING:  # type: ignore[attr-defined]
-        return Environment(gas_limit=GIGA_GAS)
+        return Environment(gas_limit=BENCHMARKING_MAX_GAS)
     return Environment()

--- a/src/pytest_plugins/shared/execute_fill.py
+++ b/src/pytest_plugins/shared/execute_fill.py
@@ -8,7 +8,6 @@ import pytest
 from ethereum_test_execution import BaseExecute, LabeledExecuteFormat
 from ethereum_test_fixtures import BaseFixture, LabeledFixtureFormat
 from ethereum_test_specs import BaseTest
-from ethereum_test_tools import Environment
 from ethereum_test_types import EOA, Alloc
 
 from ..spec_version_checker.spec_version_checker import EIPSpecTestItem
@@ -20,6 +19,19 @@ class OpMode(StrEnum):
 
     CONSENSUS = "consensus"
     BENCHMARKING = "benchmarking"
+
+
+ALL_FIXTURE_PARAMETERS = {
+    "genesis_environment",
+    "env",
+}
+"""
+List of test parameters that have a default fixture value which can be retrieved and used
+for the test instance if it was not explicitly specified when calling from the test
+function.
+
+All parameter names included in this list must define a fixture in one of the plugins.
+"""
 
 
 @pytest.hookimpl(tryfirst=True)
@@ -194,8 +206,3 @@ def pytest_addoption(parser: pytest.Parser):
         default=None,
         help=("Enable reading and filling from static test files."),
     )
-
-
-@pytest.fixture
-def env(request: pytest.FixtureRequest) -> Environment:  # noqa: D103
-    return Environment()

--- a/tests/benchmark/test_worst_blocks.py
+++ b/tests/benchmark/test_worst_blocks.py
@@ -109,6 +109,7 @@ def ether_transfer_case(
 )
 def test_block_full_of_ether_transfers(
     blockchain_test: BlockchainTestFiller,
+    env: Environment,
     pre: Alloc,
     case_id: str,
     ether_transfer_case,
@@ -151,7 +152,7 @@ def test_block_full_of_ether_transfers(
     )
 
     blockchain_test(
-        genesis_environment=Environment(),
+        genesis_environment=env,
         pre=pre,
         post=post_state,
         blocks=[Block(txs=txs)],

--- a/tests/benchmark/test_worst_blocks.py
+++ b/tests/benchmark/test_worst_blocks.py
@@ -156,6 +156,7 @@ def test_block_full_of_ether_transfers(
         post=post_state,
         blocks=[Block(txs=txs)],
         exclude_full_post_state_in_output=True,
+        expected_benchmark_gas_used=iteration_count * intrinsic_cost,
     )
 
 

--- a/tests/benchmark/test_worst_blocks.py
+++ b/tests/benchmark/test_worst_blocks.py
@@ -14,7 +14,6 @@ from ethereum_test_tools import (
     Alloc,
     Block,
     BlockchainTestFiller,
-    Environment,
     StateTestFiller,
     Transaction,
 )
@@ -109,7 +108,6 @@ def ether_transfer_case(
 )
 def test_block_full_of_ether_transfers(
     blockchain_test: BlockchainTestFiller,
-    env: Environment,
     pre: Alloc,
     case_id: str,
     ether_transfer_case,
@@ -152,7 +150,6 @@ def test_block_full_of_ether_transfers(
     )
 
     blockchain_test(
-        genesis_environment=env,
         pre=pre,
         post=post_state,
         blocks=[Block(txs=txs)],
@@ -176,7 +173,6 @@ def test_block_full_data(
     intrinsic_cost: int,
     total_cost_floor_per_token: int,
     gas_benchmark_value: int,
-    env: Environment,
 ):
     """Test a block with empty payload."""
     # Gas cost calculation based on EIP-7683: (https://eips.ethereum.org/EIPS/eip-7683)
@@ -219,7 +215,6 @@ def test_block_full_data(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,

--- a/tests/benchmark/test_worst_bytecode.py
+++ b/tests/benchmark/test_worst_bytecode.py
@@ -105,7 +105,11 @@ def test_worst_bytecode_single_opcode(
     # fits in the block (there is enough gas available in the block to execute this)
     minimum_gas_limit = code_deposit_gas_minimum * 2 * num_contracts
     if env.gas_limit < minimum_gas_limit:
-        env = Environment(gas_limit=minimum_gas_limit)
+        raise Exception(
+            f"`BENCHMARKING_MAX_GAS` ({env.gas_limit}) is no longer enough to support this test, "
+            f"which requires {minimum_gas_limit} gas for its setup. Update the value or consider "
+            "optimizing gas usage during the setup phase of this test."
+        )
 
     # The initcode will take its address as a starting point to the input to the keccak
     # hash function.
@@ -218,7 +222,6 @@ def test_worst_bytecode_single_opcode(
     )
 
     blockchain_test(
-        genesis_environment=env,
         pre=pre,
         post=post,
         blocks=[
@@ -247,7 +250,6 @@ def test_worst_initcode_jumpdest_analysis(
     pre: Alloc,
     fork: Fork,
     pattern: Bytecode,
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """
@@ -315,7 +317,6 @@ def test_worst_initcode_jumpdest_analysis(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,
@@ -355,7 +356,6 @@ def test_worst_create(
     max_code_size_ratio: float,
     non_zero_data: bool,
     value: int,
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """Test the CREATE and CREATE2 performance with different configurations."""
@@ -425,7 +425,6 @@ def test_worst_create(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,
@@ -445,7 +444,6 @@ def test_worst_creates_collisions(
     pre: Alloc,
     fork: Fork,
     opcode: Op,
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """Test the CREATE and CREATE2 collisions performance."""
@@ -500,7 +498,6 @@ def test_worst_creates_collisions(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,

--- a/tests/benchmark/test_worst_bytecode.py
+++ b/tests/benchmark/test_worst_bytecode.py
@@ -104,7 +104,6 @@ def test_worst_bytecode_single_opcode(
     # Set the block gas limit to a relative high value to ensure the code deposit tx
     # fits in the block (there is enough gas available in the block to execute this)
     minimum_gas_limit = code_deposit_gas_minimum * 2 * num_contracts
-    env = Environment()
     if env.gas_limit < minimum_gas_limit:
         env = Environment(gas_limit=minimum_gas_limit)
 

--- a/tests/benchmark/test_worst_bytecode.py
+++ b/tests/benchmark/test_worst_bytecode.py
@@ -52,6 +52,8 @@ def test_worst_bytecode_single_opcode(
     pre: Alloc,
     fork: Fork,
     opcode: Op,
+    env: Environment,
+    gas_benchmark_value: int,
 ):
     """
     Test a block execution where a single opcode execution maxes out the gas limit,
@@ -70,7 +72,7 @@ def test_worst_bytecode_single_opcode(
     # able to pay for the contract deposit. This has to take into account the 200 gas per byte,
     # but also the quadratic memory expansion costs which have to be paid each time the
     # memory is being setup
-    attack_gas_limit = Environment().gas_limit
+    attack_gas_limit = gas_benchmark_value
     max_contract_size = fork.max_code_size()
 
     gas_costs = fork.gas_costs()
@@ -101,7 +103,10 @@ def test_worst_bytecode_single_opcode(
 
     # Set the block gas limit to a relative high value to ensure the code deposit tx
     # fits in the block (there is enough gas available in the block to execute this)
-    env = Environment(gas_limit=code_deposit_gas_minimum * 2 * num_contracts)
+    minimum_gas_limit = code_deposit_gas_minimum * 2 * num_contracts
+    env = Environment()
+    if env.gas_limit < minimum_gas_limit:
+        env = Environment(gas_limit=minimum_gas_limit)
 
     # The initcode will take its address as a starting point to the input to the keccak
     # hash function.
@@ -243,6 +248,8 @@ def test_worst_initcode_jumpdest_analysis(
     pre: Alloc,
     fork: Fork,
     pattern: Bytecode,
+    env: Environment,
+    gas_benchmark_value: int,
 ):
     """
     Test the jumpdest analysis performance of the initcode.
@@ -301,12 +308,10 @@ def test_worst_initcode_jumpdest_analysis(
     code = code_prefix + code_loop_header + code_loop_body + code_loop_footer
     assert (max_code_size - len(code_invoke_create)) < len(code) <= max_code_size
 
-    env = Environment()
-
     tx = Transaction(
         to=pre.deploy_contract(code=code),
         data=tx_data,
-        gas_limit=env.gas_limit,
+        gas_limit=gas_benchmark_value,
         sender=pre.fund_eoa(),
     )
 
@@ -351,9 +356,10 @@ def test_worst_create(
     max_code_size_ratio: float,
     non_zero_data: bool,
     value: int,
+    env: Environment,
+    gas_benchmark_value: int,
 ):
     """Test the CREATE and CREATE2 performance with different configurations."""
-    env = Environment()
     max_code_size = fork.max_code_size()
 
     code_size = int(max_code_size * max_code_size_ratio)
@@ -415,7 +421,7 @@ def test_worst_create(
     tx = Transaction(
         # Set enough balance in the pre-alloc for `value > 0` configurations.
         to=pre.deploy_contract(code=code, balance=1_000_000_000 if value > 0 else 0),
-        gas_limit=env.gas_limit,
+        gas_limit=gas_benchmark_value,
         sender=pre.fund_eoa(),
     )
 
@@ -440,10 +446,10 @@ def test_worst_creates_collisions(
     pre: Alloc,
     fork: Fork,
     opcode: Op,
+    env: Environment,
+    gas_benchmark_value: int,
 ):
     """Test the CREATE and CREATE2 collisions performance."""
-    env = Environment()
-
     # We deploy a "proxy contract" which is the contract that will be called in a loop
     # using all the gas in the block. This "proxy contract" is the one executing CREATE2
     # failing with a collision.
@@ -483,14 +489,14 @@ def test_worst_creates_collisions(
         pre.deploy_contract(address=addr, code=Op.INVALID)
     else:
         # Heuristic to have an upper bound.
-        max_contract_count = 2 * env.gas_limit // gas_costs.G_CREATE
+        max_contract_count = 2 * gas_benchmark_value // gas_costs.G_CREATE
         for nonce in range(max_contract_count):
             addr = compute_create_address(address=proxy_contract, nonce=nonce)
             pre.deploy_contract(address=addr, code=Op.INVALID)
 
     tx = Transaction(
         to=tx_target,
-        gas_limit=env.gas_limit,
+        gas_limit=gas_benchmark_value,
         sender=pre.fund_eoa(),
     )
 

--- a/tests/benchmark/test_worst_compute.py
+++ b/tests/benchmark/test_worst_compute.py
@@ -2028,6 +2028,7 @@ def test_empty_block(
 ):
     """Test running an empty block as a baseline for fixed proving costs."""
     blockchain_test(
+        genesis_environment=env,
         pre=pre,
         post={},
         blocks=[Block(txs=[])],

--- a/tests/benchmark/test_worst_compute.py
+++ b/tests/benchmark/test_worst_compute.py
@@ -22,7 +22,6 @@ from ethereum_test_tools import (
     Block,
     BlockchainTestFiller,
     Bytecode,
-    Environment,
     StateTestFiller,
     Transaction,
     add_kzg_version,
@@ -88,7 +87,6 @@ def test_worst_zero_param(
     pre: Alloc,
     opcode: Op,
     fork: Fork,
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """Test running a block with as many zero-parameter opcodes as possible."""
@@ -107,7 +105,6 @@ def test_worst_zero_param(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,
@@ -121,7 +118,6 @@ def test_worst_calldatasize(
     pre: Alloc,
     fork: Fork,
     calldata_length: int,
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """Test running a block with as many CALLDATASIZE as possible."""
@@ -142,7 +138,6 @@ def test_worst_calldatasize(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,
@@ -158,7 +153,6 @@ def test_worst_callvalue(
     fork: Fork,
     non_zero_value: bool,
     from_origin: bool,
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """
@@ -196,7 +190,6 @@ def test_worst_callvalue(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,
@@ -227,7 +220,6 @@ def test_worst_returndatasize_nonzero(
     fork: Fork,
     returned_size: int,
     return_data_style: ReturnDataStyle,
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """
@@ -268,7 +260,6 @@ def test_worst_returndatasize_nonzero(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,
@@ -280,7 +271,6 @@ def test_worst_returndatasize_zero(
     state_test: StateTestFiller,
     pre: Alloc,
     fork: Fork,
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """Test running a block with as many RETURNDATASIZE opcodes as possible with a zero buffer."""
@@ -302,7 +292,6 @@ def test_worst_returndatasize_zero(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,
@@ -316,7 +305,6 @@ def test_worst_msize(
     pre: Alloc,
     fork: Fork,
     mem_size: int,
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """
@@ -344,7 +332,6 @@ def test_worst_msize(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,
@@ -356,7 +343,6 @@ def test_worst_keccak(
     state_test: StateTestFiller,
     pre: Alloc,
     fork: Fork,
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """Test running a block with as many KECCAK256 permutations as possible."""
@@ -421,7 +407,6 @@ def test_worst_keccak(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,
@@ -445,7 +430,6 @@ def test_worst_precompile_only_data_input(
     static_cost: int,
     per_word_dynamic_cost: int,
     bytes_per_unit_of_work: int,
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """Test running a block with as many precompile calls which have a single `data` input."""
@@ -501,7 +485,6 @@ def test_worst_precompile_only_data_input(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,
@@ -816,7 +799,6 @@ def test_worst_modexp(
     pre: Alloc,
     fork: Fork,
     mod_exp_input: ModExpInput,
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """
@@ -840,7 +822,6 @@ def test_worst_modexp(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,
@@ -1093,7 +1074,6 @@ def test_worst_precompile_fixed_cost(
     fork: Fork,
     precompile_address: Address,
     parameters: list[str] | list[BytesConcatenation] | list[bytes],
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """Test running a block filled with a precompile with fixed cost."""
@@ -1138,7 +1118,6 @@ def test_worst_precompile_fixed_cost(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,
@@ -1150,7 +1129,6 @@ def test_worst_precompile_fixed_cost(
 def test_worst_jumps(
     state_test: StateTestFiller,
     pre: Alloc,
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """Test running a JUMP-intensive contract."""
@@ -1164,7 +1142,6 @@ def test_worst_jumps(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,
@@ -1176,7 +1153,6 @@ def test_worst_jumpi_fallthrough(
     state_test: StateTestFiller,
     pre: Alloc,
     fork: Fork,
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """Test running a JUMPI-intensive contract with fallthrough."""
@@ -1203,7 +1179,6 @@ def test_worst_jumpi_fallthrough(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,
@@ -1214,7 +1189,6 @@ def test_worst_jumpi_fallthrough(
 def test_worst_jumpis(
     state_test: StateTestFiller,
     pre: Alloc,
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """Test running a JUMPI-intensive contract."""
@@ -1228,7 +1202,6 @@ def test_worst_jumpis(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,
@@ -1241,7 +1214,6 @@ def test_worst_jumpdests(
     state_test: StateTestFiller,
     pre: Alloc,
     fork: Fork,
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """Test running a JUMPDEST-intensive contract."""
@@ -1260,7 +1232,6 @@ def test_worst_jumpdests(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,
@@ -1416,7 +1387,6 @@ def test_worst_binop_simple(
     opcode: Op,
     fork: Fork,
     opcode_args: tuple[int, int],
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """
@@ -1443,7 +1413,6 @@ def test_worst_binop_simple(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,
@@ -1457,7 +1426,6 @@ def test_worst_unop(
     pre: Alloc,
     opcode: Op,
     fork: Fork,
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """
@@ -1480,7 +1448,6 @@ def test_worst_unop(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,
@@ -1498,7 +1465,6 @@ def test_worst_tload(
     pre: Alloc,
     key_mut: bool,
     val_mut: bool,
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """Test running a block with as many TLOAD calls as possible."""
@@ -1538,7 +1504,6 @@ def test_worst_tload(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,
@@ -1554,7 +1519,6 @@ def test_worst_tstore(
     pre: Alloc,
     key_mut: bool,
     dense_val_mut: bool,
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """Test running a block with as many TSTORE calls as possible."""
@@ -1583,7 +1547,6 @@ def test_worst_tstore(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,
@@ -1597,7 +1560,6 @@ def test_worst_shifts(
     pre: Alloc,
     fork: Fork,
     shift_right: Op,
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """
@@ -1669,7 +1631,6 @@ def test_worst_shifts(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,
@@ -1692,7 +1653,6 @@ def test_worst_blobhash(
     pre: Alloc,
     blob_index: int,
     blobs_present: bool,
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """Test running a block with as many BLOBHASH instructions as possible."""
@@ -1735,7 +1695,6 @@ def test_worst_blobhash(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,
@@ -1751,7 +1710,6 @@ def test_worst_mod(
     fork: Fork,
     mod_bits: int,
     op: Op,
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """
@@ -1860,7 +1818,6 @@ def test_worst_mod(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,
@@ -1880,7 +1837,6 @@ def test_worst_memory_access(
     offset: int,
     offset_initialized: bool,
     big_memory_expansion: bool,
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """Test running a block with as many memory access instructions as possible."""
@@ -1906,7 +1862,6 @@ def test_worst_memory_access(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,
@@ -1922,7 +1877,6 @@ def test_worst_modarith(
     fork: Fork,
     mod_bits: int,
     op: Op,
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """
@@ -2012,7 +1966,6 @@ def test_worst_modarith(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,
@@ -2023,11 +1976,9 @@ def test_worst_modarith(
 def test_empty_block(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
-    env: Environment,
 ):
     """Test running an empty block as a baseline for fixed proving costs."""
     blockchain_test(
-        genesis_environment=env,
         pre=pre,
         post={},
         blocks=[Block(txs=[])],
@@ -2040,7 +1991,6 @@ def test_amortized_bn128_pairings(
     state_test: StateTestFiller,
     pre: Alloc,
     fork: Fork,
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """Test running a block with as many BN128 pairings as possible."""
@@ -2096,7 +2046,6 @@ def test_amortized_bn128_pairings(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,
@@ -2146,7 +2095,6 @@ def test_worst_calldataload(
     pre: Alloc,
     fork: Fork,
     calldata: bytes,
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """Test running a block with as many CALLDATALOAD as possible."""
@@ -2168,7 +2116,6 @@ def test_worst_calldataload(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,
@@ -2201,7 +2148,6 @@ def test_worst_swap(
     pre: Alloc,
     fork: Fork,
     opcode: Opcode,
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """Test running a block with as many SWAP as possible."""
@@ -2220,7 +2166,6 @@ def test_worst_swap(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,
@@ -2253,7 +2198,6 @@ def test_worst_dup(
     pre: Alloc,
     fork: Fork,
     opcode: Op,
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """Test running a block with as many DUP as possible."""
@@ -2277,7 +2221,6 @@ def test_worst_dup(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,
@@ -2327,7 +2270,6 @@ def test_worst_push(
     pre: Alloc,
     fork: Fork,
     opcode: Op,
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """Test running a block with as many PUSH as possible."""
@@ -2348,7 +2290,6 @@ def test_worst_push(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,
@@ -2376,7 +2317,6 @@ def test_worst_return_revert(
     opcode: Op,
     return_size: int,
     return_non_zero_data: bool,
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """Test running a block with as many RETURN or REVERT as possible."""
@@ -2411,7 +2351,6 @@ def test_worst_return_revert(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,

--- a/tests/benchmark/test_worst_compute.py
+++ b/tests/benchmark/test_worst_compute.py
@@ -88,10 +88,10 @@ def test_worst_zero_param(
     pre: Alloc,
     opcode: Op,
     fork: Fork,
+    env: Environment,
+    gas_benchmark_value: int,
 ):
     """Test running a block with as many zero-parameter opcodes as possible."""
-    env = Environment()
-
     opcode_sequence = opcode * fork.max_stack_height()
     target_contract_address = pre.deploy_contract(code=opcode_sequence)
 
@@ -102,7 +102,7 @@ def test_worst_zero_param(
 
     tx = Transaction(
         to=code_address,
-        gas_limit=env.gas_limit,
+        gas_limit=gas_benchmark_value,
         sender=pre.fund_eoa(),
     )
 
@@ -121,9 +121,10 @@ def test_worst_calldatasize(
     pre: Alloc,
     fork: Fork,
     calldata_length: int,
+    env: Environment,
+    gas_benchmark_value: int,
 ):
     """Test running a block with as many CALLDATASIZE as possible."""
-    env = Environment()
     max_code_size = fork.max_code_size()
 
     code_prefix = Op.JUMPDEST
@@ -135,7 +136,7 @@ def test_worst_calldatasize(
 
     tx = Transaction(
         to=pre.deploy_contract(code=bytes(code)),
-        gas_limit=env.gas_limit,
+        gas_limit=gas_benchmark_value,
         sender=pre.fund_eoa(),
         data=b"\x00" * calldata_length,
     )
@@ -157,6 +158,8 @@ def test_worst_callvalue(
     fork: Fork,
     non_zero_value: bool,
     from_origin: bool,
+    env: Environment,
+    gas_benchmark_value: int,
 ):
     """
     Test running a block with as many CALLVALUE opcodes as possible.
@@ -165,7 +168,6 @@ def test_worst_callvalue(
     The `from_origin` parameter controls whether the call frame is the immediate from the
     transaction or a previous CALL.
     """
-    env = Environment()
     max_code_size = fork.max_code_size()
 
     code_prefix = Op.JUMPDEST
@@ -176,17 +178,19 @@ def test_worst_callvalue(
     assert len(code) <= max_code_size
     code_address = pre.deploy_contract(code=bytes(code))
 
-    tx_to = (
-        code_address
-        if from_origin
-        else pre.deploy_contract(
-            code=Op.CALL(address=code_address, value=1 if non_zero_value else 0), balance=10
+    if from_origin:
+        tx_to = code_address
+    else:
+        entry_code = (
+            Op.JUMPDEST
+            + Op.CALL(address=code_address, value=1 if non_zero_value else 0)
+            + Op.JUMP(Op.PUSH0)
         )
-    )
+        tx_to = pre.deploy_contract(code=entry_code, balance=1_000_000)
 
     tx = Transaction(
         to=tx_to,
-        gas_limit=env.gas_limit,
+        gas_limit=gas_benchmark_value,
         value=1 if non_zero_value and from_origin else 0,
         sender=pre.fund_eoa(),
     )
@@ -223,6 +227,8 @@ def test_worst_returndatasize_nonzero(
     fork: Fork,
     returned_size: int,
     return_data_style: ReturnDataStyle,
+    env: Environment,
+    gas_benchmark_value: int,
 ):
     """
     Test running a block which execute as many RETURNDATASIZE opcodes which return a non-zero
@@ -231,7 +237,6 @@ def test_worst_returndatasize_nonzero(
     The `returned_size` parameter indicates the size of the returned data buffer.
     The `return_data_style` indicates how returned data is produced for the opcode caller.
     """
-    env = Environment()
     max_code_size = fork.max_code_size()
 
     dummy_contract_call = Bytecode()
@@ -258,7 +263,7 @@ def test_worst_returndatasize_nonzero(
 
     tx = Transaction(
         to=pre.deploy_contract(code=bytes(code)),
-        gas_limit=env.gas_limit,
+        gas_limit=gas_benchmark_value,
         sender=pre.fund_eoa(),
     )
 
@@ -271,9 +276,14 @@ def test_worst_returndatasize_nonzero(
 
 
 @pytest.mark.valid_from("Cancun")
-def test_worst_returndatasize_zero(state_test: StateTestFiller, pre: Alloc, fork: Fork):
+def test_worst_returndatasize_zero(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    env: Environment,
+    gas_benchmark_value: int,
+):
     """Test running a block with as many RETURNDATASIZE opcodes as possible with a zero buffer."""
-    env = Environment()
     max_code_size = fork.max_code_size()
 
     dummy_contract_call = Bytecode()
@@ -287,7 +297,7 @@ def test_worst_returndatasize_zero(state_test: StateTestFiller, pre: Alloc, fork
 
     tx = Transaction(
         to=pre.deploy_contract(code=bytes(code)),
-        gas_limit=env.gas_limit,
+        gas_limit=gas_benchmark_value,
         sender=pre.fund_eoa(),
     )
 
@@ -306,13 +316,14 @@ def test_worst_msize(
     pre: Alloc,
     fork: Fork,
     mem_size: int,
+    env: Environment,
+    gas_benchmark_value: int,
 ):
     """
     Test running a block with as many MSIZE opcodes as possible.
 
     The `mem_size` parameter indicates by how much the memory is expanded.
     """
-    env = Environment()
     max_stack_height = fork.max_stack_height()
 
     code_sequence = Op.MLOAD(Op.CALLVALUE) + Op.POP + Op.MSIZE * max_stack_height
@@ -327,7 +338,7 @@ def test_worst_msize(
 
     tx = Transaction(
         to=code_address,
-        gas_limit=env.gas_limit,
+        gas_limit=gas_benchmark_value,
         sender=pre.fund_eoa(),
         value=mem_size,
     )
@@ -345,13 +356,13 @@ def test_worst_keccak(
     state_test: StateTestFiller,
     pre: Alloc,
     fork: Fork,
+    env: Environment,
+    gas_benchmark_value: int,
 ):
     """Test running a block with as many KECCAK256 permutations as possible."""
-    env = Environment()
-
     # Intrinsic gas cost is paid once.
     intrinsic_gas_calculator = fork.transaction_intrinsic_cost_calculator()
-    available_gas = env.gas_limit - intrinsic_gas_calculator()
+    available_gas = gas_benchmark_value - intrinsic_gas_calculator()
 
     gsc = fork.gas_costs()
     mem_exp_gas_calculator = fork.memory_expansion_gas_calculator()
@@ -405,7 +416,7 @@ def test_worst_keccak(
 
     tx = Transaction(
         to=code_address,
-        gas_limit=env.gas_limit,
+        gas_limit=gas_benchmark_value,
         sender=pre.fund_eoa(),
     )
 
@@ -434,13 +445,13 @@ def test_worst_precompile_only_data_input(
     static_cost: int,
     per_word_dynamic_cost: int,
     bytes_per_unit_of_work: int,
+    env: Environment,
+    gas_benchmark_value: int,
 ):
     """Test running a block with as many precompile calls which have a single `data` input."""
-    env = Environment()
-
     # Intrinsic gas cost is paid once.
     intrinsic_gas_calculator = fork.transaction_intrinsic_cost_calculator()
-    available_gas = env.gas_limit - intrinsic_gas_calculator()
+    available_gas = gas_benchmark_value - intrinsic_gas_calculator()
 
     gsc = fork.gas_costs()
     mem_exp_gas_calculator = fork.memory_expansion_gas_calculator()
@@ -485,7 +496,7 @@ def test_worst_precompile_only_data_input(
 
     tx = Transaction(
         to=code_address,
-        gas_limit=env.gas_limit,
+        gas_limit=gas_benchmark_value,
         sender=pre.fund_eoa(),
     )
 
@@ -805,6 +816,8 @@ def test_worst_modexp(
     pre: Alloc,
     fork: Fork,
     mod_exp_input: ModExpInput,
+    env: Environment,
+    gas_benchmark_value: int,
 ):
     """
     Test running a block with as many calls to the MODEXP (5) precompile as possible.
@@ -819,11 +832,9 @@ def test_worst_modexp(
         fork,
     )
 
-    env = Environment()
-
     tx = Transaction(
         to=pre.deploy_contract(code=code),
-        gas_limit=env.gas_limit,
+        gas_limit=gas_benchmark_value,
         sender=pre.fund_eoa(),
         input=calldata,
     )
@@ -1082,10 +1093,10 @@ def test_worst_precompile_fixed_cost(
     fork: Fork,
     precompile_address: Address,
     parameters: list[str] | list[BytesConcatenation] | list[bytes],
+    env: Environment,
+    gas_benchmark_value: int,
 ):
     """Test running a block filled with a precompile with fixed cost."""
-    env = Environment()
-
     if precompile_address not in fork.precompiles():
         pytest.skip("Precompile not enabled")
 
@@ -1122,7 +1133,7 @@ def test_worst_precompile_fixed_cost(
 
     tx = Transaction(
         to=code_address,
-        gas_limit=env.gas_limit,
+        gas_limit=gas_benchmark_value,
         sender=pre.fund_eoa(),
     )
 
@@ -1135,21 +1146,25 @@ def test_worst_precompile_fixed_cost(
 
 
 @pytest.mark.valid_from("Cancun")
-def test_worst_jumps(state_test: StateTestFiller, pre: Alloc):
+@pytest.mark.slow
+def test_worst_jumps(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    env: Environment,
+    gas_benchmark_value: int,
+):
     """Test running a JUMP-intensive contract."""
-    env = Environment()
-
     jumps_code = Op.JUMPDEST + Op.JUMP(Op.PUSH0)
     jumps_address = pre.deploy_contract(jumps_code)
 
     tx = Transaction(
         to=jumps_address,
-        gas_limit=env.gas_limit,
+        gas_limit=gas_benchmark_value,
         sender=pre.fund_eoa(),
     )
 
     state_test(
-        genesis_environment=env,
+        env=env,
         pre=pre,
         post={},
         tx=tx,
@@ -1161,9 +1176,10 @@ def test_worst_jumpi_fallthrough(
     state_test: StateTestFiller,
     pre: Alloc,
     fork: Fork,
+    env: Environment,
+    gas_benchmark_value: int,
 ):
     """Test running a JUMPI-intensive contract with fallthrough."""
-    env = Environment()
     max_code_size = fork.max_code_size()
 
     def jumpi_seq():
@@ -1182,7 +1198,7 @@ def test_worst_jumpi_fallthrough(
 
     tx = Transaction(
         to=jumpis_address,
-        gas_limit=env.gas_limit,
+        gas_limit=gas_benchmark_value,
         sender=pre.fund_eoa(),
     )
 
@@ -1198,16 +1214,16 @@ def test_worst_jumpi_fallthrough(
 def test_worst_jumpis(
     state_test: StateTestFiller,
     pre: Alloc,
+    env: Environment,
+    gas_benchmark_value: int,
 ):
     """Test running a JUMPI-intensive contract."""
-    env = Environment()
-
     jumpi_code = Op.JUMPDEST + Op.JUMPI(Op.PUSH0, Op.NUMBER)
     jumpi_address = pre.deploy_contract(jumpi_code)
 
     tx = Transaction(
         to=jumpi_address,
-        gas_limit=env.gas_limit,
+        gas_limit=gas_benchmark_value,
         sender=pre.fund_eoa(),
     )
 
@@ -1220,9 +1236,15 @@ def test_worst_jumpis(
 
 
 @pytest.mark.valid_from("Cancun")
-def test_worst_jumpdests(state_test: StateTestFiller, pre: Alloc, fork: Fork):
+@pytest.mark.slow
+def test_worst_jumpdests(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    env: Environment,
+    gas_benchmark_value: int,
+):
     """Test running a JUMPDEST-intensive contract."""
-    env = Environment()
     max_code_size = fork.max_code_size()
 
     # Create and deploy a contract with many JUMPDESTs
@@ -1233,12 +1255,12 @@ def test_worst_jumpdests(state_test: StateTestFiller, pre: Alloc, fork: Fork):
 
     tx = Transaction(
         to=jumpdests_address,
-        gas_limit=env.gas_limit,
+        gas_limit=gas_benchmark_value,
         sender=pre.fund_eoa(),
     )
 
     state_test(
-        genesis_environment=env,
+        env=env,
         pre=pre,
         post={},
         tx=tx,
@@ -1389,14 +1411,19 @@ DEFAULT_BINOP_ARGS = (
     ids=lambda param: "" if isinstance(param, tuple) else param,
 )
 def test_worst_binop_simple(
-    state_test: StateTestFiller, pre: Alloc, opcode: Op, fork: Fork, opcode_args: tuple[int, int]
+    state_test: StateTestFiller,
+    pre: Alloc,
+    opcode: Op,
+    fork: Fork,
+    opcode_args: tuple[int, int],
+    env: Environment,
+    gas_benchmark_value: int,
 ):
     """
     Test running a block with as many binary instructions (takes two args, produces one value)
     as possible. The execution starts with two initial values on the stack, and the stack is
     balanced by the DUP2 instruction.
     """
-    env = Environment()
     max_code_size = fork.max_code_size()
 
     tx_data = b"".join(arg.to_bytes(32, byteorder="big") for arg in opcode_args)
@@ -1411,7 +1438,7 @@ def test_worst_binop_simple(
     tx = Transaction(
         to=pre.deploy_contract(code=code),
         data=tx_data,
-        gas_limit=env.gas_limit,
+        gas_limit=gas_benchmark_value,
         sender=pre.fund_eoa(),
     )
 
@@ -1425,12 +1452,18 @@ def test_worst_binop_simple(
 
 @pytest.mark.valid_from("Cancun")
 @pytest.mark.parametrize("opcode", [Op.ISZERO, Op.NOT])
-def test_worst_unop(state_test: StateTestFiller, pre: Alloc, opcode: Op, fork: Fork):
+def test_worst_unop(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    opcode: Op,
+    fork: Fork,
+    env: Environment,
+    gas_benchmark_value: int,
+):
     """
     Test running a block with as many unary instructions (takes one arg, produces one value)
     as possible.
     """
-    env = Environment()
     max_code_size = fork.max_code_size()
 
     code_prefix = Op.JUMPDEST + Op.PUSH0  # Start with the arg 0.
@@ -1442,7 +1475,7 @@ def test_worst_unop(state_test: StateTestFiller, pre: Alloc, opcode: Op, fork: F
 
     tx = Transaction(
         to=pre.deploy_contract(code=code),
-        gas_limit=env.gas_limit,
+        gas_limit=gas_benchmark_value,
         sender=pre.fund_eoa(),
     )
 
@@ -1465,9 +1498,10 @@ def test_worst_tload(
     pre: Alloc,
     key_mut: bool,
     val_mut: bool,
+    env: Environment,
+    gas_benchmark_value: int,
 ):
     """Test running a block with as many TLOAD calls as possible."""
-    env = Environment()
     max_code_size = fork.max_code_size()
 
     start_key = 41
@@ -1498,7 +1532,7 @@ def test_worst_tload(
 
     tx = Transaction(
         to=pre.deploy_contract(code),
-        gas_limit=env.gas_limit,
+        gas_limit=gas_benchmark_value,
         sender=pre.fund_eoa(),
         value=start_key if not key_mut and val_mut else 0,
     )
@@ -1520,9 +1554,10 @@ def test_worst_tstore(
     pre: Alloc,
     key_mut: bool,
     dense_val_mut: bool,
+    env: Environment,
+    gas_benchmark_value: int,
 ):
     """Test running a block with as many TSTORE calls as possible."""
-    env = Environment()
     max_code_size = fork.max_code_size()
 
     init_key = 42
@@ -1543,7 +1578,7 @@ def test_worst_tstore(
 
     tx = Transaction(
         to=pre.deploy_contract(code),
-        gas_limit=env.gas_limit,
+        gas_limit=gas_benchmark_value,
         sender=pre.fund_eoa(),
     )
 
@@ -1562,6 +1597,8 @@ def test_worst_shifts(
     pre: Alloc,
     fork: Fork,
     shift_right: Op,
+    env: Environment,
+    gas_benchmark_value: int,
 ):
     """
     Test running a block with as many shift instructions with non-trivial arguments.
@@ -1624,12 +1661,10 @@ def test_worst_shifts(
     code = code_prefix + code_body + code_suffix
     assert len(code) == max_code_size - 2
 
-    env = Environment()
-
     tx = Transaction(
         to=pre.deploy_contract(code=code),
         data=initial_value.to_bytes(32, byteorder="big"),
-        gas_limit=env.gas_limit,
+        gas_limit=gas_benchmark_value,
         sender=pre.fund_eoa(),
     )
 
@@ -1657,9 +1692,10 @@ def test_worst_blobhash(
     pre: Alloc,
     blob_index: int,
     blobs_present: bool,
+    env: Environment,
+    gas_benchmark_value: int,
 ):
     """Test running a block with as many BLOBHASH instructions as possible."""
-    env = Environment()
     max_code_size = fork.max_code_size()
     max_stack_height = fork.max_stack_height()
 
@@ -1692,7 +1728,7 @@ def test_worst_blobhash(
     tx = Transaction(
         ty=tx_type,
         to=code_address,
-        gas_limit=env.gas_limit,
+        gas_limit=gas_benchmark_value,
         max_fee_per_blob_gas=max_fee_per_blob_gas,
         blob_versioned_hashes=blob_versioned_hashes,
         sender=pre.fund_eoa(),
@@ -1715,6 +1751,8 @@ def test_worst_mod(
     fork: Fork,
     mod_bits: int,
     op: Op,
+    env: Environment,
+    gas_benchmark_value: int,
 ):
     """
     Test running a block with as many MOD instructions with arguments of the parametrized range.
@@ -1813,13 +1851,11 @@ def test_worst_mod(
     )
     assert (max_code_size - len(code_segment)) < len(code) <= max_code_size
 
-    env = Environment()
-
     input_value = initial_mod if not should_negate else neg(initial_mod)
     tx = Transaction(
         to=pre.deploy_contract(code=code),
         data=input_value.to_bytes(32, byteorder="big"),
-        gas_limit=env.gas_limit,
+        gas_limit=gas_benchmark_value,
         sender=pre.fund_eoa(),
     )
 
@@ -1844,9 +1880,10 @@ def test_worst_memory_access(
     offset: int,
     offset_initialized: bool,
     big_memory_expansion: bool,
+    env: Environment,
+    gas_benchmark_value: int,
 ):
     """Test running a block with as many memory access instructions as possible."""
-    env = Environment()
     max_code_size = fork.max_code_size()
 
     mem_exp_code = Op.MSTORE8(10 * 1024, 1) if big_memory_expansion else Bytecode()
@@ -1864,7 +1901,7 @@ def test_worst_memory_access(
 
     tx = Transaction(
         to=pre.deploy_contract(code=code),
-        gas_limit=env.gas_limit,
+        gas_limit=gas_benchmark_value,
         sender=pre.fund_eoa(),
     )
 
@@ -1885,6 +1922,8 @@ def test_worst_modarith(
     fork: Fork,
     mod_bits: int,
     op: Op,
+    env: Environment,
+    gas_benchmark_value: int,
 ):
     """
     Test running a block with as many "op" instructions with arguments of the parametrized range.
@@ -1965,12 +2004,10 @@ def test_worst_modarith(
     code = code_constant_pool + Op.JUMPDEST + code_segment + Op.JUMP(len(code_constant_pool))
     assert (max_code_size - len(code_segment)) < len(code) <= max_code_size
 
-    env = Environment()
-
     tx = Transaction(
         to=pre.deploy_contract(code=code),
         data=initial_mod.to_bytes(32, byteorder="big"),
-        gas_limit=env.gas_limit,
+        gas_limit=gas_benchmark_value,
         sender=pre.fund_eoa(),
     )
 
@@ -1986,15 +2023,15 @@ def test_worst_modarith(
 def test_empty_block(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
+    env: Environment,
+    gas_benchmark_value: int,
 ):
     """Test running an empty block as a baseline for fixed proving costs."""
-    env = Environment()
-
     blockchain_test(
-        env=env,
         pre=pre,
         post={},
         blocks=[Block(txs=[])],
+        expected_benchmark_gas_used=0,
     )
 
 
@@ -2003,10 +2040,10 @@ def test_amortized_bn128_pairings(
     state_test: StateTestFiller,
     pre: Alloc,
     fork: Fork,
+    env: Environment,
+    gas_benchmark_value: int,
 ):
     """Test running a block with as many BN128 pairings as possible."""
-    env = Environment()
-
     base_cost = 45_000
     pairing_cost = 34_000
     size_per_pairing = 192
@@ -2017,7 +2054,7 @@ def test_amortized_bn128_pairings(
 
     # This is a theoretical maximum number of pairings that can be done in a block.
     # It is only used for an upper bound for calculating the optimal number of pairings below.
-    maximum_number_of_pairings = (env.gas_limit - base_cost) // pairing_cost
+    maximum_number_of_pairings = (gas_benchmark_value - base_cost) // pairing_cost
 
     # Discover the optimal number of pairings balancing two dimensions:
     # 1. Amortize the precompile base cost as much as possible.
@@ -2026,7 +2063,7 @@ def test_amortized_bn128_pairings(
     optimal_per_call_num_pairings = 0
     for i in range(1, maximum_number_of_pairings + 1):
         # We'll pass all pairing arguments via calldata.
-        available_gas_after_intrinsic = env.gas_limit - intrinsic_gas_calculator(
+        available_gas_after_intrinsic = gas_benchmark_value - intrinsic_gas_calculator(
             calldata=[0xFF] * size_per_pairing * i  # 0xFF is to indicate non-zero bytes.
         )
         available_gas_after_expansion = max(
@@ -2053,7 +2090,7 @@ def test_amortized_bn128_pairings(
 
     tx = Transaction(
         to=code_address,
-        gas_limit=env.gas_limit,
+        gas_limit=gas_benchmark_value,
         data=_generate_bn128_pairs(optimal_per_call_num_pairings, 42),
         sender=pre.fund_eoa(),
     )
@@ -2109,9 +2146,10 @@ def test_worst_calldataload(
     pre: Alloc,
     fork: Fork,
     calldata: bytes,
+    env: Environment,
+    gas_benchmark_value: int,
 ):
     """Test running a block with as many CALLDATALOAD as possible."""
-    env = Environment()
     max_code_size = fork.max_code_size()
 
     code_prefix = Op.PUSH0 + Op.JUMPDEST
@@ -2125,7 +2163,7 @@ def test_worst_calldataload(
     tx = Transaction(
         to=pre.deploy_contract(code=code),
         data=calldata,
-        gas_limit=env.gas_limit,
+        gas_limit=gas_benchmark_value,
         sender=pre.fund_eoa(),
     )
 
@@ -2163,9 +2201,10 @@ def test_worst_swap(
     pre: Alloc,
     fork: Fork,
     opcode: Opcode,
+    env: Environment,
+    gas_benchmark_value: int,
 ):
     """Test running a block with as many SWAP as possible."""
-    env = Environment()
     max_code_size = fork.max_code_size()
 
     code_prefix = Op.JUMPDEST + Op.PUSH0 * opcode.min_stack_height
@@ -2176,7 +2215,7 @@ def test_worst_swap(
 
     tx = Transaction(
         to=pre.deploy_contract(code=code),
-        gas_limit=env.gas_limit,
+        gas_limit=gas_benchmark_value,
         sender=pre.fund_eoa(),
     )
 
@@ -2214,9 +2253,10 @@ def test_worst_dup(
     pre: Alloc,
     fork: Fork,
     opcode: Op,
+    env: Environment,
+    gas_benchmark_value: int,
 ):
     """Test running a block with as many DUP as possible."""
-    env = Environment()
     max_stack_height = fork.max_stack_height()
 
     min_stack_height = opcode.min_stack_height
@@ -2232,7 +2272,7 @@ def test_worst_dup(
 
     tx = Transaction(
         to=code_address,
-        gas_limit=env.gas_limit,
+        gas_limit=gas_benchmark_value,
         sender=pre.fund_eoa(),
     )
 
@@ -2287,10 +2327,10 @@ def test_worst_push(
     pre: Alloc,
     fork: Fork,
     opcode: Op,
+    env: Environment,
+    gas_benchmark_value: int,
 ):
     """Test running a block with as many PUSH as possible."""
-    env = Environment()
-
     op = opcode[1] if opcode.has_data_portion() else opcode
     opcode_sequence = op * fork.max_stack_height()
     target_contract_address = pre.deploy_contract(code=opcode_sequence)
@@ -2303,7 +2343,7 @@ def test_worst_push(
 
     tx = Transaction(
         to=code_address,
-        gas_limit=env.gas_limit,
+        gas_limit=gas_benchmark_value,
         sender=pre.fund_eoa(),
     )
 
@@ -2336,9 +2376,10 @@ def test_worst_return_revert(
     opcode: Op,
     return_size: int,
     return_non_zero_data: bool,
+    env: Environment,
+    gas_benchmark_value: int,
 ):
     """Test running a block with as many RETURN or REVERT as possible."""
-    env = Environment()
     max_code_size = fork.max_code_size()
 
     # Create the contract that will be called repeatedly.
@@ -2365,7 +2406,7 @@ def test_worst_return_revert(
 
     tx = Transaction(
         to=code_address,
-        gas_limit=env.gas_limit,
+        gas_limit=gas_benchmark_value,
         sender=pre.fund_eoa(),
     )
 

--- a/tests/benchmark/test_worst_compute.py
+++ b/tests/benchmark/test_worst_compute.py
@@ -2024,7 +2024,6 @@ def test_empty_block(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
     env: Environment,
-    gas_benchmark_value: int,
 ):
     """Test running an empty block as a baseline for fixed proving costs."""
     blockchain_test(

--- a/tests/benchmark/test_worst_memory.py
+++ b/tests/benchmark/test_worst_memory.py
@@ -12,7 +12,6 @@ from ethereum_test_forks import Fork
 from ethereum_test_tools import (
     Alloc,
     Bytecode,
-    Environment,
     StateTestFiller,
     Transaction,
 )
@@ -70,7 +69,6 @@ def test_worst_calldatacopy(
     size: int,
     fixed_src_dst: bool,
     non_zero_data: bool,
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """Test running a block filled with CALLDATACOPY executions."""
@@ -123,7 +121,6 @@ def test_worst_calldatacopy(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,
@@ -154,7 +151,6 @@ def test_worst_codecopy(
     fork: Fork,
     max_code_size_ratio: float,
     fixed_src_dst: bool,
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """Test running a block filled with CODECOPY executions."""
@@ -182,7 +178,6 @@ def test_worst_codecopy(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,
@@ -212,7 +207,6 @@ def test_worst_returndatacopy(
     fork: Fork,
     size: int,
     fixed_dst: bool,
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """Test running a block filled with RETURNDATACOPY executions."""
@@ -268,7 +262,6 @@ def test_worst_returndatacopy(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,
@@ -298,7 +291,6 @@ def test_worst_mcopy(
     fork: Fork,
     size: int,
     fixed_src_dst: bool,
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """Test running a block filled with MCOPY executions."""
@@ -329,7 +321,6 @@ def test_worst_mcopy(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,

--- a/tests/benchmark/test_worst_opcode.py
+++ b/tests/benchmark/test_worst_opcode.py
@@ -52,9 +52,10 @@ def test_worst_log_opcodes(
     size: int,
     fixed_offset: bool,
     non_zero_data: bool,
+    env: Environment,
+    gas_benchmark_value: int,
 ):
     """Test running a block with as many LOG opcodes as possible."""
-    env = Environment()
     max_code_size = fork.max_code_size()
 
     calldata = Bytecode()
@@ -85,7 +86,7 @@ def test_worst_log_opcodes(
 
     tx = Transaction(
         to=code_address,
-        gas_limit=env.gas_limit,
+        gas_limit=gas_benchmark_value,
         sender=pre.fund_eoa(),
     )
 

--- a/tests/benchmark/test_worst_opcode.py
+++ b/tests/benchmark/test_worst_opcode.py
@@ -11,7 +11,6 @@ from ethereum_test_forks import Fork
 from ethereum_test_tools import (
     Alloc,
     Bytecode,
-    Environment,
     StateTestFiller,
     Transaction,
 )
@@ -52,7 +51,6 @@ def test_worst_log_opcodes(
     size: int,
     fixed_offset: bool,
     non_zero_data: bool,
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """Test running a block with as many LOG opcodes as possible."""
@@ -91,7 +89,6 @@ def test_worst_log_opcodes(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,

--- a/tests/benchmark/test_worst_stateful_opcodes.py
+++ b/tests/benchmark/test_worst_stateful_opcodes.py
@@ -570,7 +570,7 @@ def test_worst_selfdestruct_existing(
 ):
     """Test running a block with as many SELFDESTRUCTs as possible for existing contracts."""
     attack_gas_limit = gas_benchmark_value
-    pre.fund_address(env.fee_recipient, 1)
+    fee_recipient = pre.fund_eoa(amount=1)
 
     # Template code that will be used to deploy a large number of contracts.
     selfdestructable_contract_addr = pre.deploy_contract(code=Op.SELFDESTRUCT(Op.COINBASE))
@@ -691,7 +691,7 @@ def test_worst_selfdestruct_existing(
         post=post,
         blocks=[
             Block(txs=[contracts_deployment_tx]),
-            Block(txs=[opcode_tx]),
+            Block(txs=[opcode_tx], fee_recipient=fee_recipient),
         ],
         exclude_full_post_state_in_output=True,
         expected_benchmark_gas_used=expected_benchmark_gas_used,
@@ -712,7 +712,8 @@ def test_worst_selfdestruct_created(
     Test running a block with as many SELFDESTRUCTs as possible for deployed contracts in
     the same transaction.
     """
-    pre.fund_address(env.fee_recipient, 1)
+    fee_recipient = pre.fund_eoa(amount=1)
+    env.fee_recipient = fee_recipient
 
     # SELFDESTRUCT(COINBASE) contract deployment
     initcode = (
@@ -790,6 +791,7 @@ def test_worst_selfdestruct_created(
 
     post = {code_addr: Account(storage={0: 42})}  # Check for successful execution.
     state_test(
+        env=env,
         pre=pre,
         post=post,
         tx=code_tx,
@@ -808,7 +810,8 @@ def test_worst_selfdestruct_initcode(
     gas_benchmark_value: int,
 ):
     """Test running a block with as many SELFDESTRUCTs as possible executed in initcode."""
-    pre.fund_address(env.fee_recipient, 1)
+    fee_recipient = pre.fund_eoa(amount=1)
+    env.fee_recipient = fee_recipient
 
     gas_costs = fork.gas_costs()
     memory_expansion_calc = fork().memory_expansion_gas_calculator()
@@ -871,6 +874,7 @@ def test_worst_selfdestruct_initcode(
 
     post = {code_addr: Account(storage={0: 42})}  # Check for successful execution.
     state_test(
+        env=env,
         pre=pre,
         post=post,
         tx=code_tx,

--- a/tests/benchmark/test_worst_stateful_opcodes.py
+++ b/tests/benchmark/test_worst_stateful_opcodes.py
@@ -178,7 +178,7 @@ def test_worst_address_state_warm(
     )
 
     state_test(
-        genesis_environment=env,
+        env=env,
         pre=pre,
         post=post,
         tx=tx,

--- a/tests/benchmark/test_worst_stateful_opcodes.py
+++ b/tests/benchmark/test_worst_stateful_opcodes.py
@@ -109,7 +109,6 @@ def test_worst_address_state_cold(
     blocks.append(Block(txs=[op_tx]))
 
     blockchain_test(
-        genesis_environment=env,
         pre=pre,
         post=post,
         blocks=blocks,
@@ -143,7 +142,6 @@ def test_worst_address_state_warm(
     fork: Fork,
     opcode: Op,
     absent_target: bool,
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """Test running a block with as many stateful opcodes doing warm access for an account."""
@@ -178,7 +176,6 @@ def test_worst_address_state_warm(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post=post,
         tx=tx,
@@ -374,7 +371,6 @@ def test_worst_storage_access_cold(
     blocks.append(Block(txs=[op_tx]))
 
     blockchain_test(
-        genesis_environment=env,
         pre=pre,
         post={},
         blocks=blocks,
@@ -452,7 +448,6 @@ def test_worst_storage_access_warm(
     blocks.append(Block(txs=[op_tx]))
 
     blockchain_test(
-        genesis_environment=env,
         pre=pre,
         post={},
         blocks=blocks,
@@ -463,7 +458,6 @@ def test_worst_storage_access_warm(
 def test_worst_blockhash(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """Test running a block with as many blockhash accessing oldest allowed block as possible."""
@@ -483,7 +477,6 @@ def test_worst_blockhash(
     blocks.append(Block(txs=[op_tx]))
 
     blockchain_test(
-        genesis_environment=env,
         pre=pre,
         post={},
         blocks=blocks,
@@ -495,7 +488,6 @@ def test_worst_selfbalance(
     state_test: StateTestFiller,
     pre: Alloc,
     fork: Fork,
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """Test running a block with as many SELFBALANCE opcodes as possible."""
@@ -519,7 +511,6 @@ def test_worst_selfbalance(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,
@@ -539,7 +530,6 @@ def test_worst_extcodecopy_warm(
     state_test: StateTestFiller,
     pre: Alloc,
     copied_size: int,
-    env: Environment,
     gas_benchmark_value: int,
 ):
     """Test running a block with as many wamr EXTCODECOPY work as possible."""
@@ -562,7 +552,6 @@ def test_worst_extcodecopy_warm(
     )
 
     state_test(
-        env=env,
         pre=pre,
         post={},
         tx=tx,
@@ -698,7 +687,6 @@ def test_worst_selfdestruct_existing(
         deployed_contract_addresses.append(deployed_contract_address)
 
     blockchain_test(
-        genesis_environment=env,
         pre=pre,
         post=post,
         blocks=[
@@ -802,7 +790,6 @@ def test_worst_selfdestruct_created(
 
     post = {code_addr: Account(storage={0: 42})}  # Check for successful execution.
     state_test(
-        env=env,
         pre=pre,
         post=post,
         tx=code_tx,
@@ -884,7 +871,6 @@ def test_worst_selfdestruct_initcode(
 
     post = {code_addr: Account(storage={0: 42})}  # Check for successful execution.
     state_test(
-        env=env,
         pre=pre,
         post=post,
         tx=code_tx,

--- a/tests/benchmark/test_worst_stateful_opcodes.py
+++ b/tests/benchmark/test_worst_stateful_opcodes.py
@@ -779,9 +779,8 @@ def test_worst_selfdestruct_created(
     # The 0 storage slot is initialize to avoid creation costs in SSTORE above.
     code_addr = pre.deploy_contract(
         code=code,
-        balance=100_000 if value_bearing else 0,
+        balance=iterations if value_bearing else 0,
         storage={0: 1},
-        nonce=1,
     )
     code_tx = Transaction(
         to=code_addr,

--- a/tox.ini
+++ b/tox.ini
@@ -87,7 +87,7 @@ commands = fill -n auto -m "not slow and not benchmark" --output=/tmp/fixtures-t
 
 [testenv:tests-deployed-benchmark]
 description = Fill benchmarking test cases in ./tests/ for deployed mainnet forks, using evmone-t8n.
-commands = fill -n auto -m "benchmark" --block-gas-limit 5000000 --output=/tmp/fixtures-tox --clean --evm-bin=evmone-t8n
+commands = fill -n auto -m "benchmark" --gas-benchmark-values 5 --output=/tmp/fixtures-tox --clean --evm-bin=evmone-t8n
 
 [testenv:tests-develop]
 description = Fill test cases in ./tests/ for deployed and development mainnet forks


### PR DESCRIPTION
## 🗒️ Description

### Add check for gas used in blockchain and state tests

`blockchain_test` and `state_test` now have a flag called `expected_benchmark_gas_used` which can be used to specify the expected gas used by the last payload (the benchmark payload).

If the value is not specified, the test is expected to use the value specified by `--gas-benchmark-values` entirely.

### Modified all benchmark tests to use `gas_benchmark_value`

All benchmark tests now use `gas_benchmark_value`, and also `expected_benchmark_gas_used` if the test is not expected to use the entire gas (e.g. when the tx is not expected to run out-of-gas and instead consume a specific amount of gas).

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).