### PR TITLE
chore(consume): fix consume rlp for python 3.11

### DIFF
--- a/src/pytest_plugins/consume/simulators/simulator_logic/test_via_rlp.py
+++ b/src/pytest_plugins/consume/simulators/simulator_logic/test_via_rlp.py
@@ -63,7 +63,7 @@ def test_via_rlp(
                         )
                 raise AssertionError(
                     "blockHash mismatch in last block - field mismatches:"
-                    f"\n{'\n'.join(mismatches)}"
+                    "\n" + "\n".join(mismatches)
                 )
             except Exception as e:
                 raise AssertionError(


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Fixes a recent change for consume rlp for python 3.11.

The issue is that Python 3.11 doesn't allow backslash escape sequences directly inside f-strings (this was added in Python 3.12).

Error recieved when running `consume rlp` in 3.11:
```
E     File "...execution-spec-tests/src/pytest_plugins/consume/simulators/simulator_logic/test_via_rlp.py", line 67
E       )
E       ^
E   SyntaxError: f-string expression part cannot include a backslash
```

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
