### PR TITLE
feat(tests|forks|pytest): temporary BPO x EIP-7918 test (WIP)

### DIFF
--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -1533,7 +1533,101 @@ class Osaka(Prague, solc_name="cancun"):
     def max_blobs_per_tx(cls, block_number: int = 0, timestamp: int = 0) -> int:
         """Blobs in Osaka, have a static max of 6 blobs per tx. Differs from the max per block."""
         return 6
+    
 
+class OsakaBPO1(Osaka):
+    """Osaka BPO1 fork - Blob Parameter Only fork 1."""
+
+    @classmethod
+    def blob_base_fee_update_fraction(cls, block_number: int = 0, timestamp: int = 0) -> int:
+        """Return the blob base fee update fraction for BPO1."""
+        return 8832827
+
+    @classmethod
+    def target_blobs_per_block(cls, block_number: int = 0, timestamp: int = 0) -> int:
+        """Blobs in BPO1 have a target of 9 blobs per block."""
+        return 9
+
+    @classmethod
+    def max_blobs_per_block(cls, block_number: int = 0, timestamp: int = 0) -> int:
+        """Blobs in BPO1 have a max of 14 blobs per block."""
+        return 14
+
+
+class OsakaBPO2(OsakaBPO1):
+    """Osaka BPO2 fork - Blob Parameter Only fork 2."""
+
+    @classmethod
+    def blob_base_fee_update_fraction(cls, block_number: int = 0, timestamp: int = 0) -> int:
+        """Return the blob base fee update fraction for BPO2."""
+        return 13739630
+
+    @classmethod
+    def target_blobs_per_block(cls, block_number: int = 0, timestamp: int = 0) -> int:
+        """Blobs in BPO2 have a target of 14 blobs per block."""
+        return 14
+
+    @classmethod
+    def max_blobs_per_block(cls, block_number: int = 0, timestamp: int = 0) -> int:
+        """Blobs in BPO2 have a max of 21 blobs per block."""
+        return 21
+
+
+class OsakaBPO3(OsakaBPO2):
+    """Osaka BPO3 fork - Blob Parameter Only fork 3."""
+
+    @classmethod
+    def blob_base_fee_update_fraction(cls, block_number: int = 0, timestamp: int = 0) -> int:
+        """Return the blob base fee update fraction for BPO3."""
+        return 20609697
+
+    @classmethod
+    def target_blobs_per_block(cls, block_number: int = 0, timestamp: int = 0) -> int:
+        """Blobs in BPO3 have a target of 21 blobs per block."""
+        return 21
+
+    @classmethod
+    def max_blobs_per_block(cls, block_number: int = 0, timestamp: int = 0) -> int:
+        """Blobs in BPO3 have a max of 32 blobs per block."""
+        return 32
+
+
+class OsakaBPO4(OsakaBPO3):
+    """Osaka BPO4 fork - Blob Parameter Only fork 4."""
+
+    @classmethod
+    def blob_base_fee_update_fraction(cls, block_number: int = 0, timestamp: int = 0) -> int:
+        """Return the blob base fee update fraction for BPO4."""
+        return 31404902
+
+    @classmethod
+    def target_blobs_per_block(cls, block_number: int = 0, timestamp: int = 0) -> int:
+        """Blobs in BPO4 have a target of 32 blobs per block."""
+        return 32
+
+    @classmethod
+    def max_blobs_per_block(cls, block_number: int = 0, timestamp: int = 0) -> int:
+        """Blobs in BPO4 have a max of 48 blobs per block."""
+        return 48
+
+
+class OsakaBPO5(OsakaBPO4):
+    """Osaka BPO5 fork - Blob Parameter Only fork 5."""
+
+    @classmethod
+    def blob_base_fee_update_fraction(cls, block_number: int = 0, timestamp: int = 0) -> int:
+        """Return the blob base fee update fraction for BPO5."""
+        return 47107372
+
+    @classmethod
+    def target_blobs_per_block(cls, block_number: int = 0, timestamp: int = 0) -> int:
+        """Blobs in BPO5 have a target of 48 blobs per block."""
+        return 48
+
+    @classmethod
+    def max_blobs_per_block(cls, block_number: int = 0, timestamp: int = 0) -> int:
+        """Blobs in BPO5 have a max of 72 blobs per block."""
+        return 72
 
 class EOFv1(Prague, solc_name="cancun"):
     """EOF fork."""

--- a/src/ethereum_test_forks/forks/transition.py
+++ b/src/ethereum_test_forks/forks/transition.py
@@ -2,6 +2,7 @@
 
 from ..transition_base_fork import transition_fork
 from .forks import Berlin, Cancun, London, Osaka, Paris, Prague, Shanghai
+from .forks import OsakaBPO1, OsakaBPO2, OsakaBPO3, OsakaBPO4, OsakaBPO5
 
 
 # Transition Forks
@@ -37,4 +38,31 @@ class CancunToPragueAtTime15k(Cancun):
 class PragueToOsakaAtTime15k(Prague):
     """Prague to Osaka transition at Timestamp 15k."""
 
+    pass
+
+
+# Temporary Osaka BPO Transition Forks
+@transition_fork(to_fork=OsakaBPO1, at_timestamp=10_000)
+class OsakaToOsakaBPO1AtTime10k(Osaka):
+    """Osaka to OsakaBPO1 transition at Timestamp 10k."""
+    pass
+
+@transition_fork(to_fork=OsakaBPO2, at_timestamp=20_000)
+class OsakaBPO1ToOsakaBPO2AtTime20k(OsakaBPO1):
+    """OsakaBPO1 to OsakaBPO2 transition at Timestamp 20k."""
+    pass
+
+@transition_fork(to_fork=OsakaBPO3, at_timestamp=30_000)
+class OsakaBPO2ToOsakaBPO3AtTime30k(OsakaBPO2):
+    """OsakaBPO2 to OsakaBPO3 transition at Timestamp 30k."""
+    pass
+
+@transition_fork(to_fork=OsakaBPO4, at_timestamp=40_000)
+class OsakaBPO3ToOsakaBPO4AtTime40k(OsakaBPO3):
+    """OsakaBPO3 to OsakaBPO4 transition at Timestamp 40k."""
+    pass
+
+@transition_fork(to_fork=OsakaBPO5, at_timestamp=50_000)
+class OsakaBPO4ToOsakaBPO5AtTime50k(OsakaBPO4):
+    """OsakaBPO4 to OsakaBPO5 transition at Timestamp 50k."""
     pass

--- a/src/pytest_plugins/consume/simulators/helpers/ruleset.py
+++ b/src/pytest_plugins/consume/simulators/helpers/ruleset.py
@@ -281,6 +281,12 @@ ruleset: Dict[Fork, Dict[str, int]] = {
         "HIVE_CANCUN_TIMESTAMP": 0,
         "HIVE_PRAGUE_TIMESTAMP": 0,
         "HIVE_OSAKA_TIMESTAMP": 0,
+        # Arbitrary BPO timestamps to match transition times
+        "HIVE_BPO1_TIMESTAMP": 10000,
+        "HIVE_BPO2_TIMESTAMP": 20000, 
+        "HIVE_BPO3_TIMESTAMP": 30000,
+        "HIVE_BPO4_TIMESTAMP": 30000,
+        "HIVE_BPO5_TIMESTAMP": 30000,
         **get_blob_schedule_entries(Osaka),
     },
     PragueToOsakaAtTime15k: {


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

WIP.

See: https://discord.com/channels/595666850260713488/1404938250761535553

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
