### PR TITLE
refactor(benchmark): remvoe space from test name

### DIFF
--- a/src/pytest_plugins/filler/filler.py
+++ b/src/pytest_plugins/filler/filler.py
@@ -1116,6 +1116,7 @@ def pytest_collection_modifyitems(
     """
     items_for_removal = []
     for i, item in enumerate(items):
+        item.name = item.name.replace(" ", "-")
         params: Dict[str, Any] | None = None
         if isinstance(item, pytest.Function):
             params = item.callspec.params


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

The current test case names contain spaces, which would require the Nethermind team to do extra work to strip or replace them with another symbol. This PR replaces the spaces with hyphens, but I’m open to other representation.

I collect the all the benchmark test name (1520 tests in total) in this [file](https://gist.github.com/LouisTsai-Csie/131d136b49ed362bddbae13e70e87b70). 
Methodology: I print out the `item.names` for each test and then clear up the items array in `pytest_collection_modifyitems` function, so it only iterate over the test name and print out but do not fill the test.

And I found it is the following case that leads to the issue:

test_worst_create
https://github.com/ethereum/execution-spec-tests/blob/2f9784091cc9df52a784d754c174d9e0803bfb4b/tests/benchmark/test_worst_bytecode.py#L339-L348

test_worst_storage_access_cold
https://github.com/ethereum/execution-spec-tests/blob/2f9784091cc9df52a784d754c174d9e0803bfb4b/tests/benchmark/test_worst_stateful_opcodes.py#L205C9-L239C11

For better readability, I would prefer replace the space with hyphen.


## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->

Issue https://github.com/ethereum/execution-spec-tests/issues/2003

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
