### PR TITLE
Fix/warnings

### DIFF
--- a/src/ethereum_clis/transition_tool.py
+++ b/src/ethereum_clis/transition_tool.py
@@ -479,8 +479,8 @@ class TransitionTool(EthereumCLI):
             output.result.traces = self.collect_traces(
                 output.result.receipts, temp_dir, debug_output_path
             )
-            temp_dir.cleanup()
 
+        temp_dir.cleanup()
         return output
 
     def safe_t8n_args(

--- a/src/ethereum_test_specs/blockchain.py
+++ b/src/ethereum_test_specs/blockchain.py
@@ -146,6 +146,7 @@ class Header(CamelModel):
     @model_serializer(mode="wrap", when_used="json")
     def _serialize_model(self, serializer, info):
         """Exclude Removable fields from serialization."""
+        del info
         data = serializer(self)
         return {k: v for k, v in data.items() if not isinstance(v, Removable)}
 

--- a/src/ethereum_test_specs/blockchain.py
+++ b/src/ethereum_test_specs/blockchain.py
@@ -4,7 +4,7 @@ from pprint import pprint
 from typing import Any, Callable, ClassVar, Dict, Generator, List, Sequence, Tuple, Type
 
 import pytest
-from pydantic import ConfigDict, Field, field_validator
+from pydantic import ConfigDict, Field, field_validator, model_serializer
 
 from ethereum_clis import BlockExceptionWithMessage, Result, TransitionTool
 from ethereum_test_base_types import (
@@ -141,15 +141,13 @@ class Header(CamelModel):
     engine_api_error_code=EngineAPIError.InvalidParams, ) ```
     """
 
-    model_config = ConfigDict(
-        arbitrary_types_allowed=True,
-        # explicitly set Removable items to None so they are not included in
-        # the serialization (in combination with exclude_None=True in
-        # model.dump()).
-        json_encoders={
-            Removable: lambda x: None,
-        },
-    )
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    @model_serializer(mode="wrap", when_used="json")
+    def _serialize_model(self, serializer, info):
+        """Exclude Removable fields from serialization."""
+        data = serializer(self)
+        return {k: v for k, v in data.items() if not isinstance(v, Removable)}
 
     @field_validator("withdrawals_root", mode="before")
     @classmethod

--- a/src/ethereum_test_specs/static_state/account.py
+++ b/src/ethereum_test_specs/static_state/account.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, List, Mapping, Set, Tuple
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from ethereum_test_base_types import Bytes, EthereumTestRootModel, HexNumber, Storage
 from ethereum_test_types import Alloc
@@ -54,11 +54,7 @@ class AccountInFiller(BaseModel, TagDependentData):
     nonce: ValueInFiller | None = None
     storage: StorageInPre | None = None
 
-    class Config:
-        """Model Config."""
-
-        extra = "forbid"
-        arbitrary_types_allowed = True  # For CodeInFiller
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
 
     def tag_dependencies(self) -> Mapping[str, Tag]:
         """Get tag dependencies."""

--- a/src/ethereum_test_specs/static_state/environment.py
+++ b/src/ethereum_test_specs/static_state/environment.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from ethereum_test_base_types import Address
 from ethereum_test_types import Environment
@@ -26,10 +26,7 @@ class EnvironmentInStateTestFiller(BaseModel):
 
     current_excess_blob_gas: ValueInFiller | None = Field(None, alias="currentExcessBlobGas")
 
-    class Config:
-        """Model Config."""
-
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     @model_validator(mode="after")
     def check_fields(self) -> "EnvironmentInStateTestFiller":

--- a/src/ethereum_test_specs/static_state/general_transaction.py
+++ b/src/ethereum_test_specs/static_state/general_transaction.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, Generator, List, Mapping
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from ethereum_test_base_types import Address, CamelModel, EthereumTestRootModel, Hash
 from ethereum_test_exceptions import TransactionExceptionInstanceOrList
@@ -127,10 +127,7 @@ class GeneralTransactionInFiller(BaseModel, TagDependentData):
     max_fee_per_blob_gas: ValueInFiller | None = Field(None, alias="maxFeePerBlobGas")
     blob_versioned_hashes: List[Hash] | None = Field(None, alias="blobVersionedHashes")
 
-    class Config:
-        """Model Config."""
-
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     def tag_dependencies(self) -> Mapping[str, Tag]:
         """Get tag dependencies."""

--- a/src/ethereum_test_specs/static_state/state_static.py
+++ b/src/ethereum_test_specs/static_state/state_static.py
@@ -4,7 +4,7 @@ from typing import Callable, ClassVar, List, Self, Set, Union
 
 import pytest
 from _pytest.mark.structures import ParameterSet
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from ethereum_test_forks import Fork
 from ethereum_test_types import Alloc
@@ -37,10 +37,7 @@ class StateStaticTest(BaseStaticTest):
     transaction: GeneralTransactionInFiller
     expect: List[ExpectSectionInStateTestFiller]
 
-    class Config:
-        """Model Config."""
-
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     def model_post_init(self, context):
         """Initialize StateStaticTest."""

--- a/src/pytest_plugins/eels_resolver.py
+++ b/src/pytest_plugins/eels_resolver.py
@@ -61,19 +61,19 @@ def pytest_configure(config: pytest.Config) -> None:
     config._eels_resolutions_file = eels_resolutions_file  # type: ignore
 
 
-def pytest_report_header(config: pytest.Config, startdir: Path) -> str:
+def pytest_report_header(config: pytest.Config, start_path: Path) -> str:
     """
     Report the EELS_RESOLUTIONS_FILE path to the pytest report header.
 
     Args:
         config (pytest.Config): The pytest configuration object.
-        startdir (Path): The starting directory for the test run.
+        start_path (Path): The starting directory for the test run.
 
     Returns:
         str: A string to add to the pytest report header.
 
     """
-    del startdir
+    del start_path
 
     eels_resolutions_file = getattr(config, "_eels_resolutions_file", None)
     if eels_resolutions_file:

--- a/tests/homestead/identity_precompile/test_identity.py
+++ b/tests/homestead/identity_precompile/test_identity.py
@@ -20,7 +20,9 @@ def test_identity_return_overwrite(
     pre: Alloc,
     call_opcode: Op,
 ):
-    """Test the return data of the identity precompile overwriting its input."""
+    """
+    Test the return data of the identity precompile overwriting its input.
+    """
     code = (
         sum(Op.MSTORE8(offset=i, value=(i + 1)) for i in range(4))  # memory = [1, 2, 3, 4]
         + call_opcode(
@@ -62,7 +64,10 @@ def test_identity_return_buffer_modify(
     pre: Alloc,
     call_opcode: Op,
 ):
-    """Test the modification of the input range to attempt to modify the return buffer."""
+    """
+    Test the modification of the input range to attempt to modify the return
+    buffer.
+    """
     env = Environment()
     code = (
         sum(Op.MSTORE8(offset=i, value=(i + 1)) for i in range(4))  # memory = [1, 2, 3, 4]


### PR DESCRIPTION
## 🗒️ Description

This fixes any issues if `PYTHONWARNINGS` is set to `error` when filling. All other reported options no longer cause any issues. I figured this was easy enough to just silence these. I'm thinking this doesn't necessitate a CHANGELOG entry? 🤔 

Closes #1009

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).