### PR TITLE
fix(execute): relax gas validation rule for non benchmark mode

### DIFF
--- a/src/ethereum_test_specs/blockchain.py
+++ b/src/ethereum_test_specs/blockchain.py
@@ -903,6 +903,10 @@ class BlockchainTest(BaseTest):
             for block in self.blocks:
                 blocks += [block.txs]
             # Pass gas validation params for benchmark tests
+            # If not benchmark mode, skip gas used validation
+            if self._operation_mode != OpMode.BENCHMARKING:
+                self.skip_gas_used_validation = True
+
             return TransactionPost(
                 blocks=blocks,
                 post=self.post,

--- a/src/ethereum_test_specs/state.py
+++ b/src/ethereum_test_specs/state.py
@@ -445,6 +445,9 @@ class StateTest(BaseTest):
         """Generate the list of test fixtures."""
         if execute_format == TransactionPost:
             # Pass gas validation params for benchmark tests
+            # If not benchmark mode, skip gas used validation
+            if self._operation_mode != OpMode.BENCHMARKING:
+                self.skip_gas_used_validation = True
             return TransactionPost(
                 blocks=[[self.tx]],
                 post=self.post,


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

In PR #2219, we added a gas validation rule for `execute` mode that assumes full block gas consumption. This should apply only to benchmark mode, non-benchmark tests don’t have this requirement and should bypass gas validation.


### Verification
Running [anvil](https://getfoundry.sh/anvil/reference/anvil/) for quick verification: `anvil --accounts 1 --balance 300`
Some environment variable from anvil local network:
- chain id: 31337
- rpc link: `127.0.0.1:8545`
- rpc seed key: `0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80`

Test Cases:
- Benchmark Mode: uv run execute remote tests/benchmark/test_worst_compute.py::test_worst_jumps -m benchmark --gas-benchmark-values 1 --chain-id 31337 --rpc-seed-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --rpc-endpoint http://127.0.0.1:8545 --fork Prague
- Consensus Mode: uv run execute remote tests/prague/eip7702_set_code_tx/test_set_code_txs.py --chain-id 31337 --rpc-seed-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --rpc-endpoint http://127.0.0.1:8545 --fork Prague


## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
This would affect Issue #2255 and PR #2266 , and there is issue reported by ethPandaOps that affect testing.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
