### PR TITLE
fix(ci,clis): Change ci runner, fix `timeout-minutes`, Increase t8n timeout

### DIFF
--- a/.github/workflows/fixtures.yaml
+++ b/.github/workflows/fixtures.yaml
@@ -29,7 +29,8 @@ jobs:
           echo "features=$(cat features.json)" >> "$GITHUB_OUTPUT"
   build:
     needs: features
-    runs-on: [self-hosted-ghr, size-chungus-x64]
+    runs-on: [self-hosted-ghr, size-megachungus-x64]
+    timeout-minutes: 720
     strategy:
       matrix:
         name: ${{ fromJson(needs.features.outputs.features) }}
@@ -60,7 +61,6 @@ jobs:
           release_name: ${{ matrix.name }}
           uv_version: ${{ vars.UV_VERSION }}
           python_version: ${{ vars.DEFAULT_PYTHON_VERSION }}
-        timeout-minutes: 720
   release:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/fixtures_feature.yaml
+++ b/.github/workflows/fixtures_feature.yaml
@@ -23,8 +23,9 @@ jobs:
           echo names=${names}
           echo names=${names} >> "$GITHUB_OUTPUT"
   build:
-    runs-on: [self-hosted-ghr, size-chungus-x64]
     needs: feature-names
+    runs-on: [self-hosted-ghr, size-megachungus-x64]
+    timeout-minutes: 720
     strategy:
       matrix:
         feature: ${{ fromJSON(needs.feature-names.outputs.names) }}
@@ -55,7 +56,6 @@ jobs:
           release_name: ${{ matrix.feature }}
           uv_version: ${{ vars.UV_VERSION }}
           python_version: ${{ vars.DEFAULT_PYTHON_VERSION }}
-        timeout-minutes: 720
   release:
     runs-on: ubuntu-latest
     needs: build

--- a/src/ethereum_clis/transition_tool.py
+++ b/src/ethereum_clis/transition_tool.py
@@ -38,8 +38,8 @@ model_dump_config: Mapping = {"by_alias": True, "exclude_none": True}
 
 # TODO: reduce NORMAL_SERVER_TIMEOUT back down to 20 once BLS timeout issue is resolved:
 # https://github.com/ethereum/execution-spec-tests/issues/1894
-NORMAL_SERVER_TIMEOUT = 180
-SLOW_REQUEST_TIMEOUT = 180
+NORMAL_SERVER_TIMEOUT = 600
+SLOW_REQUEST_TIMEOUT = 600
 
 
 def get_valid_transition_tool_names() -> set[str]:


### PR DESCRIPTION
## 🗒️ Description

### Change CI Runner
The CI runner tag has been updated to allow use of faster vms.

### Fix `timeout-minutes`

Updated the tag `timeout-minutes` to be in the correct place.

### Increase T8N timeout

The timeout for t8n server requests has been increased in order to prevent this from making tests fail.

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] ~~All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).