### PR TITLE
feat(tests): add test cases for P256 with zero h, r, s

### DIFF
--- a/tests/osaka/eip7951_p256verify_precompiles/test_p256verify.py
+++ b/tests/osaka/eip7951_p256verify_precompiles/test_p256verify.py
@@ -189,6 +189,44 @@ def test_valid(state_test: StateTestFiller, pre: Alloc, post: dict, tx: Transact
             Spec.H0 + Spec.R0 + S(Spec.N) + Spec.X0 + Spec.Y0,
             id="s_eq_to_n",
         ),
+        # If checks for r, s, and point-at-infinity are missing, the s=0 zeros
+        # both u1 and u2, so the computed R is the point at infinity,
+        # and the signature may be considered valid in such implementation.
+        pytest.param(
+            Spec.H0 + R(0) + S(0) + X(Spec.Gx) + Y(Spec.Gy),
+            id="r_0_s_0",
+        ),
+        pytest.param(
+            Spec.H0 + R(0) + S(Spec.N) + X(Spec.Gx) + Y(Spec.Gy),
+            id="r_0_s_N",
+        ),
+        pytest.param(
+            Spec.H0 + R(Spec.N) + S(0) + X(Spec.Gx) + Y(Spec.Gy),
+            id="r_N_s_0",
+        ),
+        pytest.param(
+            Spec.H0 + R(Spec.N) + S(Spec.N) + X(Spec.Gx) + Y(Spec.Gy),
+            id="r_N_s_N",
+        ),
+        # If checks for r and point-at-infinity are missing, the h=0 and r=0
+        # zero both u1 and u2, so the computed R is the point at infinity,
+        # and the signature may be considered valid in such implementation.
+        pytest.param(
+            H(0) + R(0) + Spec.S0 + X(Spec.Gx) + Y(Spec.Gy),
+            id="hash_0_r_0",
+        ),
+        pytest.param(
+            H(0) + R(Spec.N) + Spec.S0 + X(Spec.Gx) + Y(Spec.Gy),
+            id="hash_0_r_N",
+        ),
+        pytest.param(
+            H(Spec.N) + R(0) + Spec.S0 + X(Spec.Gx) + Y(Spec.Gy),
+            id="hash_N_r_0",
+        ),
+        pytest.param(
+            H(Spec.N) + R(Spec.N) + Spec.S0 + X(Spec.Gx) + Y(Spec.Gy),
+            id="hash_N_r_N",
+        ),
         pytest.param(
             Spec.H0 + Spec.R0 + Spec.S0 + X(Spec.P) + Spec.Y0,
             id="x_eq_to_p",


### PR DESCRIPTION
## 🗒️ Description
Add better test inputs for the `p256verify` precompile where at least `r` or `s` is `0 mod N`. There test cases represent invalid inputs but in some category of incorrect implementations have chance to be positively verified.

## 🔗 Related Issues or PRs
#2194

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
