### PR TITLE
chore(ci): bump to use latest eels `forks/osaka`

### DIFF
--- a/.github/workflows/tox_verify.yaml
+++ b/.github/workflows/tox_verify.yaml
@@ -124,7 +124,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           repository: ethereum/execution-specs
-          ref: e13d33ab21ef1fdd2f073c96a3346e23eb7727f6
+          ref: 5a49b2f39a909be6a8c84bb70611febdc2b2fd98
           path: execution-specs
           fetch-depth: 1
       - name: Install uv ${{ vars.UV_VERSION }} and python ${{ matrix.python }}
@@ -167,7 +167,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           repository: ethereum/execution-specs
-          ref: e13d33ab21ef1fdd2f073c96a3346e23eb7727f6
+          ref: 5a49b2f39a909be6a8c84bb70611febdc2b2fd98
           path: execution-specs
           fetch-depth: 1
       - name: Install uv ${{ vars.UV_VERSION }} and python ${{ matrix.python }}

--- a/src/pytest_plugins/eels_resolutions.json
+++ b/src/pytest_plugins/eels_resolutions.json
@@ -1,8 +1,8 @@
 {
     "EELSMaster": {
         "git_url": "https://github.com/ethereum/execution-specs.git",
-        "branch": "master",
-        "commit": "e13d33ab21ef1fdd2f073c96a3346e23eb7727f6"
+        "branch": "forks/osaka",
+        "commit": "5a49b2f39a909be6a8c84bb70611febdc2b2fd98"
     },
     "Frontier": {
         "same_as": "EELSMaster"
@@ -38,8 +38,6 @@
         "same_as": "EELSMaster"
     },
     "Osaka": {
-        "git_url": "https://github.com/spencer-tb/execution-specs.git",
-        "branch": "forks/osaka",
-        "commit": "0e97247a9022b8c04c01e22cae6ec95d1b590838"
+        "same_as": "EELSMaster"
     }
 }


### PR DESCRIPTION
## 🗒️ Description
Use the latest EELS `forks/osaka` for all.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Requires #1884.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
