### PR TITLE
chore(tests): fix peerdas transition test

### DIFF
--- a/tests/osaka/eip7594_peerdas/test_max_blob_per_tx.py
+++ b/tests/osaka/eip7594_peerdas/test_max_blob_per_tx.py
@@ -177,7 +177,7 @@ def test_max_blobs_per_tx_fork_transition(
         exception=[expected_exception],
     )
     post_fork_block = Block(
-        txs=[tx.with_nonce(2).with_error(expected_exception)],
+        txs=[tx.with_nonce(1).with_error(expected_exception)],
         timestamp=FORK_TIMESTAMP + 1,
         exception=[expected_exception],
     )


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Fixes an issue in our test, this now passes for Geth: https://hive.ethpandaops.io/#/test/fusaka/1758120505-5c7e401b7553f1ac9d212bb6a345281f?testnumber=2235

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
