### PR TITLE
src(eth_config): added eth_config simulator prototype

### DIFF
--- a/src/ethereum_test_rpc/rpc.py
+++ b/src/ethereum_test_rpc/rpc.py
@@ -430,9 +430,9 @@ class EngineRPC(BaseRPC):
         method = f"forkchoiceUpdatedV{version}"
 
         if payload_attributes is None:
-            params = [to_json(forkchoice_state)]
-        else:
             params = [to_json(forkchoice_state), None]
+        else:
+            params = [to_json(forkchoice_state), to_json(payload_attributes)]
 
         return ForkchoiceUpdateResponse.model_validate(
             self.post_request(

--- a/src/ethereum_test_rpc/rpc.py
+++ b/src/ethereum_test_rpc/rpc.py
@@ -79,10 +79,12 @@ class BaseRPC:
 
     def post_request(
         self,
+        *,
         method: str,
-        *params: Any,
+        params: Any | None = None,
         extra_headers: Dict | None = None,
         request_id: int | str | None = None,
+        timeout: int | None = None,
     ) -> Any:
         """Send JSON-RPC POST request to the client RPC server at port defined in the url."""
         if extra_headers is None:
@@ -92,7 +94,8 @@ class BaseRPC:
         next_request_id_counter = next(self.request_id_counter)
         if request_id is None:
             request_id = next_request_id_counter
-        payload = {
+
+        json = {
             "jsonrpc": "2.0",
             "method": f"{self.namespace}_{method}",
             "params": params,
@@ -103,7 +106,9 @@ class BaseRPC:
         }
         headers = base_header | extra_headers
 
-        response = requests.post(self.url, json=payload, headers=headers)
+        # print(f"Sending RPC request to {self.url}, timeout is set to {timeout}...")
+        print(f"Sending RPC request, timeout is set to {timeout}...")  # don't leak url in logs
+        response = requests.post(self.url, json=json, headers=headers, timeout=timeout)
         response.raise_for_status()
         response_json = response.json()
 
@@ -135,11 +140,12 @@ class EthRPC(BaseRPC):
         super().__init__(*args, **kwargs)
         self.transaction_wait_timeout = transaction_wait_timeout
 
-    def config(self):
+    def config(self, timeout: int | None = None):
         """`eth_config`: Returns information about a fork configuration of the client."""
         try:
-            response = self.post_request("config")
+            response = self.post_request(method="config", timeout=timeout)
             if response is None:
+                print("eth_config request: failed to get response")
                 return None
             return EthConfigResponse.model_validate(
                 response, context=self.response_validation_context
@@ -147,41 +153,66 @@ class EthRPC(BaseRPC):
         except ValidationError as e:
             pprint(e.errors())
             raise e
+        except Exception as e:
+            print(f"exception occurred when sending JSON-RPC request: {e}")
+            raise e
 
     def chain_id(self) -> int:
         """`eth_chainId`: Returns the current chain id."""
-        return int(self.post_request("chainId"), 16)
+        response = self.post_request(method="chainId", timeout=10)
+
+        return int(response, 16)
 
     def get_block_by_number(self, block_number: BlockNumberType = "latest", full_txs: bool = True):
         """`eth_getBlockByNumber`: Returns information about a block by block number."""
         block = hex(block_number) if isinstance(block_number, int) else block_number
-        return self.post_request("getBlockByNumber", block, full_txs)
+        params = [block, full_txs]
+        response = self.post_request(method="getBlockByNumber", params=params)
+
+        return response
 
     def get_block_by_hash(self, block_hash: Hash, full_txs: bool = True):
         """`eth_getBlockByHash`: Returns information about a block by hash."""
-        return self.post_request("getBlockByHash", f"{block_hash}", full_txs)
+        params = [f"{block_hash}", full_txs]
+        response = self.post_request(method="getBlockByHash", params=params)
+
+        return response
 
     def get_balance(self, address: Address, block_number: BlockNumberType = "latest") -> int:
         """`eth_getBalance`: Returns the balance of the account of given address."""
         block = hex(block_number) if isinstance(block_number, int) else block_number
-        return int(self.post_request("getBalance", f"{address}", block), 16)
+        params = [f"{address}", block]
+
+        response = self.post_request(method="getBalance", params=params)
+
+        return int(response, 16)
 
     def get_code(self, address: Address, block_number: BlockNumberType = "latest") -> Bytes:
         """`eth_getCode`: Returns code at a given address."""
         block = hex(block_number) if isinstance(block_number, int) else block_number
-        return Bytes(self.post_request("getCode", f"{address}", block))
+        params = [f"{address}", block]
+
+        response = self.post_request(method="getCode", params=params)
+
+        return Bytes(response)
 
     def get_transaction_count(
         self, address: Address, block_number: BlockNumberType = "latest"
     ) -> int:
         """`eth_getTransactionCount`: Returns the number of transactions sent from an address."""
         block = hex(block_number) if isinstance(block_number, int) else block_number
-        return int(self.post_request("getTransactionCount", f"{address}", block), 16)
+        params = [f"{address}", block]
+
+        response = self.post_request(method="getTransactionCount", params=params)
+
+        return int(response, 16)
 
     def get_transaction_by_hash(self, transaction_hash: Hash) -> TransactionByHashResponse | None:
         """`eth_getTransactionByHash`: Returns transaction details."""
         try:
-            response = self.post_request("getTransactionByHash", f"{transaction_hash}")
+            response = self.post_request(
+                method="getTransactionByHash", params=f"{transaction_hash}"
+            )
             if response is None:
                 return None
             return TransactionByHashResponse.model_validate(
@@ -196,22 +227,29 @@ class EthRPC(BaseRPC):
     ) -> Hash:
         """`eth_getStorageAt`: Returns the value from a storage position at a given address."""
         block = hex(block_number) if isinstance(block_number, int) else block_number
-        return Hash(self.post_request("getStorageAt", f"{address}", f"{position}", block))
+        params = [f"{address}", f"{position}", block]
+
+        response = self.post_request(method="getStorageAt", params=params)
+        return Hash(response)
 
     def gas_price(self) -> int:
         """`eth_gasPrice`: Returns the number of transactions sent from an address."""
-        return int(self.post_request("gasPrice"), 16)
+        response = self.post_request(method="gasPrice")
+
+        return int(response, 16)
 
     def send_raw_transaction(
         self, transaction_rlp: Bytes, request_id: int | str | None = None
     ) -> Hash:
         """`eth_sendRawTransaction`: Send a transaction to the client."""
         try:
-            result_hash = Hash(
-                self.post_request(
-                    "sendRawTransaction", f"{transaction_rlp.hex()}", request_id=request_id
-                ),
+            response = self.post_request(
+                method="sendRawTransaction",
+                params=f"{transaction_rlp.hex()}",
+                request_id=request_id,  # noqa: E501
             )
+
+            result_hash = Hash(response)
             assert result_hash is not None
             return result_hash
         except Exception as e:
@@ -219,14 +257,15 @@ class EthRPC(BaseRPC):
 
     def send_transaction(self, transaction: Transaction) -> Hash:
         """`eth_sendRawTransaction`: Send a transaction to the client."""
+        # TODO: is this a copypaste error from above?
         try:
-            result_hash = Hash(
-                self.post_request(
-                    "sendRawTransaction",
-                    f"{transaction.rlp().hex()}",
-                    request_id=transaction.metadata_string(),
-                )
+            response = self.post_request(
+                method="sendRawTransaction",
+                params=f"{transaction.rlp().hex()}",
+                request_id=transaction.metadata_string(),  # noqa: E501
             )
+
+            result_hash = Hash(response)
             assert result_hash == transaction.hash
             assert result_hash is not None
             return transaction.hash
@@ -318,7 +357,8 @@ class DebugRPC(EthRPC):
 
     def trace_call(self, tr: dict[str, str], block_number: str):
         """`debug_traceCall`: Returns pre state required for transaction."""
-        return self.post_request("traceCall", tr, block_number, {"tracer": "prestateTracer"})
+        params = [tr, block_number, {"tracer": "prestateTracer"}]
+        return self.post_request(method="traceCall", params=params)
 
 
 class EngineRPC(BaseRPC):
@@ -341,10 +381,12 @@ class EngineRPC(BaseRPC):
 
     def post_request(
         self,
+        *,
         method: str,
-        *params: Any,
+        params: Any | None = None,
         extra_headers: Dict | None = None,
         request_id: int | str | None = None,
+        timeout: int | None = None,
     ) -> Any:
         """Send JSON-RPC POST request to the client RPC server at port defined in the url."""
         if extra_headers is None:
@@ -357,14 +399,22 @@ class EngineRPC(BaseRPC):
         extra_headers = {
             "Authorization": f"Bearer {jwt_token}",
         } | extra_headers
+
         return super().post_request(
-            method, *params, extra_headers=extra_headers, request_id=request_id
+            method=method,
+            params=params,
+            extra_headers=extra_headers,
+            timeout=timeout,
+            request_id=request_id,
         )
 
     def new_payload(self, *params: Any, version: int) -> PayloadStatus:
         """`engine_newPayloadVX`: Attempts to execute the given payload on an execution client."""
+        method = f"newPayloadV{version}"
+        params_list = [to_json(param) for param in params]
+
         return PayloadStatus.model_validate(
-            self.post_request(f"newPayloadV{version}", *[to_json(param) for param in params]),
+            self.post_request(method=method, params=params_list),
             context=self.response_validation_context,
         )
 
@@ -376,11 +426,17 @@ class EngineRPC(BaseRPC):
         version: int,
     ) -> ForkchoiceUpdateResponse:
         """`engine_forkchoiceUpdatedVX`: Updates the forkchoice state of the execution client."""
+        method = f"forkchoiceUpdatedV{version}"
+
+        if payload_attributes is None:
+            params = [to_json(forkchoice_state)]
+        else:
+            params = [to_json(forkchoice_state), to_json(payload_attributes)]
+
         return ForkchoiceUpdateResponse.model_validate(
             self.post_request(
-                f"forkchoiceUpdatedV{version}",
-                to_json(forkchoice_state),
-                to_json(payload_attributes) if payload_attributes is not None else None,
+                method=method,
+                params=params,
             ),
             context=self.response_validation_context,
         )
@@ -395,10 +451,12 @@ class EngineRPC(BaseRPC):
         `engine_getPayloadVX`: Retrieves a payload that was requested through
         `engine_forkchoiceUpdatedVX`.
         """
+        method = f"getPayloadV{version}"
+
         return GetPayloadResponse.model_validate(
             self.post_request(
-                f"getPayloadV{version}",
-                f"{payload_id}",
+                method=method,
+                params=f"{payload_id}",
             ),
             context=self.response_validation_context,
         )
@@ -410,9 +468,12 @@ class EngineRPC(BaseRPC):
         version: int,
     ) -> GetBlobsResponse | None:
         """`engine_getBlobsVX`: Retrieves blobs from an execution layers tx pool."""
+        method = f"getBlobsV{version}"
+        params = [f"{h}" for h in versioned_hashes]
+
         response = self.post_request(
-            f"getBlobsV{version}",
-            [f"{h}" for h in versioned_hashes],
+            method=method,
+            params=[params],
         )
         if response is None:  # for tests that request non-existing blobs
             logger.debug("get_blobs response received but it has value: None")
@@ -429,7 +490,7 @@ class NetRPC(BaseRPC):
 
     def peer_count(self) -> int:
         """`net_peerCount`: Get the number of peers connected to the client."""
-        response = self.post_request("peerCount")
+        response = self.post_request(method="peerCount")
         return int(response, 16)  # hex -> int
 
 
@@ -438,4 +499,4 @@ class AdminRPC(BaseRPC):
 
     def add_peer(self, enode: str) -> bool:
         """`admin_addPeer`: Add a peer by enode URL."""
-        return self.post_request("addPeer", enode)
+        return self.post_request(method="addPeer", params=enode)

--- a/src/pytest_plugins/execute/eth_config/execute_eth_config.py
+++ b/src/pytest_plugins/execute/eth_config/execute_eth_config.py
@@ -197,11 +197,14 @@ def test_eth_config_majority(
         # try only as many consensus+exec client combinations until you receive a response
         # if all combinations for a given exec client fail we panic
         for eth_rpc_target in all_rpc_endpoints[exec_client]:
-            response = eth_rpc_target.config(timeout=10)
-            if response is None:
-                # safely split url to not leak rpc_endpoint in logs
+            try:
+                response = eth_rpc_target.config(timeout=5)
+                if response is None:
+                    logger.warning(f"Got 'None' as eth_config response from {eth_rpc_target}")
+                    continue
+            except Exception as e:
                 logger.warning(
-                    f"When trying to get eth_config from {eth_rpc_target} a problem occurred"  # problem itself is logged by .config() call # noqa: E501
+                    f"When trying to get eth_config from {eth_rpc_target} a problem occurred: {e}"
                 )
                 continue
 

--- a/src/pytest_plugins/execute/eth_config/execute_eth_config.py
+++ b/src/pytest_plugins/execute/eth_config/execute_eth_config.py
@@ -1,6 +1,9 @@
 """Pytest test to verify a client's configuration using `eth_config` RPC endpoint."""
 
+import json
 import time
+from hashlib import sha256
+from typing import Dict, List
 
 import pytest
 
@@ -9,27 +12,29 @@ from ethereum_test_rpc import EthConfigResponse, EthRPC
 from .types import NetworkConfig
 
 
-@pytest.fixture(scope="session")
-def eth_config_response(eth_rpc: EthRPC) -> EthConfigResponse | None:
+@pytest.fixture(scope="function")
+def eth_config_response(eth_rpc: List[EthRPC]) -> EthConfigResponse | None:
     """Get the `eth_config` response from the client to be verified by all tests."""
-    return eth_rpc.config()
+    assert len(eth_rpc) > 0
+    return eth_rpc[0].config()  # just pick the first of possible URLs for this exec client
 
 
-@pytest.fixture(scope="session")
-def network(request: pytest.FixtureRequest) -> NetworkConfig:
+@pytest.fixture(scope="function")
+def network(request) -> NetworkConfig:
     """Get the network that will be used to verify all tests."""
-    return request.config.network  # type: ignore
+    return request.config.network
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def current_time() -> int:
     """Get the `eth_config` response from the client to be verified by all tests."""
     return int(time.time())
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def expected_eth_config(network: NetworkConfig, current_time: int) -> EthConfigResponse:
     """Calculate the current fork value to verify against the client's response."""
+    print(f"Network provided: {network}, Type: {type(network)}")
     return network.get_eth_config(current_time)
 
 
@@ -171,3 +176,64 @@ def test_eth_config_last_fork_id(
                 f"{received_fork_id} != "
                 f"{expected_last_fork_id}"
             )
+
+
+def test_eth_config_majority(
+    all_rpc_endpoints: Dict[str, List[EthRPC]],
+) -> None:
+    """Queries devnet exec clients for their eth_config and fails if not all have the same response."""  # noqa: E501
+    responses = dict()  # Dict[exec_client_name : response] # noqa: C408
+    client_to_url_used_dict = dict()  # noqa: C408
+    for exec_client in all_rpc_endpoints.keys():
+        # try only as many consensus+exec client combinations until you receive a response
+        # if all combinations for a given exec client fail we panic
+        for eth_rpc_target in all_rpc_endpoints[exec_client]:
+            response = eth_rpc_target.config(timeout=10)
+            if response is None:
+                # safely split url to not leak rpc_endpoint in logs
+                print(
+                    f"When trying to get eth_config from {eth_rpc_target} a problem occurred"  # problem itself is logged by .config() call # noqa: E501
+                )
+                continue
+
+            response_str = json.dumps(response.model_dump(mode="json"))
+            responses[exec_client] = response_str
+            client_to_url_used_dict[exec_client] = (
+                eth_rpc_target.url
+            )  # remember which cl+el combination was used  # noqa: E501
+            print(f"Response of {exec_client}: {response_str}\n\n")
+
+            break  # no need to gather more responses for this client
+
+    assert len(responses.keys()) == len(all_rpc_endpoints.keys()), (
+        "Failed to get an eth_config response "
+        f" from each specified execution client. Full list of execution clients is "
+        f"{all_rpc_endpoints.keys()} but we were only able to gather eth_config responses "
+        f"from: {responses.keys()}\n"
+        "Will try again with a different consensus-execution client combination for "
+        "this execution client"
+    )
+    # determine hashes of client responses
+    client_to_hash_dict = dict()  # Dict[exec_client : response hash] # noqa: C408
+    for client in responses.keys():
+        response_bytes = json.dumps(responses[client], sort_keys=True).encode("utf-8")
+        response_hash = sha256(response_bytes).digest().hex()
+        print(f"Response hash of client {client}: {response_hash}")
+        client_to_hash_dict[client] = response_hash
+
+    # if not all responses have the same hash there is a critical consensus issue
+    expected_hash = ""
+    for h in client_to_hash_dict.keys():
+        if expected_hash == "":
+            expected_hash = client_to_hash_dict[h]
+            continue
+
+        assert client_to_hash_dict[h] == expected_hash, (
+            "Critical consensus issue: Not all eth_config responses are the same! "
+            f"Here is an overview of client response hashes:\n{'\n\t'.join(f'{k}: {v}' for k, v in client_to_hash_dict.items())}\n\n"  # noqa: E501
+            f"Here is an overview of which URLs were contacted:\n\t{'\n\t'.join(f'{k}: @{v.split("@")[1]}' for k, v in client_to_url_used_dict.items())}\n\n"  # log which cl+el combinations were used without leaking full url # noqa: E501
+            f"Here is a dump of all client responses:\n{'\n\n'.join(f'{k}: {v}' for k, v in responses.items())}"  # noqa: E501
+        )
+    assert expected_hash != ""
+
+    print("All clients returned the same eth_config response. Test has been passed!")


### PR DESCRIPTION
## 🗒️ Description
You can run it via `uv run execute eth-config --network=Mainnet --rpc-endpoint=https://<replace>@rpc.nimbus-besu-1.fusaka-devnet-3.ethpandaops.io --clients="besu,erigon,nethermind,nimbusel,reth" --network-config-file=./src/pytest_plugins/execute/eth_config/networks.yml -vv -s`

## What happens
In the `test_eth_config_majority()` it requests and compares the `eth_config` responses of all provided `--clients`. Certain cl+el combinations might not be available so it picks the first working one for each exec client. The test is only passed if each execution client from the clients flag was successfully queried and all responses are identical. Otherwise an overview of which endpoints provided which response (which with hash) is given, so that client teams can be contacted about misconfiguration.

All other tests in `execute_eth_config` only contact the `--rpc-endpoint`, so here no additional combinations are derived and you only end up requesting info from one execution client.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
