### PR TITLE
fix(tests): Incorrect expected exception on `test_tx_intrinsic_gas.py`

### DIFF
--- a/tests/berlin/eip2930_access_list/test_tx_intrinsic_gas.py
+++ b/tests/berlin/eip2930_access_list/test_tx_intrinsic_gas.py
@@ -156,7 +156,7 @@ def test_tx_intrinsic_gas(
     intrinsic_gas_cost_calculator = fork.transaction_intrinsic_cost_calculator()
     intrinsic_gas_cost = intrinsic_gas_cost_calculator(calldata=data, access_list=access_list)
 
-    exception: TransactionException | None = None
+    exception: List[TransactionException] | TransactionException | None = None
     if below_intrinsic:
         data_floor_gas_cost_calculator = fork.transaction_data_floor_cost_calculator()
         data_floor_gas_cost = data_floor_gas_cost_calculator(data=data)

--- a/tests/berlin/eip2930_access_list/test_tx_intrinsic_gas.py
+++ b/tests/berlin/eip2930_access_list/test_tx_intrinsic_gas.py
@@ -156,6 +156,21 @@ def test_tx_intrinsic_gas(
     intrinsic_gas_cost_calculator = fork.transaction_intrinsic_cost_calculator()
     intrinsic_gas_cost = intrinsic_gas_cost_calculator(calldata=data, access_list=access_list)
 
+    exception: TransactionException | None = None
+    if below_intrinsic:
+        data_floor_gas_cost_calculator = fork.transaction_data_floor_cost_calculator()
+        data_floor_gas_cost = data_floor_gas_cost_calculator(data=data)
+        if data_floor_gas_cost > intrinsic_gas_cost:
+            exception = TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST
+        elif data_floor_gas_cost == intrinsic_gas_cost:
+            # Depending on the implementation, client might raise either exception.
+            exception = [
+                TransactionException.INTRINSIC_GAS_TOO_LOW,
+                TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST,
+            ]
+        else:
+            exception = TransactionException.INTRINSIC_GAS_TOO_LOW
+
     tx = Transaction(
         ty=tx_type,
         sender=pre.fund_eoa(),
@@ -163,7 +178,7 @@ def test_tx_intrinsic_gas(
         data=data,
         access_list=access_list,
         gas_limit=intrinsic_gas_cost + (-1 if below_intrinsic else 0),
-        error=TransactionException.INTRINSIC_GAS_TOO_LOW if below_intrinsic else None,
+        error=exception,
         protected=True,
     )
 


### PR DESCRIPTION
## 🗒️ Description
Fixes an exception expectation on `test_tx_intrinsic_gas.py`.

Depending on the implementation, the client could hit `TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST` or `TransactionException.INTRINSIC_GAS_TOO_LOW` because both values, given the conditions, were equal.

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] ~~All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).