### PR TITLE
chore(forks): revert fork fixture change

### DIFF
--- a/src/pytest_plugins/forks/forks.py
+++ b/src/pytest_plugins/forks/forks.py
@@ -556,9 +556,9 @@ def pytest_report_header(config, start_path):
 
 
 @pytest.fixture(autouse=True)
-def fork(request: pytest.FixtureRequest) -> Fork:
-    """Specific fork that is used to fill the test."""
-    raise Exception(f"Test '{request.node.nodeid}' was not correctly parametrized")
+def fork(request):
+    """Parametrize test cases by fork."""
+    pass
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Revert small change from #2080.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
