### PR TITLE
chore: unused arguments

### DIFF
--- a/docs/getting_started/code_standards.md
+++ b/docs/getting_started/code_standards.md
@@ -80,6 +80,7 @@ Code pushed to @ethereum/execution-spec-tests must fulfill the following checks 
 - **Relative Imports**: Use relative imports within the same package
 - **Error Handling**: Use explicit exception types and meaningful error messages.
 - **Type Hints**: All functions should include type annotations.
+- **Unused Function Arguments**: When  unavoidable, use `del`, e.g., `del unused_var`, at function start to avoid flagging linter errors.
 - **Variable Naming**:
     - Use `snake_case` for variables, functions, and modules.
     - Use `PascalCase` for classes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,9 +127,12 @@ ethereum_test_forks = ["forks/contracts/*.bin"]
 line-length = 99
 
 [tool.ruff.lint]
-select = ["E", "F", "B", "W", "I", "A", "N", "D", "C"]
+select = ["E", "F", "B", "W", "I", "A", "N", "D", "C", "ARG001"]
 fixable = ["I", "B", "E", "F", "W", "D", "C"]
 ignore = ["D205", "D203", "D212", "D415", "C420", "C901"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["ARG001"] # TODO: ethereum/execution-spec-tests#2188
 
 [tool.mypy]
 disable_error_code = ["import-untyped"]

--- a/src/cli/gen_index.py
+++ b/src/cli/gen_index.py
@@ -54,15 +54,6 @@ def count_json_files_exclude_index(start_path: Path) -> int:
     help="The input directory",
 )
 @click.option(
-    "--disable-infer-format",
-    "-d",
-    "disable_infer_format",
-    is_flag=True,
-    default=False,
-    expose_value=True,
-    help="Don't try to guess the fixture format from the json file's path.",
-)
-@click.option(
     "--quiet",
     "-q",
     "quiet_mode",
@@ -80,15 +71,12 @@ def count_json_files_exclude_index(start_path: Path) -> int:
     expose_value=True,
     help="Force re-generation of the index file, even if it already exists.",
 )
-def generate_fixtures_index_cli(
-    input_dir: str, quiet_mode: bool, force_flag: bool, disable_infer_format: bool
-):
+def generate_fixtures_index_cli(input_dir: str, quiet_mode: bool, force_flag: bool):
     """CLI wrapper to an index of all the fixtures in the specified directory."""
     generate_fixtures_index(
         Path(input_dir),
         quiet_mode=quiet_mode,
         force_flag=force_flag,
-        disable_infer_format=disable_infer_format,
     )
 
 
@@ -96,7 +84,6 @@ def generate_fixtures_index(
     input_path: Path,
     quiet_mode: bool = False,
     force_flag: bool = False,
-    disable_infer_format: bool = False,
 ):
     """
     Generate an index file (index.json) of all the fixtures in the specified

--- a/src/cli/gentest/tests/test_cli.py
+++ b/src/cli/gentest/tests/test_cli.py
@@ -106,6 +106,7 @@ def test_tx_type(pytester, tmp_path, monkeypatch, tx_type, transaction_hash, def
     tx = transactions_by_type[tx_type]
 
     def get_mock_context(self: StateTestProvider) -> dict:
+        del self
         return tx
 
     monkeypatch.setattr(StateTestProvider, "get_context", get_mock_context)

--- a/src/cli/pytest_commands/check_eip_versions.py
+++ b/src/cli/pytest_commands/check_eip_versions.py
@@ -14,6 +14,8 @@ from .processors import HelpFlagsProcessor
 @common_pytest_options
 def check_eip_versions(pytest_args: List[str], **kwargs) -> None:
     """Run pytest with the `spec_version_checker` plugin."""
+    del kwargs
+
     command = PytestCommand(
         config_file="pytest-check-eip-versions.ini",
         argument_processors=[HelpFlagsProcessor("check-eip-versions")],

--- a/src/cli/pytest_commands/checklist.py
+++ b/src/cli/pytest_commands/checklist.py
@@ -41,6 +41,8 @@ def checklist(output: str, eip: tuple, **kwargs) -> None:
         uv run checklist --output ./my-checklists
 
     """
+    del kwargs
+
     # Add output directory to pytest args
     args = ["--checklist-output", output]
 

--- a/src/cli/pytest_commands/consume.py
+++ b/src/cli/pytest_commands/consume.py
@@ -36,7 +36,7 @@ def create_consume_command(
     )
 
 
-def get_command_logic_test_paths(command_name: str, is_hive: bool) -> List[Path]:
+def get_command_logic_test_paths(command_name: str) -> List[Path]:
     """Determine the command paths based on the command name and hive flag."""
     base_path = Path("pytest_plugins/consume")
     if command_name in ["engine", "rlp"]:
@@ -66,7 +66,7 @@ def consume_command(is_hive: bool = False) -> Callable[[Callable[..., Any]], cli
     def decorator(func: Callable[..., Any]) -> click.Command:
         command_name = func.__name__
         command_help = func.__doc__
-        command_logic_test_paths = get_command_logic_test_paths(command_name, is_hive)
+        command_logic_test_paths = get_command_logic_test_paths(command_name)
 
         @consume.command(
             name=command_name,
@@ -76,6 +76,8 @@ def consume_command(is_hive: bool = False) -> Callable[[Callable[..., Any]], cli
         @common_pytest_options
         @functools.wraps(func)
         def command(pytest_args: List[str], **kwargs) -> None:
+            del kwargs
+
             consume_cmd = create_consume_command(
                 command_logic_test_paths=command_logic_test_paths,
                 is_hive=is_hive,
@@ -118,5 +120,7 @@ def sync() -> None:
 @common_pytest_options
 def cache(pytest_args: List[str], **kwargs) -> None:
     """Consume command to cache test fixtures."""
+    del kwargs
+
     cache_cmd = create_consume_command(command_logic_test_paths=[], is_hive=False)
     cache_cmd.execute(list(pytest_args))

--- a/src/cli/pytest_commands/fill.py
+++ b/src/cli/pytest_commands/fill.py
@@ -213,6 +213,8 @@ class PhilCommand(FillCommand):
 @common_pytest_options
 def fill(pytest_args: List[str], **kwargs) -> None:
     """Entry point for the fill command."""
+    del kwargs
+
     command = FillCommand()
     command.execute(list(pytest_args))
 
@@ -225,6 +227,8 @@ def fill(pytest_args: List[str], **kwargs) -> None:
 @common_pytest_options
 def phil(pytest_args: List[str], **kwargs) -> None:
     """Friendly alias for the fill command."""
+    del kwargs
+
     command = PhilCommand()
     command.execute(list(pytest_args))
 

--- a/src/cli/show_pre_alloc_group_stats.py
+++ b/src/cli/show_pre_alloc_group_stats.py
@@ -100,7 +100,7 @@ def calculate_size_distribution(
     return group_distribution, test_distribution
 
 
-def analyze_pre_alloc_folder(folder: Path, verbose: int = 0) -> Dict:
+def analyze_pre_alloc_folder(folder: Path) -> Dict:
     """Analyze pre-allocation folder and return statistics."""
     pre_alloc_groups = PreAllocGroups.from_folder(folder, lazy_load=False)
 
@@ -480,7 +480,7 @@ def main(pre_alloc_folder: Path, verbose: int):
     console = Console()
 
     try:
-        stats = analyze_pre_alloc_folder(pre_alloc_folder, verbose=verbose)
+        stats = analyze_pre_alloc_folder(pre_alloc_folder)
         display_stats(stats, console, verbose=verbose)
     except FileNotFoundError:
         console.print(f"[red]Error: Folder not found: {pre_alloc_folder}[/red]")

--- a/src/cli/tests/test_pytest_execute_command.py
+++ b/src/cli/tests/test_pytest_execute_command.py
@@ -28,7 +28,7 @@ def test_execute_help_shows_subcommand_docstrings(runner):
     assert "Recover funds from test executions" in result.output
 
 
-def test_execute_subcommands_have_help_text(runner):
+def test_execute_subcommands_have_help_text():
     """Test that execute sub-commands have proper help text defined."""
     from ..pytest_commands.execute import hive, recover, remote
 

--- a/src/ethereum_clis/tests/test_execution_specs.py
+++ b/src/ethereum_clis/tests/test_execution_specs.py
@@ -12,7 +12,7 @@ from pydantic import TypeAdapter
 
 from ethereum_clis import ExecutionSpecsTransitionTool, TransitionTool
 from ethereum_test_base_types import to_json
-from ethereum_test_forks import Berlin, Fork, Istanbul, London
+from ethereum_test_forks import Berlin
 from ethereum_test_types import Alloc, Environment, Transaction
 
 FIXTURES_ROOT = Path(os.path.join("src", "ethereum_clis", "tests", "fixtures"))
@@ -34,7 +34,6 @@ def monkeypatch_path_for_entry_points(monkeypatch):
     monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
 
 
-@pytest.mark.parametrize("fork", [London, Istanbul])
 @pytest.mark.parametrize(
     "alloc,base_fee,expected_hash",
     [
@@ -86,8 +85,6 @@ def monkeypatch_path_for_entry_points(monkeypatch):
     ],
 )
 def test_calc_state_root(
-    default_t8n: TransitionTool,
-    fork: Fork,
     alloc: Dict,
     base_fee: int | None,
     expected_hash: bytes,

--- a/src/ethereum_clis/tests/test_execution_specs.py
+++ b/src/ethereum_clis/tests/test_execution_specs.py
@@ -35,7 +35,7 @@ def monkeypatch_path_for_entry_points(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "alloc,base_fee,expected_hash",
+    "alloc,expected_hash",
     [
         (
             {
@@ -46,7 +46,6 @@ def monkeypatch_path_for_entry_points(monkeypatch):
                     "storage": {},
                 },
             },
-            7,
             bytes.fromhex("51e7c7508e76dca0"),
         ),
         (
@@ -55,7 +54,6 @@ def monkeypatch_path_for_entry_points(monkeypatch):
                     "balance": "0x0BA1A9CE0BA1A9CE",
                 },
             },
-            None,
             bytes.fromhex("51e7c7508e76dca0"),
         ),
         (
@@ -67,7 +65,6 @@ def monkeypatch_path_for_entry_points(monkeypatch):
                     "storage": {},
                 },
             },
-            None,
             bytes.fromhex("37c2dedbdea6b3af"),
         ),
         (
@@ -79,23 +76,15 @@ def monkeypatch_path_for_entry_points(monkeypatch):
                     },
                 },
             },
-            None,
             bytes.fromhex("096122e88929baec"),
         ),
     ],
 )
 def test_calc_state_root(
     alloc: Dict,
-    base_fee: int | None,
     expected_hash: bytes,
 ) -> None:
     """Test calculation of the state root against expected hash."""
-
-    class TestEnv:
-        base_fee: int | None
-
-    env = TestEnv()
-    env.base_fee = base_fee
     assert Alloc(alloc).state_root().startswith(expected_hash)
 
 

--- a/src/ethereum_clis/tests/test_transition_tool.py
+++ b/src/ethereum_clis/tests/test_transition_tool.py
@@ -67,9 +67,11 @@ def test_from_binary(
             self.returncode = 0
 
     def mock_which(self):
+        del self
         return which_result
 
     def mock_run(args, **kwargs):
+        del args, kwargs
         return MockCompletedProcess(read_result.encode())
 
     monkeypatch.setattr(shutil, "which", mock_which)

--- a/src/ethereum_test_base_types/tests/test_reference_spec.py
+++ b/src/ethereum_test_base_types/tests/test_reference_spec.py
@@ -63,6 +63,8 @@ def test_git_reference_spec(monkeypatch):
     """Test Git reference spec."""
 
     def mock_get(self, headers=None):
+        del self, headers
+
         class Response:
             content = (
                 '{"content": "'

--- a/src/ethereum_test_checklists/tests/test_checklist_template_consistency.py
+++ b/src/ethereum_test_checklists/tests/test_checklist_template_consistency.py
@@ -32,7 +32,7 @@ def extract_markdown_ids(markdown_content: str) -> Set[str]:
     return ids
 
 
-def get_all_checklist_ids(obj, current_path="") -> Set[str]:
+def get_all_checklist_ids(obj) -> Set[str]:
     """Recursively extract all checklist IDs from EIPChecklist and its children."""
     ids = set()
 

--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -153,6 +153,8 @@ class Frontier(BaseFork, solc_name="homestead"):
         gas_costs = cls.gas_costs(block_number, timestamp)
 
         def fn(*, data: BytesConvertible, floor: bool = False) -> int:
+            del floor
+
             cost = 0
             for b in Bytes(data):
                 if b == 0:
@@ -201,6 +203,7 @@ class Frontier(BaseFork, solc_name="homestead"):
         """At frontier, the transaction data floor cost is a constant zero."""
 
         def fn(*, data: BytesConvertible) -> int:
+            del data
             return 0
 
         return fn
@@ -221,6 +224,8 @@ class Frontier(BaseFork, solc_name="homestead"):
             authorization_list_or_count: Sized | int | None = None,
             return_cost_deducted_prior_execution: bool = False,
         ) -> int:
+            del return_cost_deducted_prior_execution
+
             assert access_list is None, f"Access list is not supported in {cls.name()}"
             assert authorization_list_or_count is None, (
                 f"Authorizations are not supported in {cls.name()}"
@@ -694,6 +699,8 @@ class Homestead(Frontier):
             authorization_list_or_count: Sized | int | None = None,
             return_cost_deducted_prior_execution: bool = False,
         ) -> int:
+            del return_cost_deducted_prior_execution
+
             intrinsic_cost: int = super_fn(
                 calldata=calldata,
                 contract_creation=contract_creation,
@@ -885,6 +892,8 @@ class Berlin(Istanbul):
             authorization_list_or_count: Sized | int | None = None,
             return_cost_deducted_prior_execution: bool = False,
         ) -> int:
+            del return_cost_deducted_prior_execution
+
             intrinsic_cost: int = super_fn(
                 calldata=calldata,
                 contract_creation=contract_creation,
@@ -1207,6 +1216,8 @@ class Cancun(Shanghai):
             parent_blob_count: int | None = None,
             parent_base_fee_per_gas: int,  # Required for Osaka as using this as base
         ) -> int:
+            del parent_base_fee_per_gas
+
             if parent_excess_blob_gas is None:
                 assert parent_excess_blobs is not None, "Parent excess blobs are required"
                 parent_excess_blob_gas = parent_excess_blobs * blob_gas_per_blob

--- a/src/ethereum_test_forks/helpers.py
+++ b/src/ethereum_test_forks/helpers.py
@@ -13,7 +13,6 @@ from pydantic import (
     ValidatorFunctionWrapHandler,
     model_validator,
 )
-from semver import Version
 
 from .base_fork import BaseFork
 from .forks import forks, transition
@@ -86,7 +85,7 @@ def get_parent_fork(fork: Type[BaseFork]) -> Type[BaseFork]:
     return parent_fork
 
 
-def get_closest_fork(fork: Type[BaseFork], solc_version: Version) -> Optional[Type[BaseFork]]:
+def get_closest_fork(fork: Type[BaseFork]) -> Optional[Type[BaseFork]]:
     """Return None if BaseFork is passed, otherwise return the fork itself."""
     if fork is BaseFork:
         return None

--- a/src/ethereum_test_forks/transition_base_fork.py
+++ b/src/ethereum_test_forks/transition_base_fork.py
@@ -66,6 +66,8 @@ def transition_fork(to_fork: Type[BaseFork], at_block: int = 0, at_timestamp: in
                 block_number: int = ALWAYS_TRANSITIONED_BLOCK_NUMBER,
                 timestamp: int = ALWAYS_TRANSITIONED_BLOCK_TIMESTAMP,
             ):
+                del cls
+
                 kwargs = {}
                 if "block_number" in base_method_parameters:
                     kwargs["block_number"] = block_number

--- a/src/ethereum_test_types/block_access_list/modifiers.py
+++ b/src/ethereum_test_types/block_access_list/modifiers.py
@@ -316,7 +316,8 @@ def reorder_accounts(indices: List[int]) -> Callable[[BlockAccessList], BlockAcc
 def clear_all() -> Callable[[BlockAccessList], BlockAccessList]:
     """Return an empty BAL."""
 
-    def transform(_bal: BlockAccessList) -> BlockAccessList:
+    def transform(bal: BlockAccessList) -> BlockAccessList:
+        del bal
         return BlockAccessList(root=[])
 
     return transform

--- a/src/ethereum_test_types/tests/test_transactions.py
+++ b/src/ethereum_test_types/tests/test_transactions.py
@@ -249,7 +249,6 @@ from ..transaction_types import Transaction
     ],
 )
 def test_transaction_signing(
-    request,
     tx: Transaction,
     expected_signature: Tuple[int, int, int],
     expected_sender: str,

--- a/src/pytest_plugins/consume/consume.py
+++ b/src/pytest_plugins/consume/consume.py
@@ -413,7 +413,6 @@ def pytest_configure(config):  # noqa: D103
             config.fixtures_source.path,
             quiet_mode=False,
             force_flag=False,
-            disable_infer_format=False,
         )
 
     index = IndexFile.model_validate_json(index_file.read_text())

--- a/src/pytest_plugins/consume/simulators/simulator_logic/test_via_sync.py
+++ b/src/pytest_plugins/consume/simulators/simulator_logic/test_via_sync.py
@@ -42,7 +42,6 @@ class LoggedError(Exception):
 
 def wait_for_sync(
     sync_eth_rpc: EthRPC,
-    sync_engine_rpc: EngineRPC,
     expected_block_hash: str | Hash,
     timeout: int = 10,
     poll_interval: float = 1.0,
@@ -105,7 +104,6 @@ def test_blockchain_via_sync(
     eth_rpc: EthRPC,
     engine_rpc: EngineRPC,
     net_rpc: NetRPC,
-    admin_rpc: AdminRPC,
     sync_eth_rpc: EthRPC,
     sync_engine_rpc: EngineRPC,
     sync_net_rpc: NetRPC,
@@ -472,7 +470,7 @@ def test_blockchain_via_sync(
         # Final verification
         assert sync_eth_rpc is not None, "sync_eth_rpc is required"
         assert sync_engine_rpc is not None, "sync_engine_rpc is required"
-        if wait_for_sync(sync_eth_rpc, sync_engine_rpc, last_valid_block_hash, timeout=5):
+        if wait_for_sync(sync_eth_rpc, last_valid_block_hash, timeout=5):
             logger.info("Sync verification successful!")
 
             # Verify the final state

--- a/src/pytest_plugins/consume/simulators/sync/conftest.py
+++ b/src/pytest_plugins/consume/simulators/sync/conftest.py
@@ -44,6 +44,8 @@ def pytest_generate_tests(metafunc):
 @pytest.hookimpl(trylast=True)
 def pytest_collection_modifyitems(session, config, items):
     """Modify test IDs to show both client and sync client clearly."""
+    del session, config
+
     for item in items:
         # Check if this test has both client_type and sync_client_type
         if (
@@ -160,7 +162,6 @@ def client_enode_url(client: Client) -> str:
 @pytest.fixture(scope="function")
 def sync_client(
     hive_test: HiveTest,
-    client: Client,  # The main client under test
     sync_client_files: dict,
     environment: dict,
     sync_client_type: ClientType,  # Separate parametrization for sync client

--- a/src/pytest_plugins/consume/simulators/timing_data.py
+++ b/src/pytest_plugins/consume/simulators/timing_data.py
@@ -39,5 +39,7 @@ def timing_data(
     total_timing_data: TimingData, client: Client
 ) -> Generator[TimingData, None, None]:
     """Record timing data for the main execution of the test case."""
+    del client
+
     with total_timing_data.time("Test case execution") as timing_data:
         yield timing_data

--- a/src/pytest_plugins/consume/tests/test_consume_args.py
+++ b/src/pytest_plugins/consume/tests/test_consume_args.py
@@ -104,6 +104,8 @@ def test_fixtures(pytester: Pytester, fixtures_dir: Path, fill_tests: None) -> L
 
     We intentionally copy the `.meta/index.json` file to test its compatibility with consume.
     """
+    del fill_tests
+
     test_fixtures = []
     for json_file in fixtures_dir.rglob("*.json"):
         target_dir = Path(pytester.path) / json_file.parent

--- a/src/pytest_plugins/custom_logging/plugin_logging.py
+++ b/src/pytest_plugins/custom_logging/plugin_logging.py
@@ -314,13 +314,15 @@ def pytest_report_header(config: pytest.Config) -> list[str]:
 
 def pytest_terminal_summary(terminalreporter: TerminalReporter, exitstatus: int) -> None:
     """Display the log file path in the terminal summary like the HTML report does."""
+    del exitstatus
+
     if terminalreporter.config.option.collectonly:
         return
     if eest_log_file_path := terminalreporter.config.option.eest_log_file_path:
         terminalreporter.write_sep("-", f"Log file: {eest_log_file_path.resolve()}", yellow=True)
 
 
-def log_only_to_file(level: int, msg: str, *args, **kwargs) -> None:
+def log_only_to_file(level: int, msg: str, *args) -> None:
     """Log a message only to the file handler, bypassing stdout."""
     if not file_handler:
         return
@@ -344,6 +346,8 @@ def log_only_to_file(level: int, msg: str, *args, **kwargs) -> None:
 
 def pytest_runtest_logstart(nodeid: str, location: tuple[str, int, str]) -> None:
     """Log test start to file."""
+    del location
+
     log_only_to_file(logging.INFO, f"ℹ️  - START TEST: {nodeid}")
 
 
@@ -383,4 +387,6 @@ def pytest_runtest_logreport(report: pytest.TestReport) -> None:
 
 def pytest_runtest_logfinish(nodeid: str, location: tuple[str, int, str]) -> None:
     """Log end of test to file."""
+    del location
+
     log_only_to_file(logging.INFO, f"ℹ️  - END TEST: {nodeid}")

--- a/src/pytest_plugins/eels_resolver.py
+++ b/src/pytest_plugins/eels_resolver.py
@@ -73,6 +73,8 @@ def pytest_report_header(config: pytest.Config, startdir: Path) -> str:
         str: A string to add to the pytest report header.
 
     """
+    del startdir
+
     eels_resolutions_file = getattr(config, "_eels_resolutions_file", None)
     if eels_resolutions_file:
         return f"EELS resolutions file: {eels_resolutions_file}"

--- a/src/pytest_plugins/execute/execute.py
+++ b/src/pytest_plugins/execute/execute.py
@@ -283,6 +283,8 @@ def collector(
     Return configured fixture collector instance used for all tests
     in one test module.
     """
+    del request
+
     collector = Collector(eth_rpc=eth_rpc)
     yield collector
 
@@ -397,6 +399,8 @@ def pytest_generate_tests(metafunc: pytest.Metafunc):
 
 def pytest_collection_modifyitems(config: pytest.Config, items: List[pytest.Item]):
     """Remove transition tests and add the appropriate execute markers to the test."""
+    del config
+
     items_for_removal = []
     for i, item in enumerate(items):
         if isinstance(item, EIPSpecTestItem):

--- a/src/pytest_plugins/execute/execute_recover.py
+++ b/src/pytest_plugins/execute/execute_recover.py
@@ -21,6 +21,8 @@ def test_recover_funds(
     eth_rpc: EthRPC,
 ) -> None:
     """Recover funds from a failed remote execution."""
+    del index
+
     remaining_balance = eth_rpc.get_balance(eoa)
     refund_gas_limit = 21_000
     tx_cost = refund_gas_limit * gas_price

--- a/src/pytest_plugins/filler/filler.py
+++ b/src/pytest_plugins/filler/filler.py
@@ -750,6 +750,8 @@ def pytest_terminal_summary(
     Emphasize that fixtures have only been filled; they must now be executed to
     actually run the tests.
     """
+    del exitstatus
+
     yield
     if config.fixture_output.is_stdout or hasattr(config, "workerinput"):  # type: ignore[attr-defined]
         return
@@ -1069,6 +1071,8 @@ def get_fixture_collection_scope(fixture_name, config):
 
     See: https://docs.pytest.org/en/stable/how-to/fixtures.html#dynamic-scope
     """
+    del fixture_name
+
     if config.fixture_output.is_stdout:
         return "session"
     if config.fixture_output.single_fixture_per_file:
@@ -1361,6 +1365,8 @@ def pytest_collection_modifyitems(
     These can't be handled in this plugins pytest_generate_tests() as the fork
     parametrization occurs in the forks plugin.
     """
+    del config
+
     items_for_removal = []
     for i, item in enumerate(items):
         item.name = item.name.strip().replace(" ", "-")
@@ -1443,6 +1449,8 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int):
     - Generate index file for all produced fixtures.
     - Create tarball of the output directory if the output is a tarball.
     """
+    del exitstatus
+
     # Save pre-allocation groups after phase 1
     fixture_output: FixtureOutput = session.config.fixture_output  # type: ignore[attr-defined]
     session_instance: FillingSession = session.config.filling_session  # type: ignore[attr-defined]
@@ -1475,9 +1483,7 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int):
         session.config.getoption("generate_index")
         and not session_instance.phase_manager.is_pre_alloc_generation
     ):
-        generate_fixtures_index(
-            fixture_output.directory, quiet_mode=True, force_flag=False, disable_infer_format=False
-        )
+        generate_fixtures_index(fixture_output.directory, quiet_mode=True, force_flag=False)
 
     # Create tarball of the output directory if the output is a tarball.
     fixture_output.create_tarball()

--- a/src/pytest_plugins/filler/static_filler.py
+++ b/src/pytest_plugins/filler/static_filler.py
@@ -372,7 +372,7 @@ def yul(fork: Fork, request: pytest.FixtureRequest):
         else:
             pytest.fail(f"{request.node.name}: Fork {marker.args[0]} not found in forks list.")
     else:
-        solc_target_fork = get_closest_fork(fork, request.config.solc_version)
+        solc_target_fork = get_closest_fork(fork)
         assert solc_target_fork is not None, "No fork supports provided solc version."
         if solc_target_fork != fork and request.config.getoption("verbose") >= 1:
             warnings.warn(

--- a/src/pytest_plugins/forks/forks.py
+++ b/src/pytest_plugins/forks/forks.py
@@ -533,6 +533,8 @@ def pytest_configure(config: pytest.Config):
 @pytest.hookimpl(trylast=True)
 def pytest_report_header(config, start_path):
     """Pytest hook called to obtain the report header."""
+    del start_path
+
     bold = "\033[1m"
     warning = "\033[93m"
     reset = "\033[39;49m"

--- a/src/pytest_plugins/pytest_hive/pytest_hive.py
+++ b/src/pytest_plugins/pytest_hive/pytest_hive.py
@@ -111,6 +111,8 @@ def get_hive_info(simulator: Simulation) -> HiveInfo | None:
 @pytest.hookimpl(trylast=True)
 def pytest_report_header(config, start_path):
     """Add lines to pytest's console output header."""
+    del start_path
+
     if config.option.collectonly:
         return
     header_lines = [f"hive simulator: {config.hive_simulator_url}"]
@@ -141,6 +143,8 @@ def pytest_runtest_makereport(item, call):
     - result_call - test result
     - result_teardown - teardown result
     """
+    del call
+
     outcome = yield
     report = outcome.get_result()
     setattr(item, f"result_{report.when}", report)
@@ -172,6 +176,8 @@ def get_test_suite_scope(fixture_name, config: pytest.Config):
 
     See: https://docs.pytest.org/en/stable/how-to/fixtures.html#dynamic-scope
     """
+    del fixture_name
+
     if hasattr(config, "test_suite_scope"):
         return config.test_suite_scope
     return "module"

--- a/src/pytest_plugins/shared/execute_fill.py
+++ b/src/pytest_plugins/shared/execute_fill.py
@@ -174,6 +174,7 @@ def pytest_make_parametrize_id(config: pytest.Config, val: str, argname: str):
     Pytest hook called when generating test ids. We use this to generate
     more readable test ids for the generated tests.
     """
+    del config
     return f"{argname}_{val}"
 
 

--- a/src/pytest_plugins/solc/solc.py
+++ b/src/pytest_plugins/solc/solc.py
@@ -128,6 +128,8 @@ def solc_bin(request: pytest.FixtureRequest):
 @pytest.hookimpl(trylast=True)
 def pytest_report_header(config, start_path):
     """Add lines to pytest's console output header."""
+    del start_path
+
     if config.option.collectonly:
         return
     solc_version = config.stash[metadata_key]["Tools"]["solc"]

--- a/src/pytest_plugins/spec_version_checker/spec_version_checker.py
+++ b/src/pytest_plugins/spec_version_checker/spec_version_checker.py
@@ -206,6 +206,8 @@ def pytest_collection_modifyitems(
     session: pytest.Session, config: pytest.Config, items: List[Item]
 ):
     """Insert a new test EIPSpecTestItem for every test module with 'eip' in its path."""
+    del session
+
     github_token = config.github_token if hasattr(config, "github_token") else None
 
     modules: Set[Module] = {item.parent for item in items if isinstance(item.parent, Module)}


### PR DESCRIPTION
## 🗒️ Description

Enables the `ARG001` lint and fixes the issues it discovers.

## 🔗 Related Issues or PRs

ethereum/execution-specs#1403

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).