### PR TITLE
chore(cli): update reth gas limit exception mapper

### DIFF
--- a/src/ethereum_clis/clis/reth.py
+++ b/src/ethereum_clis/clis/reth.py
@@ -58,7 +58,7 @@ class RethExceptionMapper(ExceptionMapper):
             r"transaction gas limit \w+ is more than blocks available gas \w+"
         ),
         TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM: (
-            r"transaction 0x[a-fA-F0-9]+ gas limit \d+ exceeds maximum \d+"
+            r"transaction gas limit.*is greater than the cap"
         ),
         BlockException.SYSTEM_CONTRACT_CALL_FAILED: r"failed to apply .* requests contract call",
         BlockException.INCORRECT_BLOB_GAS_USED: (


### PR DESCRIPTION
## 🗒️ Description
Updates the Reth exception mapper regex pattern to match the new error message format returned by the Reth client for gas limit exceeded errors.

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).