### PR TITLE
feat(tests): add invalid p256verify cases

### DIFF
--- a/tests/benchmark/test_worst_compute.py
+++ b/tests/benchmark/test_worst_compute.py
@@ -1680,6 +1680,28 @@ def test_worst_modexp(
             id="p256verify",
             marks=[pytest.mark.eip_checklist("precompile/test/excessive_gas_usage", eip=[7951])],
         ),
+        pytest.param(
+            p256verify_spec.Spec.P256VERIFY,
+            [
+                "235060CAFE19A407880C272BC3E73600E3A12294F56143ED61929C2FF4525ABB",
+                "182E5CBDF96ACCB859E8EEA1850DE5FF6E430A19D1D9A680ECD5946BBEA8A32B",
+                "76DDFAE6797FA6777CAAB9FA10E75F52E70A4E6CEB117B3C5B2F445D850BD64C",
+                "3828736CDFC4C8696008F71999260329AD8B12287846FEDCEDE3BA1205B12729",
+                "3E5141734E971A8D55015068D9B3666760F4608A49B11F92E500ACEA647978C7",
+            ],
+            id="p256verify_wrong_endianness",
+        ),
+        pytest.param(
+            p256verify_spec.Spec.P256VERIFY,
+            [
+                "BB5A52F42F9C9261ED4361F59422A1E30036E7C32B270C8807A419FECA605023",
+                "000000000000000000000000000000004319055358E8617B0C46353D039CDAAB",
+                "FFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC63254E",
+                "0AD99500288D466940031D72A9F5445A4D43784640855BF0A69874D2DE5FE103",
+                "C5011E6EF2C42DCD50D5D3D29F99AE6EBA2C80C9244F4C5422F0979FF0C3BA5E",
+            ],
+            id="p256verify_modular_comp_x_coordinate_exceeds_n",
+        ),
     ],
 )
 def test_worst_precompile_fixed_cost(


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Add invalid precompile input cases for p256verify precompile, it is one of the Nethermind gas-benchmarks cases.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->

Issue https://github.com/ethereum/execution-spec-tests/issues/2026

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
