### PR TITLE
chore(tooling): fixes mypy and ruff (non-tox config) warnings/errors

### DIFF
--- a/scripts/convert_addresses.py
+++ b/scripts/convert_addresses.py
@@ -3,7 +3,7 @@
 Simple address converter for static test fillers.
 Two-pass approach:
 1. Collect all addresses and create mappings
-2. Replace all occurrences with tags
+2. Replace all occurrences with tags.
 """
 
 import argparse
@@ -133,11 +133,9 @@ INCOMPATIBLE_PATH_PATTERNS = {
     "storageCostsFiller.yml",
     "variedContextFiller.yml",
     "vitalikTransactionTestParisFiller.json",
-
     # stExample
     "add11_ymlFiller.yml",
     "add11Filler.json",
-   
     # stExtCodeHash
     "extcodehashEmpty_ParisFiller.yml",
     "extCodeHashSelfInInitFiller.json",
@@ -164,7 +162,6 @@ INCOMPATIBLE_PATH_PATTERNS = {
     "extCodeHashCreatedAndDeletedAccountCallFiller.json",
     "createEmptyThenExtcodehashFiller.json",
     "contractCreationOOGdontLeaveEmptyContractViaTransactionFiller.json",
-    
     # Really only `ReturnTestFiller` and `ReturnTest2Filler` are compatible inside `stInitCodeTest`
     "CallContractToCreateContractAndCallItOOGFiller.json",
     "CallContractToCreateContractOOGBonusGasFiller.json",
@@ -179,8 +176,6 @@ INCOMPATIBLE_PATH_PATTERNS = {
     "OutOfGasContractCreationFiller.json",
     "OutOfGasPrefundedContractCreationFiller.json",
     "TransactionCreateStopInInitcodeFiller.json",
-
-
     # stInitCodeTest
     "ReturnTestFiller.json",
     "ReturnTest2Filler.json",
@@ -189,7 +184,6 @@ INCOMPATIBLE_PATH_PATTERNS = {
     "CREATE_BoundsFiller.json",
     "NonZeroValue_CALLCODEFiller.json",
     "NonZeroValue_DELEGATECALLFiller.json",
-
     "bufferFiller.yml",
     "bufferSrcOffsetFiller.yml",
     "callDataCopyOffsetFiller.json",
@@ -213,7 +207,6 @@ INCOMPATIBLE_PATH_PATTERNS = {
     "Create1000ShnghaiFiller.json",
     "QuadraticComplexitySolidity_CallDataCopyFiller.json",
     "testRandomTestFiller.json",
-
     # uses coinbase address (0x41) as integer memory offsets. TODO: is this necessary for the test?
     # we could end up changing this for compatibility instead.
     "randomStatetest1Filler.json",
@@ -247,17 +240,14 @@ INCOMPATIBLE_PATH_PATTERNS = {
     "Call50000_sha256Filler.json",
     "Create1000ByzantiumFiller.json",
     "Create1000Filler.json",
-
     # stRecursiveCreate
     "RecursiveCreateContractsCreate4ContractsFiller.json",
     "RecursiveCreateContractsFiller.json",
-
     # stStackTests
     "shallowStackFiller.json",
     "stackOverflowFiller.json",
     "stackOverflowDUPFiller.json",
     "stackOverflowPUSHFiller.json",
-
     "revertRetDataSizeFiller.yml",
     "returndatacopy_0_0_following_successful_createFiller.json",
     "RevertPrefoundFiller.json",
@@ -271,8 +261,6 @@ INCOMPATIBLE_PATH_PATTERNS = {
     "RevertOpcodeInInitFiller.json",
     "RevertOpcodeWithBigOutputInInitFiller.json",
     "ByZeroFiller.json",
-    "RecursiveCreateContractsCreate4ContractsFiller.json",
-    "RecursiveCreateContractsFiller.json",
     "TestCryptographicFunctionsFiller.json",
     "StackDepthLimitSECFiller.json",
     "eoaEmptyParisFiller.yml",
@@ -388,15 +376,12 @@ INCOMPATIBLE_PATH_PATTERNS = {
     "createNameRegistratorValueTooHighFiller.json",
     "suicideCallerAddresTooBigLeftFiller.json",
     "ABAcallsSuicide1Filler.json",
-
-    
     "/stCreate2/",
     "/stCreateTest/",
     "/stRecursiveCreate/",
     "/stWalletTest/",
     "/stZeroKnowledge/",
     "/stZeroKnowledge2/",
-    
     # TODO: See if these can be turned on with fine tuning
     "/stTimeConsuming/",
 }
@@ -448,9 +433,7 @@ DO_NOT_TAG_ADDRESSES = {
         "ccccccccccccccccccccccccccccccccccccccc1",
         "ccccccccccccccccccccccccccccccccccccccc2",
     },
-    "callToSuicideThenExtcodehashFiller.json": {
-        "0000000000000000000000000000000000000025"
-    },
+    "callToSuicideThenExtcodehashFiller.json": {"0000000000000000000000000000000000000025"},
     "doubleSelfdestructTouch_ParisFiller.yml": {
         "0000000000000000000000000000000000e49701",
         "0000000000000000000000000000000000e49702",
@@ -466,12 +449,12 @@ SHORT_NAME_FILLERS = {
     "coinbaseT2Filler.yml",
     "doubleSelfdestructTouch_ParisFiller.yml",
     "tooLongReturnDataCopyFiller.yml",
-    "coinbaseWarmAccountCallGasFailFiller.yml"
+    "coinbaseWarmAccountCallGasFailFiller.yml",
 }
 
 # Fillers that should have precompile check disabled
 # These tests intentionally use addresses that map to precompiles
-DISABLE_PRECOMPILE_CHECK_FILLERS = {
+DISABLE_PRECOMPILE_CHECK_FILLERS = {  # type: ignore[var-annotated]
     # "block504980Filler.json",
 }
 
@@ -491,7 +474,7 @@ NO_TAGS_IN_CODE = {
 
 # Fillers that should skip entropy validation entirely
 # These tests are deemed safe to convert addresses even if they don't pass entropy check
-VALIDATE_ADDR_ENTROPY_IN_CODE = {
+VALIDATE_ADDR_ENTROPY_IN_CODE = {  # type: ignore[var-annotated]
     # Add more fillers here that should skip entropy validation
     # "static_log_CallerFiller.json",
     # "OOGMAfterFiller.json",
@@ -521,7 +504,7 @@ SHOULDNOTEXIST_NO_CONVERSION_FILLERS = {
 
 # Fillers where addresses in storage keys should be replaced with tags
 # By default, storage keys are not replaced to avoid issues
-DONT_REPLACE_TAGS_IN_STORAGE_KEYS = {
+DONT_REPLACE_TAGS_IN_STORAGE_KEYS = {  # type: ignore[var-annotated]
     # Add fillers here that should have addresses replaced in storage keys
     # Example: tests that use addresses as storage keys intentionally
     # "randomStatetest383Filler.json",
@@ -565,7 +548,7 @@ def calculate_entropy(addr: str) -> float:
 class SimpleAddressConverter:
     """Simple two-pass converter."""
 
-    def __init__(self, filename: str = ""):
+    def __init__(self, filename: str = ""):  # noqa: D107
         self.filename = filename
         self.address_mappings: Dict[str, str] = {}  # addr -> tag
         self.pre_addresses: Set[str] = set()  # addresses from pre section
@@ -576,9 +559,7 @@ class SimpleAddressConverter:
         self.coinbase_addr: Optional[str] = None
         self.target_addr: Optional[str] = None
         self.is_json = filename.lower().endswith(".json")
-        self.skip_precompile_check = any(
-            kw in filename for kw in DISABLE_PRECOMPILE_CHECK_FILLERS
-        )
+        self.skip_precompile_check = any(kw in filename for kw in DISABLE_PRECOMPILE_CHECK_FILLERS)
         self.no_tags_in_code = any(kw in filename for kw in NO_TAGS_IN_CODE)
         self.validate_addr_entropy_in_code = any(
             kw in filename for kw in VALIDATE_ADDR_ENTROPY_IN_CODE
@@ -628,9 +609,24 @@ class SimpleAddressConverter:
                 return None  # Don't change context for empty storage
             return Context.STORAGE
         # Known fields that indicate we're back in NORMAL context
-        elif any(kw in stripped for kw in {"balance:", "nonce:", "secretKey:", "gasLimit:",
-                                           "gasPrice:", "value:", "to:", "from:", "address:",
-                                           "shouldnotexist:", "indexes:", "network:", "result:"}):
+        elif any(
+            kw in stripped
+            for kw in {
+                "balance:",
+                "nonce:",
+                "secretKey:",
+                "gasLimit:",
+                "gasPrice:",
+                "value:",
+                "to:",
+                "from:",
+                "address:",
+                "shouldnotexist:",
+                "indexes:",
+                "network:",
+                "result:",
+            }
+        ):
             return Context.NORMAL
         return None
 
@@ -674,13 +670,10 @@ class SimpleAddressConverter:
         current_result_address = None
         looking_for_shouldnotexist = False
 
-        for line_num, line in enumerate(lines, 1):
+        for _, line in enumerate(lines, 1):
             stripped = line.strip()
             stripped_no_spaces_or_quotes = (
-                stripped.replace('"', "")
-                .replace("'", "")
-                .replace(" ", "")
-                .replace(",", "")
+                stripped.replace('"', "").replace("'", "").replace(" ", "").replace(",", "")
             )
 
             # Check for section changes
@@ -698,8 +691,9 @@ class SimpleAddressConverter:
             if current_section in [Section.PRE, Section.RESULT]:
                 # Check if this line is an address key (40 hex chars followed by colon)
                 # Also check for quoted addresses in JSON format
-                if (re.match(r"^\s*(?:0x)?[a-fA-F0-9]{40}\s*:", line, re.IGNORECASE) or
-                    re.match(r'^\s*"(?:0x)?[a-fA-F0-9]{40}"\s*:', line, re.IGNORECASE)):
+                if re.match(r"^\s*(?:0x)?[a-fA-F0-9]{40}\s*:", line, re.IGNORECASE) or re.match(
+                    r'^\s*"(?:0x)?[a-fA-F0-9]{40}"\s*:', line, re.IGNORECASE
+                ):
                     current_context = Context.NORMAL
 
             # Don't reset context on closing braces - let field names determine context
@@ -712,7 +706,8 @@ class SimpleAddressConverter:
 
                 # Plain address pattern (40 hex chars followed by colon)
                 # Handle both JSON format ("address":) and YAML format (address:)
-                # Use word boundaries to ensure we match exactly 40 hex chars, not part of a longer string
+                # Use word boundaries to ensure we match exactly 40 hex chars,
+                # not part of a longer string
                 match = re.search(
                     r'["\']?(?:0x)?(?<![a-fA-F0-9])([a-fA-F0-9]{40})(?![a-fA-F0-9])["\']?\s*:',
                     line,
@@ -731,7 +726,7 @@ class SimpleAddressConverter:
                 if addr_match:
                     addr = normalize_address(addr_match.group(1))
                     if addr not in self.do_not_tag_addresses:
-                        self.address_mappings[addr] = None  # Will assign tag later
+                        self.address_mappings[addr] = None  # type: ignore[assignment]
                         self.pre_addresses.add(addr)
                         current_address = addr
                     continue
@@ -753,12 +748,12 @@ class SimpleAddressConverter:
                     # Don't convert shouldnotexist addresses if enabled for this filler
                     if not self.dont_convert_shouldnotexist:
                         # Only now add to address_mappings and mark as creation address
-                        self.address_mappings[current_result_address] = None
+                        self.address_mappings[current_result_address] = None  # type: ignore[assignment]
                         self.creation_addresses.add(current_result_address)
                     looking_for_shouldnotexist = False
                     current_result_address = None
                 elif stripped and stripped[-1] in {"}", "]"}:
-                    # End of address block without finding shouldnotexist - leave address hard-coded
+                    # End of address block without finding shouldnotexist -leave address hard-coded
                     looking_for_shouldnotexist = False
                     current_result_address = None
 
@@ -777,9 +772,7 @@ class SimpleAddressConverter:
                             if (
                                 code_content
                                 and code_content not in ["", "0x", "0X", "{}", "[]"]
-                                and (
-                                    code_content in ["|", ">"] or len(code_content) > 2
-                                )
+                                and (code_content in ["|", ">"] or len(code_content) > 2)
                             ):
                                 self.addresses_with_code.add(current_address)
                     # Also check during CODE context for multi-line code
@@ -789,12 +782,9 @@ class SimpleAddressConverter:
                             kw in stripped_no_spaces_or_quotes
                             for kw in {"balance:", "nonce:", "storage:"}
                         ):
-                            if (
-                                stripped
-                                and not stripped.startswith("#")
-                                and "{" not in stripped
-                            ):
-                                # Any non-empty, non-comment, non-brace line in code section indicates there's code
+                            if stripped and not stripped.startswith("#") and "{" not in stripped:
+                                # Any non-empty, non-comment, non-brace line in code section
+                                # indicates there's code
                                 self.addresses_with_code.add(current_address)
 
                 # For JSON files, check code lines directly
@@ -807,10 +797,7 @@ class SimpleAddressConverter:
                         if (
                             code_content
                             and code_content not in ["", "0x", "{}", "[]"]
-                            and (
-                                not code_content.startswith("0x")
-                                or len(code_content) > 3
-                            )
+                            and (not code_content.startswith("0x") or len(code_content) > 3)
                         ):  # More than just "0x"
                             self.addresses_with_code.add(current_address)
 
@@ -824,7 +811,7 @@ class SimpleAddressConverter:
                     if addr not in self.do_not_tag_addresses:
                         self.coinbase_addr = addr
                         if CONVERT_COINBASE and not self.address_mappings.get(addr):
-                            self.address_mappings[addr] = None
+                            self.address_mappings[addr] = None  # type: ignore[assignment]
 
             if current_section == Section.TRANSACTION:
                 if "to:" in stripped_no_spaces_or_quotes:
@@ -890,7 +877,8 @@ class SimpleAddressConverter:
             zero_addr = "0" * 40
             if zero_addr in self.address_mappings and self.address_mappings[zero_addr]:
                 # Simple pattern: CALL[spaces/comma]FIRST_VALUE[spaces/comma]0
-                # This captures CALL followed by any amount of space/comma, then a numeric value, then space/comma, then 0
+                # This captures CALL followed by any amount of space/comma, then a numeric value,
+                # then space/comma, then 0
                 # We ensure FIRST_VALUE and the address (0) are numeric to avoid double-tagging
                 call_pattern = re.compile(
                     r"(call)([,\s]+)(\d+)([,\s]+)0(?=[,\s\)])", re.IGNORECASE
@@ -958,9 +946,7 @@ class SimpleAddressConverter:
                         f"'{KNOWN_SECRET_KEY}'", f"'<eoa:sender:0x{KNOWN_SECRET_KEY}>'"
                     )
                 elif KNOWN_SECRET_KEY in line:
-                    line = line.replace(
-                        KNOWN_SECRET_KEY, f'"<eoa:sender:0x{KNOWN_SECRET_KEY}>"'
-                    )
+                    line = line.replace(KNOWN_SECRET_KEY, f'"<eoa:sender:0x{KNOWN_SECRET_KEY}>"')
                 return line
 
         # Sort addresses by length (longest first) to avoid partial replacements
@@ -984,34 +970,35 @@ class SimpleAddressConverter:
 
             # Skip replacements in code/storage if no_tags_in_code is set
             # EXCEPT for address keys which should always be replaced
-            if self.no_tags_in_code and context in [Context.CODE, Context.STORAGE] and not is_address_key:
+            if (
+                self.no_tags_in_code
+                and context in [Context.CODE, Context.STORAGE]
+                and not is_address_key
+            ):
                 continue
 
             # Use regex to find and replace addresses (case-insensitive)
             # Pattern 1: Address followed by colon (as a key) - with or without 0x prefix
-            pattern_key = re.compile(
-                rf'(^|\s|"|\')(?:0x)?{re.escape(addr)}(?=:)', re.IGNORECASE
-            )
+            pattern_key = re.compile(rf'(^|\s|"|\')(?:0x)?{re.escape(addr)}(?=:)', re.IGNORECASE)
             if pattern_key.search(line):
-                # Skip replacement if we're in storage context, depending on dont_replace_tags_in_storage_keys
-                if (
-                    context != Context.STORAGE
-                    and not self.dont_replace_tags_in_storage_keys
-                ):
+                # Skip replacement if we're in storage context, depending on
+                # dont_replace_tags_in_storage_keys
+                if context != Context.STORAGE and not self.dont_replace_tags_in_storage_keys:
                     # Replace while preserving the prefix (whitespace, quote, etc)
                     line = pattern_key.sub(r"\1" + tag, line)
 
             # Pattern 2: Address in other contexts (not already in a tag)
             # Replace all occurrences that aren't already part of a tag
-            # Use a simple approach: temporarily replace already-tagged addresses to avoid double-tagging
+            # Use a simple approach: temporarily replace already-tagged addresses to avoid
+            # double-tagging
 
             # First, find and temporarily replace all existing tags to protect them
             tag_pattern = re.compile(r"<[^>]+>")
-            protected_tags = []
+            protected_tags = []  # type: ignore[var-annotated]
 
             def protect_tag(match):
-                placeholder = f"__TAG_PLACEHOLDER_{len(protected_tags)}__"
-                protected_tags.append(match.group(0))
+                placeholder = f"__TAG_PLACEHOLDER_{len(protected_tags)}__"  # noqa: B023
+                protected_tags.append(match.group(0))  # noqa: B023
                 return placeholder
 
             # Protect existing tags
@@ -1022,38 +1009,26 @@ class SimpleAddressConverter:
                 # In storage context, handle keys and values separately
                 if not self.dont_replace_tags_in_storage_keys:
                     # Replace addresses everywhere in storage, including keys
-                    pattern_general = re.compile(
-                        rf"(?:0x)?{re.escape(addr)}", re.IGNORECASE
-                    )
-                    line_with_placeholders = pattern_general.sub(
-                        tag, line_with_placeholders
-                    )
+                    pattern_general = re.compile(rf"(?:0x)?{re.escape(addr)}", re.IGNORECASE)
+                    line_with_placeholders = pattern_general.sub(tag, line_with_placeholders)
                 else:
                     # Default behavior: only replace in values, not keys
                     # Split by colon and only replace in values
                     parts = line_with_placeholders.split(":")
                     for i in range(1, len(parts)):  # Skip first part (the key)
                         # Replace address in this part
-                        pattern_general = re.compile(
-                            rf"(?:0x)?{re.escape(addr)}", re.IGNORECASE
-                        )
+                        pattern_general = re.compile(rf"(?:0x)?{re.escape(addr)}", re.IGNORECASE)
                         parts[i] = pattern_general.sub(tag, parts[i])
                     line_with_placeholders = ":".join(parts)
             else:
                 # Not in storage context - replace all occurrences
-                pattern_general = re.compile(
-                    rf"(?:0x)?{re.escape(addr)}", re.IGNORECASE
-                )
-                line_with_placeholders = pattern_general.sub(
-                    tag, line_with_placeholders
-                )
+                pattern_general = re.compile(rf"(?:0x)?{re.escape(addr)}", re.IGNORECASE)
+                line_with_placeholders = pattern_general.sub(tag, line_with_placeholders)
 
             # Restore protected tags
             for i, protected_tag in enumerate(protected_tags):
                 placeholder = f"__TAG_PLACEHOLDER_{i}__"
-                line_with_placeholders = line_with_placeholders.replace(
-                    placeholder, protected_tag
-                )
+                line_with_placeholders = line_with_placeholders.replace(placeholder, protected_tag)
 
             line = line_with_placeholders
 
@@ -1072,12 +1047,12 @@ class SimpleAddressConverter:
                 # Only replace short names in code/storage values, not in address keys
                 if not is_address_key:
                     # Extract the hex part without 0x prefix from short_name
-                    hex_part = (
-                        short_name[2:] if short_name.startswith("0x") else short_name
-                    )
+                    hex_part = short_name[2:] if short_name.startswith("0x") else short_name
 
-                    # Create a pattern that matches the hex part with any number of leading/trailing zeros
-                    # Pattern: optional 0x prefix, any number of zeros, the hex part, any number of zeros
+                    # Create a pattern that matches the hex part with any number of
+                    # leading/trailing zeros
+                    # Pattern: optional 0x prefix, any number of zeros, the hex part,
+                    # any number of zeros
                     # Must be bounded by non-hex characters to avoid partial matches
                     pattern = re.compile(
                         rf"(?:0x)?0*{re.escape(hex_part)}0*(?![a-fA-F0-9])",
@@ -1089,29 +1064,24 @@ class SimpleAddressConverter:
                     if matches:
                         # Replace from end to start to preserve indices
                         for match in reversed(matches):
-                            # Only replace if it's a valid hex number (starts with 0x or is all hex)
+                            # Only replace if it's a valid hex number
+                            # (starts with 0x or is all hex)
                             match_text = match.group(0)
-                            if match_text.startswith("0x") or match_text.startswith(
-                                "0X"
-                            ):
+                            if match_text.startswith("0x") or match_text.startswith("0X"):
                                 line = line[: match.start()] + tag + line[match.end() :]
                             elif all(c in "0123456789abcdefABCDEF" for c in match_text):
-                                # Pure hex without 0x prefix - check context to ensure it's meant as an address
-                                # Look for indicators like quotes, colons, or being a standalone value
+                                # Pure hex without 0x prefix - check context to ensure it's
+                                # meant as an address
+                                # Look for indicators like quotes, colons, or being a
+                                # standalone value
                                 before = line[: match.start()].rstrip()
                                 after = line[match.end() :].lstrip()
                                 if (
                                     before.endswith(('"', "'", ":", " ", "(", "[", ","))
-                                    or after.startswith(
-                                        ('"', "'", " ", ")", "]", ",", "\n")
-                                    )
+                                    or after.startswith(('"', "'", " ", ")", "]", ",", "\n"))
                                     or not before
                                 ):  # Start of line
-                                    line = (
-                                        line[: match.start()]
-                                        + tag
-                                        + line[match.end() :]
-                                    )
+                                    line = line[: match.start()] + tag + line[match.end() :]
 
         return line
 
@@ -1194,7 +1164,7 @@ def convert_file(file_path: str) -> bool:
 
 
 def main():
-    """Main conversion function."""
+    """Main conversion function."""  # noqa: D401
     parser = argparse.ArgumentParser(
         description="Convert addresses to tags in static test fillers"
     )
@@ -1241,9 +1211,7 @@ def main():
             converted_json += 1
             print(f"Converted JSON: {file_path}")
 
-    print(
-        f"\nSummary: Converted {converted_yaml} YAML files and {converted_json} JSON files"
-    )
+    print(f"\nSummary: Converted {converted_yaml} YAML files and {converted_json} JSON files")
 
 
 if __name__ == "__main__":

--- a/src/ethereum_test_checklists/eip_checklist.py
+++ b/src/ethereum_test_checklists/eip_checklist.py
@@ -28,7 +28,7 @@ class ChecklistItemMeta(type):
     _path: str = ""
     _override_name: str = ""
 
-    def __new__(mcs, name: str, bases: tuple, namespace: dict, **kwargs):
+    def __new__(mcs, name: str, bases: tuple, namespace: dict, **kwargs):  # noqa: N804
         """Create a new class with the parent path set."""
         parent_path = kwargs.get("parent_path", "")
         override_name = kwargs.get("override_name", None)

--- a/src/ethereum_test_specs/static_state/expect_section.py
+++ b/src/ethereum_test_specs/static_state/expect_section.py
@@ -336,7 +336,7 @@ class ExpectSectionInStateTestFiller(CamelModel):
         """Validate that the expectation is coherent."""
         if self.expect_exception is None:
             return
-        all_forks: Set[Fork] = set()
+        all_forks: Set[Fork] = set()  # type: ignore[annotation-unchecked]
         for current_fork_set in self.expect_exception:
             for fork in current_fork_set:
                 assert fork not in all_forks

--- a/src/pytest_plugins/filler/filler.py
+++ b/src/pytest_plugins/filler/filler.py
@@ -1170,7 +1170,7 @@ def base_test_parametrizer(cls: Type[BaseTest]):
                 self._operation_mode = request.config.op_mode
 
                 # Get the filling session from config
-                session: FillingSession = request.config.filling_session  # type: ignore[attr-defined]
+                session: FillingSession = request.config.filling_session  # type: ignore
 
                 # Phase 1: Generate pre-allocation groups
                 if session.phase_manager.is_pre_alloc_generation:

--- a/src/pytest_plugins/filler/tests/test_format_selector.py
+++ b/src/pytest_plugins/filler/tests/test_format_selector.py
@@ -168,7 +168,7 @@ class TestFormatSelector:
     def test_comprehensive_scenarios(self):
         """Test comprehensive scenarios covering all phase and format combinations."""
         # Test matrix: (current_phase, previous_phases, format_phases, generate_all) -> expected
-        test_cases: List[
+        test_cases: List[  # type: ignore[annotation-unchecked]
             Tuple[
                 FixtureFillingPhase, Set[FixtureFillingPhase], Set[FixtureFillingPhase], bool, bool
             ]


### PR DESCRIPTION
## 🗒️ Description
No functional change, please merge quickly.

Before this PR there are warnings with:
`uv pip install mypy==1.17.1 && uv run mypy`

Before this PR there are warnings with:
`uv run ruff check`

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
