### PR TITLE
feat(tests): add EIP-7823 modexp limit test with huge exponent

### DIFF
--- a/tests/osaka/eip7823_modexp_upper_bounds/test_modexp_upper_bounds.py
+++ b/tests/osaka/eip7823_modexp_upper_bounds/test_modexp_upper_bounds.py
@@ -20,8 +20,12 @@ TX_GAS_LIMIT = 2**24
 
 
 @pytest.fixture
-def precompile_gas(fork: Fork, mod_exp_input: ModExpInput) -> int:
+def precompile_gas(fork: Fork, mod_exp_input: ModExpInput | bytes) -> int:
     """Calculate gas cost for the ModExp precompile and verify it matches expected gas."""
+
+    if isinstance(mod_exp_input, bytes):
+        return 200
+
     spec = Spec if fork < Osaka else Spec7883
     calculated_gas = spec.calculate_gas_cost(mod_exp_input)
     return calculated_gas
@@ -175,6 +179,18 @@ def precompile_gas(fork: Fork, mod_exp_input: ModExpInput) -> int:
                 declared_exponent_length=0,
             ),
             id="zero_exp_mod_exceed",
+        ),
+        pytest.param(
+            ModExpInput(
+                base=b"\1",
+                exponent=b"",
+                modulus=b"\0" * (MAX_LENGTH_BYTES + 1),
+            ),
+            id="exp_0_base_1_mod_1025",
+        ),
+        pytest.param(
+            bytes.fromhex("0000000000000000000000000000000000000000000000000000000000000000 0000000000000000000000000000000000000000000000010000000000000000 0000000000000000000000000000000000000000000000000000000000000000 80"),
+            id="exp_2**64_base_0_mod_0",
         ),
     ],
 )


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

## 🔗 Related Issues or PRs
#2043 

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
