### PR TITLE
fix(mypy): adds mypy ignore comments and add ignore rule for imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,7 @@ fixable = ["I", "B", "E", "F", "W", "D", "C"]
 ignore = ["D205", "D203", "D212", "D415", "C901", "A005", "C420"]
 
 [tool.mypy]
+disable_error_code = ["import-untyped"]
 mypy_path = ["src", "$MYPY_CONFIG_FILE_DIR/stubs"]
 files = ["src", "tests"]
 exclude = [

--- a/src/ethereum_clis/ethereum_cli.py
+++ b/src/ethereum_clis/ethereum_cli.py
@@ -89,7 +89,7 @@ class EthereumCLI:
         if not binary:
             raise CLINotFoundInPathError(binary=binary)
 
-        binary = Path(binary)
+        binary = Path(binary)  # type: ignore[assignment]
 
         # Group the tools by version flag, so we only have to call the tool once for all the
         # classes that share the same version flag

--- a/src/pytest_plugins/consume/simulators/rlp/conftest.py
+++ b/src/pytest_plugins/consume/simulators/rlp/conftest.py
@@ -51,7 +51,7 @@ def buffered_blocks_rlp(blocks_rlp: List[bytes]) -> List[io.BufferedReader]:
     for _, block_rlp in enumerate(blocks_rlp):
         block_rlp_stream = io.BytesIO(block_rlp)
         block_rlp_files.append(io.BufferedReader(cast(io.RawIOBase, block_rlp_stream)))
-    return block_rlp_files
+    return block_rlp_files  # type: ignore[return-value]
 
 
 @pytest.fixture(scope="function")

--- a/src/pytest_plugins/forks/forks.py
+++ b/src/pytest_plugins/forks/forks.py
@@ -184,7 +184,7 @@ class CovariantDescriptor:
             else argnames
         )
         self.fn = fn
-        self.selector = selector
+        self.selector = selector  # type: ignore[assignment]
         self.marks = marks
 
     def process_value(


### PR DESCRIPTION
## 🗒️ Description
Before:
```
src/ethereum_test_base_types/reference_spec/git_reference_spec.py:10: error: Library stubs not installed for "requests"  [import-untyped]
src/ethereum_clis/ethereum_cli.py:92: error: Incompatible types in assignment (expression has type "Path", variable has type "str | None")  [assignment]
src/pytest_plugins/consume/releases.py:13: error: Library stubs not installed for "requests"  [import-untyped]
src/ethereum_test_base_types/tests/test_reference_spec.py:6: error: Library stubs not installed for "requests"  [import-untyped]
src/ethereum_clis/transition_tool.py:16: error: Library stubs not installed for "requests"  [import-untyped]
src/ethereum_clis/transition_tool.py:17: error: Library stubs not installed for "requests.exceptions"  [import-untyped]
src/ethereum_clis/transition_tool.py:17: note: Hint: "python3 -m pip install types-requests"
src/ethereum_clis/transition_tool.py:17: note: (or run "mypy --install-types" to install all missing stub packages)
src/ethereum_clis/transition_tool.py:17: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
src/ethereum_test_rpc/rpc.py:8: error: Library stubs not installed for "requests"  [import-untyped]
src/pytest_plugins/consume/consume.py:14: error: Library stubs not installed for "requests"  [import-untyped]
src/pytest_plugins/consume/simulators/rlp/conftest.py:54: error: Incompatible return value type (got "list[BufferedReader[RawIOBase]]", expected "list[BufferedReader[_BufferedReaderStream]]")  [return-value]
src/pytest_plugins/forks/forks.py:187: error: Incompatible types in assignment (expression has type "FunctionType | None", variable has type "MethodType | None")  [assignment]
Found 10 errors in 9 files (checked 685 source files)
```

After:
```
Success: no issues found in 685 source files
```

Tested with mypy 1.17.0
## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
