### PR TITLE
chore(docs): remove erroneous section for exception mapper usage

### DIFF
--- a/docs/running_tests/consume/exceptions.md
+++ b/docs/running_tests/consume/exceptions.md
@@ -85,11 +85,7 @@ For development or when exception mappings are incomplete:
 
 ```bash
 # Disable for specific clients
-uv run consume engine --disable-strict-exception-matching=nimbus,besu
-
-# Via Hive
-./hive --sim ethereum/eest/consume-engine \
-  --sim.disable-strict-exception-matching=nimbus
+uv run consume engine --disable-strict-exception-matching=nimbus-el
 ```
 
 !!! warning "Production Testing"


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Remove hive command in docs for the disable exception mapper usage as it is incorrect. 

Please see the hive PR I am using instead for this: https://github.com/ethereum/hive/pull/1332

Note the exception mapper should really be mandatory, but we will re-enable once its sorted on the Nimbus-EL side.
 
## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

