### PR TITLE
fix(tests): fixed `test_push.py::test_stack_overflow` test by reducing contract size to below allowed max

### DIFF
--- a/tests/frontier/opcodes/test_push.py
+++ b/tests/frontier/opcodes/test_push.py
@@ -8,6 +8,7 @@ import pytest
 from ethereum_test_forks import Fork, Frontier, Homestead
 from ethereum_test_tools import Account, Alloc, Environment, StateTestFiller, Transaction
 from ethereum_test_tools import Opcodes as Op
+from ethereum_test_vm.bytecode import Bytecode
 
 
 def get_input_for_push_opcode(opcode: Op) -> bytes:
@@ -112,7 +113,11 @@ def test_stack_overflow(
      | SSTORE        |              | [0]: excerpt       |
      +---------------------------------------------------+
     """
-    contract_code = push_opcode(excerpt) * stack_height + Op.SSTORE
+    contract_code: Bytecode = Bytecode()
+    for _ in range(stack_height - 2):
+        contract_code += Op.PUSH0  # mostly use push0 to avoid contract size limit exceeded
+    contract_code += push_opcode(excerpt) * 2 + Op.SSTORE
+
     contract = pre.deploy_contract(contract_code)
 
     tx = Transaction(


### PR DESCRIPTION
## 🗒️ Description
Issue is described in #1699, ty for reporting!

## How to run
First run reth via:
`reth node --dev --chain dev --http --authrpc.addr 127.0.0.1 --http.port 8545`
then run:
`uv run execute remote -m state_test --fork=Shanghai --rpc-endpoint=http://127.0.0.1:8545 --rpc-seed-key=2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6 --rpc-chain-id=1337 --tx-wait-timeout 60 -vv -s tests/frontier/opcodes/test_push.py::test_stack_overflow`

Before this PR it failed from PUSH23 onwards due to max contract size (24576) exceeded. After this PR everything passes. I also tried filling and consume direct with geth's evm and it all passes. Ty for the push0 idea @marioevz !

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
