### PR TITLE
fix(tests): Block-Level Access List invalid tests

### DIFF
--- a/.github/configs/eels_resolutions.json
+++ b/.github/configs/eels_resolutions.json
@@ -52,6 +52,6 @@
     "Amsterdam": {
         "git_url": "https://github.com/fselmo/execution-specs.git",
         "branch": "feat/amsterdam-fork-and-block-access-lists",
-        "commit": "a5c7b29a658320c2432de78883d350e9f4444d14"
+        "commit": "39e0b59613be4100d2efc86702ff594c54e5bd81"
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -239,6 +239,7 @@ Users can select any of the artifacts depending on their benchmarking or testing
 - 🔀 Adds the max blob transaction limit to the tests including updates to [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844) for Osaka ([#1884](https://github.com/ethereum/execution-spec-tests/pull/1884)).
 - 🐞 Fix issues when filling block rlp size limit tests with ``--generate-pre-alloc-groups`` ([#1989](https://github.com/ethereum/execution-spec-tests/pull/1989)).
 - ✨ [EIP-7928](https://eips.ethereum.org/EIPS/eip-7928): Add test cases for `Block Level Access Lists (BAL)` to Amsterdam ([#2067](https://github.com/ethereum/execution-spec-tests/pull/2067)).
+- 🐞 Fix issues with `Block Level Access Lists (BAL)` tests for Amsterdam ([#2121](https://github.com/ethereum/execution-spec-tests/pull/2121)).
 
 ## [v4.5.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v4.5.0) - 2025-05-14
 

--- a/src/ethereum_test_specs/blockchain.py
+++ b/src/ethereum_test_specs/blockchain.py
@@ -659,8 +659,8 @@ class BlockchainTest(BaseTest):
                 and block.requests is None
                 and not block.skip_exception_verification
                 and not (
-                block.expected_block_access_list is not None
-                and block.expected_block_access_list._modifier is not None
+                    block.expected_block_access_list is not None
+                    and block.expected_block_access_list._modifier is not None
                 )
             ):
                 # Only verify block level exception if:

--- a/src/ethereum_test_specs/blockchain.py
+++ b/src/ethereum_test_specs/blockchain.py
@@ -659,8 +659,8 @@ class BlockchainTest(BaseTest):
                 and block.requests is None
                 and not block.skip_exception_verification
                 and not (
-                    block.expected_block_access_list is not None
-                    and block.expected_block_access_list.modifier is not None
+                block.expected_block_access_list is not None
+                and block.expected_block_access_list._modifier is not None
                 )
             ):
                 # Only verify block level exception if:

--- a/src/ethereum_test_types/block_access_list/__init__.py
+++ b/src/ethereum_test_types/block_access_list/__init__.py
@@ -197,13 +197,13 @@ class BlockAccessListExpectation(CamelModel):
 
     """
 
+    model_config = CamelModel.model_config | {"extra": "forbid"}
+
     account_expectations: Dict[Address, BalAccountExpectation | None] = Field(
         default_factory=dict, description="Expected account changes or exclusions to verify"
     )
 
-    _modifier: Callable[["BlockAccessList"], "BlockAccessList"] | None = PrivateAttr(
-        default=None
-    )
+    _modifier: Callable[["BlockAccessList"], "BlockAccessList"] | None = PrivateAttr(default=None)
 
     def modify(
         self, *modifiers: Callable[["BlockAccessList"], "BlockAccessList"]

--- a/src/pytest_plugins/eels_resolutions.json
+++ b/src/pytest_plugins/eels_resolutions.json
@@ -55,6 +55,6 @@
     "Amsterdam": {
       "git_url": "https://github.com/fselmo/execution-specs.git",
       "branch": "feat/amsterdam-fork-and-block-access-lists",
-      "commit": "a5c7b29a658320c2432de78883d350e9f4444d14"
+      "commit": "39e0b59613be4100d2efc86702ff594c54e5bd81"
     }
 }


### PR DESCRIPTION
## 🗒️ Description

Fixes issues not caught by #2102. We fixed the t8n model to not allow extras but we did not fix the expectation model. We still had invalid tests that we did not catch which were silently still filling. This should resolve any issues with extra fields and should correctly set up the test expectations.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.