### PR TITLE
chore(tests): update high nonce static test exception for reth

### DIFF
--- a/tests/static/state_tests/stCreateTest/CreateTransactionHighNonceFiller.yml
+++ b/tests/static/state_tests/stCreateTest/CreateTransactionHighNonceFiller.yml
@@ -15,7 +15,9 @@ CreateTransactionHighNonce:
       network:
         - ">=Cancun"
       expectException:
-        ">=Cancun": "TransactionException.NONCE_IS_MAX"
+        # `BlockException.INVALID_GAS_USED` added for Reth as they do pre-validation on the block.
+        # Removing the pre-validation and they fail with `TransactionException.NONCE_IS_MAX`.
+        ">=Cancun": "TransactionException.NONCE_IS_MAX|BlockException.INVALID_GAS_USED"
       result: {}
   pre:
     a94f5374fce5edbc8e2a8697c15331677e6ebf0b:


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Do not merge still checking.

Reth currently fails the ` tests/static/state_tests/stCreateTest/CreateTransactionHighNonceFiller.yml::CreateTransactionHighNonce` tests due to an exception mismatch. We expect clients to fail with a `TransactionException.NONCE_IS_MAX` error. Reth fails early than this due pre-validation of the block via this check: https://github.com/paradigmxyz/reth/blob/main/crates/ethereum/consensus/src/validation.rs#L26-L34

If we remove all pre-validation including reciepts root checks Reth then fails with the `TransactionException.NONCE_IS_MAX` error. Following this I've decided to add the block validation error to the expected error section of the test, allowing Reth to pass.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
