### PR TITLE
feat(tests): add test case for P256 with r max value

### DIFF
--- a/tests/osaka/eip7951_p256verify_precompiles/test_p256verify.py
+++ b/tests/osaka/eip7951_p256verify_precompiles/test_p256verify.py
@@ -198,6 +198,10 @@ def test_valid(state_test: StateTestFiller, pre: Alloc, post: dict, tx: Transact
             id="r_eq_to_n",
         ),
         pytest.param(
+            Spec.H0 + R(2**256 - 1) + Spec.S0 + Spec.X0 + Spec.Y0,
+            id="r_max",
+        ),
+        pytest.param(
             Spec.H0 + Spec.R0 + S(0) + Spec.X0 + Spec.Y0,
             id="s_eq_to_zero",
         ),


### PR DESCRIPTION
## 🗒️ Description
This test uses the max value for the `r` element of the `p256verify` precompile input. This is added for completeness only as there is no practical way to generate a semi-valid signature with arbitrary `r`.

## 🔗 Related Issues or PRs
#2194 

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
