### PR TITLE
feat(eip_checklist): Print warnings + embed links to test functions

### DIFF
--- a/docs/writing_tests/checklist_templates/eip_testing_checklist_template.md
+++ b/docs/writing_tests/checklist_templates/eip_testing_checklist_template.md
@@ -9,6 +9,8 @@ Depending on the changes introduced by an EIP, the following template is the min
 | --------------------- | ----------------------- | ---------- |
 | TOTAL_CHECKLIST_ITEMS | COVERED_CHECKLIST_ITEMS | PERCENTAGE |
 
+<!-- WARNINGS LINE -->
+
 ## General
 
 #### Code coverage

--- a/src/pytest_plugins/filler/eip_checklist.py
+++ b/src/pytest_plugins/filler/eip_checklist.py
@@ -10,7 +10,7 @@ import logging
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Set, Tuple
+from typing import ClassVar, Dict, List, Set, Tuple, Type
 
 import pytest
 
@@ -59,6 +59,7 @@ TEMPLATE_PATH = (
 TEMPLATE_CONTENT = TEMPLATE_PATH.read_text()
 EXTERNAL_COVERAGE_FILE_NAME = "eip_checklist_external_coverage.txt"
 NOT_APPLICABLE_FILE_NAME = "eip_checklist_not_applicable.txt"
+WARNINGS_LINE = "<!-- WARNINGS LINE -->"
 
 
 @pytest.hookimpl(tryfirst=True)
@@ -113,7 +114,10 @@ class EIPItem:
             status = "✅"
             tests = self.external_coverage_reason
         elif self.covered:
-            status = "✅"
+            if self.not_applicable:
+                status = "❓"
+            else:
+                status = "✅"
             tests = ", ".join(sorted(self.tests))
         elif self.not_applicable:
             status = "N/A"
@@ -156,6 +160,63 @@ def resolve_id(item_id: str) -> Set[str]:
     return covered_ids
 
 
+ALL_CHECKLIST_WARNINGS: Dict[str, Type["ChecklistWarning"]] = {}
+
+
+@dataclass(kw_only=True)
+class ChecklistWarning:
+    """Represents an EIP checklist warning."""
+
+    title: ClassVar[str] = ""
+    details: List[str]
+
+    def __init_subclass__(cls) -> None:
+        """Register the checklist warning subclass."""
+        super().__init_subclass__()
+        assert cls.title, "Title must be set"
+        if cls.title in ALL_CHECKLIST_WARNINGS:
+            raise ValueError(f"Duplicate checklist warning class: {cls}")
+        ALL_CHECKLIST_WARNINGS[cls.title] = cls
+
+    def lines(self) -> List[str]:
+        """Return the lines of the checklist warning."""
+        return ["", f"### {self.title}", ""] + self.details + [""]
+
+    @classmethod
+    def from_items(cls, all_items: Dict[str, EIPItem]) -> "ChecklistWarning | None":
+        """Generate a checklist warning from a list of items."""
+        raise NotImplementedError(f"from_items not implemented for {cls}")
+
+
+class ConflictingChecklistItemsWarning(ChecklistWarning):
+    """Represents a conflicting checklist items warning."""
+
+    title: ClassVar[str] = "Conflicting Checklist Items"
+
+    @classmethod
+    def from_items(cls, all_items: Dict[str, EIPItem]) -> ChecklistWarning | None:
+        """Generate a conflicting checklist items warning from a list of items."""
+        conflicting_items = [
+            item for item in all_items.values() if item.not_applicable and item.covered
+        ]
+        if not conflicting_items:
+            return None
+
+        details = [
+            "The following checklist items were marked both as not applicable and covered:",
+            "",
+            "| ID | Description | Not Applicable | Tests |",
+            "|---|---|---|---|",
+        ]
+        for item in conflicting_items:
+            details.append(
+                f"| {item.id} | {item.description} | "
+                + f"{item.not_applicable_reason} | {', '.join(sorted(item.tests))} |"
+            )
+
+        return cls(details=details)
+
+
 @dataclass(kw_only=True)
 class EIP:
     """Represents an EIP and its checklist."""
@@ -171,7 +232,7 @@ class EIP:
     @property
     def covered_items(self) -> int:
         """Return the number of covered items."""
-        return sum(1 for item in self.items.values() if item.covered)
+        return sum(1 for item in self.items.values() if item.covered and not item.not_applicable)
 
     @property
     def total_items(self) -> int:
@@ -187,6 +248,15 @@ class EIP:
     def completeness_emoji(self) -> str:
         """Return the completeness emoji."""
         return "🟢" if self.percentage == 100 else "🟡" if self.percentage > 50 else "🔴"
+
+    @property
+    def warnings(self) -> List[ChecklistWarning]:
+        """Return the detected inconsistencies in the checklist."""
+        warnings = []
+        for warning_cls in ALL_CHECKLIST_WARNINGS.values():
+            if warning := warning_cls.from_items(self.items):
+                warnings.append(warning)
+        return warnings
 
     def mark_not_applicable(self):
         """Read the not-applicable items from the EIP."""
@@ -263,6 +333,15 @@ class EIP:
 
         # Replace the title line with the EIP number
         lines[lines.index(TITLE_LINE)] = f"# EIP-{self.number} Test Checklist"
+
+        # Last, add the warnings if there are any, this must be the last thing we do
+        # to avoid shifting the lines below the percentage line
+        if self.warnings:
+            warnings_line_idx = lines.index(WARNINGS_LINE)
+            warnings_lines = ["", "## ⚠️ Checklist Warnings ⚠️", ""]
+            for warning in self.warnings:
+                warnings_lines.extend(warning.lines())
+            lines[warnings_line_idx:warnings_line_idx] = warnings_lines
 
         return lines
 


### PR DESCRIPTION
## 🗒️ Description

### Checklist Warnings

Prints a new section with warnings about the checklist items if any.

Only warning at the moment is if the same test is marked both as "N/A" and "covered" at the same time.

### Embed Links to Test

Embed clickable links to the test that is referenced in the checklist.

Only issue at the moment is that the docs building process prints a ton of new `INFO` lines, and perhaps the reason is that the checklist is generated before the test reference markdown documents:

```
INFO    -  Doc file 'tests/prague/eip7702_set_code_tx/checklist.md' contains an unrecognized relative link
           '../../../../tests/prague/eip7702_set_code_tx/test_set_code_txs/test_set_code_to_precompile/', it was left as is. Did you mean
           'test_set_code_txs/test_set_code_to_precompile.md'?
INFO    -  Doc file 'tests/prague/eip7702_set_code_tx/checklist.md' contains an unrecognized relative link
           '../../../../tests/prague/eip7702_set_code_tx/test_set_code_txs/test_set_code_to_precompile/', it was left as is. Did you mean
           'test_set_code_txs/test_set_code_to_precompile.md'?
```

We could merge as is because it makes it so much easier to have these links when reviewing the checklist, but it would be better if these are cleared out.

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).