### PR TITLE
fix(github): Set x-dist to auto for all evm impl

### DIFF
--- a/.github/configs/evm-impl.yaml
+++ b/.github/configs/evm-impl.yaml
@@ -1,14 +1,15 @@
 eels:
   evm-bin: ethereum-spec-evm-resolver
-  x-dist: 10
+  x-dist: auto
 geth:
   evm-bin: evm
+  x-dist: auto
 evmone:
   evm-bin: evmone-t8n
-  x-dist: 10
+  x-dist: auto
 besu:
   evm-bin: evmtool
   x-dist: 0
 ethjs:
   evm-bin: ethereumjs-t8ntool.sh
-  x-dist: 10
+  x-dist: auto


### PR DESCRIPTION
## 🗒️ Description

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).