### PR TITLE
chore(tests): Disable full `HISTORY_SERVE_WINDOW` EIP-2935 Test

### DIFF
--- a/tests/prague/eip2935_historical_block_hashes_from_state/test_block_hashes.py
+++ b/tests/prague/eip2935_historical_block_hashes_from_state/test_block_hashes.py
@@ -214,7 +214,7 @@ def test_block_hashes_history_at_transition(
         pytest.param(
             Spec.HISTORY_SERVE_WINDOW + 1,
             False,
-            marks=pytest.mark.slow,
+            marks=[pytest.mark.skip("Slow test not relevant anymore"), pytest.mark.slow],
             id="full_history_plus_one_check_blockhash_first",
         ),
     ],


### PR DESCRIPTION


## 🗒️ Description

Disables the longest running test in our test set that contains 8000+ blocks and takes around 30 minutes to fill.

Reasoning with the disabling of this test:
- We are basically testing a smart contract in these tests, if there's a failure in these contracts:
  - We are never going to catch it with these tests because our tests are not changing
  - It's not going to be a consensus failure because if the contract behaves in an unexpected way, all clients will still process the same EVM code
- Contract has been running in mainnet for sufficient time.

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
