### PR TITLE
fix(github): Remove `--solc-version` flag from fixture building action

### DIFF
--- a/.github/actions/build-fixtures/action.yaml
+++ b/.github/actions/build-fixtures/action.yaml
@@ -34,7 +34,7 @@ runs:
     - name: Generate fixtures using fill
       shell: bash
       run: |
-        uv run fill -n ${{ steps.evm-builder.outputs.x-dist }} --evm-bin=${{ steps.evm-builder.outputs.evm-bin }} --solc-version=${{ steps.properties.outputs.solc }} ${{ steps.properties.outputs.fill-params }} --output=fixtures_${{ inputs.release_name }}.tar.gz --build-name ${{ inputs.release_name }}
+        uv run fill -n ${{ steps.evm-builder.outputs.x-dist }} --evm-bin=${{ steps.evm-builder.outputs.evm-bin }} ${{ steps.properties.outputs.fill-params }} --output=fixtures_${{ inputs.release_name }}.tar.gz --build-name ${{ inputs.release_name }}
     - name: Wrap ethereum/tests fixtures with eofwrap tool
       shell: bash
       if: ${{ steps.properties.outputs.eofwrap }}

--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -2,24 +2,19 @@
 stable:
   evm-type: stable
   fill-params: --until=Prague
-  solc: 0.8.21
 develop:
   evm-type: develop
   fill-params: --until=Osaka
-  solc: 0.8.21
 static:
   evm-type: static
   fill-params: --until=Osaka --fill-static-tests ./tests/static
-  solc: 0.8.21
 benchmark_test:
   evm-type: benchmark
   fill-params: --from=Cancun --until=Prague --gas-benchmark-values 1,10,30,45,60,90,120 -m benchmark --generate-all-formats ./tests
-  solc: 0.8.21
   feature_only: true
 eip7692:
   evm-type: eip7692
   fill-params: --fork=EOFv1 ./tests/unscheduled
-  solc: 0.8.21
   eofwrap: true
   feature_only: true
 fusaka-devnet-2:


### PR DESCRIPTION
## 🗒️ Description
Minor fix to remove deprecated `--solc-version` flag from the fixture-building github action.

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] ~~All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).