### PR TITLE
src(logging plugin): allow logging in `execute`, `execute-eth-config` and `fill`

### DIFF
--- a/src/cli/pytest_commands/pytest_ini_files/pytest-execute-eth-config.ini
+++ b/src/cli/pytest_commands/pytest_ini_files/pytest-execute-eth-config.ini
@@ -8,6 +8,7 @@ markers =
 addopts = 
     -p pytest_plugins.execute.eth_config.eth_config
     -p pytest_plugins.help.help
+    -p pytest_plugins.logging.logging
     -m "not eip_version_check"
     --tb short
     --dist loadscope

--- a/src/cli/pytest_commands/pytest_ini_files/pytest-execute.ini
+++ b/src/cli/pytest_commands/pytest_ini_files/pytest-execute.ini
@@ -20,6 +20,7 @@ addopts =
     -p pytest_plugins.execute.rpc.remote
     -p pytest_plugins.forks.forks
     -p pytest_plugins.help.help
+    -p pytest_plugins.logging.logging
     --tb short
     --dist loadscope
     --ignore tests/cancun/eip4844_blobs/point_evaluation_vectors/

--- a/src/cli/pytest_commands/pytest_ini_files/pytest-fill.ini
+++ b/src/cli/pytest_commands/pytest_ini_files/pytest-fill.ini
@@ -20,6 +20,7 @@ addopts =
     -p pytest_plugins.forks.forks
     -p pytest_plugins.eels_resolver
     -p pytest_plugins.help.help
+    -p pytest_plugins.logging.logging
     --tb short
     --ignore tests/cancun/eip4844_blobs/point_evaluation_vectors/
 # these customizations require the pytest-custom-report plugin


### PR DESCRIPTION
## 🗒️ Description
It frequently interrupts my workflow that I manually have to add this. Please quick merge

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
