### PR TITLE
feat(tests): add implementation coverage tests for modexp eip7823 bounds

### DIFF
--- a/tests/osaka/eip7823_modexp_upper_bounds/test_modexp_upper_bounds.py
+++ b/tests/osaka/eip7823_modexp_upper_bounds/test_modexp_upper_bounds.py
@@ -129,6 +129,53 @@ def precompile_gas(fork: Fork, mod_exp_input: ModExpInput) -> int:
             ),
             id="exp_2_pow_64_base_0_mod_0",
         ),
+        # Implementation coverage tests
+        pytest.param(
+            ModExpInput(
+                base=b"\xff" * (MAX_LENGTH_BYTES + 1),
+                exponent=b"\xff" * (MAX_LENGTH_BYTES + 1),
+                modulus=b"\xff" * (MAX_LENGTH_BYTES + 1),
+            ),
+            id="all_exceed_check_ordering",
+        ),
+        pytest.param(
+            ModExpInput(
+                base=b"\x00" * MAX_LENGTH_BYTES,
+                exponent=b"\xff" * (MAX_LENGTH_BYTES + 1),
+                modulus=b"\xff" * (MAX_LENGTH_BYTES + 1),
+            ),
+            id="exp_mod_exceed_base_ok",
+        ),
+        pytest.param(
+            ModExpInput(
+                # Bitwise pattern for Nethermind optimization
+                base=b"\xaa" * (MAX_LENGTH_BYTES + 1),
+                exponent=b"\x55" * MAX_LENGTH_BYTES,
+                modulus=b"\xff" * MAX_LENGTH_BYTES,
+            ),
+            id="bitwise_pattern_base_exceed",
+        ),
+        pytest.param(
+            ModExpInput(
+                base=b"",
+                exponent=b"",
+                modulus=b"",
+                # Near max uint64 for revm conversion test
+                declared_base_length=2**63 - 1,
+                declared_exponent_length=1,
+                declared_modulus_length=1,
+            ),
+            id="near_uint64_max_base",
+        ),
+        pytest.param(
+            ModExpInput(
+                base=b"\x01" * MAX_LENGTH_BYTES,
+                exponent=b"",
+                modulus=b"\x02" * (MAX_LENGTH_BYTES + 1),
+                declared_exponent_length=0,
+            ),
+            id="zero_exp_mod_exceed",
+        ),
     ],
 )
 def test_modexp_upper_bounds(


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Add 5 targeted test cases to improve EIP-7823 implementation coverage:
- all_exceed_check_ordering: Tests check ordering when all bounds exceed
- exp_mod_exceed_base_ok: Tests partial bound violations
- bitwise_pattern_base_exceed: Tests Nethermind bitwise optimization
- near_uint64_max_base: Tests revm integer conversion edge case
- zero_exp_mod_exceed: Tests zero exponent with modulus exceeding

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
