### PR TITLE
fix(fill): allow lowercase fork declaration in fill command

### DIFF
--- a/src/pytest_plugins/execute/rpc/hive.py
+++ b/src/pytest_plugins/execute/rpc/hive.py
@@ -110,7 +110,7 @@ def get_fork_option(request, option_name: str) -> Fork | None:
         if option == "Merge":
             option = "Paris"
         for fork in get_forks():
-            if option == fork.name():
+            if option.lower() == fork.name().lower():
                 return fork
     return None
 

--- a/src/pytest_plugins/forks/forks.py
+++ b/src/pytest_plugins/forks/forks.py
@@ -464,13 +464,13 @@ def pytest_configure(config: pytest.Config):
             return set()
 
         forks_str = config_str.split(",")
-        forks_str = [s.strip() for s in config_str.split(",")]
+        forks_str = [s.strip().lower() for s in config_str.split(",")]
         # Alias for "Merge"
         forks_str = [("Paris" if s.lower() == "merge" else s) for s in forks_str]
 
         resulting_forks = set()
         for fork in config.all_forks_with_transitions:
-            if fork.name() in forks_str:
+            if fork.name().lower() in forks_str:
                 resulting_forks.add(fork)
 
         if len(resulting_forks) != len(forks_str):

--- a/src/pytest_plugins/forks/tests/test_forks.py
+++ b/src/pytest_plugins/forks/tests/test_forks.py
@@ -13,7 +13,7 @@ def fork_map():
     return {fork.name(): fork for fork in get_forks()}
 
 
-def test_no_options_no_validity_marker(pytester):
+def test_no_options_no_validity_marker(pytester: pytest.Pytester):
     """
     Test test parametrization with:
     - no fork command-line options,
@@ -61,7 +61,7 @@ def test_no_options_no_validity_marker(pytester):
 
 
 @pytest.mark.parametrize("fork", ["London", "Paris"])
-def test_from_london_option_no_validity_marker(pytester, fork_map, fork):
+def test_from_london_option_no_validity_marker(pytester: pytest.Pytester, fork_map, fork):
     """
     Test test parametrization with:
     - --from London command-line option,
@@ -105,7 +105,7 @@ def test_from_london_option_no_validity_marker(pytester, fork_map, fork):
     )
 
 
-def test_from_london_until_shanghai_option_no_validity_marker(pytester, fork_map):
+def test_from_london_until_shanghai_option_no_validity_marker(pytester: pytest.Pytester, fork_map):
     """
     Test test parametrization with:
     - --from London command-line option,
@@ -122,7 +122,7 @@ def test_from_london_until_shanghai_option_no_validity_marker(pytester, fork_map
     )
     pytester.copy_example(name="src/cli/pytest_commands/pytest_ini_files/pytest-fill.ini")
     result = pytester.runpytest(
-        "-c", "pytest-fill.ini", "-v", "--from", "London", "--until", "Shanghai"
+        "-c", "pytest-fill.ini", "-v", "--from", "London", "--until", "shanghai"
     )
     forks_under_test = forks_from_until(fork_map["London"], fork_map["Shanghai"])
     expected_passed = len(forks_under_test) * len(StateTest.supported_fixture_formats)
@@ -153,11 +153,11 @@ def test_from_london_until_shanghai_option_no_validity_marker(pytester, fork_map
     )
 
 
-def test_from_merge_until_merge_option_no_validity_marker(pytester, fork_map):
+def test_from_paris_until_paris_option_no_validity_marker(pytester: pytest.Pytester, fork_map):
     """
     Test test parametrization with:
-    - --from Merge command-line option,
-    - --until Merge command-line option,
+    - --from Paris command-line option,
+    - --until Paris command-line option,
     - no fork validity marker.
     """
     pytester.makepyfile(
@@ -170,11 +170,13 @@ def test_from_merge_until_merge_option_no_validity_marker(pytester, fork_map):
     )
     pytester.copy_example(name="src/cli/pytest_commands/pytest_ini_files/pytest-fill.ini")
     result = pytester.runpytest(
-        "-c", "pytest-fill.ini", "-v", "--from", "Merge", "--until", "Merge"
+        "-c", "pytest-fill.ini", "-v", "--from", "paris", "--until", "paris"
     )
     forks_under_test = forks_from_until(fork_map["Paris"], fork_map["Paris"])
     expected_passed = len(forks_under_test) * len(StateTest.supported_fixture_formats)
-    stdout = "\n".join(result.stdout.lines)
+    stdout: str = "\n".join(result.stdout.lines)
+    assert len(stdout) > 0, "stdout is empty string"
+
     for fork in forks_under_test:
         for fixture_format in StateTest.supported_fixture_formats:
             if isinstance(fixture_format, LabeledFixtureFormat):
@@ -186,6 +188,7 @@ def test_from_merge_until_merge_option_no_validity_marker(pytester, fork_map):
                 expected_passed -= 1
                 assert f":test_all_forks[fork_{fork}-{fixture_format_label}]" not in stdout
                 continue
+            print("ccccccccccccccccccccccccccc\n")
             assert f":test_all_forks[fork_{fork}-{fixture_format_label}]" in stdout
     result.assert_outcomes(
         passed=expected_passed,

--- a/src/pytest_plugins/forks/tests/test_forks.py
+++ b/src/pytest_plugins/forks/tests/test_forks.py
@@ -188,7 +188,6 @@ def test_from_paris_until_paris_option_no_validity_marker(pytester: pytest.Pytes
                 expected_passed -= 1
                 assert f":test_all_forks[fork_{fork}-{fixture_format_label}]" not in stdout
                 continue
-            print("ccccccccccccccccccccccccccc\n")
             assert f":test_all_forks[fork_{fork}-{fixture_format_label}]" in stdout
     result.assert_outcomes(
         passed=expected_passed,


### PR DESCRIPTION
## 🗒️ Description
Allows you to pass the fork either as uppercase or as lowercase.

Before this PR:
```
uv run fill -v tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1add.py::test_valid --fork prague --clean -s

Executing: pytest -c /home/user/Documents/execution-spec-tests/src/cli/pytest_commands/pytest_ini_files/pytest-fill.ini --rootdir . -v 
tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1add.py::test_valid --fork prague --clean -s
Error: Unsupported fork provided to --fork: prague 
```

After this PR: great success, no matter whether you choose Prague or prague
Inspired by #1916 

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
