### PR TITLE
chore(execute): add missing return statement for stub contract deployment

### DIFF
--- a/src/pytest_plugins/execute/pre_alloc.py
+++ b/src/pytest_plugins/execute/pre_alloc.py
@@ -259,6 +259,7 @@ class Alloc(BaseAlloc):
                     storage={},
                 ),
             )
+            return contract_address
 
         initcode_prefix = Bytecode()
 


### PR DESCRIPTION
## 🗒️ Description
When deploy_contract() is called with a stub parameter, it retrieves the existing contract from the chain and adds it to the allocation. However, the method was missing a return statement after handling the stub case, causing it to continue executing and attempt to deploy a new contract with the stub's bytecode.

This led to an assertion error when the retrieved bytecode (Bytes type) didn't match the expected types (Bytecode or Container) for deployment.

The fix adds a return statement after the stub handling block to properly exit the method and return the stub's contract address.

## 🔗 Related Issues or PRs
The related issue is the inclusion of stub contracts themseleves in https://github.com/ethereum/execution-spec-tests/pull/2073

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [x] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [x] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
