### PR TITLE
feat(tests): test accessing slots in address that appears more than once in access list

### DIFF
--- a/tests/berlin/eip2930_access_list/test_acl.py
+++ b/tests/berlin/eip2930_access_list/test_acl.py
@@ -253,3 +253,66 @@ def test_transaction_intrinsic_gas_cost(
         ),
     }
     state_test(env=env, pre=pre, post=post, tx=tx)
+
+
+def test_repeated_address_acl(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+):
+    """
+    Tests that slots are warmed correctly in an access list that has the same address repeated
+    more than once, each time with different slots.
+
+    Difference with other ACL tests is that we actually try to access both slots at runtime,
+    we also measure the gas cost of each access in order to make debugging easier.
+    """
+    sender = pre.fund_eoa()
+    gsc = fork.gas_costs()
+
+    sload0_measure = CodeGasMeasure(
+        code=Op.SLOAD(0),
+        overhead_cost=gsc.G_VERY_LOW * len(Op.SLOAD.kwargs),  # Cost of pushing SLOAD args
+        extra_stack_items=1,  # SLOAD pushes 1 item to the stack
+        sstore_key=0,
+        stop=False,  # Because it's the first CodeGasMeasure
+    )
+
+    sload1_measure = CodeGasMeasure(
+        code=Op.SLOAD(1),
+        overhead_cost=gsc.G_VERY_LOW * len(Op.SLOAD.kwargs),  # Cost of pushing SLOAD args
+        extra_stack_items=1,  # SLOAD pushes 1 item to the stack
+        sstore_key=1,
+    )
+
+    contract = pre.deploy_contract(sload0_measure + sload1_measure)
+
+    tx = Transaction(
+        gas_limit=500_000,
+        to=contract,
+        value=0,
+        sender=sender,
+        access_list=[
+            AccessList(
+                address=contract,
+                storage_keys=[0],
+            ),
+            AccessList(
+                address=contract,
+                storage_keys=[1],
+            ),
+        ],
+    )
+
+    sload_cost = gsc.G_WARM_ACCOUNT_ACCESS
+
+    state_test(
+        env=Environment(),
+        pre=pre,
+        tx=tx,
+        post={
+            contract: Account(
+                storage={0: sload_cost, 1: sload_cost},
+            )
+        },
+    )

--- a/tests/berlin/eip2930_access_list/test_acl.py
+++ b/tests/berlin/eip2930_access_list/test_acl.py
@@ -261,11 +261,12 @@ def test_repeated_address_acl(
     fork: Fork,
 ):
     """
-    Tests that slots are warmed correctly in an access list that has the same address repeated
-    more than once, each time with different slots.
+    Tests that slots are warmed correctly in an access list that has the same
+    address repeated more than once, each time with different slots.
 
-    Difference with other ACL tests is that we actually try to access both slots at runtime,
-    we also measure the gas cost of each access in order to make debugging easier.
+    Difference with other ACL tests is that we actually try to
+    access both slots at runtime. We also measure the gas cost
+    of each access in order to make debugging easier.
     """
     sender = pre.fund_eoa()
     gsc = fork.gas_costs()


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Hi! We were syncing ethrex on mainnet and we found a bug in our code in the process. We found out that we had a gas mismatch in [this transaction](https://etherscan.io/tx/0x274e16a80e3473062ac8cb75d251a9822a443405c0901c58334b5bbf805209a2/advanced). Turns out that it has a very particular access list that has the same address twice in it and we weren't contemplating that scenario. This was fixed in https://github.com/lambdaclass/ethrex/pull/4741

We thought it'd be nice to add a test for this, so here it goes. Suggestions are welcome 😄 

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
https://github.com/lambdaclass/ethrex/pull/4741

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
