### PR TITLE
chore(tests): remove slow/zkevm markers from benchmark tests

### DIFF
--- a/tests/benchmark/test_worst_bytecode.py
+++ b/tests/benchmark/test_worst_bytecode.py
@@ -46,7 +46,6 @@ XOR_TABLE = [Hash(i).sha256() for i in range(XOR_TABLE_SIZE)]
         Op.EXTCODECOPY,
     ],
 )
-@pytest.mark.slow()
 @pytest.mark.valid_from("Cancun")
 def test_worst_bytecode_single_opcode(
     blockchain_test: BlockchainTestFiller,

--- a/tests/benchmark/test_worst_compute.py
+++ b/tests/benchmark/test_worst_compute.py
@@ -426,7 +426,6 @@ def test_worst_keccak(
         pytest.param(0x04, 15, 3, 1, id="IDENTITY"),
     ],
 )
-@pytest.mark.slow()
 def test_worst_precompile_only_data_input(
     state_test: StateTestFiller,
     pre: Alloc,
@@ -1077,7 +1076,6 @@ def test_worst_modexp(
         ),
     ],
 )
-@pytest.mark.slow()
 def test_worst_precompile_fixed_cost(
     state_test: StateTestFiller,
     pre: Alloc,
@@ -1137,7 +1135,6 @@ def test_worst_precompile_fixed_cost(
 
 
 @pytest.mark.valid_from("Cancun")
-@pytest.mark.slow
 def test_worst_jumps(state_test: StateTestFiller, pre: Alloc):
     """Test running a JUMP-intensive contract."""
     env = Environment()
@@ -1159,9 +1156,7 @@ def test_worst_jumps(state_test: StateTestFiller, pre: Alloc):
     )
 
 
-@pytest.mark.zkevm
 @pytest.mark.valid_from("Cancun")
-@pytest.mark.slow
 def test_worst_jumpi_fallthrough(
     state_test: StateTestFiller,
     pre: Alloc,
@@ -1199,9 +1194,7 @@ def test_worst_jumpi_fallthrough(
     )
 
 
-@pytest.mark.zkevm
 @pytest.mark.valid_from("Cancun")
-@pytest.mark.slow
 def test_worst_jumpis(
     state_test: StateTestFiller,
     pre: Alloc,
@@ -1227,7 +1220,6 @@ def test_worst_jumpis(
 
 
 @pytest.mark.valid_from("Cancun")
-@pytest.mark.slow
 def test_worst_jumpdests(state_test: StateTestFiller, pre: Alloc, fork: Fork):
     """Test running a JUMPDEST-intensive contract."""
     env = Environment()
@@ -2007,7 +1999,6 @@ def test_empty_block(
 
 
 @pytest.mark.valid_from("Cancun")
-@pytest.mark.slow()
 def test_amortized_bn128_pairings(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/benchmark/test_worst_stateful_opcodes.py
+++ b/tests/benchmark/test_worst_stateful_opcodes.py
@@ -47,7 +47,6 @@ REFERENCE_SPEC_VERSION = "TODO"
         False,
     ],
 )
-@pytest.mark.slow()
 def test_worst_address_state_cold(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
@@ -137,7 +136,6 @@ def test_worst_address_state_cold(
         False,
     ],
 )
-@pytest.mark.slow()
 def test_worst_address_state_warm(
     state_test: StateTestFiller,
     pre: Alloc,
@@ -209,7 +207,6 @@ class StorageAction:
         False,
     ],
 )
-@pytest.mark.slow()
 def test_worst_storage_access_cold(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
@@ -315,7 +312,6 @@ def test_worst_storage_access_cold(
         pytest.param(StorageAction.WRITE_NEW_VALUE, id="SSTORE new value"),
     ],
 )
-@pytest.mark.slow()
 def test_worst_storage_access_warm(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
@@ -381,7 +377,6 @@ def test_worst_storage_access_warm(
 
 
 @pytest.mark.valid_from("Cancun")
-@pytest.mark.slow()
 def test_worst_blockhash(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
@@ -413,7 +408,6 @@ def test_worst_blockhash(
 
 
 @pytest.mark.valid_from("Cancun")
-@pytest.mark.slow()
 def test_worst_selfbalance(
     state_test: StateTestFiller,
     pre: Alloc,
@@ -457,7 +451,6 @@ def test_worst_selfbalance(
         pytest.param(5 * 1024, id="5KiB"),
     ],
 )
-@pytest.mark.slow()
 def test_worst_extcodecopy_warm(
     state_test: StateTestFiller,
     pre: Alloc,


### PR DESCRIPTION
## 🗒️ Description
Removes remaining zkevm markers from benchmark tests. 

Additionally removes all the slow markers on the assumption that all benchmark tests are slow. It that marker is intended to highlight benchmark tests that are extra slow I will add them back.

All of these tests have the benchmark marker implicitly added by default.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
