### PR TITLE
chore(tests): group mem-heavy tests together in xdist

### DIFF
--- a/tests/osaka/eip7825_transaction_gas_limit_cap/test_tx_gas_limit.py
+++ b/tests/osaka/eip7825_transaction_gas_limit_cap/test_tx_gas_limit.py
@@ -208,6 +208,7 @@ def total_cost_floor_per_token(fork: Fork):
     return gas_costs.G_TX_DATA_FLOOR_TOKEN_COST
 
 
+@pytest.mark.xdist_group(name="bigmem")
 @pytest.mark.parametrize(
     "exceed_tx_gas_limit,correct_intrinsic_cost_in_transaction_gas_limit",
     [

--- a/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
+++ b/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
@@ -381,6 +381,7 @@ def _exact_size_transactions_impl(
     return transactions, final_gas
 
 
+@pytest.mark.xdist_group(name="bigmem")
 @pytest.mark.parametrize(
     "delta",
     [
@@ -440,6 +441,7 @@ def test_block_at_rlp_size_limit_boundary(
     )
 
 
+@pytest.mark.xdist_group(name="bigmem")
 @pytest.mark.with_all_typed_transactions
 @pytest.mark.verify_sync
 def test_block_rlp_size_at_limit_with_all_typed_transactions(
@@ -479,6 +481,7 @@ def test_block_rlp_size_at_limit_with_all_typed_transactions(
     )
 
 
+@pytest.mark.xdist_group(name="bigmem")
 @pytest.mark.verify_sync
 def test_block_at_rlp_limit_with_logs(
     blockchain_test: BlockchainTestFiller,

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -1812,6 +1812,7 @@ def test_set_code_to_self_destructing_account_deployed_in_same_tx(
     )
 
 
+@pytest.mark.xdist_group(name="bigmem")
 def test_set_code_multiple_first_valid_authorization_tuples_same_signer(
     state_test: StateTestFiller,
     pre: Alloc,
@@ -1859,6 +1860,7 @@ def test_set_code_multiple_first_valid_authorization_tuples_same_signer(
     )
 
 
+@pytest.mark.xdist_group(name="bigmem")
 def test_set_code_multiple_valid_authorization_tuples_same_signer_increasing_nonce(
     state_test: StateTestFiller,
     pre: Alloc,
@@ -1906,6 +1908,7 @@ def test_set_code_multiple_valid_authorization_tuples_same_signer_increasing_non
     )
 
 
+@pytest.mark.xdist_group(name="bigmem")
 def test_set_code_multiple_valid_authorization_tuples_same_signer_increasing_nonce_self_sponsored(
     state_test: StateTestFiller,
     pre: Alloc,
@@ -2001,6 +2004,7 @@ def test_set_code_multiple_valid_authorization_tuples_first_invalid_same_signer(
     )
 
 
+@pytest.mark.xdist_group(name="bigmem")
 def test_set_code_all_invalid_authorization_tuples(
     state_test: StateTestFiller,
     pre: Alloc,
@@ -2040,6 +2044,7 @@ def test_set_code_all_invalid_authorization_tuples(
     )
 
 
+@pytest.mark.xdist_group(name="bigmem")
 def test_set_code_using_chain_specific_id(
     state_test: StateTestFiller,
     pre: Alloc,
@@ -2088,6 +2093,7 @@ SECP256K1N = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
 SECP256K1N_OVER_2 = SECP256K1N // 2
 
 
+@pytest.mark.xdist_group(name="bigmem")
 @pytest.mark.parametrize(
     "v,r,s",
     [
@@ -2148,6 +2154,7 @@ def test_set_code_using_valid_synthetic_signatures(
     )
 
 
+@pytest.mark.xdist_group(name="bigmem")
 @pytest.mark.parametrize(
     "v,r,s",
     [

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs_2.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs_2.py
@@ -1441,6 +1441,7 @@ class DelegationTo(Enum):
     RESET = 3
 
 
+@pytest.mark.xdist_group(name="bigmem")
 @pytest.mark.valid_from("Prague")
 @pytest.mark.parametrize(
     "first_delegation", [DelegationTo.CONTRACT_A, DelegationTo.CONTRACT_B, DelegationTo.RESET]
@@ -1536,6 +1537,7 @@ def test_double_auth(
     )
 
 
+@pytest.mark.xdist_group(name="bigmem")
 @pytest.mark.valid_from("Prague")
 def test_pointer_resets_an_empty_code_account_with_storage(
     blockchain_test: BlockchainTestFiller,
@@ -1754,6 +1756,7 @@ def test_set_code_type_tx_pre_fork(
 
 
 @pytest.mark.valid_from("Prague")
+@pytest.mark.xdist_group(name="bigmem")
 def test_delegation_replacement_call_previous_contract(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/shanghai/eip3855_push0/test_push0.py
+++ b/tests/shanghai/eip3855_push0/test_push0.py
@@ -29,6 +29,7 @@ REFERENCE_SPEC_VERSION = ref_spec_3855.version
 pytestmark = pytest.mark.valid_from("Shanghai")
 
 
+@pytest.mark.xdist_group(name="bigmem")
 @pytest.mark.parametrize(
     "contract_code,expected_storage",
     [
@@ -120,6 +121,7 @@ class TestPush0CallContext:
         )
         return pre.deploy_contract(call_code)
 
+    @pytest.mark.xdist_group(name="bigmem")
     @pytest.mark.parametrize(
         "call_opcode",
         [

--- a/tests/shanghai/eip3860_initcode/test_initcode.py
+++ b/tests/shanghai/eip3860_initcode/test_initcode.py
@@ -117,6 +117,7 @@ Test cases using a contract creating transaction
 """
 
 
+@pytest.mark.xdist_group(name="bigmem")
 @pytest.mark.parametrize(
     "initcode",
     [
@@ -481,6 +482,7 @@ class TestCreateInitcode:
         gas_costs = fork.gas_costs()
         return ceiling_division(len(initcode), 32) * gas_costs.G_KECCAK_256_WORD
 
+    @pytest.mark.xdist_group(name="bigmem")
     def test_create_opcode_initcode(
         self,
         state_test: StateTestFiller,

--- a/tests/shanghai/eip4895_withdrawals/test_withdrawals.py
+++ b/tests/shanghai/eip4895_withdrawals/test_withdrawals.py
@@ -651,6 +651,7 @@ def test_zero_amount(
     )
 
 
+@pytest.mark.xdist_group(name="bigmem")
 def test_large_amount(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
@@ -690,6 +691,7 @@ def test_large_amount(
     blockchain_test(pre=pre, post=post, blocks=blocks)
 
 
+@pytest.mark.xdist_group(name="bigmem")
 @pytest.mark.parametrize("amount", [0, 1])
 @pytest.mark.with_all_precompiles
 def test_withdrawing_to_precompiles(


### PR DESCRIPTION
## 🗒️ Description

Some tests make heavy use of `lru_cache`. Others are just memory hungry. By grouping these tests onto a single xdist worker, we consolidate caches and prevent multiple big-memory tests from running at the same time.

In some _very_ rough benchmarks, I see a reduction in memory use of about 1.2GB on my local machine.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).