### PR TITLE
chore(forks): update bpo hardfork params to match testnet

### DIFF
--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -1840,31 +1840,31 @@ class Osaka(Prague, solc_name="cancun"):
 
 
 class BPO1(Osaka, bpo_fork=True):
-    """BPO1 fork - Blob Parameter Only fork 1."""
+    """Mainnet BPO1 fork - Blob Parameter Only fork 1."""
 
     @classmethod
     def blob_base_fee_update_fraction(cls, block_number: int = 0, timestamp: int = 0) -> int:
         """Return the blob base fee update fraction for BPO1."""
-        return 8832827
+        return 8346193
 
     @classmethod
     def target_blobs_per_block(cls, block_number: int = 0, timestamp: int = 0) -> int:
-        """Blobs in BPO1 have a target of 9 blobs per block."""
-        return 9
+        """Blobs in BPO1 have a target of 10 blobs per block."""
+        return 10
 
     @classmethod
     def max_blobs_per_block(cls, block_number: int = 0, timestamp: int = 0) -> int:
-        """Blobs in BPO1 have a max of 14 blobs per block."""
-        return 14
+        """Blobs in BPO1 have a max of 15 blobs per block."""
+        return 15
 
 
 class BPO2(BPO1, bpo_fork=True):
-    """BPO2 fork - Blob Parameter Only fork 2."""
+    """Mainnet BPO2 fork - Blob Parameter Only fork 2."""
 
     @classmethod
     def blob_base_fee_update_fraction(cls, block_number: int = 0, timestamp: int = 0) -> int:
         """Return the blob base fee update fraction for BPO2."""
-        return 13739630
+        return 11684671
 
     @classmethod
     def target_blobs_per_block(cls, block_number: int = 0, timestamp: int = 0) -> int:
@@ -1878,7 +1878,10 @@ class BPO2(BPO1, bpo_fork=True):
 
 
 class BPO3(BPO2, bpo_fork=True):
-    """BPO3 fork - Blob Parameter Only fork 3."""
+    """
+    Pseudo BPO3 fork - Blob Parameter Only fork 3.
+    For testing purposes only.
+    """
 
     @classmethod
     def blob_base_fee_update_fraction(cls, block_number: int = 0, timestamp: int = 0) -> int:
@@ -1897,7 +1900,10 @@ class BPO3(BPO2, bpo_fork=True):
 
 
 class BPO4(BPO3, bpo_fork=True):
-    """BPO4 fork - Blob Parameter Only fork 4."""
+    """
+    Pseudo BPO4 fork - Blob Parameter Only fork 4.
+    For testing purposes only. Testing a decrease in values from BPO3.
+    """
 
     @classmethod
     def blob_base_fee_update_fraction(cls, block_number: int = 0, timestamp: int = 0) -> int:
@@ -1917,8 +1923,8 @@ class BPO4(BPO3, bpo_fork=True):
 
 class BPO5(BPO4, bpo_fork=True):
     """
-    BPO5 fork - Blob Parameter Only fork 5 (Required to parse Fusaka devnet
-    genesis files).
+    Pseudo BPO5 fork - Blob Parameter Only fork 5.
+    For testing purposes only. Required to parse Fusaka devnet genesis files.
     """
 
     pass

--- a/src/pytest_plugins/execute/eth_config/networks.yml
+++ b/src/pytest_plugins/execute/eth_config/networks.yml
@@ -27,6 +27,18 @@ Mainnet:
       target: 6
       max: 9
       baseFeeUpdateFraction: 5007716
+    Osaka:
+      target: 6
+      max: 9
+      baseFeeUpdateFraction: 5007716
+    BPO1:
+      target: 10
+      max: 15
+      baseFeeUpdateFraction: 8346193
+    BPO2:
+      target: 14
+      max: 21
+      baseFeeUpdateFraction: 11684671
 
 Sepolia:
   chainId:              0xaa36a7
@@ -37,6 +49,9 @@ Sepolia:
     Shanghai:           1677557088
     Cancun:             1706655072
     Prague:             1741159776
+    Osaka:              1760427360
+    BPO1:               1761017184
+    BPO2:               1761607008
   blobSchedule:
     Cancun:
       target: 3
@@ -46,6 +61,18 @@ Sepolia:
       target: 6
       max: 9
       baseFeeUpdateFraction: 5007716
+    Osaka:
+      target: 6
+      max: 9
+      baseFeeUpdateFraction: 5007716
+    BPO1:
+      target: 10
+      max: 15
+      baseFeeUpdateFraction: 8346193
+    BPO2:
+      target: 14
+      max: 21
+      baseFeeUpdateFraction: 11684671
   addressOverrides:
     0x00000000219ab540356cbb839cbe05303d7705fa: 0x7f02c3e3c98b133055b8b348b2ac625669ed295d
 
@@ -55,6 +82,9 @@ Hoodi:
   forkActivationTimes:
     Cancun:             0
     Prague:             1742999832
+    Osaka:              1761677592
+    BPO1:               1762365720
+    BPO2:               1762955544
   blobSchedule:
     Cancun:
       target: 3
@@ -64,6 +94,18 @@ Hoodi:
       target: 6
       max: 9
       baseFeeUpdateFraction: 5007716
+    Osaka:
+      target: 6
+      max: 9
+      baseFeeUpdateFraction: 5007716
+    BPO1:
+      target: 10
+      max: 15
+      baseFeeUpdateFraction: 8346193
+    BPO2:
+      target: 14
+      max: 21
+      baseFeeUpdateFraction: 11684671
 
 Holesky:
   chainId:              0x4268
@@ -73,6 +115,9 @@ Holesky:
     Shanghai:           1696000704
     Cancun:             1707305664
     Prague:             1740434112
+    Osaka:              1759308480
+    BPO1:               1759800000
+    BPO2:               1760389824
   addressOverrides:
     0x00000000219ab540356cbb839cbe05303d7705fa: 0x4242424242424242424242424242424242424242
   blobSchedule:
@@ -84,3 +129,15 @@ Holesky:
       target: 6
       max: 9
       baseFeeUpdateFraction: 5007716
+    Osaka:
+      target: 6
+      max: 9
+      baseFeeUpdateFraction: 5007716
+    BPO1:
+      target: 10
+      max: 15
+      baseFeeUpdateFraction: 8346193
+    BPO2:
+      target: 14
+      max: 21
+      baseFeeUpdateFraction: 11684671


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Updates BPO param valuse to match that of those set in the testnet configs:
  - Holesky: https://github.com/eth-clients/holesky/blob/main/metadata/genesis.json
  - Sepolia: https://github.com/eth-clients/sepolia/blob/main/metadata/genesis.json
  - Hoodi: https://github.com/eth-clients/hoodi/blob/main/metadata/genesis.json

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
https://github.com/ethereum/go-ethereum/pull/32735

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
