### PR TITLE
feat(tests): add test case for P256 with Q at infinity

### DIFF
--- a/tests/osaka/eip7951_p256verify_precompiles/test_p256verify.py
+++ b/tests/osaka/eip7951_p256verify_precompiles/test_p256verify.py
@@ -312,7 +312,17 @@ def test_valid(state_test: StateTestFiller, pre: Alloc, post: dict, tx: Transact
         ),
         pytest.param(
             Spec.H0 + Spec.R0 + Spec.S0 + X(0) + Y(0),
-            id="point_on_infinity",
+            id="point_at_infinity",
+        ),
+        # Test case with Q at infinity. If the implementation misses the check
+        # that Q is not the point at infinity, the signature should verify.
+        pytest.param(
+            Spec.H0
+            + R(0x2DD5CBB0E37BAEC8D1460909B206CA2C87E50CA43B8F31E46168027A7F0AEEC6)
+            + Spec.S0
+            + X(0)
+            + Y(0),
+            id="point_at_infinity_v2",
         ),
         pytest.param(
             Spec.H0 + Spec.R0 + Spec.S0 + X(Spec.X0.value + 1) + Spec.Y0,


### PR DESCRIPTION
## 🗒️ Description
Add a test case for the `p256verify` precompile with the input having public key (Q) as the point-at-infinity. If the implementation misses the check that Q is not at infinity, the signature should verify.

## 🔗 Related Issues or PRs
#2194 

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
