### PR TITLE
chore(tests): updates exceptions for data floor cost equal to intrinsic cost

### DIFF
--- a/tests/prague/eip7623_increase_calldata_cost/conftest.py
+++ b/tests/prague/eip7623_increase_calldata_cost/conftest.py
@@ -296,11 +296,23 @@ def tx_gas_limit(
 
 
 @pytest.fixture
-def tx_error(tx_gas_delta: int, data_test_type: DataTestType) -> TransactionException | None:
+def tx_error(
+    tx_gas_delta: int,
+    data_test_type: DataTestType,
+    tx_intrinsic_gas_cost_before_execution: int,
+    tx_floor_data_cost: int,
+) -> TransactionException | list[TransactionException] | None:
     """Transaction error, only expected if the gas delta is negative."""
     if tx_gas_delta < 0:
         if data_test_type == DataTestType.FLOOR_GAS_COST_GREATER_THAN_INTRINSIC_GAS:
-            return TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST
+            if tx_floor_data_cost == tx_intrinsic_gas_cost_before_execution:
+                # Depending on the implementation, client might raise either exception.
+                return [
+                    TransactionException.INTRINSIC_GAS_TOO_LOW,
+                    TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST,
+                ]
+            else:
+                return TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST
         else:
             return TransactionException.INTRINSIC_GAS_TOO_LOW
     return None


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Aims to fix the following reth errors on hive: https://hive.ethpandaops.io/#/test/fusaka/1757685753-95501b795f276d62acffa3141ff52072
- `tests/osaka/eip7825_transaction_gas_limit_cap/test_tx_gas_limit.py::test_tx_gas_limit_cap_full_calldata`
-  `tests/prague/eip7623_increase_calldata_cost/test_transaction_validity.py::test_transaction_validity_type_X`

Following #2096 this aims to catch the cases where both the floor gas cost and intrinsic gas cost are equal at threshold boundaries. The tests were failing because they expected `INTRINSIC_GAS_BELOW_FLOOR_GAS_COST` but reth was returning `INTRINSIC_GAS_TOO_LOW` when the calculated floor gas cost equals the traditional intrinsic gas cost.

This PR adds the same equality check logic from the EIP-2930 tests, allowing both exceptions to be acceptable when `floor_gas_cost == intrinsic_gas_cost`, since different client implementations may check these constraints in different orders.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Follow up to https://github.com/ethereum/execution-spec-tests/pull/2096

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
