### PR TITLE
chore(execute): add gas validation for benchmark tests in execute mode

### DIFF
--- a/src/ethereum_test_specs/base.py
+++ b/src/ethereum_test_specs/base.py
@@ -76,7 +76,6 @@ class BaseTest(BaseModel):
     _gas_optimization: int | None = PrivateAttr(None)
     _gas_optimization_max_gas_limit: int | None = PrivateAttr(None)
 
-    gas_benchmark_value: int | None = None
     expected_benchmark_gas_used: int | None = None
     skip_gas_used_validation: bool = False
 
@@ -125,7 +124,6 @@ class BaseTest(BaseModel):
         new_instance = cls(
             tag=base_test.tag,
             t8n_dump_dir=base_test.t8n_dump_dir,
-            gas_benchmark_value=base_test.gas_benchmark_value,
             expected_benchmark_gas_used=base_test.expected_benchmark_gas_used,
             skip_gas_used_validation=base_test.skip_gas_used_validation,
             **kwargs,

--- a/src/ethereum_test_specs/blockchain.py
+++ b/src/ethereum_test_specs/blockchain.py
@@ -903,7 +903,6 @@ class BlockchainTest(BaseTest):
             return TransactionPost(
                 blocks=blocks,
                 post=self.post,
-                gas_benchmark_value=self.gas_benchmark_value,
                 expected_benchmark_gas_used=self.expected_benchmark_gas_used,
                 skip_gas_used_validation=self.skip_gas_used_validation,
             )

--- a/src/ethereum_test_specs/state.py
+++ b/src/ethereum_test_specs/state.py
@@ -448,7 +448,6 @@ class StateTest(BaseTest):
             return TransactionPost(
                 blocks=[[self.tx]],
                 post=self.post,
-                gas_benchmark_value=self.gas_benchmark_value,
                 expected_benchmark_gas_used=self.expected_benchmark_gas_used,
                 skip_gas_used_validation=self.skip_gas_used_validation,
             )

--- a/src/pytest_plugins/execute/execute.py
+++ b/src/pytest_plugins/execute/execute.py
@@ -342,9 +342,11 @@ def base_test_parametrizer(cls: Type[BaseTest]):
                     kwargs["pre"] = pre
                 elif kwargs["pre"] != pre:
                     raise ValueError("The pre-alloc object was modified by the test.")
-                # Pass gas_benchmark_value if not already set
-                if "gas_benchmark_value" not in kwargs:
-                    kwargs["gas_benchmark_value"] = request.getfixturevalue("gas_benchmark_value")
+                # Set default for expected_benchmark_gas_used
+                if "expected_benchmark_gas_used" not in kwargs:
+                    kwargs["expected_benchmark_gas_used"] = request.getfixturevalue(
+                        "gas_benchmark_value"
+                    )
                 kwargs |= {
                     p: request.getfixturevalue(p)
                     for p in cls_fixture_parameters


### PR DESCRIPTION
## 🗒️ Description
Previously, execute mode was not validating that transactions consumed the expected amount of gas when expected_benchmark_gas_used was set. This could cause benchmark tests to incorrectly pass even when consuming significantly less gas than expected (e.g., due to missing factory contracts). 

This feature is needed by benchmark tests like the ones in #2186 in order to make sure that the benchmarks are indeed consuming all gas available or causing a failure otherwise when the flag is set.

Changes:
- Add expected_benchmark_gas_used and skip_gas_used_validation fields to TransactionPost
- Implement gas validation logic in TransactionPost.execute() using transaction receipts
- Pass gas validation parameters from StateTest and BlockchainTest to TransactionPost
- Add eth_getTransactionReceipt RPC method to fetch gas used from receipts

This ensures benchmark tests fail appropriately when gas consumption doesn't match expectations, preventing false positives in performance testing.

## 🔗 Related Issues or PRs
Se this discussion: https://github.com/ethereum/execution-spec-tests/pull/2186#discussion_r2382152472. for more context.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [x] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [x] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
