### PR TITLE
fix(clis/eels): Use regex for missing-module-definition exceptions

### DIFF
--- a/src/ethereum_clis/clis/execution_specs.py
+++ b/src/ethereum_clis/clis/execution_specs.py
@@ -151,12 +151,6 @@ class ExecutionSpecsExceptionMapper(ExceptionMapper):
         TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS: (
             "InsufficientMaxFeePerBlobGasError"
         ),
-        TransactionException.TYPE_3_TX_PRE_FORK: (
-            "module 'ethereum.shanghai.transactions' has no attribute 'BlobTransaction'"
-        ),
-        TransactionException.TYPE_4_TX_PRE_FORK: (
-            "'ethereum.cancun.transactions' has no attribute 'SetCodeTransaction'"
-        ),
         TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH: (
             "InvalidBlobVersionedHashError"
         ),
@@ -185,5 +179,11 @@ class ExecutionSpecsExceptionMapper(ExceptionMapper):
     mapping_regex: ClassVar[Dict[ExceptionBase, str]] = {
         TransactionException.INSUFFICIENT_MAX_FEE_PER_GAS: (
             r"InsufficientMaxFeePerGasError|InvalidBlock"  # Temporary solution for issue #1981.
+        ),
+        TransactionException.TYPE_3_TX_PRE_FORK: (
+            r"module '.*transactions' has no attribute 'BlobTransaction'"
+        ),
+        TransactionException.TYPE_4_TX_PRE_FORK: (
+            r"'.*transactions' has no attribute 'SetCodeTransaction'"
         ),
     }


### PR DESCRIPTION
## 🗒️ Description
Aid for https://github.com/ethereum/execution-specs/pull/1416 by making the exception message to not depend on the exact package name.

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] ~~All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).