### PR TITLE
chore(consume): remove `consume hive` command

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -101,6 +101,7 @@ Users can select any of the artifacts depending on their testing needs for their
 
 ### 📋 Misc
 
+- 🔀 Remove non-functional `consume hive` command. `consume rlp` and `consume engine` to be used instead instead. ([#2008](https://github.com/ethereum/execution-spec-tests/pull/2008)).
 - ✨ Add pypy3.11 support ([#1854](https://github.com/ethereum/execution-spec-tests/pull/1854)).
 - 🔀 Use only relative imports in `tests/` directory ([#1848](https://github.com/ethereum/execution-spec-tests/pull/1848)).
 - 🔀 Convert absolute imports to relative imports in `src/` directory for better code maintainability ([#1907](https://github.com/ethereum/execution-spec-tests/pull/1907)).

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -92,6 +92,7 @@ Users can select any of the artifacts depending on their testing needs for their
 - 🔀 Refactor consume simulator architecture to use explicit pytest plugin structure with forward-looking architecture ([#1801](https://github.com/ethereum/execution-spec-tests/pull/1801)).
 - 🔀 Add exponential retry logic to initial fcu within consume engine ([#1815](https://github.com/ethereum/execution-spec-tests/pull/1815)).
 - ✨ Add `consume sync` command to test client synchronization capabilities by having one client sync from another via Engine API and P2P networking ([#2007](https://github.com/ethereum/execution-spec-tests/pull/2007)).
+- 💥 Removed the `consume hive` command, this was a convenience command that ran `consume rlp` and `consume engine` in one pytest session; the individual commands should now be used instead ([#2008](https://github.com/ethereum/execution-spec-tests/pull/2008)).
 
 #### `execute`
 
@@ -101,7 +102,6 @@ Users can select any of the artifacts depending on their testing needs for their
 
 ### 📋 Misc
 
-- 🔀 Remove non-functional `consume hive` command. `consume rlp` and `consume engine` to be used instead instead. ([#2008](https://github.com/ethereum/execution-spec-tests/pull/2008)).
 - ✨ Add pypy3.11 support ([#1854](https://github.com/ethereum/execution-spec-tests/pull/1854)).
 - 🔀 Use only relative imports in `tests/` directory ([#1848](https://github.com/ethereum/execution-spec-tests/pull/1848)).
 - 🔀 Convert absolute imports to relative imports in `src/` directory for better code maintainability ([#1907](https://github.com/ethereum/execution-spec-tests/pull/1907)).

--- a/src/cli/pytest_commands/consume.py
+++ b/src/cli/pytest_commands/consume.py
@@ -39,12 +39,7 @@ def create_consume_command(
 def get_command_logic_test_paths(command_name: str, is_hive: bool) -> List[Path]:
     """Determine the command paths based on the command name and hive flag."""
     base_path = Path("pytest_plugins/consume")
-    if command_name == "hive":
-        commands = ["rlp", "engine"]
-        command_logic_test_paths = [
-            base_path / "simulators" / "simulator_logic" / f"test_via_{cmd}.py" for cmd in commands
-        ]
-    elif command_name in ["engine", "rlp"]:
+    if command_name in ["engine", "rlp"]:
         command_logic_test_paths = [
             base_path / "simulators" / "simulator_logic" / f"test_via_{command_name}.py"
         ]
@@ -114,12 +109,6 @@ def engine() -> None:
 @consume_command(is_hive=True)
 def sync() -> None:
     """Client consumes via the Engine API with sync testing."""
-    pass
-
-
-@consume_command(is_hive=True)
-def hive() -> None:
-    """Client consumes via all available hive methods (rlp, engine)."""
     pass
 
 

--- a/src/pytest_plugins/help/tests/test_help.py
+++ b/src/pytest_plugins/help/tests/test_help.py
@@ -40,7 +40,6 @@ CONSUME_TEST_ARGS = (
         ("direct", "--consume-help"),
         ("rlp", "--consume-help"),
         ("engine", "--consume-help"),
-        ("hive", "--consume-help"),
     ],
 )
 def test_local_arguments_present_in_base_consume_help(pytester, help_flag, command):


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

* Remove broken `consume hive` command and related code paths
* Update help tests to exclude removed command

I went with sunsetting the cmd because users can already achieve the same result by running both commands separately:
`uv run consume rlp --input ./fixtures`
`uv run consume engine --input ./fixtures`

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Fixes #1984

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
