### PR TITLE
chore(tests): workaround for EIP-6110 deposit log checks

### DIFF
--- a/tests/prague/eip6110_deposits/test_modified_contract.py
+++ b/tests/prague/eip6110_deposits/test_modified_contract.py
@@ -205,18 +205,22 @@ def test_invalid_layout(
                 exception=[
                     BlockException.INVALID_DEPOSIT_EVENT_LAYOUT,
                     BlockException.INVALID_REQUESTS,
-                    # INVALID_REQUESTS is an alternative workaround for Geth/Reth only.
+                    # INVALID_REQUESTS is an alternative workaround for
+                    # Geth/Reth only.
                     #
-                    # Geth/Reth do not validate the sizes or offsets of the  deposit contract logs.
-                    # Although this is out of spec, it is understood that this will not cause an
-                    # issue so long as the mainnet/testnet deposit contracts don't change.
+                    # Geth/Reth do not validate the sizes or offsets of the
+                    # deposit contract logs.
                     #
-                    # This offsets are checked second and the sizes are checked third within the
-                    # `is_valid_deposit_event_data` function:
+                    # Although this is out of spec, it is understood that this
+                    # will not cause an issue so long as the mainnet/testnet
+                    # deposit contracts don't change.
+                    #
+                    # This offsets are checked second and the sizes are checked
+                    # third within the `is_valid_deposit_event_data` function:
                     # https://eips.ethereum.org/EIPS/eip-6110#block-validity
                     #
                     # EELS definition for `is_valid_deposit_event_data`:
-                    # https://github.com/ethereum/execution-specs/blob/forks/osaka/src/ethereum/forks/prague/requests.py#L51
+                    # https://github.com/ethereum/execution-specs/blob/5ddb904fa7ba27daeff423e78466744c51e8cb6a/src/ethereum/forks/prague/requests.py#L51
                 ],
             ),
         ],
@@ -274,17 +278,22 @@ def test_invalid_log_length(blockchain_test: BlockchainTestFiller, pre: Alloc, s
                 exception=[
                     BlockException.INVALID_DEPOSIT_EVENT_LAYOUT,
                     BlockException.INVALID_REQUESTS,
-                    # INVALID_REQUESTS is an alternative workaround for Reth only.
+                    # INVALID_REQUESTS is an alternative workaround for
+                    # Geth/Reth only.
                     #
-                    # Reth does not validate the length of the deposit contract logs.
-                    # Although this is out of spec, it is understood that this will not cause an
-                    # issue so long as the mainnet/testnet deposit contracts don't change.
+                    # Geth/Reth do not validate the sizes or offsets of the
+                    # deposit contract logs.
                     #
-                    # This log length is the first check within `is_valid_deposit_event_data`:
+                    # Although this is out of spec, it is understood that this
+                    # will not cause an issue so long as the mainnet/testnet
+                    # deposit contracts don't change.
+                    #
+                    # This offsets are checked second and the sizes are checked
+                    # third within the `is_valid_deposit_event_data` function:
                     # https://eips.ethereum.org/EIPS/eip-6110#block-validity
                     #
                     # EELS definition for `is_valid_deposit_event_data`:
-                    # https://github.com/ethereum/execution-specs/blob/forks/osaka/src/ethereum/forks/prague/requests.py#L51
+                    # https://github.com/ethereum/execution-specs/blob/5ddb904fa7ba27daeff423e78466744c51e8cb6a/src/ethereum/forks/prague/requests.py#L51
                 ],
             ),
         ],


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Adds a workaround for the invalid deposit log tests for Geth/Reth:
- Reth doesn't check the length of the deposit logs.
- Geth/Reth don't check the offsets and the sizes of the deposit logs.

### Geth
https://hive.ethpandaops.io/#/test/fusaka/1758206019-3d8e1ef2d1c0829ec602a80ba1b23b1d?testnumber=18233

### Reth
https://hive.ethpandaops.io/#/test/fusaka/1758204471-aa8d60fbce3ef54fecbaf57a3fd84ef3?testnumber=17831


## Spec Details

This means Geth/Reth are "technically" out of spec for EIP-6110.

From [EIP-6110](https://eips.ethereum.org/EIPS/eip-6110#block-validity) we have the `is_valid_deposit_event_data` function. This first checks the log length, secondly the offsets and thirdly the sizes of the deposit event data.

Although this is out of spec it is assumed that this workaround (Geth/Reth not implementing the checks) will not cause an issue, where the mainnet/testnet deposit contracts will not change.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->

PR to implement these checks in Geth/Reth:
- https://github.com/ethereum/go-ethereum/pull/32669
- https://github.com/paradigmxyz/reth/pull/18578

If Geth/Reth prefer not to add these checks then we will merge this PR in EEST instead.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
