### PR TITLE
feat(fill): Disable `--generate-all-formats` for static tests

### DIFF
--- a/src/cli/pytest_commands/fill.py
+++ b/src/cli/pytest_commands/fill.py
@@ -153,6 +153,9 @@ class FillCommand(PytestCommand):
             "--generate-pre-alloc-groups" in args
             or "--generate-all-formats" in args
             or self._is_tarball_output(args)
+        ) and (
+            "--fill-static-tests"
+            not in args  # TODO: remove this once we have better grouping for static tests
         )
 
     def _ensure_generate_all_formats_for_tarball(self, args: List[str]) -> List[str]:

--- a/src/ethereum_test_specs/static_state/state_static.py
+++ b/src/ethereum_test_specs/static_state/state_static.py
@@ -188,6 +188,9 @@ class StateStaticTest(BaseStaticTest):
                 test_state_vectors = pytest.mark.fully_tagged(test_state_vectors)
         else:
             test_state_vectors = pytest.mark.untagged(test_state_vectors)
+            test_state_vectors = pytest.mark.pre_alloc_group(
+                "separate", reason="Uses hard-coded addresses"
+            )(test_state_vectors)
 
         return test_state_vectors
 


### PR DESCRIPTION
## 🗒️ Description

This PR does two things:
- Disables `--generate-all-formats` automatic generation if `--fill-static-tests` is passed to the command: Currently, there's still a ton of [untagged static tests](https://github.com/ethereum/execution-spec-tests/blob/b815fee3a11dedbf30ecec7fc8455785a690e6da/src/ethereum_test_specs/static_state/state_static.py#L185-L190), which means they use hard-coded addresses and therefore have to be put in different groups to disallow collisions, and this results in 71% of tests being placed in different groups, which makes pre-alloc grouping not worth it.
- Adds the `pytest.mark.pre_alloc_group` mark to all untagged static tests, in order to, if we decide to fill static tests with pre-alloc grouping, the fill won't fail and we ensure these tests all have their own pre-alloc group.

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).