### PR TITLE
chore(tests): Update 7951 Checklist Markers

### DIFF
--- a/docs/writing_tests/checklist_templates/eip_testing_checklist_template.md
+++ b/docs/writing_tests/checklist_templates/eip_testing_checklist_template.md
@@ -297,9 +297,6 @@ Opcode is used to attempt to recreate a contract that is currently mid-creation 
 
 ### Framework Changes
 
-| ID  | Description | Status | Tests |
-| --- | ----------- | ------ | ----- |
-
 - Add opcode to `src/ethereum_test_vm/opcode.py`
 - Add opcode to relevant methods in the fork where the EIP is introduced in `src/ethereum_test_forks/forks/forks.py`
 
@@ -401,6 +398,8 @@ If the precompile requires a minimum value (fee) to execute, either constant or 
 
 If the precompile does not require any minimum value (fee) to execute.
 
+| ID                                               | Description                   | Status | Tests |
+| ------------------------------------------------ | ----------------------------- | ------ | ----- |
 | `precompile/test/value_transfer/no_fee` | Sending non-zero value does not cause an exception (unless otherwise specified by the EIP). | | |
 
 #### Out-of-bounds checks
@@ -866,6 +865,8 @@ Verify the transaction is correctly rejected if it contains an invalid signature
 
 Verify values or variables that are persistent through the execution of the transaction (e.g. transient storage, warm/cold accounts).
 
+| ID                                                                    | Description                                   | Status | Tests |
+| --------------------------------------------------------------------- | ----------------------------------------------| ------ | ----- |
 | `transaction_type/test/tx_scoped_attributes/persistent/throughout` | Persist throughout the entire transaction. | | |
 | `transaction_type/test/tx_scoped_attributes/persistent/reset` | Reset on subsequent transactions in the same block. | | |
 

--- a/tests/berlin/eip2929_gas_cost_increases/test_precompile_warming.py
+++ b/tests/berlin/eip2929_gas_cost_increases/test_precompile_warming.py
@@ -70,6 +70,8 @@ def precompile_addresses_in_predecessor_successor(
     "address,precompile_in_successor,precompile_in_predecessor",
     precompile_addresses_in_predecessor_successor,
 )
+@pytest.mark.eip_checklist("precompile/test/fork_transition/before/cold")
+@pytest.mark.eip_checklist("precompile/test/fork_transition/after/warm")
 def test_precompile_warming(
     blockchain_test: BlockchainTestFiller,
     fork: Fork,

--- a/tests/berlin/eip2929_gas_cost_increases/test_precompile_warming.py
+++ b/tests/berlin/eip2929_gas_cost_increases/test_precompile_warming.py
@@ -70,8 +70,8 @@ def precompile_addresses_in_predecessor_successor(
     "address,precompile_in_successor,precompile_in_predecessor",
     precompile_addresses_in_predecessor_successor,
 )
-@pytest.mark.eip_checklist("precompile/test/fork_transition/before/cold")
-@pytest.mark.eip_checklist("precompile/test/fork_transition/after/warm")
+@pytest.mark.eip_checklist("precompile/test/fork_transition/before/cold", eip=[7951])
+@pytest.mark.eip_checklist("precompile/test/fork_transition/after/warm", eip=[7951])
 def test_precompile_warming(
     blockchain_test: BlockchainTestFiller,
     fork: Fork,

--- a/tests/osaka/eip7951_p256verify_precompiles/eip_checklist_not_applicable.txt
+++ b/tests/osaka/eip7951_p256verify_precompiles/eip_checklist_not_applicable.txt
@@ -1,0 +1,15 @@
+system_contract = EIP does not include a new system contract
+opcode = EIP does not introduce a new opcode
+removed_precompile = EIP does not remove a precompile
+precompile/test/gas_usage/dynamic = EIP uses a constant amount of gas
+precompile/test/input_lengths/dynamic = EIP input is a constant length
+precompile/test/value_transfer/fee = EIP does not require a minimum value to execute
+transaction_type = EIP does not introduce a new transaction type
+block_header_field = EIP does not add any new block header fields
+gas_cost_changes = EIP does not introduce any gas cost changes
+gas_refunds_changes = EIP does not introduce any gas refund changes
+blob_count_changes = EIP does not introduce any blob count changes
+execution_layer_request = EIP does not introduce an execution layer request
+new_transaction_validity_constraint = EIP does not introduce a new transaction validity constraint
+modified_transaction_validity_constraint = EIP does not introduce a modified transaction validity constraint
+block_body_field = EIP does not add any new block body fields

--- a/tests/osaka/eip7951_p256verify_precompiles/test_p256verify.py
+++ b/tests/osaka/eip7951_p256verify_precompiles/test_p256verify.py
@@ -319,6 +319,7 @@ def test_precompile_will_return_success_with_tx_value(
     tx: Transaction,
     call_contract_address: Address,
     input_data: bytes,
+    expected_output: bytes,
 ):
     """Test P256Verify precompile will not fail if value is sent."""
     sender = pre.fund_eoa()

--- a/tests/osaka/eip7951_p256verify_precompiles/test_p256verify.py
+++ b/tests/osaka/eip7951_p256verify_precompiles/test_p256verify.py
@@ -363,6 +363,7 @@ def test_modular_comparison(state_test: StateTestFiller, pre: Alloc, post: dict,
     ],
 )
 @pytest.mark.parametrize("precompile_address", [Spec.P256VERIFY], ids=[""])
+@pytest.mark.eip_checklist("precompile/test/call_contexts/initcode/tx")
 def test_contract_creation_transaction(
     state_test: StateTestFiller,
     pre: Alloc,
@@ -426,6 +427,9 @@ def test_contract_creation_transaction(
 )
 @pytest.mark.parametrize("precompile_address", [Spec.P256VERIFY], ids=[""])
 @pytest.mark.parametrize("opcode", [Op.CREATE, Op.CREATE2])
+@pytest.mark.eip_checklist("precompile/test/call_contexts/create")
+@pytest.mark.eip_checklist("precompile/test/call_contexts/create2")
+@pytest.mark.eip_checklist("precompile/test/call_contexts/initcode/CREATE")
 def test_contract_initcode(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/osaka/eip7951_p256verify_precompiles/test_p256verify_before_fork.py
+++ b/tests/osaka/eip7951_p256verify_precompiles/test_p256verify_before_fork.py
@@ -17,17 +17,36 @@ pytestmark = pytest.mark.valid_at_transition_to("Osaka", subsequent_forks=True)
 
 
 @pytest.mark.parametrize(
-    "precompile_address,input_data",
+    "precompile_address,input_data,expected_output,precompile_gas_modifier,call_succeeds",
     [
         pytest.param(
             Spec.P256VERIFY,
             Spec.H0 + Spec.R0 + Spec.S0 + Spec.X0 + Spec.Y0,
-            id="P256VERIFY",
+            Spec.INVALID_RETURN_VALUE,
+            0,
+            True,
+            id="P256VERIFY_valid_input_6900_gas",
+        ),
+        pytest.param(
+            Spec.P256VERIFY,
+            Spec.H0 + Spec.R0 + Spec.S0 + Spec.X0 + Spec.X0,
+            Spec.INVALID_RETURN_VALUE,
+            0,
+            True,
+            id="P256VERIFY_invalid_input",
+        ),
+        pytest.param(
+            Spec.P256VERIFY,
+            Spec.H0 + Spec.R0 + Spec.S0 + Spec.X0 + Spec.Y0,
+            Spec.INVALID_RETURN_VALUE,
+            -6900,
+            True,
+            id="P256VERIFY_valid_input_zero_gas",
         ),
     ],
 )
-@pytest.mark.parametrize("expected_output,call_succeeds", [pytest.param(b"", True, id="")])
 @pytest.mark.eip_checklist("precompile/test/fork_transition/before/invalid_input")
+@pytest.mark.eip_checklist("precompile/test/fork_transition/before/zero_gas")
 def test_precompile_before_fork(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -2556,7 +2556,7 @@ def test_set_code_to_log(
 
 @pytest.mark.with_all_call_opcodes
 @pytest.mark.with_all_precompiles
-@pytest.mark.eip_checklist("precompile/test/call_contexts/set_code", eips=[7951, 7883])
+@pytest.mark.eip_checklist("precompile/test/call_contexts/set_code", eip=[7951, 7883])
 def test_set_code_to_precompile(
     state_test: StateTestFiller,
     pre: Alloc,


### PR DESCRIPTION
## 🗒️ Description
Went through the docs checklist and added either N/A as appropriate, or a checkmark using `pytest.mark`. Also added a couple minor tests that were missing. 

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- ~~[ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.~~
- ~~[ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.~~
