### PR TITLE
chore(tooling): enforce ruff rule c420

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,7 @@ line-length = 99
 [tool.ruff.lint]
 select = ["E", "F", "B", "W", "I", "A", "N", "D", "C"]
 fixable = ["I", "B", "E", "F", "W", "D", "C"]
-ignore = ["D205", "D203", "D212", "D415", "C901", "A005", "C420"]
+ignore = ["D205", "D203", "D212", "D415", "C901", "A005"]
 
 [tool.mypy]
 disable_error_code = ["import-untyped"]

--- a/tests/cancun/eip1153_tstore/test_tstorage.py
+++ b/tests/cancun/eip1153_tstore/test_tstorage.py
@@ -157,7 +157,7 @@ def test_tload_after_tstore_is_zero(state_test: StateTestFiller, pre: Alloc):
 
     code_address = pre.deploy_contract(
         code=code,  # type: ignore
-        storage=dict.fromkeys(slots_to_write + slots_to_read, 65535),
+        storage=dict.fromkeys(slots_to_write + slots_to_read, 0xFFFF),
     )
 
     tx = Transaction(

--- a/tests/cancun/eip1153_tstore/test_tstorage.py
+++ b/tests/cancun/eip1153_tstore/test_tstorage.py
@@ -79,7 +79,7 @@ def test_tload_after_tstore(state_test: StateTestFiller, pre: Alloc):
     )
     code_address = pre.deploy_contract(
         code=code,  # type: ignore
-        storage=dict.fromkeys(slots_under_test, 255),
+        storage=dict.fromkeys(slots_under_test, 0xFF),
     )
 
     tx = Transaction(

--- a/tests/cancun/eip1153_tstore/test_tstorage.py
+++ b/tests/cancun/eip1153_tstore/test_tstorage.py
@@ -168,7 +168,7 @@ def test_tload_after_tstore_is_zero(state_test: StateTestFiller, pre: Alloc):
 
     post = {
         code_address: Account(
-            storage=dict.fromkeys(slots_to_read, 0) | dict.fromkeys(slots_to_write, 65535)
+            storage=dict.fromkeys(slots_to_read, 0) | dict.fromkeys(slots_to_write, 0xFFFF)
         )
     }
 

--- a/tests/cancun/eip1153_tstore/test_tstorage.py
+++ b/tests/cancun/eip1153_tstore/test_tstorage.py
@@ -45,7 +45,7 @@ def test_transient_storage_unset_values(state_test: StateTestFiller, pre: Alloc)
 
     code_address = pre.deploy_contract(
         code=code,  # type: ignore
-        storage={slot: 1 for slot in slots_under_test},
+        storage=dict.fromkeys(slots_under_test, 1),
     )
 
     tx = Transaction(
@@ -54,7 +54,7 @@ def test_transient_storage_unset_values(state_test: StateTestFiller, pre: Alloc)
         gas_limit=1_000_000,
     )
 
-    post = {code_address: Account(storage={slot: 0 for slot in slots_under_test})}
+    post = {code_address: Account(storage=dict.fromkeys(slots_under_test, 0))}
 
     state_test(
         env=env,
@@ -79,7 +79,7 @@ def test_tload_after_tstore(state_test: StateTestFiller, pre: Alloc):
     )
     code_address = pre.deploy_contract(
         code=code,  # type: ignore
-        storage={slot: 0xFF for slot in slots_under_test},
+        storage=dict.fromkeys(slots_under_test, 255),
     )
 
     tx = Transaction(
@@ -114,7 +114,7 @@ def test_tload_after_sstore(state_test: StateTestFiller, pre: Alloc):
     )
     code_address = pre.deploy_contract(
         code=code,  # type: ignore
-        storage={slot: 1 for slot in slots_under_test},
+        storage=dict.fromkeys(slots_under_test, 1),
     )
 
     tx = Transaction(
@@ -127,7 +127,7 @@ def test_tload_after_sstore(state_test: StateTestFiller, pre: Alloc):
         code_address: Account(
             code=code,
             storage={slot - 1: 0xFF for slot in slots_under_test}
-            | {slot: 0 for slot in slots_under_test},
+            | dict.fromkeys(slots_under_test, 0),
         )
     }
 
@@ -157,7 +157,7 @@ def test_tload_after_tstore_is_zero(state_test: StateTestFiller, pre: Alloc):
 
     code_address = pre.deploy_contract(
         code=code,  # type: ignore
-        storage={slot: 0xFFFF for slot in slots_to_write + slots_to_read},
+        storage=dict.fromkeys(slots_to_write + slots_to_read, 65535),
     )
 
     tx = Transaction(
@@ -168,7 +168,7 @@ def test_tload_after_tstore_is_zero(state_test: StateTestFiller, pre: Alloc):
 
     post = {
         code_address: Account(
-            storage={slot: 0 for slot in slots_to_read} | {slot: 0xFFFF for slot in slots_to_write}
+            storage=dict.fromkeys(slots_to_read, 0) | dict.fromkeys(slots_to_write, 65535)
         )
     }
 

--- a/tests/cancun/eip4788_beacon_root/spec.py
+++ b/tests/cancun/eip4788_beacon_root/spec.py
@@ -58,7 +58,7 @@ class SpecHelpers:
         - validity of the timestamp input used within the call.
         """
         # By default assume the call is unsuccessful and all keys are zero
-        storage = Storage({k: 0 for k in range(4)})  # type: ignore
+        storage = Storage(dict.fromkeys(range(4), 0))  # type: ignore
         if valid_call and valid_input:
             # beacon root contract call is successful
             storage[0] = 1

--- a/tests/cancun/eip4844_blobs/test_blobhash_opcode.py
+++ b/tests/cancun/eip4844_blobs/test_blobhash_opcode.py
@@ -387,7 +387,7 @@ def test_blobhash_multiple_txs_in_block(
             storage={i: random_blob_hashes[i] for i in range(max_blobs_per_tx)}
         )
         if address in (addresses[1], addresses[3])
-        else Account(storage={i: 0 for i in range(max_blobs_per_tx)})
+        else Account(storage=dict.fromkeys(range(max_blobs_per_tx), 0))
         for address in addresses
     }
     blockchain_test(

--- a/tests/cancun/eip4844_blobs/test_point_evaluation_precompile.py
+++ b/tests/cancun/eip4844_blobs/test_point_evaluation_precompile.py
@@ -700,7 +700,7 @@ def test_precompile_during_fork(
 
     post = {
         precompile_caller_address: Account(
-            storage={b: 1 for b in range(1, len(PRE_FORK_BLOCK_RANGE) + 1)},
+            storage=dict.fromkeys(range(1, len(PRE_FORK_BLOCK_RANGE) + 1), 1),
             # Only the call in the last block's tx fails; storage 0 by default.
         ),
         Address(Spec.POINT_EVALUATION_PRECOMPILE_ADDRESS): Account(

--- a/tests/prague/eip7702_set_code_tx/test_gas.py
+++ b/tests/prague/eip7702_set_code_tx/test_gas.py
@@ -959,7 +959,7 @@ def test_account_warming(
     callee_code += Op.STOP
     callee_address = pre.deploy_contract(
         callee_code,
-        storage={check_address: 0xDEADBEEF for check_address in addresses_to_check},
+        storage=dict.fromkeys(addresses_to_check, 3735928559),
     )
 
     tx = Transaction(

--- a/tests/prague/eip7702_set_code_tx/test_gas.py
+++ b/tests/prague/eip7702_set_code_tx/test_gas.py
@@ -959,7 +959,7 @@ def test_account_warming(
     callee_code += Op.STOP
     callee_address = pre.deploy_contract(
         callee_code,
-        storage=dict.fromkeys(addresses_to_check, 3735928559),
+        storage=dict.fromkeys(addresses_to_check, 0xDEADBEEF),
     )
 
     tx = Transaction(

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -128,7 +128,7 @@ def test_self_sponsored_set_code(
         pre=pre,
         tx=tx,
         post={
-            set_code_to_address: Account(storage={k: 0 for k in storage}),
+            set_code_to_address: Account(storage=dict.fromkeys(storage, 0)),
             sender: Account(
                 nonce=2,
                 code=Spec.delegation_designation(set_code_to_address),
@@ -208,7 +208,7 @@ def test_set_code_to_sstore(
         tx=tx,
         post={
             set_code_to_address: Account(
-                storage={k: 0 for k in storage},
+                storage=dict.fromkeys(storage, 0),
             ),
             auth_signer: Account(
                 nonce=2 if self_sponsored else 1,
@@ -799,8 +799,8 @@ def test_set_code_call_set_code(
         pre=pre,
         tx=tx,
         post={
-            set_code_to_address_1: Account(storage={k: 0 for k in storage_1}),
-            set_code_to_address_2: Account(storage={k: 0 for k in storage_2}),
+            set_code_to_address_1: Account(storage=dict.fromkeys(storage_1, 0)),
+            set_code_to_address_2: Account(storage=dict.fromkeys(storage_2, 0)),
             auth_signer_1: Account(
                 nonce=1,
                 code=Spec.delegation_designation(set_code_to_address_1),

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs_2.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs_2.py
@@ -1743,7 +1743,7 @@ def test_set_code_type_tx_pre_fork(
         pre=pre,
         tx=tx,
         post={
-            set_code_to_address: Account(storage={k: 0 for k in storage}),
+            set_code_to_address: Account(storage=dict.fromkeys(storage, 0)),
             sender: Account(
                 nonce=0,
                 code="",

--- a/tests/unscheduled/eip7692_eof_v1/eip3540_eof_v1/test_execution_function.py
+++ b/tests/unscheduled/eip7692_eof_v1/eip3540_eof_v1/test_execution_function.py
@@ -419,7 +419,7 @@ def test_eof_functions_contract_call_within_deep_nested(
         sender=sender,
     )
     post = {
-        callee_address: Account(storage={i: 1 for i in range(MAX_CODE_SECTIONS)}),
+        callee_address: Account(storage=dict.fromkeys(range(MAX_CODE_SECTIONS), 1)),
         nested_callee_address: Account(
             storage={
                 0: 1,


### PR DESCRIPTION
## 🗒️ Description
Rule C420 is [unnecessary-dict-comprehension-for-iterable (C420)](https://docs.astral.sh/ruff/rules/unnecessary-dict-comprehension-for-iterable/#unnecessary-dict-comprehension-for-iterable-c420).

The 18 errors are only visible in newer ruff versions (e.g. `0.9.6` will show 0 errors, but `0.11.8` will show 18 errors). To use the same ruff version that tox will use in CI run 
`.tox/lint/bin/ruff check --no-fix --show-fixes src tests .github/scripts`. 
Ruff was able to autofix everything with 
`.tox/lint/bin/ruff check --fix --show-fixes src tests .github/scripts`, 
I re-ran mypy after that and there are no complaints. Should be safe to merge.

Relevant for #2128 

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
