### PR TITLE
chore(tests): fix shanghai to cancun transition test genesis block

### DIFF
--- a/tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py
+++ b/tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py
@@ -47,7 +47,11 @@ def block_gas_limit(fork: Fork) -> int:  # noqa: D103
 
 
 @pytest.fixture
-def genesis_environment(block_gas_limit: int, block_base_fee_per_gas: int) -> Environment:  # noqa: D103
+def genesis_environment(block_gas_limit: int, block_base_fee_per_gas: int) -> Environment:
+    """
+    Genesis environment that enables existing transition tests to be used of BPO forks.
+    Compatible with all fork transitions.
+    """
     return Environment(
         base_fee_per_gas=(block_base_fee_per_gas * BASE_FEE_MAX_CHANGE_DENOMINATOR) // 7,
         gas_limit=block_gas_limit,
@@ -320,7 +324,7 @@ def post(  # noqa: D103
 @pytest.mark.exception_test
 def test_invalid_pre_fork_block_with_blob_fields(
     blockchain_test: BlockchainTestFiller,
-    env: Environment,
+    genesis_environment: Environment,
     pre: Alloc,
     pre_fork_blocks: List[Block],
     excess_blob_gas_present: bool,
@@ -349,7 +353,7 @@ def test_invalid_pre_fork_block_with_blob_fields(
                 engine_api_error_code=EngineAPIError.InvalidParams,
             )
         ],
-        genesis_environment=env,
+        genesis_environment=genesis_environment,
     )
 
 
@@ -365,7 +369,7 @@ def test_invalid_pre_fork_block_with_blob_fields(
 @pytest.mark.exception_test
 def test_invalid_post_fork_block_without_blob_fields(
     blockchain_test: BlockchainTestFiller,
-    env: Environment,
+    genesis_environment: Environment,
     pre: Alloc,
     pre_fork_blocks: List[Block],
     excess_blob_gas_missing: bool,
@@ -395,7 +399,7 @@ def test_invalid_post_fork_block_without_blob_fields(
                 engine_api_error_code=EngineAPIError.InvalidParams,
             )
         ],
-        genesis_environment=env,
+        genesis_environment=genesis_environment,
     )
 
 
@@ -419,7 +423,7 @@ def test_invalid_post_fork_block_without_blob_fields(
 )
 def test_fork_transition_excess_blob_gas_at_blob_genesis(
     blockchain_test: BlockchainTestFiller,
-    env: Environment,
+    genesis_environment: Environment,
     pre: Alloc,
     pre_fork_blocks: List[Block],
     post_fork_blocks: List[Block],
@@ -435,7 +439,7 @@ def test_fork_transition_excess_blob_gas_at_blob_genesis(
         pre=pre,
         post=post,
         blocks=pre_fork_blocks + post_fork_blocks,
-        genesis_environment=env,
+        genesis_environment=genesis_environment,
     )
 
 


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
We broke the Shanghai to Cancun transition tests in #2059. The change to the `genesis_env` fixture led to these tests using the default conftest genesis fixture, adding Cancun blob fields to the Shanghai genesis block.

In the future we should consider adding validation for the block headers based on the forks they represent.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
https://github.com/paradigmxyz/reth/pull/18412

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
