### PR TITLE
fix(tests): Fix `ModExpInput.from_bytes`

### DIFF
--- a/tests/byzantium/eip198_modexp_precompile/helpers.py
+++ b/tests/byzantium/eip198_modexp_precompile/helpers.py
@@ -66,14 +66,14 @@ class ModExpInput(TestParameterGroup):
         assert not isinstance(input_data, str)
         padded_input_data = input_data
         if len(padded_input_data) < 96:
-            padded_input_data = padded_input_data.ljust(96, b"\0")
+            padded_input_data = Bytes(padded_input_data.ljust(96, b"\0"))
         base_length = int.from_bytes(padded_input_data[0:32], byteorder="big")
         exponent_length = int.from_bytes(padded_input_data[32:64], byteorder="big")
         modulus_length = int.from_bytes(padded_input_data[64:96], byteorder="big")
 
         total_required_length = 96 + base_length + exponent_length + modulus_length
         if len(padded_input_data) < total_required_length:
-            padded_input_data = padded_input_data.ljust(total_required_length, b"\0")
+            padded_input_data = Bytes(padded_input_data.ljust(total_required_length, b"\0"))
 
         current_index = 96
         base = padded_input_data[current_index : current_index + base_length]

--- a/tests/byzantium/eip198_modexp_precompile/helpers.py
+++ b/tests/byzantium/eip198_modexp_precompile/helpers.py
@@ -23,6 +23,7 @@ class ModExpInput(TestParameterGroup):
     exponent: Bytes
     modulus: Bytes
     extra_data: Bytes = Field(default_factory=Bytes)
+    raw_input: Bytes | None = None
 
     @property
     def length_base(self) -> Bytes:
@@ -41,6 +42,8 @@ class ModExpInput(TestParameterGroup):
 
     def __bytes__(self):
         """Generate input for the MODEXP precompile."""
+        if self.raw_input is not None:
+            return self.raw_input
         return (
             self.length_base
             + self.length_exponent
@@ -60,20 +63,28 @@ class ModExpInput(TestParameterGroup):
         """
         if isinstance(input_data, str):
             input_data = Bytes(input_data)
-        base_length = int.from_bytes(input_data[0:32], byteorder="big")
-        exponent_length = int.from_bytes(input_data[32:64], byteorder="big")
-        modulus_length = int.from_bytes(input_data[64:96], byteorder="big")
+        assert not isinstance(input_data, str)
+        padded_input_data = input_data
+        if len(padded_input_data) < 96:
+            padded_input_data = padded_input_data.ljust(96, b"\0")
+        base_length = int.from_bytes(padded_input_data[0:32], byteorder="big")
+        exponent_length = int.from_bytes(padded_input_data[32:64], byteorder="big")
+        modulus_length = int.from_bytes(padded_input_data[64:96], byteorder="big")
+
+        total_required_length = 96 + base_length + exponent_length + modulus_length
+        if len(padded_input_data) < total_required_length:
+            padded_input_data = padded_input_data.ljust(total_required_length, b"\0")
 
         current_index = 96
-        base = input_data[current_index : current_index + base_length]
+        base = padded_input_data[current_index : current_index + base_length]
         current_index += base_length
 
-        exponent = input_data[current_index : current_index + exponent_length]
+        exponent = padded_input_data[current_index : current_index + exponent_length]
         current_index += exponent_length
 
-        modulus = input_data[current_index : current_index + modulus_length]
+        modulus = padded_input_data[current_index : current_index + modulus_length]
 
-        return cls(base=base, exponent=exponent, modulus=modulus)
+        return cls(base=base, exponent=exponent, modulus=modulus, raw_input=input_data)
 
 
 class ModExpOutput(TestParameterGroup):

--- a/tests/osaka/eip7883_modexp_gas_increase/conftest.py
+++ b/tests/osaka/eip7883_modexp_gas_increase/conftest.py
@@ -68,7 +68,12 @@ def precompile_gas(fork: Fork, vector: Vector) -> int:
         vector.input.exponent,
     )
     assert calculated_gas == expected_gas, (
-        f"Calculated gas {calculated_gas} != Vector gas {expected_gas}"
+        f"Calculated gas {calculated_gas} != Vector gas {expected_gas}\n"
+        f"Lengths: base: {hex(len(vector.input.base))} ({len(vector.input.base)}), "
+        f"exponent: {hex(len(vector.input.exponent))} ({len(vector.input.exponent)}), "
+        f"modulus: {hex(len(vector.input.modulus))} ({len(vector.input.modulus)})\n"
+        f"Exponent: {vector.input.exponent} "
+        f"({int.from_bytes(vector.input.exponent, byteorder='big')})"
     )
     return calculated_gas
 

--- a/tests/osaka/eip7883_modexp_gas_increase/vectors.json
+++ b/tests/osaka/eip7883_modexp_gas_increase/vectors.json
@@ -141,7 +141,7 @@
     },
     {
         "Input": "00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000181000000000000000000000000000000000000000000000000000000000000000801ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff2cffffffffffffffffffffffffffffffffffffffffffffffffffffffff3b10000000006c01ffffffffffffffffffffffffffffffffffffffffffffffdffffb97ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3bffffffffffffffffffffffffffffffffffffffffffffffffffffffffebafd93b37ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc5bb6affffffff3fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff2a",
-        "Expected": "0001",
+        "Expected": "0001000000000000",
         "Name": "guido-4-even",
         "GasOld": 1026,
         "GasNew": 94448


### PR DESCRIPTION
## 🗒️ Description
Fixes the `ModExpInput.from_bytes` parser to pad inputs when necessary, but also retain the unpadded input which later becomes the actual input to the precompile in the test.

#### Previous behavior

The `ModExpInput.from_bytes` parser would not pad and in fact modify the lengths passed to the pre-compile.

#### New behavior

The `ModExpInput.from_bytes` parser now pads the input before processing and calculating the gas but also retains the original input to then pass it unpadded to the pre-compile.

#### Affected tests

Only `guido-4-even`, but the gas calculation remained unaffected, the only change was the expected output.

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] ~~All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
