### PR TITLE
feat(pre_alloc): Add maximum bytecode size limit for contract deployment

### DIFF
--- a/src/pytest_plugins/filler/tests/test_pre_alloc.py
+++ b/src/pytest_plugins/filler/tests/test_pre_alloc.py
@@ -5,6 +5,7 @@ from itertools import count
 import pytest
 
 from ethereum_test_base_types import Address, TestPrivateKey, TestPrivateKey2
+from ethereum_test_forks import Prague
 from ethereum_test_types import EOA
 from ethereum_test_vm import EVMCodeType
 from ethereum_test_vm import Opcodes as Op
@@ -33,6 +34,7 @@ def create_test_alloc(
         alloc_mode=alloc_mode,
         contract_address_iterator=contract_iter,
         eoa_iterator=eoa_iter,
+        fork=Prague,
         evm_code_type=evm_code_type,
     )
 

--- a/src/pytest_plugins/filler/tests/test_pre_alloc.py
+++ b/src/pytest_plugins/filler/tests/test_pre_alloc.py
@@ -5,7 +5,7 @@ from itertools import count
 import pytest
 
 from ethereum_test_base_types import Address, TestPrivateKey, TestPrivateKey2
-from ethereum_test_forks import Prague
+from ethereum_test_forks import Fork, Prague
 from ethereum_test_types import EOA
 from ethereum_test_vm import EVMCodeType
 from ethereum_test_vm import Opcodes as Op
@@ -19,7 +19,9 @@ from ..pre_alloc import (
 
 
 def create_test_alloc(
-    alloc_mode: AllocMode = AllocMode.PERMISSIVE, evm_code_type: EVMCodeType = EVMCodeType.LEGACY
+    alloc_mode: AllocMode = AllocMode.PERMISSIVE,
+    fork: Fork = Prague,
+    evm_code_type: EVMCodeType = EVMCodeType.LEGACY,
 ) -> Alloc:
     """Create a test Alloc instance with default iterators."""
     contract_iter = iter(
@@ -34,7 +36,7 @@ def create_test_alloc(
         alloc_mode=alloc_mode,
         contract_address_iterator=contract_iter,
         eoa_iterator=eoa_iter,
-        fork=Prague,
+        fork=fork,
         evm_code_type=evm_code_type,
     )
 

--- a/tests/benchmark/test_worst_compute.py
+++ b/tests/benchmark/test_worst_compute.py
@@ -2872,13 +2872,20 @@ def test_worst_push(
 ):
     """Test running a block with as many PUSH as possible."""
     op = opcode[1] if opcode.has_data_portion() else opcode
-    opcode_sequence = op * fork.max_stack_height()
-    target_contract_address = pre.deploy_contract(code=opcode_sequence)
+
+    op_seq = Bytecode()
+    for _ in range(fork.max_stack_height()):
+        if len(op_seq) + len(op) > fork.max_code_size():
+            break
+        op_seq += op
+
+    target_contract_address = pre.deploy_contract(code=op_seq)
 
     calldata = Bytecode()
     attack_block = Op.POP(Op.STATICCALL(Op.GAS, target_contract_address, 0, 0, 0, 0))
 
     code = code_loop_precompile_call(calldata, attack_block, fork)
+
     code_address = pre.deploy_contract(code=code)
 
     tx = Transaction(


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

We do not verify the deployed code size limit in fill, this leads to several issue:
- The `PUSH` benchmark test is actually invalid.
- We do not notice the limit in bloatnet benchmark test -> i left a review that is impossible to implement.

This PR enforces the deployed contract size limit check and resolve the failing test.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->

PR #2090 

Comment: https://github.com/ethereum/execution-spec-tests/pull/2090#issuecomment-3285384772

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
