### PR TITLE
feat(tests): add test for large args offset with size zero on CALL opcode

### DIFF
--- a/tests/frontier/opcodes/test_call.py
+++ b/tests/frontier/opcodes/test_call.py
@@ -151,14 +151,16 @@ def test_call_memory_expands_on_early_revert(
 
 # TODO: There's an issue with gas definitions on forks previous to Berlin, remove this when fixed.
 # https://github.com/ethereum/execution-spec-tests/pull/1952#discussion_r2237634275
+@pytest.mark.with_all_call_opcodes
 @pytest.mark.valid_from("Berlin")
 def test_call_large_args_offset_size_zero(
     state_test: StateTestFiller,
     pre: Alloc,
     fork: Fork,
+    call_opcode: Op,
 ):
     """
-    Test CALL with an extremely large args_offset and args_size set to zero.
+    Test xCALL with an extremely large args_offset and args_size set to zero.
     Since the size is zero, the large offset should not cause a revert.
     """
     sender = pre.fund_eoa()
@@ -167,11 +169,10 @@ def test_call_large_args_offset_size_zero(
     very_large_offset = 2**100
 
     call_measure = CodeGasMeasure(
-        code=Op.CALL(gas=0, args_offset=very_large_offset, args_size=0),
-        overhead_cost=gsc.G_VERY_LOW * len(Op.CALL.kwargs),  # Cost of pushing CALL args
-        extra_stack_items=1,  # Because CALL pushes 1 item to the stack
+        code=call_opcode(gas=0, args_offset=very_large_offset, args_size=0),
+        overhead_cost=gsc.G_VERY_LOW * len(call_opcode.kwargs),  # Cost of pushing xCALL args
+        extra_stack_items=1,  # Because xCALL pushes 1 item to the stack
         sstore_key=0,
-        stop=False,  # Because it's the first CodeGasMeasure
     )
 
     contract = pre.deploy_contract(call_measure)

--- a/tests/frontier/opcodes/test_call.py
+++ b/tests/frontier/opcodes/test_call.py
@@ -147,3 +147,54 @@ def test_call_memory_expands_on_early_revert(
             )
         },
     )
+
+
+# TODO: There's an issue with gas definitions on forks previous to Berlin, remove this when fixed.
+# https://github.com/ethereum/execution-spec-tests/pull/1952#discussion_r2237634275
+@pytest.mark.valid_from("Berlin")
+def test_call_large_args_offset_size_zero(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+):
+    """
+    Test CALL with an extremely large args_offset and args_size set to zero.
+    Since the size is zero, the large offset should not cause a revert.
+    """
+    sender = pre.fund_eoa()
+
+    gsc = fork.gas_costs()
+    very_large_offset = 2**100
+
+    call_measure = CodeGasMeasure(
+        code=Op.CALL(gas=0, args_offset=very_large_offset, args_size=0),
+        overhead_cost=gsc.G_VERY_LOW * len(Op.CALL.kwargs),  # Cost of pushing CALL args
+        extra_stack_items=1,  # Because CALL pushes 1 item to the stack
+        sstore_key=0,
+        stop=False,  # Because it's the first CodeGasMeasure
+    )
+
+    contract = pre.deploy_contract(call_measure)
+
+    tx = Transaction(
+        gas_limit=500_000,
+        to=contract,
+        value=0,
+        sender=sender,
+    )
+
+    # this call cost is just the address_access_cost
+    call_cost = gsc.G_COLD_ACCOUNT_ACCESS
+
+    state_test(
+        env=Environment(),
+        pre=pre,
+        tx=tx,
+        post={
+            contract: Account(
+                storage={
+                    0: call_cost,
+                },
+            )
+        },
+    )


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Hi! I believe a test like this exists for other opcodes but not for CALL, it is one of those that have a very large offset but size zero and therefore execution shouldn't revert because of the offset. In ethrex we had a bug that was fixed in [this PR](https://github.com/lambdaclass/ethrex/pull/3950). I created this test and tried it out before and after the fix and it detects the bug.
I am making these tests just for the CALL opcode but they apply to all xCALL opcodes, I don't know what the nicest way of making this more generic is. But generally this would be enough because these opcodes tend to have pretty similar logic inside of them.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

