### PR TITLE
fix(print): fix shown log path (its in ./logs not in ./src/logs) when using e.g. consume engine

### DIFF
--- a/src/pytest_plugins/logging/logging.py
+++ b/src/pytest_plugins/logging/logging.py
@@ -317,7 +317,9 @@ def pytest_terminal_summary(terminalreporter: TerminalReporter, exitstatus: int)
     if terminalreporter.config.option.collectonly:
         return
     if eest_log_file_path := terminalreporter.config.option.eest_log_file_path:
-        terminalreporter.write_sep("-", f"Log file: {eest_log_file_path.resolve()}", yellow=True)
+        log_file_output_path = eest_log_file_path.resolve()
+        log_file_output_path_fixed = str(log_file_output_path).replace("/src/", "/")
+        terminalreporter.write_sep("-", f"Log file: {log_file_output_path_fixed}", yellow=True)
 
 
 def log_only_to_file(level: int, msg: str, *args, **kwargs) -> None:


### PR DESCRIPTION
## 🗒️ Description
While trying to look into #1917 i noticed that the shown log path is incorrect. When you run `uv run consume engine --input fixtures -s -n auto` it shows you that logs are in `./src/logs` when they actually are in `./logs`

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
