### PR TITLE
chore(cli): nethermind max nonce exception mapper

### DIFF
--- a/src/ethereum_clis/clis/nethermind.py
+++ b/src/ethereum_clis/clis/nethermind.py
@@ -343,7 +343,7 @@ class NethermindExceptionMapper(ExceptionMapper):
             "InvalidMaxPriorityFeePerGas: Cannot be higher than maxFeePerGas"
         ),
         TransactionException.GAS_ALLOWANCE_EXCEEDED: "Block gas limit exceeded",
-        TransactionException.NONCE_IS_MAX: "nonce overflow",
+        TransactionException.NONCE_IS_MAX: "NonceTooHigh",
         TransactionException.INITCODE_SIZE_EXCEEDED: "max initcode size exceeded",
         TransactionException.NONCE_MISMATCH_TOO_LOW: "wrong transaction nonce",
         TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS: (


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Latest from hive.
```
E   pytest_plugins.consume.simulators.simulator_logic.test_via_engine.LoggedError: Undefined exception message: expected exception: "TransactionException.NONCE_IS_MAX", returned exception: "NonceTooHigh: Nonce exceeds max nonce" (mapper: "NethermindExceptionMapper")
```

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
