### PR TITLE
chore(ci): fix fill prepatched coverage script fork compatibility

### DIFF
--- a/.github/scripts/fill_prepatched_tests.sh
+++ b/.github/scripts/fill_prepatched_tests.sh
@@ -25,16 +25,15 @@ echo "Select files that were changed and exist on the main branch:"
 echo "$MODIFIED_DELETED_FILES"
 
 rm -rf fixtures
-rm -f filloutput.log
 
-uv run fill $MODIFIED_DELETED_FILES --clean --until=$FILL_UNTIL --evm-bin evmone-t8n --block-gas-limit $BLOCK_GAS_LIMIT -m "state_test or blockchain_test" --output $BASE_TEST_PATH > >(tee -a filloutput.log) 2> >(tee -a filloutput.log >&2)
-
-if grep -q "FAILURES" filloutput.log; then
-    echo "Error: failed to generate .py tests from before the PR."
-    exit 1
-fi
-
-if grep -q "ERROR collecting test session" filloutput.log; then
+set +e
+uv run fill $MODIFIED_DELETED_FILES --clean --until=$FILL_UNTIL --evm-bin evmone-t8n --block-gas-limit $BLOCK_GAS_LIMIT -m "state_test or blockchain_test" --output $BASE_TEST_PATH
+FILL_RETURN_CODE=$?
+set -e
+if [ $FILL_RETURN_CODE -eq 5 ]; then
+    echo "any_modified_fixtures=false" >> "$GITHUB_OUTPUT"
+    exit 0
+elif [ $FILL_RETURN_CODE -ne 0 ]; then
     echo "Error: failed to generate .py tests from before the PR."
     exit 1
 fi


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

### Problem

The coverage workflow's `fill_prepatched_tests.sh` script fails when tests cannot run due to fork compatibility issues. This occurs when:
- Tests require future forks (Prague/Osaka) but the script is limited to `--until=Cancun`
- All collected tests get filtered out at execution time, resulting in "no tests ran"
- Script continues execution despite no fixtures being generated

This occurs in #1929 due to the small change in `tests/prague/eip7702_set_code_tx/test_set_code_txs.py` and via the removal of `"!tests/prague/**"` in `coverage.yaml` from #1970.


## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
#1929 

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

