### PR TITLE
feat(fill): Improve mem usage by: fixture collector flush + lazy loading pre-alloc groups

### DIFF
--- a/src/cli/show_pre_alloc_group_stats.py
+++ b/src/cli/show_pre_alloc_group_stats.py
@@ -102,7 +102,7 @@ def calculate_size_distribution(
 
 def analyze_pre_alloc_folder(folder: Path, verbose: int = 0) -> Dict:
     """Analyze pre-allocation folder and return statistics."""
-    pre_alloc_groups = PreAllocGroups.from_folder(folder)
+    pre_alloc_groups = PreAllocGroups.from_folder(folder, lazy_load=False)
 
     # Basic stats
     total_groups = len(pre_alloc_groups)

--- a/src/cli/show_pre_alloc_group_stats.py
+++ b/src/cli/show_pre_alloc_group_stats.py
@@ -147,7 +147,7 @@ def analyze_pre_alloc_folder(folder: Path, verbose: int = 0) -> Dict:
 
     # Calculate frequency distribution of group sizes
     group_distribution, test_distribution = calculate_size_distribution(
-        [g["tests"] for g in group_details]
+        [g["tests"] for g in group_details]  # type: ignore
     )
 
     # Analyze test functions split across multiple size-1 groups

--- a/src/ethereum_test_fixtures/collector.py
+++ b/src/ethereum_test_fixtures/collector.py
@@ -113,6 +113,7 @@ class FixtureCollector:
     single_fixture_per_file: bool
     filler_path: Path
     base_dump_dir: Optional[Path] = None
+    flush_interval: int = 1000
 
     # Internal state
     all_fixtures: Dict[Path, Fixtures] = field(default_factory=dict)
@@ -151,6 +152,9 @@ class FixtureCollector:
 
         self.all_fixtures[fixture_path][info.get_id()] = fixture
 
+        if self.flush_interval > 0 and len(self.all_fixtures) >= self.flush_interval:
+            self.dump_fixtures()
+
         return fixture_path
 
     def dump_fixtures(self) -> None:
@@ -167,6 +171,8 @@ class FixtureCollector:
             if len({fixture.__class__ for fixture in fixtures.values()}) != 1:
                 raise TypeError("All fixtures in a single file must have the same format.")
             fixtures.collect_into_file(fixture_path)
+
+        self.all_fixtures.clear()
 
     def verify_fixture_files(self, evm_fixture_verification: FixtureConsumer) -> None:
         """Run `evm [state|block]test` on each fixture."""

--- a/src/pytest_plugins/filler/tests/test_prealloc_group.py
+++ b/src/pytest_plugins/filler/tests/test_prealloc_group.py
@@ -436,7 +436,7 @@ def test_pre_alloc_grouping_by_test_type(
         Path(default_output_directory()).absolute() / "blockchain_tests_engine_x" / "pre_alloc"
     )
     assert output_dir.exists()
-    groups = PreAllocGroups.from_folder(output_dir)
+    groups = PreAllocGroups.from_folder(output_dir, lazy_load=True)
     if (
         len([f for f in output_dir.iterdir() if f.name.endswith(".json")])
         != expected_different_pre_alloc_groups

--- a/src/pytest_plugins/filler/tests/test_prealloc_group.py
+++ b/src/pytest_plugins/filler/tests/test_prealloc_group.py
@@ -436,7 +436,7 @@ def test_pre_alloc_grouping_by_test_type(
         Path(default_output_directory()).absolute() / "blockchain_tests_engine_x" / "pre_alloc"
     )
     assert output_dir.exists()
-    groups = PreAllocGroups.from_folder(output_dir, lazy_load=True)
+    groups = PreAllocGroups.from_folder(output_dir, lazy_load=False)
     if (
         len([f for f in output_dir.iterdir() if f.name.endswith(".json")])
         != expected_different_pre_alloc_groups


### PR DESCRIPTION
## 🗒️ Description

### Fixture Collector Flush

The fixture collector now has a flushing mechanism to flush to disk and remove from memory once a certain number of test fixtures have been collected (defaults to 1000).

### Lazy-load pre-alloc groups

Problem: when using x-dist, all workers had to load all pre-allocation groups at once at the start of the fill, without discrimination, and even when they would never use them throughout the fill.

The `PreAllocGroups` class is improved in this PR with lazy loading so the pre-allocation contents are only loaded when they are actually needed.

This results in around half of memory usage than with previous implementation.

Running:
```bash
uv run fill --clean --until=Osaka --fill-static-tests --ignore=tests/static/state_tests/stQuadraticComplexityTest --output=fixtures-develop.tar.gz -n auto
```

Before: 64G+ and OOM issues.
After:
```
               total        used        free      shared  buff/cache   available
Mem:            62Gi        31Gi        28Gi       612Ki       4.2Gi        31Gi
Swap:             0B          0B          0B
```

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] ~~All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).