### PR TITLE
feat(execute): Support for contract address stubs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -105,6 +105,7 @@ Users can select any of the artifacts depending on their testing needs for their
 - ✨ Added new `Blob` class which can use the ckzg library to generate valid blobs at runtime ([#1614](https://github.com/ethereum/execution-spec-tests/pull/1614)).
 - ✨ Added `blob_transaction_test` execute test spec, which allows tests that send blob transactions to a running client and verifying its `engine_getBlobsVX` endpoint behavior ([#1644](https://github.com/ethereum/execution-spec-tests/pull/1644)).
 - ✨ Added `execute eth-config` command to test the `eth_config` RPC endpoint of a client, and includes configurations by default for Mainnet, Sepolia, Holesky, and Hoodi ([#1863](https://github.com/ethereum/execution-spec-tests/pull/1863)).
+- ✨ Added `--address-stubs` flag to the `execute` command which allows to specify a JSON-formatted string, JSON file or YAML file which contains label-to-address of specific pre-deployed contracts already existing in the network where the tests are executed ([#2073](https://github.com/ethereum/execution-spec-tests/pull/2073)).
 
 ### 📋 Misc
 

--- a/docs/running_tests/execute/remote.md
+++ b/docs/running_tests/execute/remote.md
@@ -48,16 +48,19 @@ Address stubs allow you to map contract labels used in tests to actual addresses
 You can provide address stubs in several formats:
 
 **JSON string:**
+
 ```bash
 uv run execute remote --fork=Prague --rpc-endpoint=https://rpc.endpoint.io --rpc-seed-key 0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f --rpc-chain-id 12345 --address-stubs '{"DEPOSIT_CONTRACT": "0x00000000219ab540356cbb839cbe05303d7705fa", "UNISWAP_V3_FACTORY": "0x1F98431c8aD98523631AE4a59f267346ea31F984"}'
 ```
 
 **JSON file:**
+
 ```bash
 uv run execute remote --fork=Prague --rpc-endpoint=https://rpc.endpoint.io --rpc-seed-key 0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f --rpc-chain-id 12345 --address-stubs ./contracts.json
 ```
 
 **YAML file:**
+
 ```bash
 uv run execute remote --fork=Prague --rpc-endpoint=https://rpc.endpoint.io --rpc-seed-key 0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f --rpc-chain-id 12345 --address-stubs ./contracts.yaml
 ```
@@ -65,6 +68,7 @@ uv run execute remote --fork=Prague --rpc-endpoint=https://rpc.endpoint.io --rpc
 ### Address Stubs File Format
 
 **JSON format (contracts.json):**
+
 ```json
 {
   "DEPOSIT_CONTRACT": "0x00000000219ab540356cbb839cbe05303d7705fa",
@@ -74,6 +78,7 @@ uv run execute remote --fork=Prague --rpc-endpoint=https://rpc.endpoint.io --rpc
 ```
 
 **YAML format (contracts.yaml):**
+
 ```yaml
 DEPOSIT_CONTRACT: 0x00000000219ab540356cbb839cbe05303d7705fa
 UNISWAP_V3_FACTORY: 0x1F98431c8aD98523631AE4a59f267346ea31F984
@@ -99,6 +104,7 @@ Address stubs are especially valuable when testing on **bloat-net**, a specializ
 - Redeploying these contracts would lose the valuable historical state and storage bloat
 
 Using address stubs on bloat-net allows you to:
+
 - Test against contracts with realistic storage bloat patterns
 - Preserve the complex state that has been built up over time
 - Avoid the computational and storage costs of recreating this state

--- a/docs/running_tests/execute/remote.md
+++ b/docs/running_tests/execute/remote.md
@@ -32,6 +32,78 @@ It is recommended to only run a subset of the tests when executing on a live net
 uv run execute remote --fork=Prague --rpc-endpoint=https://rpc.endpoint.io --rpc-seed-key 0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f --rpc-chain-id 12345 ./tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_sstore
 ```
 
+## Address Stubs for Pre-deployed Contracts
+
+When running tests on networks that already have specific contracts deployed (such as mainnet or testnets with pre-deployed contracts), you can use the `--address-stubs` flag to specify these contracts instead of deploying new ones.
+
+Address stubs allow you to map contract labels used in tests to actual addresses where those contracts are already deployed on the network. This is particularly useful for:
+
+- Testing against mainnet with existing contracts (e.g., Uniswap, Compound)
+- Using pre-deployed contracts on testnets
+- Testing on bloat-net, a network containing pre-existing contracts with extensive storage history
+- Avoiding redeployment of large contracts to save gas and time
+
+### Using Address Stubs
+
+You can provide address stubs in several formats:
+
+**JSON string:**
+```bash
+uv run execute remote --fork=Prague --rpc-endpoint=https://rpc.endpoint.io --rpc-seed-key 0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f --rpc-chain-id 12345 --address-stubs '{"DEPOSIT_CONTRACT": "0x00000000219ab540356cbb839cbe05303d7705fa", "UNISWAP_V3_FACTORY": "0x1F98431c8aD98523631AE4a59f267346ea31F984"}'
+```
+
+**JSON file:**
+```bash
+uv run execute remote --fork=Prague --rpc-endpoint=https://rpc.endpoint.io --rpc-seed-key 0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f --rpc-chain-id 12345 --address-stubs ./contracts.json
+```
+
+**YAML file:**
+```bash
+uv run execute remote --fork=Prague --rpc-endpoint=https://rpc.endpoint.io --rpc-seed-key 0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f --rpc-chain-id 12345 --address-stubs ./contracts.yaml
+```
+
+### Address Stubs File Format
+
+**JSON format (contracts.json):**
+```json
+{
+  "DEPOSIT_CONTRACT": "0x00000000219ab540356cbb839cbe05303d7705fa",
+  "UNISWAP_V3_FACTORY": "0x1F98431c8aD98523631AE4a59f267346ea31F984",
+  "COMPOUND_COMPTROLLER": "0x3d9819210A31b4961b30EF54bE2aeD79B9c9Cd3B"
+}
+```
+
+**YAML format (contracts.yaml):**
+```yaml
+DEPOSIT_CONTRACT: 0x00000000219ab540356cbb839cbe05303d7705fa
+UNISWAP_V3_FACTORY: 0x1F98431c8aD98523631AE4a59f267346ea31F984
+COMPOUND_COMPTROLLER: 0x3d9819210A31b4961b30EF54bE2aeD79B9c9Cd3B
+```
+
+### How Address Stubs Work
+
+When a test uses a contract label that matches a key in the address stubs, the test framework will:
+
+1. Use the pre-deployed contract at the specified address instead of deploying a new contract
+2. Skip the contract deployment transaction, saving gas and time
+3. Use the existing contract's code and state for the test
+
+This is particularly useful when testing interactions with well-known contracts that are expensive to deploy or when you want to test against the actual deployed versions of contracts.
+
+### Bloat-net Testing
+
+Address stubs are especially valuable when testing on **bloat-net**, a specialized network that contains pre-existing contracts with extensive storage history. On bloat-net:
+
+- Contracts have been deployed and used extensively, accumulating large amounts of storage data
+- The storage state represents real-world usage patterns with complex data structures
+- Redeploying these contracts would lose the valuable historical state and storage bloat
+
+Using address stubs on bloat-net allows you to:
+- Test against contracts with realistic storage bloat patterns
+- Preserve the complex state that has been built up over time
+- Avoid the computational and storage costs of recreating this state
+- Test edge cases that only emerge with large, real-world storage datasets
+
 ## Transaction Metadata on Remote Networks
 
 When executing tests on remote networks, all transactions include metadata that helps with debugging and monitoring. This metadata is embedded in the RPC request ID and includes:

--- a/src/pytest_plugins/execute/tests/__init__.py
+++ b/src/pytest_plugins/execute/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the execute pytest plugin."""

--- a/src/pytest_plugins/execute/tests/test_pre_alloc.py
+++ b/src/pytest_plugins/execute/tests/test_pre_alloc.py
@@ -13,15 +13,20 @@ from ..pre_alloc import AddressStubs
     "input_value,expected",
     [
         pytest.param(
-            {},
+            "{}",
             AddressStubs({}),
-            id="empty_address_stubs",
+            id="empty_address_stubs_string",
+        ),
+        pytest.param(
+            '{"some_address": "0x0000000000000000000000000000000000000001"}',
+            AddressStubs({"some_address": Address("0x0000000000000000000000000000000000000001")}),
+            id="address_stubs_string_with_some_address",
         ),
     ],
 )
 def test_address_stubs(input_value: Any, expected: AddressStubs):
     """Test the address stubs."""
-    assert AddressStubs.model_validate(input_value) == expected
+    assert AddressStubs.model_validate_json_or_file(input_value) == expected
 
 
 @pytest.mark.parametrize(
@@ -75,4 +80,4 @@ def test_address_stubs_from_files(
     filename = pytester.path.joinpath(file_name)
     filename.write_text(file_contents)
 
-    assert AddressStubs.model_validate(str(filename)) == expected
+    assert AddressStubs.model_validate_json_or_file(str(filename)) == expected

--- a/src/pytest_plugins/execute/tests/test_pre_alloc.py
+++ b/src/pytest_plugins/execute/tests/test_pre_alloc.py
@@ -1,0 +1,78 @@
+"""Test the pre-allocation models used during test execution."""
+
+from typing import Any
+
+import pytest
+
+from ethereum_test_base_types import Address
+
+from ..pre_alloc import AddressStubs
+
+
+@pytest.mark.parametrize(
+    "input_value,expected",
+    [
+        pytest.param(
+            {},
+            AddressStubs({}),
+            id="empty_address_stubs",
+        ),
+    ],
+)
+def test_address_stubs(input_value: Any, expected: AddressStubs):
+    """Test the address stubs."""
+    assert AddressStubs.model_validate(input_value) == expected
+
+
+@pytest.mark.parametrize(
+    "file_name,file_contents,expected",
+    [
+        pytest.param(
+            "empty.json",
+            "{}",
+            AddressStubs({}),
+            id="empty_address_stubs_json",
+        ),
+        pytest.param(
+            "empty.yaml",
+            "",
+            AddressStubs({}),
+            id="empty_address_stubs_yaml",
+        ),
+        pytest.param(
+            "one_address.json",
+            '{"DEPOSIT_CONTRACT_ADDRESS": "0x00000000219ab540356cbb839cbe05303d7705fa"}',
+            AddressStubs(
+                {
+                    "DEPOSIT_CONTRACT_ADDRESS": Address(
+                        "0x00000000219ab540356cbb839cbe05303d7705fa"
+                    ),
+                }
+            ),
+            id="single_address_json",
+        ),
+        pytest.param(
+            "one_address.yaml",
+            "DEPOSIT_CONTRACT_ADDRESS: 0x00000000219ab540356cbb839cbe05303d7705fa",
+            AddressStubs(
+                {
+                    "DEPOSIT_CONTRACT_ADDRESS": Address(
+                        "0x00000000219ab540356cbb839cbe05303d7705fa"
+                    ),
+                }
+            ),
+            id="single_address_yaml",
+        ),
+    ],
+)
+def test_address_stubs_from_files(
+    pytester: pytest.Pytester,
+    file_name: str,
+    file_contents: str,
+    expected: AddressStubs,
+):
+    """Test the address stubs."""
+    filename = pytester.path.joinpath(file_name)
+    filename.write_text(file_contents)
+
+    assert AddressStubs.model_validate(str(filename)) == expected


### PR DESCRIPTION
## 🗒️ Description
## Address Stubs for Pre-deployed Contracts

When running tests on networks that already have specific contracts deployed (such as mainnet or testnets with pre-deployed contracts), you can use the `--address-stubs` flag to specify these contracts instead of deploying new ones.

Address stubs allow you to map contract labels used in tests to actual addresses where those contracts are already deployed on the network. This is particularly useful for:

- Testing against mainnet with existing contracts (e.g., Uniswap, Compound)
- Using pre-deployed contracts on testnets
- Testing on bloat-net, a network containing pre-existing contracts with extensive storage history
- Avoiding redeployment of large contracts to save gas and time

### Using Address Stubs

You can provide address stubs in several formats:

**JSON string:**
```bash
uv run execute remote --fork=Prague --rpc-endpoint=https://rpc.endpoint.io --rpc-seed-key 0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f --rpc-chain-id 12345 --address-stubs '{"DEPOSIT_CONTRACT": "0x00000000219ab540356cbb839cbe05303d7705fa", "UNISWAP_V3_FACTORY": "0x1F98431c8aD98523631AE4a59f267346ea31F984"}'
```

**JSON file:**
```bash
uv run execute remote --fork=Prague --rpc-endpoint=https://rpc.endpoint.io --rpc-seed-key 0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f --rpc-chain-id 12345 --address-stubs ./contracts.json
```

**YAML file:**
```bash
uv run execute remote --fork=Prague --rpc-endpoint=https://rpc.endpoint.io --rpc-seed-key 0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f --rpc-chain-id 12345 --address-stubs ./contracts.yaml
```

### Address Stubs File Format

**JSON format (contracts.json):**
```json
{
  "DEPOSIT_CONTRACT": "0x00000000219ab540356cbb839cbe05303d7705fa",
  "UNISWAP_V3_FACTORY": "0x1F98431c8aD98523631AE4a59f267346ea31F984",
  "COMPOUND_COMPTROLLER": "0x3d9819210A31b4961b30EF54bE2aeD79B9c9Cd3B"
}
```

**YAML format (contracts.yaml):**
```yaml
DEPOSIT_CONTRACT: 0x00000000219ab540356cbb839cbe05303d7705fa
UNISWAP_V3_FACTORY: 0x1F98431c8aD98523631AE4a59f267346ea31F984
COMPOUND_COMPTROLLER: 0x3d9819210A31b4961b30EF54bE2aeD79B9c9Cd3B
```

### How Address Stubs Work

When a test uses a contract label that matches a key in the address stubs, the test framework will:

1. Use the pre-deployed contract at the specified address instead of deploying a new contract
2. Skip the contract deployment transaction, saving gas and time
3. Use the existing contract's code and state for the test

This is particularly useful when testing interactions with well-known contracts that are expensive to deploy or when you want to test against the actual deployed versions of contracts.

### Bloat-net Testing

Address stubs are especially valuable when testing on **bloat-net**, a specialized network that contains pre-existing contracts with extensive storage history. On bloat-net:

- Contracts have been deployed and used extensively, accumulating large amounts of storage data
- The storage state represents real-world usage patterns with complex data structures
- Redeploying these contracts would lose the valuable historical state and storage bloat

Using address stubs on bloat-net allows you to:
- Test against contracts with realistic storage bloat patterns
- Preserve the complex state that has been built up over time
- Avoid the computational and storage costs of recreating this state
- Test edge cases that only emerge with large, real-world storage datasets

## 🔗 Related Issues or PRs
Implements #1976

## ✅ Checklist
- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).