### PR TITLE
chore(ci): bump tox verify gh runner

### DIFF
--- a/.github/workflows/tox_verify.yaml
+++ b/.github/workflows/tox_verify.yaml
@@ -154,8 +154,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: [self-hosted-ghr, size-gigachungus-x64]
-            name: self-hosted-ghr-gigachungus-x64
+          - os: [self-hosted-ghr, size-chungus-x64]
+            name: self-hosted-ghr-chungus-x64
             python: "3.11"
           - os: macos-15
             name: macos-15


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Aims to fix the random fails during the `tests-develop` fill stage in the tox verify workflow.

cc https://github.com/ethereum/execution-spec-tests/actions/runs/17620738824/job/50115936119

The workflow is still running so the assumption is that the runner is running out of memory.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
