### PR TITLE
feat(tests): add critical BLS tests with invalid point coordinates

### DIFF
--- a/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1add.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1add.py
@@ -274,6 +274,22 @@ def test_valid(
             id="b_y_equal_to_p",
         ),
         pytest.param(
+            PointG1(Spec.P1.x + Spec.P, Spec.P1.y) + Spec.G1,
+            id="a_x_above_p",
+        ),
+        pytest.param(
+            PointG1(Spec.P1.x, Spec.P1.y + Spec.P) + Spec.G1,
+            id="a_y_above_p",
+        ),
+        pytest.param(
+            Spec.P1 + PointG1(Spec.G1.x + Spec.P, Spec.G1.y),
+            id="b_x_above_p",
+        ),
+        pytest.param(
+            Spec.P1 + PointG1(Spec.G1.x, Spec.G1.y + Spec.P),
+            id="b_y_above_p",
+        ),
+        pytest.param(
             b"\x80" + bytes(Spec.INF_G1)[1:] + Spec.INF_G1,
             id="invalid_encoding_a",
         ),

--- a/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g2add.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g2add.py
@@ -290,6 +290,38 @@ def test_valid(
             id="b_y_2_equal_to_p",
         ),
         pytest.param(
+            PointG2((Spec.P2.x[0] + Spec.P, Spec.P2.x[1]), Spec.P2.y) + Spec.G2,
+            id="a_x_1_above_p",
+        ),
+        pytest.param(
+            PointG2((Spec.P2.x[0], Spec.P2.x[1] + Spec.P), Spec.P2.y) + Spec.G2,
+            id="a_x_2_above_p",
+        ),
+        pytest.param(
+            PointG2(Spec.P2.x, (Spec.P2.y[0] + Spec.P, Spec.P2.y[1])) + Spec.G2,
+            id="a_y_1_above_p",
+        ),
+        pytest.param(
+            PointG2(Spec.P2.x, (Spec.P2.y[0], Spec.P2.y[1] + Spec.P)) + Spec.G2,
+            id="a_y_2_above_p",
+        ),
+        pytest.param(
+            Spec.P2 + PointG2((Spec.G2.x[0] + Spec.P, Spec.G2.x[1]), Spec.G2.y),
+            id="b_x_1_above_p",
+        ),
+        pytest.param(
+            Spec.P2 + PointG2((Spec.G2.x[0], Spec.G2.x[1] + Spec.P), Spec.G2.y),
+            id="b_x_2_above_p",
+        ),
+        pytest.param(
+            Spec.P2 + PointG2(Spec.G2.x, (Spec.G2.y[0] + Spec.P, Spec.G2.y[1])),
+            id="b_y_1_above_p",
+        ),
+        pytest.param(
+            Spec.P2 + PointG2(Spec.G2.x, (Spec.G2.y[0], Spec.G2.y[1] + Spec.P)),
+            id="b_y_2_above_p",
+        ),
+        pytest.param(
             b"\x80" + bytes(Spec.INF_G2)[1:] + Spec.INF_G2,
             id="invalid_encoding_a",
         ),


### PR DESCRIPTION
## 🗒️ Description
This adds test cases for BLS precompiles where one of the point (G1/G2) coordinates is "slightly" above the value of the field prime P. The "slightly above" means that a valid point is modified by adding P to one of its field elements. Such test case has a chance of detecting an invalid implementation where the field element is loaded as 384-bit integer and converted to the Montgomery form. The Montgomery form round-trip has the effect of computing a value mod P, i.e. `(x + P) % P` gives `x` and the invalid point becomes valid.

In the similar way test cases may be extended to other BLS precompiles. However, I assume BLS precompiles implementations share the input validation code.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
