### PR TITLE
feat(specs,filler,ci): Merge static tests into stable/develop, make `--generate-all-formats` compatible with static tests

### DIFF
--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -1,15 +1,11 @@
 # Unless filling for special features, all features should fill for previous forks (starting from Frontier) too
 stable:
   evm-type: stable
-  fill-params: --until=Prague
+  fill-params: --until=Prague --fill-static-tests
 
 develop:
   evm-type: develop 
-  fill-params: --until=Osaka
-
-static: # TODO: remove and add `--fill-static-tests` to both develop & static
-  evm-type: static
-  fill-params: --until=Osaka --fill-static-tests ./tests/static
+  fill-params: --until=Osaka --fill-static-tests
 
 benchmark:
   evm-type: benchmark # Evmone only fully supports up to Prague

--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -1,11 +1,11 @@
 # Unless filling for special features, all features should fill for previous forks (starting from Frontier) too
 stable:
   evm-type: stable
-  fill-params: --until=Prague --fill-static-tests
+  fill-params: --until=Prague --fill-static-tests --ignore=tests/static/state_tests/stQuadraticComplexityTest
 
 develop:
   evm-type: develop 
-  fill-params: --until=Osaka --fill-static-tests
+  fill-params: --until=Osaka --fill-static-tests --ignore=tests/static/state_tests/stQuadraticComplexityTest
 
 benchmark:
   evm-type: benchmark # Evmone only fully supports up to Prague

--- a/.github/workflows/fixtures.yaml
+++ b/.github/workflows/fixtures.yaml
@@ -60,6 +60,7 @@ jobs:
           release_name: ${{ matrix.name }}
           uv_version: ${{ vars.UV_VERSION }}
           python_version: ${{ vars.DEFAULT_PYTHON_VERSION }}
+        timeout-minutes: 720
   release:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/fixtures_feature.yaml
+++ b/.github/workflows/fixtures_feature.yaml
@@ -55,6 +55,7 @@ jobs:
           release_name: ${{ matrix.feature }}
           uv_version: ${{ vars.UV_VERSION }}
           python_version: ${{ vars.DEFAULT_PYTHON_VERSION }}
+        timeout-minutes: 720
   release:
     runs-on: ubuntu-latest
     needs: build

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - Python 3.10 support was removed in this release ([#1808](https://github.com/ethereum/execution-spec-tests/pull/1808)).
 - Tests for the Prague fork are now marked as stable will be included in the `fixtures_stable.tar.gz` tarball from now on.
 - Tests for the Osaka fork are now included in the `fixtures_develop.tar.gz` tarball.
+- `fixtures_static.tar.gz` has been deprecated and filled static tests are now included in `fixtures_stable.tar.gz` and `fixtures_develop.tar.gz`.
 
 #### 💥 Important Change for EEST developers
 
@@ -80,6 +81,7 @@ Users can select any of the artifacts depending on their testing needs for their
 - ✨ Generate unique addresses with Python for compatible static tests, instead of using hard-coded addresses from legacy static test fillers ([#1781](https://github.com/ethereum/execution-spec-tests/pull/1781)).
 - ✨ Added support for the `--benchmark-gas-values` flag in the `fill` command, allowing a single genesis file to be used across different gas limit settings when generating fixtures. ([#1895](https://github.com/ethereum/execution-spec-tests/pull/1895)).
 - ✨ Static tests can now specify a maximum fork where they should be filled for ([#1977](https://github.com/ethereum/execution-spec-tests/pull/1977)).
+- ✨ Static tests can now be filled in every format using `--generate-all-formats` ([#2006](https://github.com/ethereum/execution-spec-tests/pull/2006)).
 
 #### `consume`
 

--- a/src/cli/pytest_commands/fill.py
+++ b/src/cli/pytest_commands/fill.py
@@ -153,9 +153,6 @@ class FillCommand(PytestCommand):
             "--generate-pre-alloc-groups" in args
             or "--generate-all-formats" in args
             or self._is_tarball_output(args)
-        ) and (
-            "--fill-static-tests"
-            not in args  # TODO: remove this once we have better grouping for static tests
         )
 
     def _ensure_generate_all_formats_for_tarball(self, args: List[str]) -> List[str]:

--- a/src/ethereum_test_fixtures/__init__.py
+++ b/src/ethereum_test_fixtures/__init__.py
@@ -1,6 +1,6 @@
 """Ethereum test fixture format definitions."""
 
-from .base import BaseFixture, FixtureFormat, LabeledFixtureFormat
+from .base import BaseFixture, FixtureFillingPhase, FixtureFormat, LabeledFixtureFormat
 from .blockchain import (
     BlockchainEngineFixture,
     BlockchainEngineFixtureCommon,
@@ -25,6 +25,7 @@ __all__ = [
     "EOFFixture",
     "FixtureCollector",
     "FixtureConsumer",
+    "FixtureFillingPhase",
     "FixtureFormat",
     "LabeledFixtureFormat",
     "PreAllocGroups",

--- a/src/ethereum_test_fixtures/base.py
+++ b/src/ethereum_test_fixtures/base.py
@@ -3,8 +3,9 @@
 import hashlib
 import json
 from functools import cached_property
-from typing import Annotated, Any, ClassVar, Dict, Type, Union
+from typing import Annotated, Any, ClassVar, Dict, List, Type, Union
 
+import pytest
 from pydantic import (
     Discriminator,
     Field,
@@ -144,6 +145,15 @@ class BaseFixture(CamelModel):
         By default, all fixtures support all forks.
         """
         return True
+
+    @classmethod
+    def discard_fixture_format_by_marks(
+        cls,
+        fork: Fork,
+        markers: List[pytest.Mark],
+    ) -> bool:
+        """Discard a fixture format from filling if the appropriate marker is used."""
+        return False
 
 
 class LabeledFixtureFormat:

--- a/src/ethereum_test_fixtures/base.py
+++ b/src/ethereum_test_fixtures/base.py
@@ -2,8 +2,9 @@
 
 import hashlib
 import json
+from enum import Enum, auto
 from functools import cached_property
-from typing import Annotated, Any, ClassVar, Dict, List, Type, Union
+from typing import Annotated, Any, ClassVar, Dict, List, Set, Type, Union
 
 import pytest
 from pydantic import (
@@ -39,6 +40,13 @@ def fixture_format_discriminator(v: Any) -> str | None:
     return fixture_format
 
 
+class FixtureFillingPhase(Enum):
+    """Execution phase for fixture generation."""
+
+    PRE_ALLOC_GENERATION = auto()
+    FILL = auto()
+
+
 class BaseFixture(CamelModel):
     """Represents a base Ethereum test fixture of any type."""
 
@@ -52,6 +60,7 @@ class BaseFixture(CamelModel):
     format_name: ClassVar[str] = ""
     output_file_extension: ClassVar[str] = ".json"
     description: ClassVar[str] = "Unknown fixture format; it has not been set."
+    format_phases: ClassVar[Set[FixtureFillingPhase]] = {FixtureFillingPhase.FILL}
 
     @classmethod
     def output_base_dir_name(cls) -> str:
@@ -189,8 +198,13 @@ class LabeledFixtureFormat:
 
     @property
     def format_name(self) -> str:
-        """Get the execute format name."""
+        """Get the filling format name."""
         return self.format.format_name
+
+    @property
+    def format_phases(self) -> Set[FixtureFillingPhase]:
+        """Get the filling format phases where it should be included."""
+        return self.format.format_phases
 
     def __eq__(self, other: Any) -> bool:
         """

--- a/src/ethereum_test_fixtures/blockchain.py
+++ b/src/ethereum_test_fixtures/blockchain.py
@@ -7,6 +7,7 @@ from typing import (
     ClassVar,
     List,
     Literal,
+    Set,
     Tuple,
     Union,
     cast,
@@ -44,7 +45,7 @@ from ethereum_test_types import (
 from ethereum_test_types.block_types import WithdrawalGeneric
 from ethereum_test_types.transaction_types import TransactionFixtureConverter, TransactionGeneric
 
-from .base import BaseFixture
+from .base import BaseFixture, FixtureFillingPhase
 from .common import FixtureAuthorizationTuple, FixtureBlobSchedule
 
 
@@ -557,6 +558,10 @@ class BlockchainEngineXFixture(BlockchainEngineFixtureCommon):
 
     format_name: ClassVar[str] = "blockchain_test_engine_x"
     description: ClassVar[str] = "Tests that generate a Blockchain Test Engine X fixture."
+    format_phases: ClassVar[Set[FixtureFillingPhase]] = {
+        FixtureFillingPhase.FILL,
+        FixtureFillingPhase.PRE_ALLOC_GENERATION,
+    }
 
     pre_hash: str
     """Hash of the pre-allocation group this test belongs to."""

--- a/src/ethereum_test_fixtures/blockchain.py
+++ b/src/ethereum_test_fixtures/blockchain.py
@@ -15,6 +15,7 @@ from typing import (
 )
 
 import ethereum_rlp as eth_rlp
+import pytest
 from ethereum_types.numeric import Uint
 from pydantic import AliasChoices, Field, PlainSerializer, computed_field, model_validator
 
@@ -568,3 +569,17 @@ class BlockchainEngineXFixture(BlockchainEngineFixtureCommon):
 
     sync_payload: FixtureEngineNewPayload | None = None
     """Optional sync payload for blockchain synchronization."""
+
+    @classmethod
+    def discard_fixture_format_by_marks(
+        cls,
+        fork: Fork,
+        markers: List[pytest.Mark],
+    ) -> bool:
+        """Discard a fixture format from filling if the appropriate marker is used."""
+        marker_names = [m.name for m in markers]
+        if "untagged" in marker_names:
+            # Untagged static tests are incompatible with Engine X because they require a
+            # separate pre-alloc group each.
+            return True
+        return False

--- a/src/ethereum_test_fixtures/blockchain.py
+++ b/src/ethereum_test_fixtures/blockchain.py
@@ -16,7 +16,6 @@ from typing import (
 )
 
 import ethereum_rlp as eth_rlp
-import pytest
 from ethereum_types.numeric import Uint
 from pydantic import AliasChoices, Field, PlainSerializer, computed_field, model_validator
 
@@ -574,17 +573,3 @@ class BlockchainEngineXFixture(BlockchainEngineFixtureCommon):
 
     sync_payload: FixtureEngineNewPayload | None = None
     """Optional sync payload for blockchain synchronization."""
-
-    @classmethod
-    def discard_fixture_format_by_marks(
-        cls,
-        fork: Fork,
-        markers: List[pytest.Mark],
-    ) -> bool:
-        """Discard a fixture format from filling if the appropriate marker is used."""
-        marker_names = [m.name for m in markers]
-        if "untagged" in marker_names:
-            # Untagged static tests are incompatible with Engine X because they require a
-            # separate pre-alloc group each.
-            return True
-        return False

--- a/src/ethereum_test_specs/blockchain.py
+++ b/src/ethereum_test_specs/blockchain.py
@@ -437,10 +437,14 @@ class BlockchainTest(BaseTest):
         markers: List[pytest.Mark],
     ) -> bool:
         """Discard a fixture format from filling if the appropriate marker is used."""
-        if "blockchain_test_only" in [m.name for m in markers]:
-            return fixture_format != BlockchainFixture
-        if "blockchain_test_engine_only" in [m.name for m in markers]:
-            return fixture_format != BlockchainEngineFixture
+        marker_names = [m.name for m in markers]
+        if fixture_format != BlockchainFixture and "blockchain_test_only" in marker_names:
+            return True
+        if (
+            fixture_format not in [BlockchainEngineFixture, BlockchainEngineXFixture]
+            and "blockchain_test_engine_only" in marker_names
+        ):
+            return True
         return False
 
     def get_genesis_environment(self, fork: Fork) -> Environment:

--- a/src/pytest_plugins/filler/filler.py
+++ b/src/pytest_plugins/filler/filler.py
@@ -315,7 +315,7 @@ def select_format_by_phases(
     current_filling_phase: FixtureFillingPhase,
     format_phases: Set[FixtureFillingPhase],
 ) -> bool:
-    """Determine the fixture formats that will be used ."""
+    """Determine the fixture formats that will be used."""
     if current_filling_phase == FixtureFillingPhase.PRE_ALLOC_GENERATION:
         # We are generating pre-allocation groups, so we can select any format that contains
         # the pre-allocation phase

--- a/src/pytest_plugins/filler/filler.py
+++ b/src/pytest_plugins/filler/filler.py
@@ -343,11 +343,11 @@ def pytest_sessionstart(session: pytest.Session):
     load the pre-allocation groups for phase 2 execution.
     """
     # Initialize empty pre-allocation groups container for phase 1
-    if session.config.current_filling_phase == FixtureFillingPhase.PRE_ALLOC_GENERATION:
+    if session.config.current_filling_phase == FixtureFillingPhase.PRE_ALLOC_GENERATION:  # type: ignore[attr-defined]
         session.config.pre_alloc_groups = PreAllocGroups(root={})  # type: ignore[attr-defined]
 
     # Load the pre-allocation groups for phase 2
-    if FixtureFillingPhase.PRE_ALLOC_GENERATION in session.config.previous_filling_phases:
+    if FixtureFillingPhase.PRE_ALLOC_GENERATION in session.config.previous_filling_phases:  # type: ignore[attr-defined]
         pre_alloc_groups_folder = session.config.fixture_output.pre_alloc_groups_folder_path  # type: ignore[attr-defined]
         if pre_alloc_groups_folder.exists():
             session.config.pre_alloc_groups = PreAllocGroups.from_folder(  # type: ignore[attr-defined]
@@ -485,7 +485,7 @@ def pytest_terminal_summary(
     stats = terminalreporter.stats
     if "passed" in stats and stats["passed"]:
         # Custom message for Phase 1 (pre-allocation group generation)
-        if config.current_filling_phase == FixtureFillingPhase.PRE_ALLOC_GENERATION:
+        if config.current_filling_phase == FixtureFillingPhase.PRE_ALLOC_GENERATION:  # type: ignore[attr-defined]
             # Generate summary stats
             pre_alloc_groups: PreAllocGroups
             if config.pluginmanager.hasplugin("xdist"):
@@ -1072,8 +1072,8 @@ def pytest_generate_tests(metafunc: pytest.Metafunc):
             for i, format_with_or_without_label in enumerate(test_type.supported_fixture_formats):
                 if not select_format_by_phases(
                     generate_all_formats=generate_all_formats,
-                    previous_filling_phases=metafunc.config.previous_filling_phases,
-                    current_filling_phase=metafunc.config.current_filling_phase,
+                    previous_filling_phases=metafunc.config.previous_filling_phases,  # type: ignore[attr-defined]
+                    current_filling_phase=metafunc.config.current_filling_phase,  # type: ignore[attr-defined]
                     format_phases=format_with_or_without_label.format_phases,
                 ):
                     continue
@@ -1165,7 +1165,7 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int):
     # Save pre-allocation groups after phase 1
     fixture_output = session.config.fixture_output  # type: ignore[attr-defined]
     if (
-        session.config.current_filling_phase == FixtureFillingPhase.PRE_ALLOC_GENERATION
+        session.config.current_filling_phase == FixtureFillingPhase.PRE_ALLOC_GENERATION  # type: ignore[attr-defined]
         and hasattr(session.config, "pre_alloc_groups")
     ):
         pre_alloc_groups_folder = fixture_output.pre_alloc_groups_folder_path
@@ -1186,7 +1186,7 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int):
     # Generate index file for all produced fixtures.
     if (
         session.config.getoption("generate_index")
-        and not session.config.current_filling_phase == FixtureFillingPhase.PRE_ALLOC_GENERATION
+        and not session.config.current_filling_phase == FixtureFillingPhase.PRE_ALLOC_GENERATION  # type: ignore[attr-defined]
     ):
         generate_fixtures_index(
             fixture_output.directory, quiet_mode=True, force_flag=False, disable_infer_format=False

--- a/src/pytest_plugins/filler/filler.py
+++ b/src/pytest_plugins/filler/filler.py
@@ -10,9 +10,8 @@ import configparser
 import datetime
 import os
 import warnings
-from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, Generator, List, Type
+from typing import Any, Dict, Generator, List, Set, Tuple, Type
 
 import pytest
 import xdist
@@ -26,10 +25,9 @@ from ethereum_clis.clis.geth import FixtureConsumerTool
 from ethereum_test_base_types import Account, Address, Alloc, ReferenceSpec
 from ethereum_test_fixtures import (
     BaseFixture,
-    BlockchainEngineXFixture,
     FixtureCollector,
     FixtureConsumer,
-    LabeledFixtureFormat,
+    FixtureFillingPhase,
     PreAllocGroup,
     PreAllocGroups,
     TestInfo,
@@ -294,6 +292,49 @@ def pytest_addoption(parser: pytest.Parser):
     )
 
 
+def _determine_filling_phases(
+    *,
+    generate_pre_alloc_groups: bool,
+    use_pre_alloc_groups: bool,
+    generate_all_formats: bool,
+) -> Tuple[Set[FixtureFillingPhase], FixtureFillingPhase]:
+    """Determine which execution phase we're in based on the flags."""
+    if use_pre_alloc_groups:
+        return {FixtureFillingPhase.PRE_ALLOC_GENERATION}, FixtureFillingPhase.FILL
+    elif generate_pre_alloc_groups or generate_all_formats:
+        return set(), FixtureFillingPhase.PRE_ALLOC_GENERATION
+    else:
+        # Normal filling
+        return set(), FixtureFillingPhase.FILL
+
+
+def select_format_by_phases(
+    *,
+    generate_all_formats: bool,
+    previous_filling_phases: Set[FixtureFillingPhase],
+    current_filling_phase: FixtureFillingPhase,
+    format_phases: Set[FixtureFillingPhase],
+) -> bool:
+    """Determine the fixture formats that will be used ."""
+    if current_filling_phase == FixtureFillingPhase.PRE_ALLOC_GENERATION:
+        # We are generating pre-allocation groups, so we can select any format that contains
+        # the pre-allocation phase
+        return FixtureFillingPhase.PRE_ALLOC_GENERATION in format_phases
+    elif current_filling_phase == FixtureFillingPhase.FILL:
+        if FixtureFillingPhase.PRE_ALLOC_GENERATION in previous_filling_phases:
+            # We are filling and the pre-allocation already passed
+            if generate_all_formats:
+                # Generate all formats, including the ones that didn't need pre-allocation groups
+                return True
+            else:
+                # Generate only the formats that need pre-allocation groups
+                return FixtureFillingPhase.PRE_ALLOC_GENERATION in format_phases
+        else:
+            # Discriminate to select fixtures that only have the filling phase and not both
+            return format_phases == {FixtureFillingPhase.FILL}
+    raise ValueError(f"Invalid filling phase: {current_filling_phase}")
+
+
 def pytest_sessionstart(session: pytest.Session):
     """
     Initialize session-level state.
@@ -302,11 +343,11 @@ def pytest_sessionstart(session: pytest.Session):
     load the pre-allocation groups for phase 2 execution.
     """
     # Initialize empty pre-allocation groups container for phase 1
-    if session.config.getoption("generate_pre_alloc_groups"):
+    if session.config.current_filling_phase == FixtureFillingPhase.PRE_ALLOC_GENERATION:
         session.config.pre_alloc_groups = PreAllocGroups(root={})  # type: ignore[attr-defined]
 
     # Load the pre-allocation groups for phase 2
-    if session.config.getoption("use_pre_alloc_groups"):
+    if FixtureFillingPhase.PRE_ALLOC_GENERATION in session.config.previous_filling_phases:
         pre_alloc_groups_folder = session.config.fixture_output.pre_alloc_groups_folder_path  # type: ignore[attr-defined]
         if pre_alloc_groups_folder.exists():
             session.config.pre_alloc_groups = PreAllocGroups.from_folder(  # type: ignore[attr-defined]
@@ -343,6 +384,13 @@ def pytest_configure(config):
     # Initialize fixture output configuration
     config.fixture_output = FixtureOutput.from_config(config)
 
+    # Determine the filling phase
+    config.previous_filling_phases, config.current_filling_phase = _determine_filling_phases(
+        generate_pre_alloc_groups=config.getoption("generate_pre_alloc_groups"),
+        use_pre_alloc_groups=config.getoption("use_pre_alloc_groups"),
+        generate_all_formats=config.getoption("generate_all_formats"),
+    )
+
     if is_help_or_collectonly_mode(config):
         return
 
@@ -355,7 +403,7 @@ def pytest_configure(config):
     if (
         not config.getoption("disable_html")
         and config.getoption("htmlpath") is None
-        and not config.getoption("generate_pre_alloc_groups")
+        and config.current_filling_phase != FixtureFillingPhase.PRE_ALLOC_GENERATION
     ):
         config.option.htmlpath = config.fixture_output.directory / default_html_report_file_path()
 
@@ -437,7 +485,7 @@ def pytest_terminal_summary(
     stats = terminalreporter.stats
     if "passed" in stats and stats["passed"]:
         # Custom message for Phase 1 (pre-allocation group generation)
-        if config.getoption("generate_pre_alloc_groups"):
+        if config.current_filling_phase == FixtureFillingPhase.PRE_ALLOC_GENERATION:
             # Generate summary stats
             pre_alloc_groups: PreAllocGroups
             if config.pluginmanager.hasplugin("xdist"):
@@ -930,8 +978,9 @@ def base_test_parametrizer(cls: Type[BaseTest]):
                 self._operation_mode = request.config.op_mode
 
                 # Phase 1: Generate pre-allocation groups
-                if fixture_format is BlockchainEngineXFixture and request.config.getoption(
-                    "generate_pre_alloc_groups"
+                if (
+                    request.config.current_filling_phase
+                    == FixtureFillingPhase.PRE_ALLOC_GENERATION
                 ):
                     self.update_pre_alloc_groups(
                         request.config.pre_alloc_groups, fork, request.node.nodeid
@@ -940,9 +989,7 @@ def base_test_parametrizer(cls: Type[BaseTest]):
 
                 # Phase 2: Use pre-allocation groups (only for BlockchainEngineXFixture)
                 pre_alloc_hash = None
-                if fixture_format is BlockchainEngineXFixture and request.config.getoption(
-                    "use_pre_alloc_groups"
-                ):
+                if FixtureFillingPhase.PRE_ALLOC_GENERATION in fixture_format.format_phases:
                     pre_alloc_hash = self.compute_pre_alloc_group_hash(fork=fork)
                     if pre_alloc_hash not in request.config.pre_alloc_groups:
                         pre_alloc_path = (
@@ -967,8 +1014,7 @@ def base_test_parametrizer(cls: Type[BaseTest]):
 
                 # Post-process for Engine X format (add pre_hash and state diff)
                 if (
-                    fixture_format is BlockchainEngineXFixture
-                    and request.config.getoption("use_pre_alloc_groups")
+                    FixtureFillingPhase.PRE_ALLOC_GENERATION in fixture_format.format_phases
                     and pre_alloc_hash is not None
                 ):
                     fixture.pre_hash = pre_alloc_hash
@@ -1011,85 +1057,26 @@ for cls in BaseTest.spec_types.values():
     globals()[cls.pytest_parameter_name()] = base_test_parametrizer(cls)
 
 
-class ExecutionPhase(Enum):
-    """Execution phase for fixture generation."""
-
-    NORMAL = "normal"
-    PHASE_1_PREALLOC = "phase_1_prealloc"
-    PHASE_2_ENGINE_X_ONLY = "phase_2_engine_x_only"
-    PHASE_2_ALL_FORMATS = "phase_2_all_formats"
-
-
-def _determine_execution_phase(
-    generate_pre_alloc_groups: bool,
-    use_pre_alloc_groups: bool,
-    generate_all_formats: bool,
-) -> ExecutionPhase:
-    """Determine which execution phase we're in based on the flags."""
-    if generate_all_formats and use_pre_alloc_groups:
-        return ExecutionPhase.PHASE_2_ALL_FORMATS
-    elif use_pre_alloc_groups:
-        return ExecutionPhase.PHASE_2_ENGINE_X_ONLY
-    elif generate_pre_alloc_groups or generate_all_formats:
-        return ExecutionPhase.PHASE_1_PREALLOC
-    else:
-        return ExecutionPhase.NORMAL
-
-
-def _is_blockchain_engine_x_fixture(format_item) -> bool:
-    """Check if a fixture format is BlockchainEngineXFixture."""
-    return format_item is BlockchainEngineXFixture or (
-        isinstance(format_item, LabeledFixtureFormat)
-        and format_item.format is BlockchainEngineXFixture
-    )
-
-
-def _determine_fixture_formats(test_type, execution_phase: ExecutionPhase) -> List:
-    """Determine which fixture formats to generate based on execution phase."""
-    all_formats = test_type.supported_fixture_formats
-
-    if execution_phase == ExecutionPhase.PHASE_2_ALL_FORMATS:
-        # Phase 2 with --generate-all-formats: Generate ALL fixture formats
-        return all_formats
-    elif execution_phase in (
-        ExecutionPhase.PHASE_1_PREALLOC,
-        ExecutionPhase.PHASE_2_ENGINE_X_ONLY,
-    ):
-        # Phase 1 or Phase 2 without --generate-all-formats: only BlockchainEngineXFixture
-        return [
-            format_item
-            for format_item in all_formats
-            if _is_blockchain_engine_x_fixture(format_item)
-        ]
-    else:
-        # Normal execution: Filter out BlockchainEngineXFixture
-        return [
-            format_item
-            for format_item in all_formats
-            if not _is_blockchain_engine_x_fixture(format_item)
-        ]
-
-
 def pytest_generate_tests(metafunc: pytest.Metafunc):
     """
     Pytest hook used to dynamically generate test cases for each fixture format a given
     test spec supports.
+
+    NOTE: The static test filler does NOT use this hook. See FillerFile.collect() in
+    ./static_filler.py for more details.
     """
+    generate_all_formats = metafunc.config.getoption("generate_all_formats", False)
     for test_type in BaseTest.spec_types.values():
         if test_type.pytest_parameter_name() in metafunc.fixturenames:
-            generate_pre_alloc_groups = metafunc.config.getoption(
-                "generate_pre_alloc_groups", False
-            )
-            use_pre_alloc_groups = metafunc.config.getoption("use_pre_alloc_groups", False)
-            generate_all_formats = metafunc.config.getoption("generate_all_formats", False)
-
-            execution_phase = _determine_execution_phase(
-                generate_pre_alloc_groups, use_pre_alloc_groups, generate_all_formats
-            )
-            supported_formats = _determine_fixture_formats(test_type, execution_phase)
-
             parameters = []
-            for i, format_with_or_without_label in enumerate(supported_formats):
+            for i, format_with_or_without_label in enumerate(test_type.supported_fixture_formats):
+                if not select_format_by_phases(
+                    generate_all_formats=generate_all_formats,
+                    previous_filling_phases=metafunc.config.previous_filling_phases,
+                    current_filling_phase=metafunc.config.current_filling_phase,
+                    format_phases=format_with_or_without_label.format_phases,
+                ):
+                    continue
                 parameter = labeled_format_parameter_set(format_with_or_without_label)
                 if i > 0:
                     parameter.marks.append(pytest.mark.derived_test)  # type: ignore
@@ -1177,8 +1164,9 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int):
     """
     # Save pre-allocation groups after phase 1
     fixture_output = session.config.fixture_output  # type: ignore[attr-defined]
-    if session.config.getoption("generate_pre_alloc_groups") and hasattr(
-        session.config, "pre_alloc_groups"
+    if (
+        session.config.current_filling_phase == FixtureFillingPhase.PRE_ALLOC_GENERATION
+        and hasattr(session.config, "pre_alloc_groups")
     ):
         pre_alloc_groups_folder = fixture_output.pre_alloc_groups_folder_path
         pre_alloc_groups_folder.mkdir(parents=True, exist_ok=True)
@@ -1196,8 +1184,9 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int):
         file.unlink()
 
     # Generate index file for all produced fixtures.
-    if session.config.getoption("generate_index") and not session.config.getoption(
-        "generate_pre_alloc_groups"
+    if (
+        session.config.getoption("generate_index")
+        and not session.config.current_filling_phase == FixtureFillingPhase.PRE_ALLOC_GENERATION
     ):
         generate_fixtures_index(
             fixture_output.directory, quiet_mode=True, force_flag=False, disable_infer_format=False

--- a/src/pytest_plugins/filler/filler.py
+++ b/src/pytest_plugins/filler/filler.py
@@ -1134,6 +1134,11 @@ def pytest_collection_modifyitems(
             items_for_removal.append(i)
             continue
         markers = list(item.iter_markers())
+        # Both the fixture format itself and the spec filling it have a chance to veto the
+        # filling of a specific format.
+        if fixture_format.discard_fixture_format_by_marks(fork, markers):
+            items_for_removal.append(i)
+            continue
         if spec_type.discard_fixture_format_by_marks(fixture_format, fork, markers):
             items_for_removal.append(i)
             continue

--- a/src/pytest_plugins/filler/static_filler.py
+++ b/src/pytest_plugins/filler/static_filler.py
@@ -23,7 +23,6 @@ from ethereum_test_tools.code.yul import Yul
 
 from ..forks.forks import ValidityMarker, get_intersection_set
 from ..shared.helpers import labeled_format_parameter_set
-from .filler import select_format_by_phases
 
 
 def get_test_id_from_arg_names_and_values(
@@ -179,20 +178,15 @@ class FillerFile(pytest.File):
 
                     fixture_formats: List[Type[BaseFixture] | LabeledFixtureFormat] = []
                     spec_parameter_name = ""
-                    generate_all_formats = self.config.getoption("generate_all_formats", False)
                     for test_type in BaseTest.spec_types.values():
                         if test_type.pytest_parameter_name() in func_parameters:
                             assert not spec_parameter_name, "Multiple spec parameters found"
                             spec_parameter_name = test_type.pytest_parameter_name()
+                            session = self.config.filling_session  # type: ignore[attr-defined]
                             fixture_formats.extend(
                                 fixture_format
                                 for fixture_format in test_type.supported_fixture_formats
-                                if select_format_by_phases(
-                                    generate_all_formats=generate_all_formats,
-                                    previous_filling_phases=self.config.previous_filling_phases,  # type: ignore[attr-defined]
-                                    current_filling_phase=self.config.current_filling_phase,  # type: ignore[attr-defined]
-                                    format_phases=fixture_format.format_phases,
-                                )
+                                if session.should_generate_format(fixture_format)
                             )
 
                     validity_markers: List[ValidityMarker] = (

--- a/src/pytest_plugins/filler/static_filler.py
+++ b/src/pytest_plugins/filler/static_filler.py
@@ -189,8 +189,8 @@ class FillerFile(pytest.File):
                                 for fixture_format in test_type.supported_fixture_formats
                                 if select_format_by_phases(
                                     generate_all_formats=generate_all_formats,
-                                    previous_filling_phases=self.config.previous_filling_phases,
-                                    current_filling_phase=self.config.current_filling_phase,
+                                    previous_filling_phases=self.config.previous_filling_phases,  # type: ignore[attr-defined]
+                                    current_filling_phase=self.config.current_filling_phase,  # type: ignore[attr-defined]
                                     format_phases=fixture_format.format_phases,
                                 )
                             )

--- a/src/pytest_plugins/filler/tests/test_filling_session.py
+++ b/src/pytest_plugins/filler/tests/test_filling_session.py
@@ -1,0 +1,294 @@
+"""Unit tests for the FillingSession class."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ethereum_test_base_types import Alloc
+from ethereum_test_fixtures import (
+    FixtureFillingPhase,
+    PreAllocGroup,
+    PreAllocGroups,
+)
+from ethereum_test_forks import Prague
+from ethereum_test_types import Environment
+
+from ..filler import FillingSession
+
+
+class MockConfig:
+    """Mock pytest config for testing."""
+
+    def __init__(self, **options):
+        """Initialize with option values."""
+        self._options = options
+        self.op_mode = "fill"  # Default operation mode
+
+    def getoption(self, name, default=None):
+        """Mock getoption method."""
+        return self._options.get(name, default)
+
+
+class MockFixtureOutput:
+    """Mock fixture output for testing."""
+
+    def __init__(self, pre_alloc_folder_exists=True):
+        """Initialize with test conditions."""
+        self._folder_exists = pre_alloc_folder_exists
+        self.pre_alloc_groups_folder_path = Path("/tmp/test_pre_alloc")
+
+    @classmethod
+    def from_config(cls, config):
+        """Mock factory method."""
+        return cls()
+
+
+class TestFillingSession:
+    """Test cases for FillingSession class."""
+
+    def test_init_normal_fill(self):
+        """Test initialization for normal single-phase fill."""
+        config = MockConfig()
+
+        with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
+            session = FillingSession.from_config(config)
+
+        assert session.phase_manager.is_single_phase_fill
+        assert session.pre_alloc_groups is None
+
+    def test_init_pre_alloc_generation(self):
+        """Test initialization for pre-alloc generation phase."""
+        config = MockConfig(generate_pre_alloc_groups=True)
+
+        with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
+            session = FillingSession.from_config(config)
+
+        assert session.phase_manager.is_pre_alloc_generation
+        assert session.pre_alloc_groups is not None
+        assert len(session.pre_alloc_groups.root) == 0
+
+    def test_init_use_pre_alloc(self):
+        """Test initialization for phase 2 (using pre-alloc groups)."""
+        config = MockConfig(use_pre_alloc_groups=True)
+
+        # Mock the file system operations
+        test_group = PreAllocGroup(
+            pre=Alloc().model_dump(mode="json"),
+            environment=Environment().model_dump(mode="json"),
+            network=Prague.name(),
+        )
+        mock_groups = PreAllocGroups(root={"test_hash": test_group})
+
+        with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
+            with patch.object(Path, "exists", return_value=True):
+                with patch.object(PreAllocGroups, "from_folder", return_value=mock_groups):
+                    session = FillingSession.from_config(config)
+
+        assert session.phase_manager.is_fill_after_pre_alloc
+        assert session.pre_alloc_groups is mock_groups
+
+    def test_init_use_pre_alloc_missing_folder(self):
+        """Test initialization fails when pre-alloc folder is missing."""
+        config = MockConfig(use_pre_alloc_groups=True)
+
+        with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
+            with patch.object(Path, "exists", return_value=False):
+                with pytest.raises(
+                    FileNotFoundError, match="Pre-allocation groups folder not found"
+                ):
+                    FillingSession.from_config(config)
+
+    def test_should_generate_format(self):
+        """Test format generation decision."""
+        config = MockConfig()
+
+        with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
+            session = FillingSession.from_config(config)
+
+        # Mock fixture format
+        class MockFormat:
+            format_phases = {FixtureFillingPhase.FILL}
+
+        assert session.should_generate_format(MockFormat())
+
+    def test_should_generate_format_with_generate_all(self):
+        """Test format generation with generate_all_formats flag."""
+        config = MockConfig(generate_all_formats=True, use_pre_alloc_groups=True)
+
+        mock_groups = PreAllocGroups(root={})
+
+        with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
+            with patch.object(Path, "exists", return_value=True):
+                with patch.object(PreAllocGroups, "from_folder", return_value=mock_groups):
+                    session = FillingSession.from_config(config)
+
+        # Mock fixture format that normally wouldn't generate in phase 2
+        class MockFormat:
+            format_phases = {FixtureFillingPhase.FILL}
+
+        # Should generate because generate_all=True
+        assert session.should_generate_format(MockFormat())
+
+    def test_get_pre_alloc_group(self):
+        """Test getting a pre-alloc group by hash."""
+        config = MockConfig(use_pre_alloc_groups=True)
+
+        test_group = PreAllocGroup(
+            pre=Alloc().model_dump(mode="json"),
+            environment=Environment().model_dump(mode="json"),
+            network=Prague.name(),
+        )
+        mock_groups = PreAllocGroups(root={"test_hash": test_group})
+
+        with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
+            with patch.object(Path, "exists", return_value=True):
+                with patch.object(PreAllocGroups, "from_folder", return_value=mock_groups):
+                    session = FillingSession.from_config(config)
+
+        assert session.get_pre_alloc_group("test_hash") is test_group
+
+    def test_get_pre_alloc_group_not_found(self):
+        """Test getting a non-existent pre-alloc group."""
+        config = MockConfig(use_pre_alloc_groups=True)
+
+        mock_groups = PreAllocGroups(root={})
+
+        with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
+            with patch.object(Path, "exists", return_value=True):
+                with patch.object(PreAllocGroups, "from_folder", return_value=mock_groups):
+                    session = FillingSession.from_config(config)
+
+        with pytest.raises(ValueError, match="Pre-allocation hash .* not found"):
+            session.get_pre_alloc_group("missing_hash")
+
+    def test_get_pre_alloc_group_not_initialized(self):
+        """Test getting pre-alloc group when not initialized."""
+        config = MockConfig()  # Normal fill, no pre-alloc groups
+
+        with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
+            session = FillingSession.from_config(config)
+
+        with pytest.raises(ValueError, match="Pre-allocation groups not initialized"):
+            session.get_pre_alloc_group("any_hash")
+
+    def test_update_pre_alloc_group(self):
+        """Test updating a pre-alloc group."""
+        config = MockConfig(generate_pre_alloc_groups=True)
+
+        with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
+            session = FillingSession.from_config(config)
+
+        test_group = PreAllocGroup(
+            pre=Alloc().model_dump(mode="json"),
+            environment=Environment().model_dump(mode="json"),
+            network=Prague.name(),
+        )
+        session.update_pre_alloc_group("test_hash", test_group)
+
+        assert "test_hash" in session.pre_alloc_groups
+        assert session.pre_alloc_groups["test_hash"] is test_group
+
+    def test_update_pre_alloc_group_wrong_phase(self):
+        """Test updating pre-alloc group in wrong phase."""
+        config = MockConfig()  # Normal fill
+
+        with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
+            session = FillingSession.from_config(config)
+
+        test_group = PreAllocGroup(
+            pre=Alloc().model_dump(mode="json"),
+            environment=Environment().model_dump(mode="json"),
+            network=Prague.name(),
+        )
+        with pytest.raises(
+            ValueError, match="Can only update pre-alloc groups in generation phase"
+        ):
+            session.update_pre_alloc_group("test_hash", test_group)
+
+    def test_save_pre_alloc_groups(self):
+        """Test saving pre-alloc groups to disk."""
+        config = MockConfig(generate_pre_alloc_groups=True)
+
+        with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
+            session = FillingSession.from_config(config)
+
+        # Add a test group
+        test_group = PreAllocGroup(
+            pre=Alloc().model_dump(mode="json"),
+            environment=Environment().model_dump(mode="json"),
+            network=Prague.name(),
+        )
+        session.update_pre_alloc_group("test_hash", test_group)
+
+        # Mock file operations
+        with patch.object(Path, "mkdir") as mock_mkdir:
+            with patch.object(PreAllocGroups, "to_folder") as mock_to_folder:
+                session.save_pre_alloc_groups()
+
+        mock_mkdir.assert_called_once_with(parents=True, exist_ok=True)
+        mock_to_folder.assert_called_once()
+
+    def test_save_pre_alloc_groups_none(self):
+        """Test saving when no pre-alloc groups exist."""
+        config = MockConfig()  # Normal fill
+
+        with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
+            session = FillingSession.from_config(config)
+
+        # Should not raise, just return
+        session.save_pre_alloc_groups()
+
+    def test_aggregate_pre_alloc_groups(self):
+        """Test aggregating pre-alloc groups from workers (xdist)."""
+        config = MockConfig(generate_pre_alloc_groups=True)
+
+        with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
+            session = FillingSession.from_config(config)
+
+        # Worker groups to aggregate
+        group1 = PreAllocGroup(
+            pre=Alloc().model_dump(mode="json"),
+            environment=Environment().model_dump(mode="json"),
+            network=Prague.name(),
+        )
+        group2 = PreAllocGroup(
+            pre=Alloc().model_dump(mode="json"),
+            environment=Environment().model_dump(mode="json"),
+            network=Prague.name(),
+        )
+        worker_groups = PreAllocGroups(root={"hash1": group1, "hash2": group2})
+
+        session.aggregate_pre_alloc_groups(worker_groups)
+
+        assert "hash1" in session.pre_alloc_groups
+        assert "hash2" in session.pre_alloc_groups
+
+    def test_aggregate_pre_alloc_groups_conflict(self):
+        """Test aggregating conflicting pre-alloc groups."""
+        config = MockConfig(generate_pre_alloc_groups=True)
+
+        with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
+            session = FillingSession.from_config(config)
+
+        # Add initial group
+        alloc1 = Alloc().model_dump(mode="json")
+        group1 = PreAllocGroup(
+            pre=alloc1,
+            environment=Environment().model_dump(mode="json"),
+            network=Prague.name(),
+        )
+        session.update_pre_alloc_group("hash1", group1)
+
+        # Try to aggregate conflicting group with same hash but different pre
+        alloc2_dict = Alloc().model_dump(mode="json")
+        alloc2_dict["0x1234567890123456789012345678901234567890"] = None  # Make it different
+        group2 = PreAllocGroup(
+            pre=alloc2_dict,
+            environment=Environment().model_dump(mode="json"),
+            network=Prague.name(),
+        )
+        worker_groups = PreAllocGroups(root={"hash1": group2})
+
+        with pytest.raises(ValueError, match="Conflicting pre-alloc groups"):
+            session.aggregate_pre_alloc_groups(worker_groups)

--- a/src/pytest_plugins/filler/tests/test_format_selector.py
+++ b/src/pytest_plugins/filler/tests/test_format_selector.py
@@ -1,0 +1,247 @@
+"""Unit tests for the FormatSelector class."""
+
+from typing import List, Set, Tuple
+
+from ethereum_test_fixtures import BaseFixture, FixtureFillingPhase, LabeledFixtureFormat
+
+from ..filler import FormatSelector, PhaseManager
+
+
+class TestFormatSelector:
+    """Test cases for FormatSelector class."""
+
+    def test_init(self):
+        """Test basic initialization."""
+        phase_manager = PhaseManager(current_phase=FixtureFillingPhase.FILL)
+        format_selector = FormatSelector(phase_manager=phase_manager, generate_all_formats=False)
+        assert format_selector.phase_manager is phase_manager
+
+    def test_should_generate_pre_alloc_phase_with_pre_alloc_format(self):
+        """Test pre-alloc phase with format that supports pre-alloc."""
+        phase_manager = PhaseManager(current_phase=FixtureFillingPhase.PRE_ALLOC_GENERATION)
+        format_selector = FormatSelector(phase_manager=phase_manager, generate_all_formats=False)
+
+        # MySub = type("MySub", (BaseClass,), {"MY_CLASSVAR": 42})
+        format_with_pre_alloc = type(
+            "MockFixtureFormat",
+            (BaseFixture,),
+            {
+                "format_phases": {
+                    FixtureFillingPhase.PRE_ALLOC_GENERATION,
+                    FixtureFillingPhase.FILL,
+                }
+            },
+        )
+
+        assert format_selector.should_generate(format_with_pre_alloc)
+
+    def test_should_generate_pre_alloc_phase_without_pre_alloc_format(self):
+        """Test pre-alloc phase with format that doesn't support pre-alloc."""
+        phase_manager = PhaseManager(current_phase=FixtureFillingPhase.PRE_ALLOC_GENERATION)
+        format_selector = FormatSelector(phase_manager=phase_manager, generate_all_formats=False)
+
+        format_without_pre_alloc = type(
+            "MockFixtureFormat",
+            (BaseFixture,),
+            {"format_phases": {FixtureFillingPhase.FILL}},
+        )
+
+        assert not format_selector.should_generate(format_without_pre_alloc)
+
+    def test_should_generate_single_phase_fill_only_format(self):
+        """Test single-phase fill with fill-only format."""
+        phase_manager = PhaseManager(current_phase=FixtureFillingPhase.FILL)
+        format_selector = FormatSelector(phase_manager=phase_manager, generate_all_formats=False)
+
+        fill_only_format = type(
+            "MockFixtureFormat",
+            (BaseFixture,),
+            {"format_phases": {FixtureFillingPhase.FILL}},
+        )
+
+        assert format_selector.should_generate(fill_only_format)
+
+    def test_should_generate_single_phase_pre_alloc_format(self):
+        """Test single-phase fill with format that supports pre-alloc."""
+        phase_manager = PhaseManager(current_phase=FixtureFillingPhase.FILL)
+        format_selector = FormatSelector(phase_manager=phase_manager, generate_all_formats=False)
+
+        format_with_pre_alloc = type(
+            "MockFixtureFormat",
+            (BaseFixture,),
+            {
+                "format_phases": {
+                    FixtureFillingPhase.PRE_ALLOC_GENERATION,
+                    FixtureFillingPhase.FILL,
+                }
+            },
+        )
+
+        # Should not generate because it needs pre-alloc but we're in single phase
+        assert not format_selector.should_generate(format_with_pre_alloc)
+
+    def test_should_generate_phase2_with_pre_alloc_format(self):
+        """Test phase 2 (after pre-alloc) with format that supports pre-alloc."""
+        phase_manager = PhaseManager(
+            current_phase=FixtureFillingPhase.FILL,
+            previous_phases={FixtureFillingPhase.PRE_ALLOC_GENERATION},
+        )
+        format_selector = FormatSelector(phase_manager=phase_manager, generate_all_formats=False)
+
+        format_with_pre_alloc = type(
+            "MockFixtureFormat",
+            (BaseFixture,),
+            {
+                "format_phases": {
+                    FixtureFillingPhase.PRE_ALLOC_GENERATION,
+                    FixtureFillingPhase.FILL,
+                }
+            },
+        )
+
+        # Should generate in phase 2
+        assert format_selector.should_generate(format_with_pre_alloc)
+
+    def test_should_generate_phase2_without_pre_alloc_format(self):
+        """Test phase 2 (after pre-alloc) with fill-only format."""
+        phase_manager = PhaseManager(
+            current_phase=FixtureFillingPhase.FILL,
+            previous_phases={FixtureFillingPhase.PRE_ALLOC_GENERATION},
+        )
+        format_selector = FormatSelector(phase_manager=phase_manager, generate_all_formats=False)
+
+        fill_only_format = type(
+            "MockFixtureFormat",
+            (BaseFixture,),
+            {"format_phases": {FixtureFillingPhase.FILL}},
+        )
+
+        # Should not generate because it doesn't need pre-alloc
+        assert not format_selector.should_generate(fill_only_format)
+
+    def test_should_generate_phase2_with_generate_all(self):
+        """Test phase 2 with --generate-all-formats flag."""
+        phase_manager = PhaseManager(
+            current_phase=FixtureFillingPhase.FILL,
+            previous_phases={FixtureFillingPhase.PRE_ALLOC_GENERATION},
+        )
+        format_selector = FormatSelector(phase_manager=phase_manager, generate_all_formats=True)
+
+        fill_only_format = type(
+            "MockFixtureFormat",
+            (BaseFixture,),
+            {"format_phases": {FixtureFillingPhase.FILL}},
+        )
+        format_with_pre_alloc = type(
+            "MockFixtureFormat",
+            (BaseFixture,),
+            {
+                "format_phases": {
+                    FixtureFillingPhase.PRE_ALLOC_GENERATION,
+                    FixtureFillingPhase.FILL,
+                }
+            },
+        )
+
+        # With generate_all=True, both formats should be generated
+        assert format_selector.should_generate(fill_only_format)
+        assert format_selector.should_generate(format_with_pre_alloc)
+
+    def test_should_generate_labeled_format(self):
+        """Test with LabeledFixtureFormat wrapper."""
+        phase_manager = PhaseManager(current_phase=FixtureFillingPhase.FILL)
+        format_selector = FormatSelector(phase_manager=phase_manager, generate_all_formats=False)
+
+        fill_only_format = type(
+            "MockFixtureFormat",
+            (BaseFixture,),
+            {"format_phases": {FixtureFillingPhase.FILL}},
+        )
+        labeled_format = LabeledFixtureFormat(
+            fill_only_format,
+            "mock_labeled_format",
+            "A mock labeled fixture format",
+        )
+
+        assert format_selector.should_generate(labeled_format)
+
+    def test_comprehensive_scenarios(self):
+        """Test comprehensive scenarios covering all phase and format combinations."""
+        # Test matrix: (current_phase, previous_phases, format_phases, generate_all) -> expected
+        test_cases: List[
+            Tuple[
+                FixtureFillingPhase, Set[FixtureFillingPhase], Set[FixtureFillingPhase], bool, bool
+            ]
+        ] = [
+            # Pre-alloc generation phase
+            (
+                FixtureFillingPhase.PRE_ALLOC_GENERATION,
+                set(),
+                {FixtureFillingPhase.PRE_ALLOC_GENERATION, FixtureFillingPhase.FILL},
+                False,
+                True,
+            ),
+            (
+                FixtureFillingPhase.PRE_ALLOC_GENERATION,
+                set(),
+                {FixtureFillingPhase.FILL},
+                False,
+                False,
+            ),
+            # Single-phase fill
+            (FixtureFillingPhase.FILL, set(), {FixtureFillingPhase.FILL}, False, True),
+            (
+                FixtureFillingPhase.FILL,
+                set(),
+                {FixtureFillingPhase.PRE_ALLOC_GENERATION, FixtureFillingPhase.FILL},
+                False,
+                False,
+            ),
+            # Phase 2 without generate_all
+            (
+                FixtureFillingPhase.FILL,
+                {FixtureFillingPhase.PRE_ALLOC_GENERATION},
+                {FixtureFillingPhase.PRE_ALLOC_GENERATION, FixtureFillingPhase.FILL},
+                False,
+                True,
+            ),
+            (
+                FixtureFillingPhase.FILL,
+                {FixtureFillingPhase.PRE_ALLOC_GENERATION},
+                {FixtureFillingPhase.FILL},
+                False,
+                False,
+            ),
+            # Phase 2 with generate_all
+            (
+                FixtureFillingPhase.FILL,
+                {FixtureFillingPhase.PRE_ALLOC_GENERATION},
+                {FixtureFillingPhase.PRE_ALLOC_GENERATION, FixtureFillingPhase.FILL},
+                True,
+                True,
+            ),
+            (
+                FixtureFillingPhase.FILL,
+                {FixtureFillingPhase.PRE_ALLOC_GENERATION},
+                {FixtureFillingPhase.FILL},
+                True,
+                True,
+            ),
+        ]
+
+        for current, previous, format_phases, gen_all, expected in test_cases:
+            phase_manager = PhaseManager(current_phase=current, previous_phases=previous)
+            format_selector = FormatSelector(
+                phase_manager=phase_manager, generate_all_formats=gen_all
+            )
+            fixture_format = type(
+                "MockFixtureFormat",
+                (BaseFixture,),
+                {"format_phases": format_phases},
+            )
+
+            result = format_selector.should_generate(fixture_format)
+            assert result == expected, (
+                f"Failed for phase={current}, previous={previous}, "
+                f"format_phases={format_phases}, generate_all={gen_all}"
+            )

--- a/src/pytest_plugins/filler/tests/test_phase_manager.py
+++ b/src/pytest_plugins/filler/tests/test_phase_manager.py
@@ -1,0 +1,142 @@
+"""Unit tests for the PhaseManager class."""
+
+import pytest
+
+from ethereum_test_fixtures import FixtureFillingPhase
+
+from ..filler import PhaseManager
+
+
+class MockConfig:
+    """Mock pytest config for testing."""
+
+    def __init__(
+        self,
+        generate_pre_alloc_groups=False,
+        use_pre_alloc_groups=False,
+        generate_all_formats=False,
+    ):
+        """Initialize with flag values."""
+        self._options = {
+            "generate_pre_alloc_groups": generate_pre_alloc_groups,
+            "use_pre_alloc_groups": use_pre_alloc_groups,
+            "generate_all_formats": generate_all_formats,
+        }
+
+    def getoption(self, name, default=None):
+        """Mock getoption method."""
+        return self._options.get(name, default)
+
+
+class TestPhaseManager:
+    """Test cases for PhaseManager class."""
+
+    def test_init(self):
+        """Test basic initialization."""
+        phase_manager = PhaseManager(
+            current_phase=FixtureFillingPhase.FILL,
+            previous_phases={FixtureFillingPhase.PRE_ALLOC_GENERATION},
+        )
+        assert phase_manager.current_phase == FixtureFillingPhase.FILL
+        assert phase_manager.previous_phases == {FixtureFillingPhase.PRE_ALLOC_GENERATION}
+
+    def test_from_config_normal_fill(self):
+        """Test normal single-phase filling (no flags set)."""
+        config = MockConfig()
+        phase_manager = PhaseManager.from_config(config)
+
+        assert phase_manager.current_phase == FixtureFillingPhase.FILL
+        assert phase_manager.previous_phases == set()
+        assert phase_manager.is_single_phase_fill
+        assert not phase_manager.is_pre_alloc_generation
+        assert not phase_manager.is_fill_after_pre_alloc
+
+    def test_from_config_generate_pre_alloc(self):
+        """Test phase 1: generate pre-allocation groups."""
+        config = MockConfig(generate_pre_alloc_groups=True)
+        phase_manager = PhaseManager.from_config(config)
+
+        assert phase_manager.current_phase == FixtureFillingPhase.PRE_ALLOC_GENERATION
+        assert phase_manager.previous_phases == set()
+        assert phase_manager.is_pre_alloc_generation
+        assert not phase_manager.is_single_phase_fill
+        assert not phase_manager.is_fill_after_pre_alloc
+
+    def test_from_config_use_pre_alloc(self):
+        """Test phase 2: use pre-allocation groups."""
+        config = MockConfig(use_pre_alloc_groups=True)
+        phase_manager = PhaseManager.from_config(config)
+
+        assert phase_manager.current_phase == FixtureFillingPhase.FILL
+        assert phase_manager.previous_phases == {FixtureFillingPhase.PRE_ALLOC_GENERATION}
+        assert phase_manager.is_fill_after_pre_alloc
+        assert not phase_manager.is_pre_alloc_generation
+        assert not phase_manager.is_single_phase_fill
+
+    def test_from_config_generate_all_formats(self):
+        """Test that generate_all_formats triggers PRE_ALLOC_GENERATION phase."""
+        config = MockConfig(generate_all_formats=True)
+        phase_manager = PhaseManager.from_config(config)
+
+        assert phase_manager.current_phase == FixtureFillingPhase.PRE_ALLOC_GENERATION
+        assert phase_manager.previous_phases == set()
+        assert phase_manager.is_pre_alloc_generation
+        assert not phase_manager.is_single_phase_fill
+        assert not phase_manager.is_fill_after_pre_alloc
+
+    def test_from_config_generate_all_and_pre_alloc(self):
+        """Test both generate_all_formats and generate_pre_alloc_groups set."""
+        config = MockConfig(generate_pre_alloc_groups=True, generate_all_formats=True)
+        phase_manager = PhaseManager.from_config(config)
+
+        assert phase_manager.current_phase == FixtureFillingPhase.PRE_ALLOC_GENERATION
+        assert phase_manager.previous_phases == set()
+        assert phase_manager.is_pre_alloc_generation
+
+    def test_from_config_use_pre_alloc_with_generate_all(self):
+        """Test phase 2 with generate_all_formats (passed by CLI to phase 2)."""
+        config = MockConfig(use_pre_alloc_groups=True, generate_all_formats=True)
+        phase_manager = PhaseManager.from_config(config)
+
+        # use_pre_alloc_groups takes precedence
+        assert phase_manager.current_phase == FixtureFillingPhase.FILL
+        assert phase_manager.previous_phases == {FixtureFillingPhase.PRE_ALLOC_GENERATION}
+        assert phase_manager.is_fill_after_pre_alloc
+
+    def test_all_flag_combinations(self):
+        """Test all 8 possible flag combinations to ensure correct phase determination."""
+        test_cases = [
+            # (generate_pre_alloc, use_pre_alloc, generate_all) -> (current_phase, has_previous)
+            (False, False, False, FixtureFillingPhase.FILL, False),  # Normal fill
+            # Generate all triggers phase 1
+            (False, False, True, FixtureFillingPhase.PRE_ALLOC_GENERATION, False),
+            (False, True, False, FixtureFillingPhase.FILL, True),  # Phase 2
+            (False, True, True, FixtureFillingPhase.FILL, True),  # Phase 2 with generate all
+            (True, False, False, FixtureFillingPhase.PRE_ALLOC_GENERATION, False),  # Phase 1
+            # Phase 1 with generate all
+            (True, False, True, FixtureFillingPhase.PRE_ALLOC_GENERATION, False),
+            (True, True, False, FixtureFillingPhase.FILL, True),  # Invalid but use_pre_alloc wins
+            (True, True, True, FixtureFillingPhase.FILL, True),  # Invalid but use_pre_alloc wins
+        ]
+
+        for gen_pre, use_pre, gen_all, expected_phase, has_previous in test_cases:
+            config = MockConfig(
+                generate_pre_alloc_groups=gen_pre,
+                use_pre_alloc_groups=use_pre,
+                generate_all_formats=gen_all,
+            )
+            phase_manager = PhaseManager.from_config(config)
+
+            assert phase_manager.current_phase == expected_phase, (
+                f"Failed for flags: generate_pre_alloc={gen_pre}, "
+                f"use_pre_alloc={use_pre}, generate_all={gen_all}"
+            )
+
+            if has_previous:
+                assert FixtureFillingPhase.PRE_ALLOC_GENERATION in phase_manager.previous_phases
+            else:
+                assert phase_manager.previous_phases == set()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## 🗒️ Description

This PR deprecates `fixtures_static.tar.gz` from releases by moving them to their respective `fixtures_stable.tar.gz` or `fixtures_develop.tar.gz` depending on the fork.

Required refactoring the fixtures abstract class and the pytest filler plugin, along with the static tests filler.

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).