### PR TITLE
chore(consume): update sync timeout for consume sync

### DIFF
--- a/src/pytest_plugins/consume/simulators/simulator_logic/test_via_sync.py
+++ b/src/pytest_plugins/consume/simulators/simulator_logic/test_via_sync.py
@@ -442,7 +442,7 @@ def test_blockchain_via_sync(
         last_forkchoice_time = time.time()
         forkchoice_interval = 2.0  # Send forkchoice updates every 2 seconds
 
-        while time.time() - sync_start_time < 10:  # 10 second timeout
+        while time.time() - sync_start_time < 60:  # 60 second timeout
             # Send periodic forkchoice updates to keep sync alive
             if time.time() - last_forkchoice_time >= forkchoice_interval:
                 try:


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Bumps the timeout for consume sync in hive. Aims to resolve most of the [failures](https://hive.ethpandaops.io/#/compare/fusaka?runs=1757942250-a22f5b71ad90e2fa8c4edff781d9c61d,1757855648-5f4a5238bf9c3751129adad6c86cc0bd,1757769164-8be7ac6894a932d5669a373da175dee9,1757683547-e6d2983e5c5a9909299e28718f13c8b3,1757596451-79db9d78d267c7339a042b9c0f163e01,1757510040-76936787c4a5a95d84185d3bd315d8b9).



## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

