### PR TITLE
feat(consume): Clarify mismatched fields on blockhash mismatch

### DIFF
--- a/src/pytest_plugins/consume/simulators/simulator_logic/test_via_rlp.py
+++ b/src/pytest_plugins/consume/simulators/simulator_logic/test_via_rlp.py
@@ -41,7 +41,6 @@ def test_via_rlp(
         assert block, "`getBlockByNumber` didn't return a block."
         if block["hash"] != str(fixture.last_block_hash):
             try:
-                mismatches = []
                 block_header = FixtureHeader.model_validate(block).model_dump()
                 last_block = FixtureBlock.model_validate(fixture.blocks[-1])
                 last_block_header = last_block.header.model_dump()
@@ -55,6 +54,7 @@ def test_via_rlp(
                     )
 
                 # find all mismatched fields
+                mismatches = []
                 for block_field, block_value in block_header.items():
                     fixture_value = last_block_header[block_field]
                     if str(block_value) != str(fixture_value):


### PR DESCRIPTION
## 🗒️ Description

Trying to debug and this helped quite a bit. I figured it couldn't hurt to push this up. Not sure this needs a CHANGELOG entry?

e.g. (this is a quite verbose case where the expected block didn't process but just to highlight)
```
src/pytest_plugins/consume/simulators/simulator_logic/test_via_rlp.py:54: in test_via_rlp
    raise AssertionError(
E   AssertionError: blockHash mismatch in last block - field mismatches:
E       parent_hash: got `0x0000000000000000000000000000000000000000000000000000000000000000`, expected `0x3e1b7b2e45eae4e89d8c4112f43d929b7315f4551736961c067b5ca006e91902`
E       fee_recipient: got `0x0000000000000000000000000000000000000000`, expected `0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba`
E       state_root: got `0x8480481f5ed7d79e588108794266376ee56a8750c6e8eb0ada3f823f9b70ec70`, expected `0x7651413e6c9b35bb962da97ee77bb05e65f7c074b64113d65e16a1358f1f55e4`
E       transactions_trie: got `0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421`, expected `0x40ffaf2d04c97a2126702a3cdbe426b245ed0cc21fe19b4ce415a6482e731970`
E       receipts_root: got `0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421`, expected `0x7c159ddaf740b35b12100c6f4a64845195d7cf6d8c36b6269f35a48c18b06ff8`
E       number: got `0x00`, expected `0x01`
E       gas_used: got `0x00`, expected `0x5a3f`
E       timestamp: got `0x00`, expected `0x0c`
E       extra_data: got `0x00`, expected `0x`
E       block_access_list_hash: got `None`, expected `0x8ce62a32b5d1902e0fe6f0dcd8ae54c7faca117d52248c9572d804f741e3b78b`
E       block_hash: got `0x0b01f0f2a610cf1ed2cb540c4613b04adb41bc108c0b2d1b544ddde9c6bdd788`, expected `0xb7f1e550c05345a0aec2b4d843a848ea6a75b7ada842cbca252bef6c676270f6`
```

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md). -- has NOT been added... but can add if this feels necessary
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).