### PR TITLE
fix(tests,forks): Implement Base-Fee-Per-Gas calculation methods in `Fork`, fix BPO4 tests

### DIFF
--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -5,7 +5,7 @@ stable:
 
 develop:
   evm-type: develop 
-  fill-params: --until=BPO3 --fill-static-tests --ignore=tests/static/state_tests/stQuadraticComplexityTest
+  fill-params: --until=BPO4 --fill-static-tests --ignore=tests/static/state_tests/stQuadraticComplexityTest
 
 benchmark:
   evm-type: benchmark # Evmone only fully supports up to Prague

--- a/src/ethereum_test_forks/base_fork.py
+++ b/src/ethereum_test_forks/base_fork.py
@@ -57,6 +57,30 @@ class TransactionDataFloorCostCalculator(Protocol):
         pass
 
 
+class BaseFeePerGasCalculator(Protocol):
+    """A protocol to calculate the base fee per gas at a given fork."""
+
+    def __call__(
+        self, *, parent_base_fee_per_gas: int, parent_gas_used: int, parent_gas_limit: int
+    ) -> int:
+        """Return the base fee per gas at a given fork."""
+        pass
+
+
+class BaseFeeChangeCalculator(Protocol):
+    """A protocol to calculate the gas that needs to be used to change the base fee."""
+
+    def __call__(
+        self,
+        *,
+        parent_base_fee_per_gas: int,
+        parent_gas_limit: int,
+        required_base_fee_per_gas: int,
+    ) -> int:
+        """Return the gas that needs to be used to change the base fee."""
+        pass
+
+
 class TransactionIntrinsicCostCalculator(Protocol):
     """A protocol to calculate the intrinsic gas cost of a transaction at a given fork."""
 
@@ -270,6 +294,37 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
         Return callable that calculates the transaction gas cost for its calldata
         depending on its contents.
         """
+        pass
+
+    @classmethod
+    @abstractmethod
+    def base_fee_per_gas_calculator(
+        cls, block_number: int = 0, timestamp: int = 0
+    ) -> BaseFeePerGasCalculator:
+        """Return a callable that calculates the base fee per gas at a given fork."""
+        pass
+
+    @classmethod
+    @abstractmethod
+    def base_fee_change_calculator(
+        cls, block_number: int = 0, timestamp: int = 0
+    ) -> BaseFeeChangeCalculator:
+        """
+        Return a callable that calculates the gas that needs to be used to change the
+        base fee.
+        """
+        pass
+
+    @classmethod
+    @abstractmethod
+    def base_fee_max_change_denominator(cls, block_number: int = 0, timestamp: int = 0) -> int:
+        """Return the base fee max change denominator at a given fork."""
+        pass
+
+    @classmethod
+    @abstractmethod
+    def base_fee_elasticity_multiplier(cls, block_number: int = 0, timestamp: int = 0) -> int:
+        """Return the base fee elasticity multiplier at a given fork."""
         pass
 
     @classmethod

--- a/tests/osaka/eip7918_blob_reserve_price/test_blob_reserve_price_with_bpo_transitions.py
+++ b/tests/osaka/eip7918_blob_reserve_price/test_blob_reserve_price_with_bpo_transitions.py
@@ -1,7 +1,7 @@
 """Tests EIP-7918 on BPO fork transitions."""
 
 from dataclasses import dataclass
-from typing import Iterator, List, Self
+from typing import Iterator, List
 
 import pytest
 
@@ -349,90 +349,52 @@ class ParentHeader:
 class BlobSchedule:
     """Blob schedule for a fork."""
 
-    max: int
-    target: int
-    base_fee_update_fraction: int
-    blob_gas_per_blob: int
-    blob_base_cost: int | None
+    fork: Fork
+    timestamp: int
 
-    @classmethod
-    def from_fork(cls, fork: Fork, timestamp: int) -> Self:
-        """Return an instance of the blob schedule given the fork."""
-        blob_base_cost = None
-        if fork.blob_reserve_price_active(timestamp=timestamp):
-            blob_base_cost = fork.blob_base_cost(timestamp=timestamp)
-        return cls(
-            max=fork.max_blobs_per_block(timestamp=timestamp),
-            target=fork.target_blobs_per_block(timestamp=timestamp),
-            base_fee_update_fraction=fork.blob_base_fee_update_fraction(timestamp=timestamp),
-            blob_gas_per_blob=fork.blob_gas_per_blob(timestamp=timestamp),
-            blob_base_cost=blob_base_cost,
-        )
+    @property
+    def max(self) -> int:
+        """Return the max blobs per block."""
+        return self.fork.max_blobs_per_block(timestamp=self.timestamp)
+
+    @property
+    def target(self) -> int:
+        """Return the target blobs per block."""
+        return self.fork.target_blobs_per_block(timestamp=self.timestamp)
+
+    @property
+    def base_fee_update_fraction(self) -> int:
+        """Return the base fee update fraction."""
+        return self.fork.blob_base_fee_update_fraction(timestamp=self.timestamp)
+
+    @property
+    def blob_gas_per_blob(self) -> int:
+        """Return the blob gas per blob."""
+        return self.fork.blob_gas_per_blob(timestamp=self.timestamp)
+
+    @property
+    def blob_base_cost(self) -> int | None:
+        """Return the blob base cost."""
+        if self.fork.blob_reserve_price_active(timestamp=self.timestamp):
+            return self.fork.blob_base_cost(timestamp=self.timestamp)
+        return None
 
     @property
     def target_blob_gas_per_block(self) -> int:
         """Return the target blob gas per block."""
         return self.target * self.blob_gas_per_blob
 
-    @staticmethod
-    def taylor_exponential(factor: int, numerator: int, denominator: int) -> int:
-        """
-        Approximates factor * e ** (numerator / denominator) using Taylor expansion.
-
-        This function is used to compute the blob gas price.
-        """
-        i = 1
-        output = 0
-        numerator_accum = factor * denominator
-        while numerator_accum > 0:
-            output += numerator_accum
-            numerator_accum = (numerator_accum * numerator) // (denominator * i)
-            i += 1
-        return output // denominator
-
-    def calculate_blob_gas_price(self, excess_blob_gas: int) -> int:
-        """
-        Calculate the blob gasprice for a block.
-
-        Parameters
-        ----------
-        excess_blob_gas :
-            The excess blob gas for the block.
-
-        Returns
-        -------
-        blob_gasprice: `Uint`
-            The blob gasprice.
-
-        """
-        return BlobSchedule.taylor_exponential(
-            MIN_BLOB_GASPRICE,
-            excess_blob_gas,
-            self.base_fee_update_fraction,
-        )
-
     def calculate_excess_blob_gas(self, parent_header: ParentHeader) -> int:
         """
         Calculate the excess blob gas for the current block based
         on the gas used in the parent block.
         """
-        parent_blob_gas = parent_header.excess_blob_gas + parent_header.blob_gas_used
-        if parent_blob_gas < self.target_blob_gas_per_block:
-            return 0
-
-        target_blob_gas_price = self.blob_gas_per_blob
-        target_blob_gas_price *= self.calculate_blob_gas_price(parent_header.excess_blob_gas)
-
-        if self.blob_base_cost is not None:
-            base_blob_tx_price = self.blob_base_cost * parent_header.base_fee_per_gas
-            if base_blob_tx_price > target_blob_gas_price:
-                blob_schedule_delta = self.max - self.target
-                return (
-                    parent_header.excess_blob_gas
-                    + parent_header.blob_gas_used * blob_schedule_delta // self.max
-                )
-
-        return parent_blob_gas - self.target_blob_gas_per_block
+        excess_blob_gas_calculator = self.fork.excess_blob_gas_calculator(timestamp=self.timestamp)
+        return excess_blob_gas_calculator(
+            parent_excess_blob_gas=parent_header.excess_blob_gas,
+            parent_blob_count=parent_header.blob_gas_used,
+            parent_base_fee_per_gas=parent_header.base_fee_per_gas,
+        )
 
     def execution_base_fee_threshold_from_excess_blob_gas(
         self, excess_blob_gas: int
@@ -444,7 +406,8 @@ class BlobSchedule:
         if self.blob_base_cost is None:
             return None
         target_blob_gas_price = self.blob_gas_per_blob
-        target_blob_gas_price *= self.calculate_blob_gas_price(excess_blob_gas)
+        blob_gas_price_calculator = self.fork.blob_gas_price_calculator(timestamp=self.timestamp)
+        target_blob_gas_price *= blob_gas_price_calculator(excess_blob_gas=excess_blob_gas)
         base_blob_tx_price = target_blob_gas_price
         return (base_blob_tx_price // self.blob_base_cost) + 1
 
@@ -454,8 +417,8 @@ def get_fork_scenarios(fork: Fork) -> Iterator[ParameterSet]:
     Return the list of scenarios at the fork boundary depending on the source fork and
     transition fork properties.
     """
-    source_blob_schedule = BlobSchedule.from_fork(fork=fork, timestamp=0)
-    transition_blob_schedule = BlobSchedule.from_fork(fork=fork, timestamp=15_000)
+    source_blob_schedule = BlobSchedule(fork=fork, timestamp=0)
+    transition_blob_schedule = BlobSchedule(fork=fork, timestamp=15_000)
 
     excess_blobs_combinations = [0, 1, 10, 100]
 


### PR DESCRIPTION
## 🗒️ Description

### New Fork Methods

#### `base_fee_per_gas_calculator`

Implements a simple calculator for the base fee of the next block given the parent values.

#### `base_fee_change_calculator`

Implements a calculator to get the gas-used of a parent block so that the next block has a specific base fee, given the parent values.

### Fix BPO4 Tests

Fixes BPO4 tests in `tests/osaka/eip7918_blob_reserve_price/test_blob_reserve_price_with_bpo_transitions.py`.

Culprit is that, given the base fee and excess blob gas of the genesis, the block 1 excess blob gas value was exceeding the expected value for the test given the that the reserve mechanism was being activated.

Since there's no easy way to calculate the excess blob gas of the genesis given a static base fee, if the fixture detects that the reserve fee is being activated give the current test values, the fixture starts a binary search until it encounter a genesis excess blob gas so that all test's parameters are satisfied.

## 🔗 Related Issues or PR
N/A.

## ✅ Checklis
- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).