### PR TITLE
refactor(fill): extract phase management into testable components

### DIFF
--- a/src/pytest_plugins/filler/filler.py
+++ b/src/pytest_plugins/filler/filler.py
@@ -139,7 +139,6 @@ class FormatSelector:
 
         Args:
             fixture_format: The fixture format to check (may be wrapped in LabeledFixtureFormat)
-            generate_all: Whether --generate-all-formats flag is set
 
         Returns:
             True if the format should be generated in the current phase

--- a/src/pytest_plugins/filler/static_filler.py
+++ b/src/pytest_plugins/filler/static_filler.py
@@ -23,7 +23,7 @@ from ethereum_test_tools.code.yul import Yul
 
 from ..forks.forks import ValidityMarker, get_intersection_set
 from ..shared.helpers import labeled_format_parameter_set
-from .filler import select_format_by_phases
+from .filler import get_filling_session
 
 
 def get_test_id_from_arg_names_and_values(
@@ -179,20 +179,15 @@ class FillerFile(pytest.File):
 
                     fixture_formats: List[Type[BaseFixture] | LabeledFixtureFormat] = []
                     spec_parameter_name = ""
-                    generate_all_formats = self.config.getoption("generate_all_formats", False)
                     for test_type in BaseTest.spec_types.values():
                         if test_type.pytest_parameter_name() in func_parameters:
                             assert not spec_parameter_name, "Multiple spec parameters found"
                             spec_parameter_name = test_type.pytest_parameter_name()
+                            session = get_filling_session()
                             fixture_formats.extend(
                                 fixture_format
                                 for fixture_format in test_type.supported_fixture_formats
-                                if select_format_by_phases(
-                                    generate_all_formats=generate_all_formats,
-                                    previous_filling_phases=self.config.previous_filling_phases,  # type: ignore[attr-defined]
-                                    current_filling_phase=self.config.current_filling_phase,  # type: ignore[attr-defined]
-                                    format_phases=fixture_format.format_phases,
-                                )
+                                if session.should_generate_format(fixture_format)
                             )
 
                     validity_markers: List[ValidityMarker] = (

--- a/src/pytest_plugins/filler/static_filler.py
+++ b/src/pytest_plugins/filler/static_filler.py
@@ -23,7 +23,6 @@ from ethereum_test_tools.code.yul import Yul
 
 from ..forks.forks import ValidityMarker, get_intersection_set
 from ..shared.helpers import labeled_format_parameter_set
-from .filler import get_filling_session
 
 
 def get_test_id_from_arg_names_and_values(
@@ -183,7 +182,7 @@ class FillerFile(pytest.File):
                         if test_type.pytest_parameter_name() in func_parameters:
                             assert not spec_parameter_name, "Multiple spec parameters found"
                             spec_parameter_name = test_type.pytest_parameter_name()
-                            session = get_filling_session()
+                            session = self.config.filling_session  # type: ignore[attr-defined]
                             fixture_formats.extend(
                                 fixture_format
                                 for fixture_format in test_type.supported_fixture_formats

--- a/src/pytest_plugins/filler/tests/test_filling_session.py
+++ b/src/pytest_plugins/filler/tests/test_filling_session.py
@@ -52,9 +52,8 @@ class TestFillingSession:
         config = MockConfig()
 
         with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
-            session = FillingSession(config)
+            session = FillingSession.from_config(config)
 
-        assert session.config is config
         assert session.phase_manager.is_single_phase_fill
         assert session.pre_alloc_groups is None
 
@@ -63,7 +62,7 @@ class TestFillingSession:
         config = MockConfig(generate_pre_alloc_groups=True)
 
         with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
-            session = FillingSession(config)
+            session = FillingSession.from_config(config)
 
         assert session.phase_manager.is_pre_alloc_generation
         assert session.pre_alloc_groups is not None
@@ -84,7 +83,7 @@ class TestFillingSession:
         with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
             with patch.object(Path, "exists", return_value=True):
                 with patch.object(PreAllocGroups, "from_folder", return_value=mock_groups):
-                    session = FillingSession(config)
+                    session = FillingSession.from_config(config)
 
         assert session.phase_manager.is_fill_after_pre_alloc
         assert session.pre_alloc_groups is mock_groups
@@ -98,14 +97,14 @@ class TestFillingSession:
                 with pytest.raises(
                     FileNotFoundError, match="Pre-allocation groups folder not found"
                 ):
-                    FillingSession(config)
+                    FillingSession.from_config(config)
 
     def test_should_generate_format(self):
         """Test format generation decision."""
         config = MockConfig()
 
         with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
-            session = FillingSession(config)
+            session = FillingSession.from_config(config)
 
         # Mock fixture format
         class MockFormat:
@@ -122,7 +121,7 @@ class TestFillingSession:
         with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
             with patch.object(Path, "exists", return_value=True):
                 with patch.object(PreAllocGroups, "from_folder", return_value=mock_groups):
-                    session = FillingSession(config)
+                    session = FillingSession.from_config(config)
 
         # Mock fixture format that normally wouldn't generate in phase 2
         class MockFormat:
@@ -145,7 +144,7 @@ class TestFillingSession:
         with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
             with patch.object(Path, "exists", return_value=True):
                 with patch.object(PreAllocGroups, "from_folder", return_value=mock_groups):
-                    session = FillingSession(config)
+                    session = FillingSession.from_config(config)
 
         assert session.get_pre_alloc_group("test_hash") is test_group
 
@@ -158,7 +157,7 @@ class TestFillingSession:
         with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
             with patch.object(Path, "exists", return_value=True):
                 with patch.object(PreAllocGroups, "from_folder", return_value=mock_groups):
-                    session = FillingSession(config)
+                    session = FillingSession.from_config(config)
 
         with pytest.raises(ValueError, match="Pre-allocation hash .* not found"):
             session.get_pre_alloc_group("missing_hash")
@@ -168,7 +167,7 @@ class TestFillingSession:
         config = MockConfig()  # Normal fill, no pre-alloc groups
 
         with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
-            session = FillingSession(config)
+            session = FillingSession.from_config(config)
 
         with pytest.raises(ValueError, match="Pre-allocation groups not initialized"):
             session.get_pre_alloc_group("any_hash")
@@ -178,7 +177,7 @@ class TestFillingSession:
         config = MockConfig(generate_pre_alloc_groups=True)
 
         with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
-            session = FillingSession(config)
+            session = FillingSession.from_config(config)
 
         test_group = PreAllocGroup(
             pre=Alloc().model_dump(mode="json"),
@@ -195,7 +194,7 @@ class TestFillingSession:
         config = MockConfig()  # Normal fill
 
         with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
-            session = FillingSession(config)
+            session = FillingSession.from_config(config)
 
         test_group = PreAllocGroup(
             pre=Alloc().model_dump(mode="json"),
@@ -212,7 +211,7 @@ class TestFillingSession:
         config = MockConfig(generate_pre_alloc_groups=True)
 
         with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
-            session = FillingSession(config)
+            session = FillingSession.from_config(config)
 
         # Add a test group
         test_group = PreAllocGroup(
@@ -235,7 +234,7 @@ class TestFillingSession:
         config = MockConfig()  # Normal fill
 
         with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
-            session = FillingSession(config)
+            session = FillingSession.from_config(config)
 
         # Should not raise, just return
         session.save_pre_alloc_groups()
@@ -245,7 +244,7 @@ class TestFillingSession:
         config = MockConfig(generate_pre_alloc_groups=True)
 
         with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
-            session = FillingSession(config)
+            session = FillingSession.from_config(config)
 
         # Worker groups to aggregate
         group1 = PreAllocGroup(
@@ -270,7 +269,7 @@ class TestFillingSession:
         config = MockConfig(generate_pre_alloc_groups=True)
 
         with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
-            session = FillingSession(config)
+            session = FillingSession.from_config(config)
 
         # Add initial group
         alloc1 = Alloc().model_dump(mode="json")
@@ -293,7 +292,3 @@ class TestFillingSession:
 
         with pytest.raises(ValueError, match="Conflicting pre-alloc groups"):
             session.aggregate_pre_alloc_groups(worker_groups)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])

--- a/src/pytest_plugins/filler/tests/test_filling_session.py
+++ b/src/pytest_plugins/filler/tests/test_filling_session.py
@@ -1,0 +1,327 @@
+"""Unit tests for the FillingSession class."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ethereum_test_base_types import Alloc
+from ethereum_test_fixtures import (
+    FixtureFillingPhase,
+    PreAllocGroup,
+    PreAllocGroups,
+)
+from ethereum_test_forks import Prague
+from ethereum_test_types import Environment
+from pytest_plugins.filler.filler import FillingSession, get_filling_session
+
+
+class MockConfig:
+    """Mock pytest config for testing."""
+
+    def __init__(self, **options):
+        """Initialize with option values."""
+        self._options = options
+        self.op_mode = "fill"  # Default operation mode
+
+    def getoption(self, name, default=None):
+        """Mock getoption method."""
+        return self._options.get(name, default)
+
+
+class MockFixtureOutput:
+    """Mock fixture output for testing."""
+
+    def __init__(self, pre_alloc_folder_exists=True):
+        """Initialize with test conditions."""
+        self._folder_exists = pre_alloc_folder_exists
+        self.pre_alloc_groups_folder_path = Path("/tmp/test_pre_alloc")
+
+    @classmethod
+    def from_config(cls, config):
+        """Mock factory method."""
+        return cls()
+
+
+class TestFillingSession:
+    """Test cases for FillingSession class."""
+
+    def test_init_normal_fill(self):
+        """Test initialization for normal single-phase fill."""
+        config = MockConfig()
+
+        with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
+            session = FillingSession(config)
+
+        assert session.config is config
+        assert session.phase_manager.is_single_phase_fill
+        assert session.pre_alloc_groups is None
+
+    def test_init_pre_alloc_generation(self):
+        """Test initialization for pre-alloc generation phase."""
+        config = MockConfig(generate_pre_alloc_groups=True)
+
+        with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
+            session = FillingSession(config)
+
+        assert session.phase_manager.is_pre_alloc_generation
+        assert session.pre_alloc_groups is not None
+        assert len(session.pre_alloc_groups.root) == 0
+
+    def test_init_use_pre_alloc(self):
+        """Test initialization for phase 2 (using pre-alloc groups)."""
+        config = MockConfig(use_pre_alloc_groups=True)
+
+        # Mock the file system operations
+        test_group = PreAllocGroup(
+            pre=Alloc().model_dump(mode="json"),
+            environment=Environment().model_dump(mode="json"),
+            network=Prague.name(),
+        )
+        mock_groups = PreAllocGroups(root={"test_hash": test_group})
+
+        with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
+            with patch.object(Path, "exists", return_value=True):
+                with patch.object(PreAllocGroups, "from_folder", return_value=mock_groups):
+                    session = FillingSession(config)
+
+        assert session.phase_manager.is_fill_after_pre_alloc
+        assert session.pre_alloc_groups is mock_groups
+
+    def test_init_use_pre_alloc_missing_folder(self):
+        """Test initialization fails when pre-alloc folder is missing."""
+        config = MockConfig(use_pre_alloc_groups=True)
+
+        with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
+            with patch.object(Path, "exists", return_value=False):
+                with pytest.raises(
+                    FileNotFoundError, match="Pre-allocation groups folder not found"
+                ):
+                    FillingSession(config)
+
+    def test_should_generate_format(self):
+        """Test format generation decision."""
+        config = MockConfig()
+
+        with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
+            session = FillingSession(config)
+
+        # Mock fixture format
+        class MockFormat:
+            format_phases = {FixtureFillingPhase.FILL}
+
+        assert session.should_generate_format(MockFormat())
+
+    def test_should_generate_format_with_generate_all(self):
+        """Test format generation with generate_all_formats flag."""
+        config = MockConfig(generate_all_formats=True, use_pre_alloc_groups=True)
+
+        mock_groups = PreAllocGroups(root={})
+
+        with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
+            with patch.object(Path, "exists", return_value=True):
+                with patch.object(PreAllocGroups, "from_folder", return_value=mock_groups):
+                    session = FillingSession(config)
+
+        # Mock fixture format that normally wouldn't generate in phase 2
+        class MockFormat:
+            format_phases = {FixtureFillingPhase.FILL}
+
+        # Should generate because generate_all=True
+        assert session.should_generate_format(MockFormat())
+
+    def test_get_pre_alloc_group(self):
+        """Test getting a pre-alloc group by hash."""
+        config = MockConfig(use_pre_alloc_groups=True)
+
+        test_group = PreAllocGroup(
+            pre=Alloc().model_dump(mode="json"),
+            environment=Environment().model_dump(mode="json"),
+            network=Prague.name(),
+        )
+        mock_groups = PreAllocGroups(root={"test_hash": test_group})
+
+        with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
+            with patch.object(Path, "exists", return_value=True):
+                with patch.object(PreAllocGroups, "from_folder", return_value=mock_groups):
+                    session = FillingSession(config)
+
+        assert session.get_pre_alloc_group("test_hash") is test_group
+
+    def test_get_pre_alloc_group_not_found(self):
+        """Test getting a non-existent pre-alloc group."""
+        config = MockConfig(use_pre_alloc_groups=True)
+
+        mock_groups = PreAllocGroups(root={})
+
+        with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
+            with patch.object(Path, "exists", return_value=True):
+                with patch.object(PreAllocGroups, "from_folder", return_value=mock_groups):
+                    session = FillingSession(config)
+
+        with pytest.raises(ValueError, match="Pre-allocation hash .* not found"):
+            session.get_pre_alloc_group("missing_hash")
+
+    def test_get_pre_alloc_group_not_initialized(self):
+        """Test getting pre-alloc group when not initialized."""
+        config = MockConfig()  # Normal fill, no pre-alloc groups
+
+        with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
+            session = FillingSession(config)
+
+        with pytest.raises(ValueError, match="Pre-allocation groups not initialized"):
+            session.get_pre_alloc_group("any_hash")
+
+    def test_update_pre_alloc_group(self):
+        """Test updating a pre-alloc group."""
+        config = MockConfig(generate_pre_alloc_groups=True)
+
+        with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
+            session = FillingSession(config)
+
+        test_group = PreAllocGroup(
+            pre=Alloc().model_dump(mode="json"),
+            environment=Environment().model_dump(mode="json"),
+            network=Prague.name(),
+        )
+        session.update_pre_alloc_group("test_hash", test_group)
+
+        assert "test_hash" in session.pre_alloc_groups
+        assert session.pre_alloc_groups["test_hash"] is test_group
+
+    def test_update_pre_alloc_group_wrong_phase(self):
+        """Test updating pre-alloc group in wrong phase."""
+        config = MockConfig()  # Normal fill
+
+        with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
+            session = FillingSession(config)
+
+        test_group = PreAllocGroup(
+            pre=Alloc().model_dump(mode="json"),
+            environment=Environment().model_dump(mode="json"),
+            network=Prague.name(),
+        )
+        with pytest.raises(
+            ValueError, match="Can only update pre-alloc groups in generation phase"
+        ):
+            session.update_pre_alloc_group("test_hash", test_group)
+
+    def test_save_pre_alloc_groups(self):
+        """Test saving pre-alloc groups to disk."""
+        config = MockConfig(generate_pre_alloc_groups=True)
+
+        with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
+            session = FillingSession(config)
+
+        # Add a test group
+        test_group = PreAllocGroup(
+            pre=Alloc().model_dump(mode="json"),
+            environment=Environment().model_dump(mode="json"),
+            network=Prague.name(),
+        )
+        session.update_pre_alloc_group("test_hash", test_group)
+
+        # Mock file operations
+        with patch.object(Path, "mkdir") as mock_mkdir:
+            with patch.object(PreAllocGroups, "to_folder") as mock_to_folder:
+                session.save_pre_alloc_groups()
+
+        mock_mkdir.assert_called_once_with(parents=True, exist_ok=True)
+        mock_to_folder.assert_called_once()
+
+    def test_save_pre_alloc_groups_none(self):
+        """Test saving when no pre-alloc groups exist."""
+        config = MockConfig()  # Normal fill
+
+        with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
+            session = FillingSession(config)
+
+        # Should not raise, just return
+        session.save_pre_alloc_groups()
+
+    def test_aggregate_pre_alloc_groups(self):
+        """Test aggregating pre-alloc groups from workers (xdist)."""
+        config = MockConfig(generate_pre_alloc_groups=True)
+
+        with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
+            session = FillingSession(config)
+
+        # Worker groups to aggregate
+        group1 = PreAllocGroup(
+            pre=Alloc().model_dump(mode="json"),
+            environment=Environment().model_dump(mode="json"),
+            network=Prague.name(),
+        )
+        group2 = PreAllocGroup(
+            pre=Alloc().model_dump(mode="json"),
+            environment=Environment().model_dump(mode="json"),
+            network=Prague.name(),
+        )
+        worker_groups = PreAllocGroups(root={"hash1": group1, "hash2": group2})
+
+        session.aggregate_pre_alloc_groups(worker_groups)
+
+        assert "hash1" in session.pre_alloc_groups
+        assert "hash2" in session.pre_alloc_groups
+
+    def test_aggregate_pre_alloc_groups_conflict(self):
+        """Test aggregating conflicting pre-alloc groups."""
+        config = MockConfig(generate_pre_alloc_groups=True)
+
+        with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
+            session = FillingSession(config)
+
+        # Add initial group
+        alloc1 = Alloc().model_dump(mode="json")
+        group1 = PreAllocGroup(
+            pre=alloc1,
+            environment=Environment().model_dump(mode="json"),
+            network=Prague.name(),
+        )
+        session.update_pre_alloc_group("hash1", group1)
+
+        # Try to aggregate conflicting group with same hash but different pre
+        alloc2_dict = Alloc().model_dump(mode="json")
+        alloc2_dict["0x1234567890123456789012345678901234567890"] = None  # Make it different
+        group2 = PreAllocGroup(
+            pre=alloc2_dict,
+            environment=Environment().model_dump(mode="json"),
+            network=Prague.name(),
+        )
+        worker_groups = PreAllocGroups(root={"hash1": group2})
+
+        with pytest.raises(ValueError, match="Conflicting pre-alloc groups"):
+            session.aggregate_pre_alloc_groups(worker_groups)
+
+
+class TestGlobalSession:
+    """Test cases for global session management."""
+
+    def test_get_filling_session_not_initialized(self):
+        """Test getting session before initialization."""
+        # Reset global session
+        import pytest_plugins.filler.filler
+
+        pytest_plugins.filler.filler._filling_session = None
+
+        with pytest.raises(RuntimeError, match="Filling session not initialized"):
+            get_filling_session()
+
+    def test_get_filling_session_initialized(self):
+        """Test getting session after initialization."""
+        import pytest_plugins.filler.filler
+
+        # Create a mock session
+        config = MockConfig()
+        with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
+            session = FillingSession(config)
+            pytest_plugins.filler.filler._filling_session = session
+
+        assert get_filling_session() is session
+
+        # Clean up
+        pytest_plugins.filler.filler._filling_session = None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/src/pytest_plugins/filler/tests/test_filling_session.py
+++ b/src/pytest_plugins/filler/tests/test_filling_session.py
@@ -14,7 +14,7 @@ from ethereum_test_fixtures import (
 from ethereum_test_forks import Prague
 from ethereum_test_types import Environment
 
-from ..filler import FillingSession, get_filling_session
+from ..filler import FillingSession
 
 
 class MockConfig:
@@ -293,35 +293,6 @@ class TestFillingSession:
 
         with pytest.raises(ValueError, match="Conflicting pre-alloc groups"):
             session.aggregate_pre_alloc_groups(worker_groups)
-
-
-class TestGlobalSession:
-    """Test cases for global session management."""
-
-    def test_get_filling_session_not_initialized(self):
-        """Test getting session before initialization."""
-        # Reset global session
-        import pytest_plugins.filler.filler
-
-        pytest_plugins.filler.filler._filling_session = None
-
-        with pytest.raises(RuntimeError, match="Filling session not initialized"):
-            get_filling_session()
-
-    def test_get_filling_session_initialized(self):
-        """Test getting session after initialization."""
-        import pytest_plugins.filler.filler
-
-        # Create a mock session
-        config = MockConfig()
-        with patch("pytest_plugins.filler.filler.FixtureOutput", MockFixtureOutput):
-            session = FillingSession(config)
-            pytest_plugins.filler.filler._filling_session = session
-
-        assert get_filling_session() is session
-
-        # Clean up
-        pytest_plugins.filler.filler._filling_session = None
 
 
 if __name__ == "__main__":

--- a/src/pytest_plugins/filler/tests/test_filling_session.py
+++ b/src/pytest_plugins/filler/tests/test_filling_session.py
@@ -13,7 +13,8 @@ from ethereum_test_fixtures import (
 )
 from ethereum_test_forks import Prague
 from ethereum_test_types import Environment
-from pytest_plugins.filler.filler import FillingSession, get_filling_session
+
+from ..filler import FillingSession, get_filling_session
 
 
 class MockConfig:

--- a/src/pytest_plugins/filler/tests/test_format_selector.py
+++ b/src/pytest_plugins/filler/tests/test_format_selector.py
@@ -1,28 +1,10 @@
 """Unit tests for the FormatSelector class."""
 
-from typing import Set
+from typing import List, Set, Tuple
 
-import pytest
-
-from ethereum_test_fixtures import FixtureFillingPhase
+from ethereum_test_fixtures import BaseFixture, FixtureFillingPhase, LabeledFixtureFormat
 
 from ..filler import FormatSelector, PhaseManager
-
-
-class MockFixtureFormat:
-    """Mock fixture format for testing."""
-
-    def __init__(self, format_phases: Set[FixtureFillingPhase]):
-        """Initialize with format phases."""
-        self.format_phases = format_phases
-
-
-class MockLabeledFixtureFormat:
-    """Mock labeled fixture format for testing."""
-
-    def __init__(self, format_phases: Set[FixtureFillingPhase]):
-        """Initialize with format phases."""
-        self.format = MockFixtureFormat(format_phases)
 
 
 class TestFormatSelector:
@@ -30,46 +12,69 @@ class TestFormatSelector:
 
     def test_init(self):
         """Test basic initialization."""
-        phase_manager = PhaseManager(FixtureFillingPhase.FILL, set())
-        format_selector = FormatSelector(phase_manager)
+        phase_manager = PhaseManager(current_phase=FixtureFillingPhase.FILL)
+        format_selector = FormatSelector(phase_manager=phase_manager, generate_all_formats=False)
         assert format_selector.phase_manager is phase_manager
 
     def test_should_generate_pre_alloc_phase_with_pre_alloc_format(self):
         """Test pre-alloc phase with format that supports pre-alloc."""
-        phase_manager = PhaseManager(FixtureFillingPhase.PRE_ALLOC_GENERATION, set())
-        format_selector = FormatSelector(phase_manager)
+        phase_manager = PhaseManager(current_phase=FixtureFillingPhase.PRE_ALLOC_GENERATION)
+        format_selector = FormatSelector(phase_manager=phase_manager, generate_all_formats=False)
 
-        format_with_pre_alloc = MockFixtureFormat(
-            {FixtureFillingPhase.PRE_ALLOC_GENERATION, FixtureFillingPhase.FILL}
+        # MySub = type("MySub", (BaseClass,), {"MY_CLASSVAR": 42})
+        format_with_pre_alloc = type(
+            "MockFixtureFormat",
+            (BaseFixture,),
+            {
+                "format_phases": {
+                    FixtureFillingPhase.PRE_ALLOC_GENERATION,
+                    FixtureFillingPhase.FILL,
+                }
+            },
         )
 
         assert format_selector.should_generate(format_with_pre_alloc)
 
     def test_should_generate_pre_alloc_phase_without_pre_alloc_format(self):
         """Test pre-alloc phase with format that doesn't support pre-alloc."""
-        phase_manager = PhaseManager(FixtureFillingPhase.PRE_ALLOC_GENERATION, set())
-        format_selector = FormatSelector(phase_manager)
+        phase_manager = PhaseManager(current_phase=FixtureFillingPhase.PRE_ALLOC_GENERATION)
+        format_selector = FormatSelector(phase_manager=phase_manager, generate_all_formats=False)
 
-        format_without_pre_alloc = MockFixtureFormat({FixtureFillingPhase.FILL})
+        format_without_pre_alloc = type(
+            "MockFixtureFormat",
+            (BaseFixture,),
+            {"format_phases": {FixtureFillingPhase.FILL}},
+        )
 
         assert not format_selector.should_generate(format_without_pre_alloc)
 
     def test_should_generate_single_phase_fill_only_format(self):
         """Test single-phase fill with fill-only format."""
-        phase_manager = PhaseManager(FixtureFillingPhase.FILL, set())
-        format_selector = FormatSelector(phase_manager)
+        phase_manager = PhaseManager(current_phase=FixtureFillingPhase.FILL)
+        format_selector = FormatSelector(phase_manager=phase_manager, generate_all_formats=False)
 
-        fill_only_format = MockFixtureFormat({FixtureFillingPhase.FILL})
+        fill_only_format = type(
+            "MockFixtureFormat",
+            (BaseFixture,),
+            {"format_phases": {FixtureFillingPhase.FILL}},
+        )
 
         assert format_selector.should_generate(fill_only_format)
 
     def test_should_generate_single_phase_pre_alloc_format(self):
         """Test single-phase fill with format that supports pre-alloc."""
-        phase_manager = PhaseManager(FixtureFillingPhase.FILL, set())
-        format_selector = FormatSelector(phase_manager)
+        phase_manager = PhaseManager(current_phase=FixtureFillingPhase.FILL)
+        format_selector = FormatSelector(phase_manager=phase_manager, generate_all_formats=False)
 
-        format_with_pre_alloc = MockFixtureFormat(
-            {FixtureFillingPhase.PRE_ALLOC_GENERATION, FixtureFillingPhase.FILL}
+        format_with_pre_alloc = type(
+            "MockFixtureFormat",
+            (BaseFixture,),
+            {
+                "format_phases": {
+                    FixtureFillingPhase.PRE_ALLOC_GENERATION,
+                    FixtureFillingPhase.FILL,
+                }
+            },
         )
 
         # Should not generate because it needs pre-alloc but we're in single phase
@@ -78,12 +83,20 @@ class TestFormatSelector:
     def test_should_generate_phase2_with_pre_alloc_format(self):
         """Test phase 2 (after pre-alloc) with format that supports pre-alloc."""
         phase_manager = PhaseManager(
-            FixtureFillingPhase.FILL, {FixtureFillingPhase.PRE_ALLOC_GENERATION}
+            current_phase=FixtureFillingPhase.FILL,
+            previous_phases={FixtureFillingPhase.PRE_ALLOC_GENERATION},
         )
-        format_selector = FormatSelector(phase_manager)
+        format_selector = FormatSelector(phase_manager=phase_manager, generate_all_formats=False)
 
-        format_with_pre_alloc = MockFixtureFormat(
-            {FixtureFillingPhase.PRE_ALLOC_GENERATION, FixtureFillingPhase.FILL}
+        format_with_pre_alloc = type(
+            "MockFixtureFormat",
+            (BaseFixture,),
+            {
+                "format_phases": {
+                    FixtureFillingPhase.PRE_ALLOC_GENERATION,
+                    FixtureFillingPhase.FILL,
+                }
+            },
         )
 
         # Should generate in phase 2
@@ -92,11 +105,16 @@ class TestFormatSelector:
     def test_should_generate_phase2_without_pre_alloc_format(self):
         """Test phase 2 (after pre-alloc) with fill-only format."""
         phase_manager = PhaseManager(
-            FixtureFillingPhase.FILL, {FixtureFillingPhase.PRE_ALLOC_GENERATION}
+            current_phase=FixtureFillingPhase.FILL,
+            previous_phases={FixtureFillingPhase.PRE_ALLOC_GENERATION},
         )
-        format_selector = FormatSelector(phase_manager)
+        format_selector = FormatSelector(phase_manager=phase_manager, generate_all_formats=False)
 
-        fill_only_format = MockFixtureFormat({FixtureFillingPhase.FILL})
+        fill_only_format = type(
+            "MockFixtureFormat",
+            (BaseFixture,),
+            {"format_phases": {FixtureFillingPhase.FILL}},
+        )
 
         # Should not generate because it doesn't need pre-alloc
         assert not format_selector.should_generate(fill_only_format)
@@ -104,43 +122,57 @@ class TestFormatSelector:
     def test_should_generate_phase2_with_generate_all(self):
         """Test phase 2 with --generate-all-formats flag."""
         phase_manager = PhaseManager(
-            FixtureFillingPhase.FILL, {FixtureFillingPhase.PRE_ALLOC_GENERATION}
+            current_phase=FixtureFillingPhase.FILL,
+            previous_phases={FixtureFillingPhase.PRE_ALLOC_GENERATION},
         )
-        format_selector = FormatSelector(phase_manager)
+        format_selector = FormatSelector(phase_manager=phase_manager, generate_all_formats=True)
 
-        fill_only_format = MockFixtureFormat({FixtureFillingPhase.FILL})
-        format_with_pre_alloc = MockFixtureFormat(
-            {FixtureFillingPhase.PRE_ALLOC_GENERATION, FixtureFillingPhase.FILL}
+        fill_only_format = type(
+            "MockFixtureFormat",
+            (BaseFixture,),
+            {"format_phases": {FixtureFillingPhase.FILL}},
+        )
+        format_with_pre_alloc = type(
+            "MockFixtureFormat",
+            (BaseFixture,),
+            {
+                "format_phases": {
+                    FixtureFillingPhase.PRE_ALLOC_GENERATION,
+                    FixtureFillingPhase.FILL,
+                }
+            },
         )
 
         # With generate_all=True, both formats should be generated
-        assert format_selector.should_generate(fill_only_format, generate_all=True)
-        assert format_selector.should_generate(format_with_pre_alloc, generate_all=True)
+        assert format_selector.should_generate(fill_only_format)
+        assert format_selector.should_generate(format_with_pre_alloc)
 
     def test_should_generate_labeled_format(self):
         """Test with LabeledFixtureFormat wrapper."""
-        phase_manager = PhaseManager(FixtureFillingPhase.FILL, set())
-        format_selector = FormatSelector(phase_manager)
+        phase_manager = PhaseManager(current_phase=FixtureFillingPhase.FILL)
+        format_selector = FormatSelector(phase_manager=phase_manager, generate_all_formats=False)
 
-        labeled_format = MockLabeledFixtureFormat({FixtureFillingPhase.FILL})
+        fill_only_format = type(
+            "MockFixtureFormat",
+            (BaseFixture,),
+            {"format_phases": {FixtureFillingPhase.FILL}},
+        )
+        labeled_format = LabeledFixtureFormat(
+            fill_only_format,
+            "mock_labeled_format",
+            "A mock labeled fixture format",
+        )
 
         assert format_selector.should_generate(labeled_format)
-
-    def test_should_generate_no_format_phases_attribute(self):
-        """Test with object that has no format_phases attribute."""
-        phase_manager = PhaseManager(FixtureFillingPhase.FILL, set())
-        format_selector = FormatSelector(phase_manager)
-
-        class SimpleFormat:
-            pass
-
-        # Should default to FILL phase only
-        assert format_selector.should_generate(SimpleFormat())
 
     def test_comprehensive_scenarios(self):
         """Test comprehensive scenarios covering all phase and format combinations."""
         # Test matrix: (current_phase, previous_phases, format_phases, generate_all) -> expected
-        test_cases = [
+        test_cases: List[
+            Tuple[
+                FixtureFillingPhase, Set[FixtureFillingPhase], Set[FixtureFillingPhase], bool, bool
+            ]
+        ] = [
             # Pre-alloc generation phase
             (
                 FixtureFillingPhase.PRE_ALLOC_GENERATION,
@@ -198,16 +230,18 @@ class TestFormatSelector:
         ]
 
         for current, previous, format_phases, gen_all, expected in test_cases:
-            phase_manager = PhaseManager(current, previous)
-            format_selector = FormatSelector(phase_manager)
-            fixture_format = MockFixtureFormat(format_phases)
+            phase_manager = PhaseManager(current_phase=current, previous_phases=previous)
+            format_selector = FormatSelector(
+                phase_manager=phase_manager, generate_all_formats=gen_all
+            )
+            fixture_format = type(
+                "MockFixtureFormat",
+                (BaseFixture,),
+                {"format_phases": format_phases},
+            )
 
-            result = format_selector.should_generate(fixture_format, generate_all=gen_all)
+            result = format_selector.should_generate(fixture_format)
             assert result == expected, (
                 f"Failed for phase={current}, previous={previous}, "
                 f"format_phases={format_phases}, generate_all={gen_all}"
             )
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])

--- a/src/pytest_plugins/filler/tests/test_format_selector.py
+++ b/src/pytest_plugins/filler/tests/test_format_selector.py
@@ -1,0 +1,212 @@
+"""Unit tests for the FormatSelector class."""
+
+from typing import Set
+
+import pytest
+
+from ethereum_test_fixtures import FixtureFillingPhase
+from pytest_plugins.filler.filler import FormatSelector, PhaseManager
+
+
+class MockFixtureFormat:
+    """Mock fixture format for testing."""
+
+    def __init__(self, format_phases: Set[FixtureFillingPhase]):
+        """Initialize with format phases."""
+        self.format_phases = format_phases
+
+
+class MockLabeledFixtureFormat:
+    """Mock labeled fixture format for testing."""
+
+    def __init__(self, format_phases: Set[FixtureFillingPhase]):
+        """Initialize with format phases."""
+        self.format = MockFixtureFormat(format_phases)
+
+
+class TestFormatSelector:
+    """Test cases for FormatSelector class."""
+
+    def test_init(self):
+        """Test basic initialization."""
+        phase_manager = PhaseManager(FixtureFillingPhase.FILL, set())
+        format_selector = FormatSelector(phase_manager)
+        assert format_selector.phase_manager is phase_manager
+
+    def test_should_generate_pre_alloc_phase_with_pre_alloc_format(self):
+        """Test pre-alloc phase with format that supports pre-alloc."""
+        phase_manager = PhaseManager(FixtureFillingPhase.PRE_ALLOC_GENERATION, set())
+        format_selector = FormatSelector(phase_manager)
+
+        format_with_pre_alloc = MockFixtureFormat(
+            {FixtureFillingPhase.PRE_ALLOC_GENERATION, FixtureFillingPhase.FILL}
+        )
+
+        assert format_selector.should_generate(format_with_pre_alloc)
+
+    def test_should_generate_pre_alloc_phase_without_pre_alloc_format(self):
+        """Test pre-alloc phase with format that doesn't support pre-alloc."""
+        phase_manager = PhaseManager(FixtureFillingPhase.PRE_ALLOC_GENERATION, set())
+        format_selector = FormatSelector(phase_manager)
+
+        format_without_pre_alloc = MockFixtureFormat({FixtureFillingPhase.FILL})
+
+        assert not format_selector.should_generate(format_without_pre_alloc)
+
+    def test_should_generate_single_phase_fill_only_format(self):
+        """Test single-phase fill with fill-only format."""
+        phase_manager = PhaseManager(FixtureFillingPhase.FILL, set())
+        format_selector = FormatSelector(phase_manager)
+
+        fill_only_format = MockFixtureFormat({FixtureFillingPhase.FILL})
+
+        assert format_selector.should_generate(fill_only_format)
+
+    def test_should_generate_single_phase_pre_alloc_format(self):
+        """Test single-phase fill with format that supports pre-alloc."""
+        phase_manager = PhaseManager(FixtureFillingPhase.FILL, set())
+        format_selector = FormatSelector(phase_manager)
+
+        format_with_pre_alloc = MockFixtureFormat(
+            {FixtureFillingPhase.PRE_ALLOC_GENERATION, FixtureFillingPhase.FILL}
+        )
+
+        # Should not generate because it needs pre-alloc but we're in single phase
+        assert not format_selector.should_generate(format_with_pre_alloc)
+
+    def test_should_generate_phase2_with_pre_alloc_format(self):
+        """Test phase 2 (after pre-alloc) with format that supports pre-alloc."""
+        phase_manager = PhaseManager(
+            FixtureFillingPhase.FILL, {FixtureFillingPhase.PRE_ALLOC_GENERATION}
+        )
+        format_selector = FormatSelector(phase_manager)
+
+        format_with_pre_alloc = MockFixtureFormat(
+            {FixtureFillingPhase.PRE_ALLOC_GENERATION, FixtureFillingPhase.FILL}
+        )
+
+        # Should generate in phase 2
+        assert format_selector.should_generate(format_with_pre_alloc)
+
+    def test_should_generate_phase2_without_pre_alloc_format(self):
+        """Test phase 2 (after pre-alloc) with fill-only format."""
+        phase_manager = PhaseManager(
+            FixtureFillingPhase.FILL, {FixtureFillingPhase.PRE_ALLOC_GENERATION}
+        )
+        format_selector = FormatSelector(phase_manager)
+
+        fill_only_format = MockFixtureFormat({FixtureFillingPhase.FILL})
+
+        # Should not generate because it doesn't need pre-alloc
+        assert not format_selector.should_generate(fill_only_format)
+
+    def test_should_generate_phase2_with_generate_all(self):
+        """Test phase 2 with --generate-all-formats flag."""
+        phase_manager = PhaseManager(
+            FixtureFillingPhase.FILL, {FixtureFillingPhase.PRE_ALLOC_GENERATION}
+        )
+        format_selector = FormatSelector(phase_manager)
+
+        fill_only_format = MockFixtureFormat({FixtureFillingPhase.FILL})
+        format_with_pre_alloc = MockFixtureFormat(
+            {FixtureFillingPhase.PRE_ALLOC_GENERATION, FixtureFillingPhase.FILL}
+        )
+
+        # With generate_all=True, both formats should be generated
+        assert format_selector.should_generate(fill_only_format, generate_all=True)
+        assert format_selector.should_generate(format_with_pre_alloc, generate_all=True)
+
+    def test_should_generate_labeled_format(self):
+        """Test with LabeledFixtureFormat wrapper."""
+        phase_manager = PhaseManager(FixtureFillingPhase.FILL, set())
+        format_selector = FormatSelector(phase_manager)
+
+        labeled_format = MockLabeledFixtureFormat({FixtureFillingPhase.FILL})
+
+        assert format_selector.should_generate(labeled_format)
+
+    def test_should_generate_no_format_phases_attribute(self):
+        """Test with object that has no format_phases attribute."""
+        phase_manager = PhaseManager(FixtureFillingPhase.FILL, set())
+        format_selector = FormatSelector(phase_manager)
+
+        class SimpleFormat:
+            pass
+
+        # Should default to FILL phase only
+        assert format_selector.should_generate(SimpleFormat())
+
+    def test_comprehensive_scenarios(self):
+        """Test comprehensive scenarios covering all phase and format combinations."""
+        # Test matrix: (current_phase, previous_phases, format_phases, generate_all) -> expected
+        test_cases = [
+            # Pre-alloc generation phase
+            (
+                FixtureFillingPhase.PRE_ALLOC_GENERATION,
+                set(),
+                {FixtureFillingPhase.PRE_ALLOC_GENERATION, FixtureFillingPhase.FILL},
+                False,
+                True,
+            ),
+            (
+                FixtureFillingPhase.PRE_ALLOC_GENERATION,
+                set(),
+                {FixtureFillingPhase.FILL},
+                False,
+                False,
+            ),
+            # Single-phase fill
+            (FixtureFillingPhase.FILL, set(), {FixtureFillingPhase.FILL}, False, True),
+            (
+                FixtureFillingPhase.FILL,
+                set(),
+                {FixtureFillingPhase.PRE_ALLOC_GENERATION, FixtureFillingPhase.FILL},
+                False,
+                False,
+            ),
+            # Phase 2 without generate_all
+            (
+                FixtureFillingPhase.FILL,
+                {FixtureFillingPhase.PRE_ALLOC_GENERATION},
+                {FixtureFillingPhase.PRE_ALLOC_GENERATION, FixtureFillingPhase.FILL},
+                False,
+                True,
+            ),
+            (
+                FixtureFillingPhase.FILL,
+                {FixtureFillingPhase.PRE_ALLOC_GENERATION},
+                {FixtureFillingPhase.FILL},
+                False,
+                False,
+            ),
+            # Phase 2 with generate_all
+            (
+                FixtureFillingPhase.FILL,
+                {FixtureFillingPhase.PRE_ALLOC_GENERATION},
+                {FixtureFillingPhase.PRE_ALLOC_GENERATION, FixtureFillingPhase.FILL},
+                True,
+                True,
+            ),
+            (
+                FixtureFillingPhase.FILL,
+                {FixtureFillingPhase.PRE_ALLOC_GENERATION},
+                {FixtureFillingPhase.FILL},
+                True,
+                True,
+            ),
+        ]
+
+        for current, previous, format_phases, gen_all, expected in test_cases:
+            phase_manager = PhaseManager(current, previous)
+            format_selector = FormatSelector(phase_manager)
+            fixture_format = MockFixtureFormat(format_phases)
+
+            result = format_selector.should_generate(fixture_format, generate_all=gen_all)
+            assert result == expected, (
+                f"Failed for phase={current}, previous={previous}, "
+                f"format_phases={format_phases}, generate_all={gen_all}"
+            )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/src/pytest_plugins/filler/tests/test_format_selector.py
+++ b/src/pytest_plugins/filler/tests/test_format_selector.py
@@ -5,7 +5,8 @@ from typing import Set
 import pytest
 
 from ethereum_test_fixtures import FixtureFillingPhase
-from pytest_plugins.filler.filler import FormatSelector, PhaseManager
+
+from ..filler import FormatSelector, PhaseManager
 
 
 class MockFixtureFormat:

--- a/src/pytest_plugins/filler/tests/test_phase_manager.py
+++ b/src/pytest_plugins/filler/tests/test_phase_manager.py
@@ -3,7 +3,8 @@
 import pytest
 
 from ethereum_test_fixtures import FixtureFillingPhase
-from pytest_plugins.filler.filler import PhaseManager
+
+from ..filler import PhaseManager
 
 
 class MockConfig:

--- a/src/pytest_plugins/filler/tests/test_phase_manager.py
+++ b/src/pytest_plugins/filler/tests/test_phase_manager.py
@@ -1,0 +1,141 @@
+"""Unit tests for the PhaseManager class."""
+
+import pytest
+
+from ethereum_test_fixtures import FixtureFillingPhase
+from pytest_plugins.filler.filler import PhaseManager
+
+
+class MockConfig:
+    """Mock pytest config for testing."""
+
+    def __init__(
+        self,
+        generate_pre_alloc_groups=False,
+        use_pre_alloc_groups=False,
+        generate_all_formats=False,
+    ):
+        """Initialize with flag values."""
+        self._options = {
+            "generate_pre_alloc_groups": generate_pre_alloc_groups,
+            "use_pre_alloc_groups": use_pre_alloc_groups,
+            "generate_all_formats": generate_all_formats,
+        }
+
+    def getoption(self, name, default=None):
+        """Mock getoption method."""
+        return self._options.get(name, default)
+
+
+class TestPhaseManager:
+    """Test cases for PhaseManager class."""
+
+    def test_init(self):
+        """Test basic initialization."""
+        phase_manager = PhaseManager(
+            current_phase=FixtureFillingPhase.FILL,
+            previous_phases={FixtureFillingPhase.PRE_ALLOC_GENERATION},
+        )
+        assert phase_manager.current_phase == FixtureFillingPhase.FILL
+        assert phase_manager.previous_phases == {FixtureFillingPhase.PRE_ALLOC_GENERATION}
+
+    def test_from_config_normal_fill(self):
+        """Test normal single-phase filling (no flags set)."""
+        config = MockConfig()
+        phase_manager = PhaseManager.from_config(config)
+
+        assert phase_manager.current_phase == FixtureFillingPhase.FILL
+        assert phase_manager.previous_phases == set()
+        assert phase_manager.is_single_phase_fill
+        assert not phase_manager.is_pre_alloc_generation
+        assert not phase_manager.is_fill_after_pre_alloc
+
+    def test_from_config_generate_pre_alloc(self):
+        """Test phase 1: generate pre-allocation groups."""
+        config = MockConfig(generate_pre_alloc_groups=True)
+        phase_manager = PhaseManager.from_config(config)
+
+        assert phase_manager.current_phase == FixtureFillingPhase.PRE_ALLOC_GENERATION
+        assert phase_manager.previous_phases == set()
+        assert phase_manager.is_pre_alloc_generation
+        assert not phase_manager.is_single_phase_fill
+        assert not phase_manager.is_fill_after_pre_alloc
+
+    def test_from_config_use_pre_alloc(self):
+        """Test phase 2: use pre-allocation groups."""
+        config = MockConfig(use_pre_alloc_groups=True)
+        phase_manager = PhaseManager.from_config(config)
+
+        assert phase_manager.current_phase == FixtureFillingPhase.FILL
+        assert phase_manager.previous_phases == {FixtureFillingPhase.PRE_ALLOC_GENERATION}
+        assert phase_manager.is_fill_after_pre_alloc
+        assert not phase_manager.is_pre_alloc_generation
+        assert not phase_manager.is_single_phase_fill
+
+    def test_from_config_generate_all_formats(self):
+        """Test that generate_all_formats triggers PRE_ALLOC_GENERATION phase."""
+        config = MockConfig(generate_all_formats=True)
+        phase_manager = PhaseManager.from_config(config)
+
+        assert phase_manager.current_phase == FixtureFillingPhase.PRE_ALLOC_GENERATION
+        assert phase_manager.previous_phases == set()
+        assert phase_manager.is_pre_alloc_generation
+        assert not phase_manager.is_single_phase_fill
+        assert not phase_manager.is_fill_after_pre_alloc
+
+    def test_from_config_generate_all_and_pre_alloc(self):
+        """Test both generate_all_formats and generate_pre_alloc_groups set."""
+        config = MockConfig(generate_pre_alloc_groups=True, generate_all_formats=True)
+        phase_manager = PhaseManager.from_config(config)
+
+        assert phase_manager.current_phase == FixtureFillingPhase.PRE_ALLOC_GENERATION
+        assert phase_manager.previous_phases == set()
+        assert phase_manager.is_pre_alloc_generation
+
+    def test_from_config_use_pre_alloc_with_generate_all(self):
+        """Test phase 2 with generate_all_formats (passed by CLI to phase 2)."""
+        config = MockConfig(use_pre_alloc_groups=True, generate_all_formats=True)
+        phase_manager = PhaseManager.from_config(config)
+
+        # use_pre_alloc_groups takes precedence
+        assert phase_manager.current_phase == FixtureFillingPhase.FILL
+        assert phase_manager.previous_phases == {FixtureFillingPhase.PRE_ALLOC_GENERATION}
+        assert phase_manager.is_fill_after_pre_alloc
+
+    def test_all_flag_combinations(self):
+        """Test all 8 possible flag combinations to ensure correct phase determination."""
+        test_cases = [
+            # (generate_pre_alloc, use_pre_alloc, generate_all) -> (current_phase, has_previous)
+            (False, False, False, FixtureFillingPhase.FILL, False),  # Normal fill
+            # Generate all triggers phase 1
+            (False, False, True, FixtureFillingPhase.PRE_ALLOC_GENERATION, False),
+            (False, True, False, FixtureFillingPhase.FILL, True),  # Phase 2
+            (False, True, True, FixtureFillingPhase.FILL, True),  # Phase 2 with generate all
+            (True, False, False, FixtureFillingPhase.PRE_ALLOC_GENERATION, False),  # Phase 1
+            # Phase 1 with generate all
+            (True, False, True, FixtureFillingPhase.PRE_ALLOC_GENERATION, False),
+            (True, True, False, FixtureFillingPhase.FILL, True),  # Invalid but use_pre_alloc wins
+            (True, True, True, FixtureFillingPhase.FILL, True),  # Invalid but use_pre_alloc wins
+        ]
+
+        for gen_pre, use_pre, gen_all, expected_phase, has_previous in test_cases:
+            config = MockConfig(
+                generate_pre_alloc_groups=gen_pre,
+                use_pre_alloc_groups=use_pre,
+                generate_all_formats=gen_all,
+            )
+            phase_manager = PhaseManager.from_config(config)
+
+            assert phase_manager.current_phase == expected_phase, (
+                f"Failed for flags: generate_pre_alloc={gen_pre}, "
+                f"use_pre_alloc={use_pre}, generate_all={gen_all}"
+            )
+
+            if has_previous:
+                assert FixtureFillingPhase.PRE_ALLOC_GENERATION in phase_manager.previous_phases
+            else:
+                assert phase_manager.previous_phases == set()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## 🗒️ Description

A suggestion for #2006 that attempts to better encapsulate filler logic regarding different "filling phases", i.e., pre-alloc-group generation and test filling.
- #2006 

This PR refactors the complex phase management and format selection logic in the filler plugin into clean, testable components. The changes improve code maintainability, eliminate duplication, and provide better separation of concerns without affecting existing functionality.

### Problem

The original implementation had several issues:

- Complex conditional logic scattered across multiple functions
- Tight coupling between phase management and format selection  
- Difficult-to-test logic buried in pytest hooks
- Code duplication between `filler.py` and `static_filler.py`
- Direct config attribute access throughout the codebase

### Solution

#### New Architecture

**PhaseManager** - Encapsulates execution phase determination:

- Determines current phase (PRE_ALLOC_GENERATION, FILL) from CLI flags
- Provides clear boolean properties (`is_pre_alloc_generation`, `is_single_phase_fill`, etc.)

**FormatSelector** - Handles fixture format selection:

- Decides which fixture formats to generate based on current phase
- Supports `--generate-all-formats` flag logic
- Works with both labeled and unlabeled fixture formats

**FillingSession** - Central state management:

- Manages pre-allocation groups lifecycle (load/save/aggregate)
- Provides unified interface via `get_filling_session()`
- Handles xdist worker coordination
- Single source of truth for all phase/format decisions


<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
