### PR TITLE
feat(test): add test for memory expansion on early revert in CALL

### DIFF
--- a/tests/frontier/opcodes/test_call.py
+++ b/tests/frontier/opcodes/test_call.py
@@ -75,3 +75,67 @@ def test_call_large_offset_mstore(
             )
         },
     )
+
+
+# TODO: There's an issue with gas definitions on forks previous to Berlin, remove this when fixed.
+# https://github.com/ethereum/execution-spec-tests/pull/1952#discussion_r2237634275
+@pytest.mark.valid_from("Berlin")
+def test_call_memory_expands_on_empty_output(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+):
+    """
+    CALL to an account with no code with positive ret_size.
+    Memory should be expanded during the CALL despite having an empty output.
+    We check this with an MSTORE.
+
+    This is for bug in a faulty EVM implementation where memory is not expanded when it should.
+    """
+    sender = pre.fund_eoa()
+
+    gsc = fork.gas_costs()
+    ret_size = 128  # arbitrary number
+
+    call_measure = CodeGasMeasure(
+        code=Op.CALL(gas=0, ret_offset=0, ret_size=ret_size),
+        overhead_cost=gsc.G_VERY_LOW * len(Op.CALL.kwargs),  # Cost of pushing CALL args
+        extra_stack_items=1,  # Because CALL pushes 1 item to the stack
+        sstore_key=0,
+        stop=False,  # Because it's the first CodeGasMeasure
+    )
+    mstore_measure = CodeGasMeasure(
+        code=Op.MSTORE(offset=ret_size // 2, value=1),  # Low offset for not expanding memory
+        overhead_cost=gsc.G_VERY_LOW * len(Op.MSTORE.kwargs),  # Cost of pushing MSTORE args
+        extra_stack_items=0,
+        sstore_key=1,
+    )
+
+    contract = pre.deploy_contract(call_measure + mstore_measure)
+
+    tx = Transaction(
+        gas_limit=500_000,
+        to=contract,
+        value=0,
+        sender=sender,
+    )
+
+    memory_expansion_gas_calc = fork.memory_expansion_gas_calculator()
+    # call cost: address_access_cost + memory_expansion_cost
+    call_cost = gsc.G_COLD_ACCOUNT_ACCESS + memory_expansion_gas_calc(new_bytes=ret_size)
+
+    # mstore cost: base cost. No memory expansion cost needed if it was previously expanded.
+    mstore_cost = gsc.G_MEMORY
+    state_test(
+        env=Environment(),
+        pre=pre,
+        tx=tx,
+        post={
+            contract: Account(
+                storage={
+                    0: call_cost,
+                    1: mstore_cost,
+                },
+            )
+        },
+    )

--- a/tests/frontier/opcodes/test_call.py
+++ b/tests/frontier/opcodes/test_call.py
@@ -80,25 +80,26 @@ def test_call_large_offset_mstore(
 # TODO: There's an issue with gas definitions on forks previous to Berlin, remove this when fixed.
 # https://github.com/ethereum/execution-spec-tests/pull/1952#discussion_r2237634275
 @pytest.mark.valid_from("Berlin")
-def test_call_memory_expands_on_empty_output(
+def test_call_memory_expands_on_early_revert(
     state_test: StateTestFiller,
     pre: Alloc,
     fork: Fork,
 ):
     """
-    CALL to an account with no code with positive ret_size.
-    Memory should be expanded during the CALL despite having an empty output.
+    When CALL reverts early (e.g. because of not enough balance by the sender),
+    memory should be expanded anyway.
     We check this with an MSTORE.
 
-    This is for bug in a faulty EVM implementation where memory is not expanded when it should.
+    This is for a bug in an EVM implementation where memory is expanded after executing a CALL, but
+    not when an early revert happens.
     """
     sender = pre.fund_eoa()
 
     gsc = fork.gas_costs()
-    ret_size = 128  # arbitrary number
+    ret_size = 128  # arbitrary number, greater than memory size to trigger an expansion
 
     call_measure = CodeGasMeasure(
-        code=Op.CALL(gas=0, ret_offset=0, ret_size=ret_size),
+        code=Op.CALL(gas=0, value=100, ret_size=ret_size),  # CALL with value
         overhead_cost=gsc.G_VERY_LOW * len(Op.CALL.kwargs),  # Cost of pushing CALL args
         extra_stack_items=1,  # Because CALL pushes 1 item to the stack
         sstore_key=0,
@@ -111,7 +112,8 @@ def test_call_memory_expands_on_empty_output(
         sstore_key=1,
     )
 
-    contract = pre.deploy_contract(call_measure + mstore_measure)
+    # Contract without enough balance to send value transfer
+    contract = pre.deploy_contract(code=call_measure + mstore_measure, balance=0)
 
     tx = Transaction(
         gas_limit=500_000,
@@ -121,10 +123,16 @@ def test_call_memory_expands_on_empty_output(
     )
 
     memory_expansion_gas_calc = fork.memory_expansion_gas_calculator()
-    # call cost: address_access_cost + memory_expansion_cost
-    call_cost = gsc.G_COLD_ACCOUNT_ACCESS + memory_expansion_gas_calc(new_bytes=ret_size)
+    # call cost: address_access_cost + new_acc_cost + memory_expansion_cost + value - stipend
+    call_cost = (
+        gsc.G_COLD_ACCOUNT_ACCESS
+        + gsc.G_NEW_ACCOUNT
+        + memory_expansion_gas_calc(new_bytes=ret_size)
+        + gsc.G_CALL_VALUE
+        - gsc.G_CALL_STIPEND
+    )
 
-    # mstore cost: base cost. No memory expansion cost needed if it was previously expanded.
+    # mstore cost: base cost. No memory expansion cost needed, it was expanded on CALL.
     mstore_cost = gsc.G_MEMORY
     state_test(
         env=Environment(),


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Hi again! This is another test very similar to #1952 but this time we are testing that the memory should be expanded during a CALL even in cases where there’s an early revert. It seems obvious but previously we used to expand the memory after the sub-context execution and we were not expanding it in cases in which we reverted early (like a transfer without enough balance). We encountered this on a [sepolia transaction](https://sepolia.etherscan.io/tx/0xa1765d420522a40d59d15f8dee1bf095499be687d6e1a7c978fc87eb85bce948).
I tested this with an old ethrex commit and the test fails, but after the fix in the PR linked down below it passes 😄 
Any suggestions are welcome

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
On ethrex: https://github.com/lambdaclass/ethrex/pull/3592

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
