### PR TITLE
chore(tests): add modexp length mismatch functionality

### DIFF
--- a/tests/byzantium/eip198_modexp_precompile/helpers.py
+++ b/tests/byzantium/eip198_modexp_precompile/helpers.py
@@ -25,20 +25,62 @@ class ModExpInput(TestParameterGroup):
     extra_data: Bytes = Field(default_factory=Bytes)
     raw_input: Bytes | None = None
 
+    override_base_length: int | None = None
+    override_exponent_length: int | None = None
+    override_modulus_length: int | None = None
+
     @property
     def length_base(self) -> Bytes:
         """Return the length of the base."""
-        return Bytes(len(self.base).to_bytes(32, "big"))
+        length = (
+            self.override_base_length if self.override_base_length is not None else len(self.base)
+        )
+        return Bytes(length.to_bytes(32, "big"))
 
     @property
     def length_exponent(self) -> Bytes:
         """Return the length of the exponent."""
-        return Bytes(len(self.exponent).to_bytes(32, "big"))
+        length = (
+            self.override_exponent_length
+            if self.override_exponent_length is not None
+            else len(self.exponent)
+        )
+        return Bytes(length.to_bytes(32, "big"))
 
     @property
     def length_modulus(self) -> Bytes:
         """Return the length of the modulus."""
-        return Bytes(len(self.modulus).to_bytes(32, "big"))
+        length = (
+            self.override_modulus_length
+            if self.override_modulus_length is not None
+            else len(self.modulus)
+        )
+        return Bytes(length.to_bytes(32, "big"))
+
+    @property
+    def declared_base_length(self) -> int:
+        """Return the declared base length as int."""
+        return (
+            self.override_base_length if self.override_base_length is not None else len(self.base)
+        )
+
+    @property
+    def declared_exponent_length(self) -> int:
+        """Return the declared exponent length as int."""
+        return (
+            self.override_exponent_length
+            if self.override_exponent_length is not None
+            else len(self.exponent)
+        )
+
+    @property
+    def declared_modulus_length(self) -> int:
+        """Return the declared modulus length as int."""
+        return (
+            self.override_modulus_length
+            if self.override_modulus_length is not None
+            else len(self.modulus)
+        )
 
     def __bytes__(self):
         """Generate input for the MODEXP precompile."""
@@ -85,6 +127,26 @@ class ModExpInput(TestParameterGroup):
         modulus = padded_input_data[current_index : current_index + modulus_length]
 
         return cls(base=base, exponent=exponent, modulus=modulus, raw_input=input_data)
+
+    @classmethod
+    def create_mismatch(
+        cls,
+        base="",
+        exponent="",
+        modulus="",
+        declared_base_length=None,
+        declared_exponent_length=None,
+        declared_modulus_length=None,
+    ):
+        """Create a ModExpInput with mismatched lengths."""
+        return cls(
+            base=Bytes(base),
+            exponent=Bytes(exponent),
+            modulus=Bytes(modulus),
+            override_base_length=declared_base_length,
+            override_exponent_length=declared_exponent_length,
+            override_modulus_length=declared_modulus_length,
+        )
 
 
 class ModExpOutput(TestParameterGroup):


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Aims to update the modexp helpers to allow for length mismatch tests.

Requires an update to https://github.com/ethereum/execution-spec-tests/blob/main/tests/osaka/eip7883_modexp_gas_increase/conftest.py#L60-L78 once #1929 is merged.

Length mismatch tests can be added with the following, copied over and refactored from #2044.
```
pytest.param(
    ModExpInput.create_mismatch(
        exponent="80",
        declared_exponent_length=2**64,
    ),
    id="exp_2_pow_64_base_0_mod_0",
),
```

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Fixes #2043 (attemps to).

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
