### PR TITLE
chore(consume): mark sync tests flaky

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,12 +22,13 @@ Test fixtures for use by clients are available for each release on the [Github r
 #### `consume`
 
 - ✨ Add retry logic to RPC requests to fix flaky connection issues in Hive ([#2205](https://github.com/ethereum/execution-spec-tests/pull/2205)).
+- 🛠️ Mark `consume sync` tests as `flaky` with 3 retires due to client sync inconsistencies ([#2252](https://github.com/ethereum/execution-spec-tests/pull/2252)).
 
 ### 📋 Misc
 
 - ✨ Add tighter validation for EIP-7928 model coming from t8n when filling ([#2138](https://github.com/ethereum/execution-spec-tests/pull/2138)).
 - ✨ Add flexible API for absence checks for EIP-7928 (BAL) tests ([#2124](https://github.com/ethereum/execution-spec-tests/pull/2124)).
-- 🐞 Use ``engine_newPayloadV5`` for `>=Amsterdam` forks in `consume engine` ([#2170](https://github.com/ethereum/execution-spec-tests/pull/2170)).
+- 🐞 Use `engine_newPayloadV5` for `>=Amsterdam` forks in `consume engine` ([#2170](https://github.com/ethereum/execution-spec-tests/pull/2170)).
 - 🔀 Refactor EIP-7928 (BAL) absence checks into a friendlier class-based DevEx ([#2175](https://github.com/ethereum/execution-spec-tests/pull/2175)).
 
 ### 🧪 Test Cases

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "questionary>=2.1.0,<3",
     "ethereum-rlp>=0.1.3,<0.2",
     "pytest-regex>=0.2.0,<0.3",
+    "pytest-rerunfailures>=16.0,<17",
     "eth-abi>=5.2.0",
     "joblib>=1.4.2",
     "ckzg>=2.1.3,<3",

--- a/src/pytest_plugins/consume/simulators/sync/conftest.py
+++ b/src/pytest_plugins/consume/simulators/sync/conftest.py
@@ -47,6 +47,10 @@ def pytest_collection_modifyitems(session, config, items):
     del session, config
 
     for item in items:
+        # Auto-mark all verify_sync tests as flaky with 3 reruns
+        if item.get_closest_marker("blockchain_test_sync"):
+            item.add_marker(pytest.mark.flaky(reruns=3))
+
         # Check if this test has both client_type and sync_client_type
         if (
             hasattr(item, "callspec")

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 
 [[package]]
@@ -587,6 +587,7 @@ dependencies = [
     { name = "pytest-json-report" },
     { name = "pytest-metadata" },
     { name = "pytest-regex" },
+    { name = "pytest-rerunfailures" },
     { name = "pytest-xdist" },
     { name = "pyyaml" },
     { name = "questionary" },
@@ -671,6 +672,7 @@ requires-dist = [
     { name = "pytest-json-report", specifier = ">=1.5.0,<2" },
     { name = "pytest-metadata", specifier = ">=3,<4" },
     { name = "pytest-regex", specifier = ">=0.2.0,<0.3" },
+    { name = "pytest-rerunfailures", specifier = ">=16.0,<17" },
     { name = "pytest-xdist", specifier = ">=3.3.1,<4" },
     { name = "pyyaml", specifier = ">=6.0.2,<7" },
     { name = "questionary", specifier = ">=2.1.0,<3" },
@@ -1619,6 +1621,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/73/67/e3f3700e8f95fc9e80ab83d589346c117de4e6d01e6b922f7300282e7fc9/pytest-regex-0.2.0.tar.gz", hash = "sha256:f4076c49abece2503815c8b2e282a8fd22d330f06f9bf91d620b3ef02de7a353", size = 4097, upload-time = "2023-05-29T22:08:11.071Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/72/d4143c66c1806599358c119c0af530bab92ef0c48129f17522dfd5a7ff6a/pytest_regex-0.2.0-py3-none-any.whl", hash = "sha256:c97e9c49e8c7e7482bd1fa701e3a5cccd18eb78d263752e32dba4937d8cee6d9", size = 3824, upload-time = "2023-05-29T22:08:09.551Z" },
+]
+
+[[package]]
+name = "pytest-rerunfailures"
+version = "16.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/53/a543a76f922a5337d10df22441af8bf68f1b421cadf9aedf8a77943b81f6/pytest_rerunfailures-16.0.1.tar.gz", hash = "sha256:ed4b3a6e7badb0a720ddd93f9de1e124ba99a0cb13bc88561b3c168c16062559", size = 27612, upload-time = "2025-09-02T06:48:25.193Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/73/67dc14cda1942914e70fbb117fceaf11e259362c517bdadd76b0dd752524/pytest_rerunfailures-16.0.1-py3-none-any.whl", hash = "sha256:0bccc0e3b0e3388275c25a100f7077081318196569a121217688ed05e58984b9", size = 13610, upload-time = "2025-09-02T06:48:23.615Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🗒️ Description

This should be a quick merge if we accept the flakiness of client syncing. Here we add `flaky` to all `verify_sync` tests in order to re-run them as most of the time this is flakiness on the side of spinning up the clients and getting them to sync. I think this is inherent where sometimes it works and sometimes it doesn't. Perhaps we can investigate a way to remove this in the future but it's important to discern what is an actual fail and what can be "fixed" by just retrying the sync.

I also simplified the sync check a bit as we had an outdated setup still lingering.

With these changes, ran locally, I got:

```
========== 288 passed, 4 rerun in 1017.33s (0:16:57) ==========
```

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).