### PR TITLE
chore(consume): increase fcu retries to 30 (at 1 second each)

### DIFF
--- a/src/pytest_plugins/consume/simulators/simulator_logic/test_via_engine.py
+++ b/src/pytest_plugins/consume/simulators/simulator_logic/test_via_engine.py
@@ -18,6 +18,9 @@ from ..helpers.timing import TimingData
 
 logger = get_logger(__name__)
 
+MAX_RETRIES = 30
+DELAY_BETWEEN_RETRIES_IN_SEC = 1
+
 
 class LoggedError(Exception):
     """Exception that uses the logger to log the failure."""
@@ -44,8 +47,7 @@ def test_blockchain_via_engine(
     # Send a initial forkchoice update
     with timing_data.time("Initial forkchoice update"):
         logger.info("Sending initial forkchoice update to genesis block...")
-        delay = 0.5
-        for attempt in range(3):
+        for attempt in range(1, MAX_RETRIES + 1):
             forkchoice_response = engine_rpc.forkchoice_updated(
                 forkchoice_state=ForkchoiceState(
                     head_block_hash=fixture.genesis.block_hash,
@@ -54,16 +56,15 @@ def test_blockchain_via_engine(
                 version=fixture.payloads[0].forkchoice_updated_version,
             )
             status = forkchoice_response.payload_status.status
-            logger.info(f"Initial forkchoice update response attempt {attempt + 1}: {status}")
+            logger.info(f"Initial forkchoice update response attempt {attempt}: {status}")
             if status != PayloadStatusEnum.SYNCING:
                 break
-            if attempt < 2:
-                time.sleep(delay)
-                delay *= 2
+
+            time.sleep(DELAY_BETWEEN_RETRIES_IN_SEC)
 
         if forkchoice_response.payload_status.status != PayloadStatusEnum.VALID:
             logger.error(
-                f"Client failed to initialize properly after 3 attempts, "
+                f"Client failed to initialize properly after {MAX_RETRIES} attempts, "
                 f"final status: {forkchoice_response.payload_status.status}"
             )
             raise LoggedError(

--- a/src/pytest_plugins/consume/simulators/simulator_logic/test_via_engine.py
+++ b/src/pytest_plugins/consume/simulators/simulator_logic/test_via_engine.py
@@ -60,7 +60,8 @@ def test_blockchain_via_engine(
             if status != PayloadStatusEnum.SYNCING:
                 break
 
-            time.sleep(DELAY_BETWEEN_RETRIES_IN_SEC)
+            if attempt < MAX_RETRIES:
+                time.sleep(DELAY_BETWEEN_RETRIES_IN_SEC)
 
         if forkchoice_response.payload_status.status != PayloadStatusEnum.VALID:
             logger.error(


### PR DESCRIPTION
## 🗒️ Description
Title. As requested by Erigon.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
