### PR TITLE
fix(unit_tests): fixed blob unit tests when run with xdist

### DIFF
--- a/src/ethereum_test_types/tests/test_blob_types.py
+++ b/src/ethereum_test_types/tests/test_blob_types.py
@@ -69,7 +69,7 @@ def wait_until_counter_reached(target: int, poll_interval: float = 0.1):
                         pytest.fail(
                             f"The blob_unit_test lock counter is too high! "
                             f"Expected {target}, but got {current_value}. "
-                            f"It probably re-used an existing file that was not cleared. "
+                            f"It probably reused an existing file that was not cleared. "
                             f"Delete {file_path} manually to fix this."
                         )
                 except Exception:

--- a/src/ethereum_test_types/tests/test_blob_types.py
+++ b/src/ethereum_test_types/tests/test_blob_types.py
@@ -1,8 +1,11 @@
 """Test suite for blobs."""
 
+# import contextlib
 import copy
+import time
 
 import pytest
+from filelock import FileLock
 
 from ethereum_test_forks import (
     Cancun,
@@ -16,6 +19,65 @@ from ethereum_test_forks.forks.transition import (
 )
 
 from ..blob_types import CACHED_BLOBS_DIRECTORY, Blob, clear_blob_cache
+
+
+def increment_counter(timeout: float = 10):
+    """
+    Increment counter in file, creating if doesn't exist.
+
+    This is needed because we require the unit test 'test_transition_fork_blobs' to run
+    at the end without having to include another dependency for ordering tests.
+    That test has to run at the end because it assumes that no json blobs not created
+    by itself are created while it is running.
+
+    The hardcoded counter value in the test above has to be updated if any new blob_related
+    unit tests that create json blobs are added in the future.
+
+    """
+    file_path = CACHED_BLOBS_DIRECTORY / "blob_unit_test_counter.txt"
+    lock_file = file_path.with_suffix(".lock")
+
+    with FileLock(lock_file, timeout=timeout):
+        # Read current value or start at 0
+        if file_path.exists():
+            current_value = int(file_path.read_text().strip())
+        else:
+            current_value = 0
+
+        # Increment and write back
+        new_value = current_value + 1
+        file_path.write_text(str(new_value))
+
+        return new_value
+
+
+def wait_until_counter_reached(target: int, poll_interval: float = 0.1):
+    """Wait until blob unit test counter reaches target value."""
+    file_path = CACHED_BLOBS_DIRECTORY / "blob_unit_test_counter.txt"
+    lock_file = file_path.with_suffix(".lock")  # Add lock file path
+
+    while True:
+        # Use FileLock when reading!
+        with FileLock(lock_file, timeout=10):
+            if file_path.exists():
+                try:
+                    current_value = int(file_path.read_text().strip())
+                    if current_value == target:
+                        # file_path.unlink()  # get rid to effectively reset counter to 0
+                        return current_value
+                    elif current_value > target:
+                        pytest.fail(
+                            f"The blob_unit_test lock counter is too high! "
+                            f"Expected {target}, but got {current_value}. "
+                            f"It probably re-used an existing file that was not cleared. "
+                            f"Delete {file_path} manually to fix this."
+                        )
+                except Exception:
+                    current_value = 0
+            else:
+                current_value = 0
+
+        time.sleep(poll_interval)
 
 
 @pytest.mark.parametrize("seed", [0, 10, 100])
@@ -41,6 +103,8 @@ def test_blob_creation_and_writing_and_reading(
 
     # ensure file you read equals file you wrote
     assert b.model_dump() == restored.model_dump()
+
+    increment_counter()
 
 
 @pytest.mark.parametrize(
@@ -71,6 +135,8 @@ def test_blob_proof_corruption(
         "proof is unchanged!"
     )
 
+    increment_counter()
+
 
 @pytest.mark.parametrize("timestamp", [14999, 15000])
 @pytest.mark.parametrize(
@@ -81,6 +147,9 @@ def test_transition_fork_blobs(
     timestamp,
 ):
     """Generates blobs for transition forks (time 14999 is old fork, time 15000 is new fork)."""
+    # line below guarantees that this test runs only after the other blob unit tests are done
+    wait_until_counter_reached(21)
+
     clear_blob_cache(CACHED_BLOBS_DIRECTORY)
 
     print(f"Original fork: {fork}, Timestamp: {timestamp}")
@@ -109,3 +178,7 @@ def test_transition_fork_blobs(
             f"Transition fork failure! Fork {fork.name()} at timestamp: {timestamp} should have "
             f"transitioned to {post_transition_fork_at_15k.name()} but is still at {b.fork.name()}"
         )
+
+    # delete counter at last iteration (otherwise re-running all unit tests will fail)
+    if timestamp == 15_000 and pre_transition_fork == Prague:
+        (CACHED_BLOBS_DIRECTORY / "blob_unit_test_counter.txt").unlink()

--- a/src/ethereum_test_types/tests/test_blob_types.py
+++ b/src/ethereum_test_types/tests/test_blob_types.py
@@ -1,6 +1,5 @@
 """Test suite for blobs."""
 
-# import contextlib
 import copy
 import time
 


### PR DESCRIPTION
## 🗒️ Description
Introduces a mechanism that guarantees that the unit test that clears the blob cache folder (which is a requirement for it function as from our blob filenames we can not infer which fork they were created for) always runs after all other blob unit tests. This has never been a real problem outside of unit testing itself.

Related issue: #1942 

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
