### PR TITLE
chore(consume): fix consume cache for python 3.11

### DIFF
--- a/src/pytest_plugins/consume/consume.py
+++ b/src/pytest_plugins/consume/consume.py
@@ -88,7 +88,7 @@ class FixtureDownloader:
         response.raise_for_status()
 
         with tarfile.open(fileobj=BytesIO(response.content), mode="r:gz") as tar:
-            tar.extractall(path=self.destination_folder, filter="data")
+            tar.extractall(path=self.destination_folder)
 
         return self.detect_extracted_directory()
 


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Quick fix spotted only on the new server when trying to reproduce an error.

```
INTERNALERROR>   File "/home/spencer-tb/execution-spec-tests/src/pytest_plugins/consume/consume.py", line 91, in fetch_and_extract
INTERNALERROR>     tar.extractall(path=self.destination_folder, filter="data")
INTERNALERROR> TypeError: TarFile.extractall() got an unexpected keyword argument 'filter'
```

`filter` is only added in Python ~~3.12~~, 3.11.4 (cc comment from @felix314159), so I removed it in this PR.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
