### PR TITLE
chore**s**(src): use `--chain-id` in ProgramChainid

### DIFF
--- a/tests/frontier/scenarios/programs/context_calls.py
+++ b/tests/frontier/scenarios/programs/context_calls.py
@@ -430,8 +430,7 @@ class ProgramChainid(ScenarioTestProgram):
 
     def result(self) -> ProgramResult:
         """Test result."""
-        # TODO: why attribute error when accessing ChainConfig.chain_id?
-        #       only ChainConfigDefaults works
+        # TODO: use `chain_config` fixture instead.
         chain_id = ChainConfigDefaults.chain_id
 
         return ProgramResult(result=chain_id, from_fork=Istanbul)


### PR DESCRIPTION
## 🗒️ Description
If you run geth with 
`geth --dev --http -http.addr=localhost --http.port=8545` 
and then run
`uv run execute remote -m blockchain_test --fork=frontier --rpc-endpoint=http://127.0.0.1:8545 --rpc-seed-key=b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291 --tx-wait-timeout 60 -vv -s tests/frontier/scenarios/test_scenarios.py::test_scenarios -k "ChainId" -vv -s --chain-id=1337`
you can see that the passed chain-id is used (if you print it).

But why does it only work with `ChainConfigDefaults.chain_id` and not with `ChainConfig.chain_id`? The [PR](https://github.com/ethereum/execution-spec-tests/pull/2084) that introduces this uses the latter without problems.

Fixes #2095

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
