### PR TITLE
chore: update eels resolutions to point to latest commit for amsterdam

### DIFF
--- a/.github/configs/eels_resolutions.json
+++ b/.github/configs/eels_resolutions.json
@@ -52,6 +52,6 @@
     "Amsterdam": {
         "git_url": "https://github.com/fselmo/execution-specs.git",
         "branch": "feat/amsterdam-fork-and-block-access-lists",
-        "commit": "a5c7b29a658320c2432de78883d350e9f4444d14"
+        "commit": "c730e6d47f99f0d06c2c1ee961ad1e661b0abfcb"
     }
 }

--- a/src/pytest_plugins/eels_resolutions.json
+++ b/src/pytest_plugins/eels_resolutions.json
@@ -55,6 +55,6 @@
     "Amsterdam": {
       "git_url": "https://github.com/fselmo/execution-specs.git",
       "branch": "feat/amsterdam-fork-and-block-access-lists",
-      "commit": "a5c7b29a658320c2432de78883d350e9f4444d14"
+      "commit": "c730e6d47f99f0d06c2c1ee961ad1e661b0abfcb"
     }
 }


### PR DESCRIPTION
## 🗒️ Description

- There was a fix on the specifications side since the first pre-release for BAL tests. This change points to the latest commit on the EELS branch.

## 🔗 Related Issues or PRs

- ethereum/execution-specs#1381

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).