### PR TITLE
feat(consume): `consume direct` using evmone-state and blockchaintest

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 - ✨ Add retry logic to RPC requests to fix flaky connection issues in Hive ([#2205](https://github.com/ethereum/execution-spec-tests/pull/2205)).
 - 🛠️ Mark `consume sync` tests as `flaky` with 3 retires due to client sync inconsistencies ([#2252](https://github.com/ethereum/execution-spec-tests/pull/2252)).
+- ✨ Add `consume direct` using `evmone-statetest` and `evmone-blockchaintest` ([#2243](https://github.com/ethereum/execution-spec-tests/pull/2243)).
 
 ### 📋 Misc
 

--- a/docs/running_tests/consume/direct.md
+++ b/docs/running_tests/consume/direct.md
@@ -15,7 +15,7 @@ uv run consume direct --bin=<evm-binary> [OPTIONS]
 
     - go-ethereum `statetest` and `blocktest`
     - Nethermind `nethtest`
-    - evmone `evmone-statetest`
+    - evmone `evmone-statetest` and `evmone-blockchaintest`
 
 ## Advantages
 
@@ -25,7 +25,7 @@ uv run consume direct --bin=<evm-binary> [OPTIONS]
 
 ## Limitations
 
-- **Limited client support**: Only go-ethereum, Nethermind and (partially) evmone
+- **Limited client support**: Only go-ethereum, Nethermind and evmone
 - **Module scope**: Tests EVM, respectively block import, in isolation, not full client behavior.
 - **Interface dependency**: Requires client-specific test interfaces.
 
@@ -46,7 +46,7 @@ uv run consume direct --input ./fixtures -m state_test --bin=nethtest
 or evmone:
 
 ```bash
-uv run consume direct --input ./fixtures -m state_test --bin=evmone-statetest
+uv run consume direct --input ./fixtures --bin=evmone-statetest --bin=evmone-blockchaintest
 ```
 
 Run fixtures in the blockchain test format for the Prague fork:

--- a/src/ethereum_clis/__init__.py
+++ b/src/ethereum_clis/__init__.py
@@ -12,7 +12,12 @@ from .cli_types import (
 )
 from .clis.besu import BesuTransitionTool
 from .clis.ethereumjs import EthereumJSTransitionTool
-from .clis.evmone import EvmoneExceptionMapper, EvmOneFixtureConsumer, EvmOneTransitionTool
+from .clis.evmone import (
+    EvmOneBlockchainFixtureConsumer,
+    EvmoneExceptionMapper,
+    EvmOneStateFixtureConsumer,
+    EvmOneTransitionTool,
+)
 from .clis.execution_specs import ExecutionSpecsTransitionTool
 from .clis.geth import GethFixtureConsumer, GethTransitionTool
 from .clis.nethermind import Nethtest, NethtestFixtureConsumer
@@ -31,7 +36,8 @@ __all__ = (
     "EthereumJSTransitionTool",
     "EvmoneExceptionMapper",
     "EvmOneTransitionTool",
-    "EvmOneFixtureConsumer",
+    "EvmOneStateFixtureConsumer",
+    "EvmOneBlockchainFixtureConsumer",
     "ExecutionSpecsTransitionTool",
     "FixtureConsumerTool",
     "GethFixtureConsumer",


### PR DESCRIPTION
## 🗒️ Description

First step towards supporting `consume direct` with `evmone`.

Remarks:
1) Starting off with just `state_test` support to get the ball rolling
2) `evmone` has two things which make things harder. One is that it has two separate binaries: `evmone-statetest` and `evmone-blockchaintest`, rather than a single one with 2 subcommands, as EEST assumes. Decision we need to make where do we adjust - on EEST end or on `evmone` end. Gut tells me it is more elegant to adjust `evmone`, but overall easier to do so in EEST (assuming we can cut a corner and let EEST choose state/blockchain binary on the fly as it picks up fixtures). EDIT: using evmone-blockchaintest is handled in this PR :point_down: 
3) Other is that `evmone` tests on the granularity level of a single `json` file. This means a failed test case fails the entire file, making it a bit harder to figure out where the failure is (failure message provides a good hint, but is pretty messy). Also test filtering is very coarse. Something we need to tackle on `evmone` end as we progress.

Opening as draft - let me know if OK to proceed with such first step into `main`.

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
