### PR TITLE
fix(tests): Issues with rlp block limit tests and `--generate-pre-alloc-groups`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -142,6 +142,7 @@ Users can select any of the artifacts depending on their testing needs for their
 - ✨ [EIP-7825](https://eips.ethereum.org/EIPS/eip-7825): Pre-Osaka tests have been updated to either (1) dynamically adapt to the transaction gas limit cap, or (2) reduce overall gas consumption to fit the new limit ([#1928](https://github.com/ethereum/EIPs/pull/1928)).
 - ✨ [EIP-7918](https://eips.ethereum.org/EIPS/eip-7918): Blob base fee bounded by execution cost test cases (initial), includes some adjustments to [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844) tests ([#1685](https://github.com/ethereum/execution-spec-tests/pull/1685)).
 - 🔀 Adds the max blob transaction limit to the tests including updates to [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844) for Osaka ([#1884](https://github.com/ethereum/execution-spec-tests/pull/1884)).
+- 🐞 Fix issues when filling block rlp size limit tests with ``--generate-pre-alloc-groups`` ([#1989](https://github.com/ethereum/execution-spec-tests/pull/1989)).
 
 ## [v4.5.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v4.5.0) - 2025-05-14
 

--- a/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
+++ b/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
@@ -108,6 +108,7 @@ def exact_size_transactions(
     block_size_limit: int,
     fork: Fork,
     pre: Alloc,
+    gas_limit: int,
     emit_logs: bool = False,
     specific_transaction_to_include: Transaction | None = None,
 ) -> Tuple[List[Transaction], int]:
@@ -122,6 +123,7 @@ def exact_size_transactions(
         block_size_limit: The target block RLP size limit
         fork: The fork to generate transactions for
         pre: Required if emit_logs is True, used to deploy the log contract
+        gas_limit: The gas limit for the block
         emit_logs: If True, transactions will call a contract that emits logs
         specific_transaction_to_include: If provided, this transaction will be included
 
@@ -154,13 +156,14 @@ def exact_size_transactions(
     if not specific_transaction_to_include:
         # use cached version when possible for performance
         stubbed_transactions, gas_used = _exact_size_transactions_cached(
-            block_size_limit, fork, emit_logs_contract=log_contract
+            block_size_limit, fork, gas_limit, emit_logs_contract=log_contract
         )
     else:
         # Direct calculation, no cache, since `Transaction` is not hashable
         stubbed_transactions, gas_used = _exact_size_transactions_impl(
             block_size_limit,
             fork,
+            gas_limit,
             specific_transaction_to_include=specific_transaction_to_include,
         )
 
@@ -180,18 +183,26 @@ def exact_size_transactions(
 def _exact_size_transactions_cached(
     block_size_limit: int,
     fork: Fork,
+    gas_limit: int,
     emit_logs_contract: Address | None = None,
 ) -> Tuple[List[Transaction], int]:
     """
     Generate transactions that fill a block to exactly the RLP size limit. Abstracted
     with hashable arguments for caching block calculations.
     """
-    return _exact_size_transactions_impl(block_size_limit, fork, None, emit_logs_contract)
+    return _exact_size_transactions_impl(
+        block_size_limit,
+        fork,
+        gas_limit,
+        None,
+        emit_logs_contract,
+    )
 
 
 def _exact_size_transactions_impl(
     block_size_limit: int,
     fork: Fork,
+    block_gas_limit: int,
     specific_transaction_to_include: Transaction | None = None,
     emit_logs_contract: Address | None = None,
 ) -> Tuple[List[Transaction], int]:
@@ -203,7 +214,6 @@ def _exact_size_transactions_impl(
     sender = EOA("0x" + "00" * 20, key=123)
     nonce = 0
     total_gas_used = 0
-    max_block_gas = 100_000_000
 
     calculator = fork.transaction_intrinsic_cost_calculator()
 
@@ -268,7 +278,7 @@ def _exact_size_transactions_impl(
 
     current_size = get_block_rlp_size(transactions, gas_used=total_gas_used)
     remaining_bytes = block_size_limit - current_size
-    remaining_gas = max_block_gas - total_gas_used
+    remaining_gas = block_gas_limit - total_gas_used
 
     if remaining_bytes > 0 and remaining_gas > 50_000:
         # create an empty transaction to measure base contribution
@@ -360,7 +370,9 @@ def _exact_size_transactions_impl(
     final_gas = sum(tx.gas_limit for tx in transactions)
 
     assert final_size == block_size_limit, (
-        f"Size mismatch: got {final_size}, expected {block_size_limit}"
+        f"Size mismatch: got {final_size}, "
+        f"expected {block_size_limit} "
+        f"({final_size - block_size_limit} bytes diff)"
     )
     return transactions, final_gas
 
@@ -395,6 +407,7 @@ def test_block_at_rlp_size_limit_boundary(
         block_size_limit,
         fork,
         pre,
+        env.gas_limit,
     )
     block_rlp_size = get_block_rlp_size(transactions, gas_used=gas_used)
     assert block_rlp_size == block_size_limit, (
@@ -441,6 +454,7 @@ def test_block_rlp_size_at_limit_with_all_typed_transactions(
         block_size_limit,
         fork,
         pre,
+        env.gas_limit,
         specific_transaction_to_include=typed_transaction,
     )
     block_rlp_size = get_block_rlp_size(transactions, gas_used=gas_used)
@@ -477,6 +491,7 @@ def test_block_at_rlp_limit_with_logs(
         block_size_limit,
         fork,
         pre,
+        env.gas_limit,
         emit_logs=True,
     )
 


### PR DESCRIPTION
## 🗒️ Description

Previously, I was using a random `sender` to fill the "fake" block when estimating the block rlp size. This PR fixes these tests to use the `sender` fixture instead for all transactions, instead of swapping with the real `sender` on the final block.

The issue here is that a signed transaction's signature fields, if they have leading zeros, these will be stripped in the rlp encoding. So we have variability across different senders with different signature fields on the final block rlp.

Not only is it not necessary to use a fake `sender` for the block filling and then swap it, it also leads to issues like these. This is fixed here, as well as always using the block gas limit from the `env`, rather than hard-coding as I originally did during Berlinterop when this test was written (refactor).

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
#1975 

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).