### PR TITLE
chore(tooling): fix `launch.recommended.json` - vs code debugging

### DIFF
--- a/.vscode/launch.recommended.json
+++ b/.vscode/launch.recommended.json
@@ -8,13 +8,29 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Launch consume direct",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "pytest",
+            "args": [
+                "-c",
+                "${workspaceFolder}/src/cli/pytest_commands/pytest_ini_files/pytest-consume.ini",
+                "src/pytest_plugins/consume/direct/test_via_direct.py",
+                "--bin",
+                "${input:evmBinary}",
+                "--input",
+                "${input:fixturePath}"
+            ],
+            "cwd": "${workspaceFolder}"
+        },
+        {
             "name": "Launch fill --until choose fork",
             "type": "debugpy",
             "request": "launch",
             "module": "pytest",
             "args": [
                 "-c",
-                "pytest.ini",
+                "${workspaceFolder}/src/cli/pytest_commands/pytest_ini_files/pytest-fill.ini",
                 "--until",
                 "${input:fork}",
                 "--evm-bin",
@@ -30,7 +46,7 @@
             "module": "pytest",
             "args": [
                 "-c",
-                "pytest.ini",
+                "${workspaceFolder}/src/cli/pytest_commands/pytest_ini_files/pytest-fill.ini",
                 "--until",
                 "Cancun",
                 "--evm-bin",
@@ -48,7 +64,7 @@
             "module": "pytest",
             "args": [
                 "-c",
-                "pytest.ini",
+                "${workspaceFolder}/src/cli/pytest_commands/pytest_ini_files/pytest-fill.ini",
                 "--until",
                 "Cancun",
                 "--evm-bin",
@@ -64,7 +80,7 @@
             "module": "pytest",
             "args": [
                 "-c",
-                "pytest.ini",
+                "${workspaceFolder}/src/cli/pytest_commands/pytest_ini_files/pytest-fill.ini",
                 "--until",
                 "Prague",
                 "--evm-bin",
@@ -128,6 +144,12 @@
             "id": "testPathOrId",
             "description": "Enter a test path string or id to provide to pytest -k",
             "default": "test_"
+        },
+        {
+            "type": "promptString",
+            "id": "fixturePath",
+            "description": "Enter a fixture path",
+            "default": "${workspaceFolder}/fixtures"
         }
     ]
 }


### PR DESCRIPTION
## 🗒️ Description

`launch.recommended.json` which is being advised for VS code debugging in Getting Started didn't work, as the `pytest.ini` files have moved. This PR is just a minimal set of updates to make it work for `fill` and also adding support for `consume direct`.

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
