### PR TITLE
feat(tests): add case for large exp with zero mod/base length

### DIFF
--- a/tests/osaka/eip7823_modexp_upper_bounds/test_modexp_upper_bounds.py
+++ b/tests/osaka/eip7823_modexp_upper_bounds/test_modexp_upper_bounds.py
@@ -59,6 +59,30 @@ def precompile_gas(fork: Fork, mod_exp_input: ModExpInput) -> int:
             ),
             id="excess_length_modulus",
         ),
+        pytest.param(
+            ModExpInput(
+                base=b"",
+                exponent=b"\0" * (MAX_LENGTH_BYTES + 1),
+                modulus=b"",
+            ),
+            id="exp_1025_base_0_mod_0",
+        ),
+        pytest.param(
+            ModExpInput(
+                base=b"\0" * (MAX_LENGTH_BYTES + 1),
+                exponent=b"",
+                modulus=b"",
+            ),
+            id="exp_0_base_1025_mod_0",
+        ),
+        pytest.param(
+            ModExpInput(
+                base=b"",
+                exponent=b"",
+                modulus=b"\0" * (MAX_LENGTH_BYTES + 1),
+            ),
+            id="exp_0_base_0_mod_1025",
+        ),
     ],
 )
 def test_modexp_upper_bounds(


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Adds basic cases to EIP-7823. Rotating the case where the length is 1025 and 0 for completeness.

1) exp=1025, mod=0, base=0
2) exp=0, mod=1025, base=0
3) exp=0, mod=0, base=1025

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).