### PR TITLE
chore(tests): remove temp fix for block rlp type 4

### DIFF
--- a/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
+++ b/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
@@ -454,13 +454,6 @@ def test_block_rlp_size_at_limit_with_all_typed_transactions(
     request: pytest.FixtureRequest,
 ) -> None:
     """Test the block RLP size limit with all transaction types."""
-    # TODO: fix this for generate all formats.
-    if typed_transaction.ty == 4 and (
-        request.config.getoption("generate_pre_alloc_groups")
-        or request.config.getoption("use_pre_alloc_groups")
-    ):
-        pytest.skip("EIP-7702 fixture generates different transactions in Phase 1")
-
     transactions, gas_used = exact_size_transactions(
         sender,
         block_size_limit,


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Removes temp fix added for type 4 tx in max size block rlp test.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
#1989 #1955 

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
