### PR TITLE
test(tests): add BLOCKHASH genesis hash availability test

### DIFF
--- a/tests/frontier/opcodes/test_blockhash.py
+++ b/tests/frontier/opcodes/test_blockhash.py
@@ -16,19 +16,25 @@ from ethereum_test_tools import Opcodes as Op
 @pytest.mark.valid_from("Frontier")
 def test_genesis_hash_available(blockchain_test: BlockchainTestFiller, pre: Alloc):
     """
-    Verify BLOCKHASH(0) returns genesis hash in block 1.
+    Verify BLOCKHASH returns genesis and block 1 hashes.
 
-    Regression test: Blockchain test infrastructure must populate genesis hash
-    before execution. Without this, BLOCKHASH(0) returns 0, breaking dynamic
+    Regression test: Blockchain test infrastructure must populate block hashes
+    before execution. Without this, BLOCKHASH returns 0, breaking dynamic
     address computations like BLOCKHASH(0) | TIMESTAMP.
+
+    Tests both genesis (block 0) and first executed block (block 1) hash
+    insertion by calling the contract in block 2.
 
     Bug context: revm blockchaintest runner wasn't inserting block_hashes,
     causing failures in tests with BLOCKHASH-derived addresses.
     """
     storage = Storage()
 
-    # Store ISZERO(BLOCKHASH(0)) - should be 0 (false) if genesis hash exists
-    code = Op.SSTORE(storage.store_next(0), Op.ISZERO(Op.BLOCKHASH(0)))
+    # Store ISZERO(BLOCKHASH(0)) and ISZERO(BLOCKHASH(1))
+    # Both should be 0 (false) if hashes exist
+    code = Op.SSTORE(storage.store_next(0), Op.ISZERO(Op.BLOCKHASH(0))) + Op.SSTORE(
+        storage.store_next(0), Op.ISZERO(Op.BLOCKHASH(1))
+    )
 
     contract = pre.deploy_contract(code=code)
     sender = pre.fund_eoa()
@@ -43,13 +49,24 @@ def test_genesis_hash_available(blockchain_test: BlockchainTestFiller, pre: Allo
                     protected=False,
                 )
             ]
-        )
+        ),
+        Block(
+            txs=[
+                Transaction(
+                    sender=sender,
+                    to=contract,
+                    gas_limit=100_000,
+                    protected=False,
+                )
+            ]
+        ),
     ]
 
     post = {
         contract: Account(
             storage={
-                0: 0,  # ISZERO(BLOCKHASH(0)) should be 0 (genesis hash exists and is non-zero)
+                0: 0,  # ISZERO(BLOCKHASH(0)) = 0 (genesis hash exists)
+                1: 0,  # ISZERO(BLOCKHASH(1)) = 0 (block 1 hash exists)
             }
         )
     }


### PR DESCRIPTION
## 🗒️ Description

Add minimal regression test for BLOCKHASH opcode to verify genesis hash availability in blockchain tests. This test ensures that `BLOCKHASH(0)` returns the genesis hash (non-zero value) when executed in block 1, validating that blockchain test infrastructure properly initializes the `block_hashes` mapping before execution.

**Context**: This is a regression test for a bug found in the revm blockchaintest runner where `block_hashes` weren't being populated, causing `BLOCKHASH(0)` to incorrectly return 0. This broke tests using dynamic address computations like `BLOCKHASH(0) | TIMESTAMP`, where the computed address would be wrong, leading to test failures.

The test validates infrastructure correctness by:
1. Executing `ISZERO(BLOCKHASH(0))` in a contract deployed in block 1
2. Verifying the result is 0 (false), proving the genesis hash exists and is non-zero
3. Ensuring future tests with BLOCKHASH-derived addresses will work correctly

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

## 📝 Additional Notes

**File Added**: `tests/frontier/opcodes/test_blockhash.py`
- Test: `test_genesis_hash_available` (57 lines)
- Valid from: Frontier (earliest fork with BLOCKHASH support)
- Test type: BlockchainTestFiller (requires multiple blocks)

**Quality Checks Passed**:
- ✅ `ruff check` - no linting issues
- ✅ `ruff format` - properly formatted
- ✅ `mypy` - no type errors
- ✅ `uv run fill --fork=Frontier` - generates valid fixtures
- ✅ `uv run fill --fork=Cancun` - works across all forks

**Suggested PR Title**:
```
test(tests): add BLOCKHASH genesis hash availability test
```