### PR TITLE
fix(tests): Collect issue in test_p256verify_before_fork.py

### DIFF
--- a/tests/osaka/eip7951_p256verify_precompiles/test_p256verify_before_fork.py
+++ b/tests/osaka/eip7951_p256verify_precompiles/test_p256verify_before_fork.py
@@ -6,14 +6,14 @@ abstract: Tests P256VERIFY precompiles of [EIP-7951: Precompile for secp256r1 Cu
 
 import pytest
 
-from ethereum_test_tools import Alloc, Environment, StateTestFiller, Transaction
+from ethereum_test_tools import Alloc, Block, BlockchainTestFiller, Transaction
 
 from .spec import Spec, ref_spec_7951
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_7951.git_path
 REFERENCE_SPEC_VERSION = ref_spec_7951.version
 
-pytestmark = pytest.mark.valid_at_transition_to("Osaka", subsequent_forks=True)
+pytestmark = pytest.mark.valid_at_transition_to("Osaka")
 
 
 @pytest.mark.parametrize(
@@ -26,10 +26,12 @@ pytestmark = pytest.mark.valid_at_transition_to("Osaka", subsequent_forks=True)
         ),
     ],
 )
-@pytest.mark.parametrize("expected_output,call_succeeds", [pytest.param(b"", True, id="")])
+@pytest.mark.parametrize(
+    "expected_output,call_succeeds", [pytest.param(b"", True, id=pytest.HIDDEN_PARAM)]
+)
 @pytest.mark.eip_checklist("precompile/test/fork_transition/before/invalid_input")
 def test_precompile_before_fork(
-    state_test: StateTestFiller,
+    blockchain_test: BlockchainTestFiller,
     pre: Alloc,
     post: dict,
     tx: Transaction,
@@ -39,9 +41,8 @@ def test_precompile_before_fork(
 
     The call must succeed but the output must be empty.
     """
-    state_test(
-        env=Environment(),
+    blockchain_test(
         pre=pre,
-        tx=tx,
+        blocks=[Block(txs=[tx])],
         post=post,
     )


### PR DESCRIPTION
## 🗒️ Description
Fixes a small issue that only happened during test collection in vscode, which is `tests/osaka/eip7951_p256verify_precompiles/test_p256verify_before_fork::py::test_precompile_before_fork` being a state test on a fork transition.

Issue appeared as:
```bash
nodeid: tests/osaka/eip7951_p256verify_precompiles/test_p256verify_before_fork.py::test_precompile_before_fork[fork_Prague-state_test--P256VERIFY]
kind: ('function', False)
class: Function
name: test_precompile_before_fork[fork_PragueToOsakaAtTime15k-state_test--P256VERIFY]
fspath: /home/marioevz/Development/Eth/execution-spec-tests/tests/osaka/eip7951_p256verify_precompiles/test_p256verify_before_fork.py
location: ('tests/osaka/eip7951_p256verify_precompiles/test_p256verify_before_fork.py', 18, 'test_precompile_before_fork[fork_PragueToOsakaAtTime15k-state_test--P256VERIFY]')
function: <function test_precompile_before_fork at 0x7f180b781440>
markers: [Mark(name='eip_checklist', args=('precompile/test/fork_transition/before/invalid_input',), kwargs={}), Mark(name='parametrize', args=('expected_output,call_succeeds', [ParameterSet(values=(b'', True), marks=(), id='')]), kwargs={}), Mark(name='parametrize', args=('precompile_address,input_data', [ParameterSet(values=(256, b'\xbbZR\xf4/\x9c\x92a\xedCa\xf5\x94"\xa1\xe3\x006\xe7\xc3+\'\x0c\x88\x07\xa4\x19\xfe\xca`P#+\xa3\xa8\xbek\x94\xd5\xec\x80\xa6\xd9\xd1\x19\nCn\xff\xe5\r\x85\xa1\xee\xe8Y\xb8\xccj\xf9\xbd\\.\x18L\xd6\x0b\x85]D/[<{\x11\xeblN\n\xe7R_\xe7\x10\xfa\xb9\xaa|w\xa6\x7fy\xe6\xfa\xddv)\'\xb1\x05\x12\xba\xe3\xed\xdc\xfeFx(\x12\x8b\xad)\x03&\x99\x19\xf7\x08`i\xc8\xc4\xdfls(8\xc7xyd\xea\xac\x00\xe5\x92\x1f\xb1I\x8a`\xf4`gf\xb3\xd9hP\x01U\x8d\x1a\x97NsAQ>'), marks=(), id='P256VERIFY')]), kwargs={}), Mark(name='state_test', args=(), kwargs={})]
user_properties: []
attrnames: ['_ALLOW_MARKERS', '__abstractmethods__', '__annotations__', '__class__', '__delattr__', '__dict__', '__dir__', '__doc__', '__eq__', '__format__', '__ge__', '__getattribute__', '__getstate__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__slots__', '__str__', '__subclasshook__', '__weakref__', '_abc_impl', '_check_item_and_collector_diamond_inheritance', '_fixtureinfo', '_getinstance', '_getobj', '_initrequest', '_instance', '_nodeid', '_obj', '_pyfuncitem', '_pytest_diamond_inheritance_warning_shown', '_report_sections', '_repr_failure_py', '_request', '_store', '_traceback_filter', 'add_marker', 'add_report_section', 'addfinalizer', 'callspec', 'cls', 'config', 'extra_keyword_matches', 'fixturenames', 'from_parent', 'fspath', 'funcargs', 'function', 'get_closest_marker', 'getmodpath', 'getparent', 'ihook', 'instance', 'iter_markers', 'iter_markers_with_node', 'iter_parents', 'keywords', 'listchain', 'listextrakeywords', 'listnames', 'location', 'module', 'name', 'nextitem', 'nodeid', 'obj', 'originalname', 'own_markers', 'parent', 'path', 'reportinfo', 'repr_failure', 'runtest', 'session', 'setup', 'stash', 'teardown', 'user_properties', 'warn']

extra info:
fullname: test_precompile_before_fork[fork_PragueToOsakaAtTime15k-state_test--P256VERIFY]
testfunc: test_precom
parameterized:[fork_PragueToOsakaAtTime15k-state_test--P256VERIFY]

traceback:
  File "/home/marioevz/.cursor-server/extensions/ms-python.python-2023.6.0/pythonFiles/testing_tools/run_adapter.py", line 22, in <module>
...
  File "/home/marioevz/.cursor-server/extensions/ms-python.python-2023.6.0/pythonFiles/testing_tools/adapter/pytest/_pytest_item.py", line 132, in should_never_reach_here
    traceback.print_stack()
```

Specifically the issue happens because the `nodeid` does not match the test's `fullname` for some reason.

This should in theory be possible because the state test would simply execute in the Prague fork due to the default timestamp in the environment for the state tests, but the root cause needs to be further investigated.

In my local machine this now allows running tests in vscode again.

Another fix is that `subsequent_forks=True` is removed from the `pytest.mark.valid_at_transition_to` marker, and reason being that if we were to run this same test on, e.g. Osaka->Amsterdam transition fork, the test would fail because the pre-compile is already enabled in Osaka.

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).