### PR TITLE
bug(cli): apply tx gas limit cap to eest make cli template

### DIFF
--- a/src/cli/eest/make/templates/blockchain_test.py.j2
+++ b/src/cli/eest/make/templates/blockchain_test.py.j2
@@ -5,7 +5,15 @@ abstract: Tests [EIP-{{eip_number}} {{eip_name}}](https://eips.ethereum.org/EIPS
 
 import pytest
 
-from ethereum_test_tools import Account, Alloc, Block, BlockchainTestFiller, Transaction
+from ethereum_test_forks import Fork
+from ethereum_test_tools import (
+    Account,
+    Alloc,
+    Block,
+    BlockchainTestFiller,
+    Environment,
+    Transaction,
+)
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 REFERENCE_SPEC_GIT_PATH = "DUMMY/eip-DUMMY.md"
@@ -13,7 +21,9 @@ REFERENCE_SPEC_VERSION = "DUMMY_VERSION"
 
 
 @pytest.mark.valid_from("{{fork}}")
-def {{module_name}}(blockchain_test: BlockchainTestFiller, pre: Alloc):
+def {{module_name}}(
+    blockchain_test: BlockchainTestFiller, pre: Alloc, fork: Fork, env: Environment
+):
     """
     TODO: Enter a one-line test summary here.
 
@@ -40,7 +50,7 @@ def {{module_name}}(blockchain_test: BlockchainTestFiller, pre: Alloc):
 
     tx = Transaction(
         to=contract_address,
-        gas_limit=100000000,
+        gas_limit=fork.transaction_gas_limit_cap() or env.gas_limit,
         data=b"",
         value=0,
         sender=sender,

--- a/src/cli/eest/make/templates/state_test.py.j2
+++ b/src/cli/eest/make/templates/state_test.py.j2
@@ -5,6 +5,7 @@ abstract: Tests [EIP-{{eip_number}} {{eip_name}}](https://eips.ethereum.org/EIPS
 
 import pytest
 
+from ethereum_test_forks import Fork
 from ethereum_test_tools import Account, Alloc, Environment, StateTestFiller, Transaction
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
@@ -13,7 +14,7 @@ REFERENCE_SPEC_VERSION = "DUMMY_VERSION"
 
 
 @pytest.mark.valid_from("{{fork}}")
-def {{module_name}}(state_test: StateTestFiller, pre: Alloc):
+def {{module_name}}(state_test: StateTestFiller, pre: Alloc, fork: Fork, env: Environment):
     """
     TODO: Enter a one-line test summary here.
 
@@ -42,7 +43,7 @@ def {{module_name}}(state_test: StateTestFiller, pre: Alloc):
 
     tx = Transaction(
         to=contract_address,
-        gas_limit=100000000,
+        gas_limit=fork.transaction_gas_limit_cap() or env.gas_limit,
         data=b"",
         value=0,
         sender=sender,


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

The original test template did not consider the transaction gas limit cap, while this template update the configuration.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
fixes https://github.com/ethereum/execution-spec-tests/issues/2038

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
