### PR TITLE
chore: bump eels resolver

### DIFF
--- a/.github/configs/eels_resolutions.json
+++ b/.github/configs/eels_resolutions.json
@@ -35,6 +35,6 @@
     "Osaka": {
         "git_url": "https://github.com/spencer-tb/execution-specs.git",
         "branch": "forks/osaka",
-        "commit": "07699170182691533023fa5d83086258c3edcfd3"
+        "commit": "0e97247a9022b8c04c01e22cae6ec95d1b590838"
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,4 +174,4 @@ addopts = [
 required-version = ">=0.7.0"
 
 [tool.uv.sources]
-ethereum-spec-evm-resolver = { git = "https://github.com/spencer-tb/ethereum-spec-evm-resolver", rev = "38d4d19d9bc9e2aea900aac5c4b511665c294322" }
+ethereum-spec-evm-resolver = { git = "https://github.com/spencer-tb/ethereum-spec-evm-resolver", rev = "aec6a628b8d0f1c791a8378c5417a089566135ac" }

--- a/src/pytest_plugins/eels_resolutions.json
+++ b/src/pytest_plugins/eels_resolutions.json
@@ -40,6 +40,6 @@
     "Osaka": {
         "git_url": "https://github.com/spencer-tb/execution-specs.git",
         "branch": "forks/osaka",
-        "commit": "07699170182691533023fa5d83086258c3edcfd3"
+        "commit": "0e97247a9022b8c04c01e22cae6ec95d1b590838"
     }
 }

--- a/uv.lock
+++ b/uv.lock
@@ -615,7 +615,7 @@ requires-dist = [
     { name = "eth-abi", specifier = ">=5.2.0" },
     { name = "ethereum-hive", specifier = ">=0.1.0a1,<1.0.0" },
     { name = "ethereum-rlp", specifier = ">=0.1.3,<0.2" },
-    { name = "ethereum-spec-evm-resolver", git = "https://github.com/spencer-tb/ethereum-spec-evm-resolver?rev=38d4d19d9bc9e2aea900aac5c4b511665c294322" },
+    { name = "ethereum-spec-evm-resolver", git = "https://github.com/spencer-tb/ethereum-spec-evm-resolver?rev=aec6a628b8d0f1c791a8378c5417a089566135ac" },
     { name = "ethereum-types", specifier = ">=0.2.1,<0.3" },
     { name = "filelock", specifier = ">=3.15.1,<4" },
     { name = "gitpython", specifier = ">=3.1.31,<4" },
@@ -690,7 +690,7 @@ wheels = [
 [[package]]
 name = "ethereum-spec-evm-resolver"
 version = "0.0.5"
-source = { git = "https://github.com/spencer-tb/ethereum-spec-evm-resolver?rev=38d4d19d9bc9e2aea900aac5c4b511665c294322#38d4d19d9bc9e2aea900aac5c4b511665c294322" }
+source = { git = "https://github.com/spencer-tb/ethereum-spec-evm-resolver?rev=aec6a628b8d0f1c791a8378c5417a089566135ac#aec6a628b8d0f1c791a8378c5417a089566135ac" }
 dependencies = [
     { name = "coincurve" },
     { name = "cryptography" },


### PR DESCRIPTION
## 🗒️ Description

Bumps the EELS resolver to an updated commit. Should prevent EELS t8n timeouts when filling benchmark tests at 100M gas.

https://github.com/spencer-tb/ethereum-spec-evm-resolver

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] ~~All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
