### PR TITLE
feat(ci): Build releases in self-hosted-ghr, fetch solidity, lllc from github releases

### DIFF
--- a/.github/actions/fetch-binary/action.yaml
+++ b/.github/actions/fetch-binary/action.yaml
@@ -1,0 +1,31 @@
+name: "Fetch and Install Binary"
+description: "Downloads a binary from a GitHub release, verifies its checksum, and installs it to PATH. Only works for Linux."
+inputs:
+  version:
+    description: "Release version (e.g., v0.8.24)"
+    required: true
+  repo_owner:
+    description: "GitHub repository owner"
+    required: true
+  repo_name:
+    description: "GitHub repository name"
+    required: true
+  remote_name:
+    description: "Binary filename in the release"
+    required: true
+  binary_name:
+    description: "Name to install the binary as"
+    required: true
+  expected_sha256:
+    description: "Expected SHA256 checksum"
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Download binary
+      shell: bash
+      run: |
+        curl -sSL "https://github.com/${{ inputs.repo_owner }}/${{ inputs.repo_name }}/releases/download/${{ inputs.version }}/${{ inputs.remote_name }}" -o ./${{ inputs.binary_name }}
+        echo "${{ inputs.expected_sha256 }}  ${{ inputs.binary_name }}" | sha256sum -c -
+        sudo mv ./${{ inputs.binary_name }} /usr/local/bin/${{ inputs.binary_name }}
+        sudo chmod +x /usr/local/bin/${{ inputs.binary_name }}

--- a/.github/workflows/fixtures.yaml
+++ b/.github/workflows/fixtures.yaml
@@ -37,6 +37,24 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           submodules: true
+      - name: Fetch lllc
+        uses: ./.github/actions/fetch-binary
+        with:
+          version: v1.0.0
+          repo_owner: felix314159
+          repo_name: lllc-custom
+          remote_name: lllc
+          binary_name: lllc
+          expected_sha256: 865a0d5379acb3b5471337b5dcf686a2dd71587c6b65b9da6c963de627e0b300
+      - name: Fetch Solidity
+        uses: ./.github/actions/fetch-binary
+        with:
+          version: v0.8.24
+          repo_owner: ethereum
+          repo_name: solidity
+          remote_name: solc-static-linux
+          binary_name: solc
+          expected_sha256: fb03a29a517452b9f12bcf459ef37d0a543765bb3bbc911e70a87d6a37c30d5f
       - uses: ./.github/actions/build-fixtures
         with:
           release_name: ${{ matrix.name }}

--- a/.github/workflows/fixtures_feature.yaml
+++ b/.github/workflows/fixtures_feature.yaml
@@ -32,6 +32,24 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           submodules: true
+      - name: Fetch lllc
+        uses: ./.github/actions/fetch-binary
+        with:
+          version: v1.0.0
+          repo_owner: felix314159
+          repo_name: lllc-custom
+          remote_name: lllc
+          binary_name: lllc
+          expected_sha256: 865a0d5379acb3b5471337b5dcf686a2dd71587c6b65b9da6c963de627e0b300
+      - name: Fetch Solidity
+        uses: ./.github/actions/fetch-binary
+        with:
+          version: v0.8.24
+          repo_owner: ethereum
+          repo_name: solidity
+          remote_name: solc-static-linux
+          binary_name: solc
+          expected_sha256: fb03a29a517452b9f12bcf459ef37d0a543765bb3bbc911e70a87d6a37c30d5f
       - uses: ./.github/actions/build-fixtures
         with:
           release_name: ${{ matrix.feature }}


### PR DESCRIPTION
## 🗒️ Description
Updates the builders to be `self-hosted-ghr`.

Updates fixture-building workflows to fetch solidity and lllc from github release pages (Only required for static-tests).

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] ~~All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).