### PR TITLE
chore(ci|fill): bump eels for bpo1/2 param changes

### DIFF
--- a/.github/configs/eels_resolutions.json
+++ b/.github/configs/eels_resolutions.json
@@ -33,9 +33,9 @@
         "path": "$GITHUB_WORKSPACE/execution-specs/"
     },
     "Osaka": {
-        "git_url": "https://github.com/spencer-tb/execution-specs.git",
-        "branch": "forks/bpo1",
-        "commit": "c0cdc5ed0e8c0d940d9277da4f532c2d8431e28d"
+        "git_url": "https://github.com/ethereum/execution-specs.git",
+        "branch": "forks/bpos",
+        "commit": "7aacb2c54111391af5e98c505d5010b5698a770f"
     },
     "BPO1": {
         "same_as": "Osaka"

--- a/.github/configs/eels_resolutions.json
+++ b/.github/configs/eels_resolutions.json
@@ -33,9 +33,9 @@
         "path": "$GITHUB_WORKSPACE/execution-specs/"
     },
     "Osaka": {
-        "git_url": "https://github.com/marioevz/execution-specs.git",
+        "git_url": "https://github.com/spencer-tb/execution-specs.git",
         "branch": "forks/bpo1",
-        "commit": "3387e5f4aedfe99becfdc39b444d6371e25e0924"
+        "commit": "c0cdc5ed0e8c0d940d9277da4f532c2d8431e28d"
     },
     "BPO1": {
         "same_as": "Osaka"

--- a/src/pytest_plugins/eels_resolutions.json
+++ b/src/pytest_plugins/eels_resolutions.json
@@ -1,8 +1,8 @@
 {
     "EELSMaster": {
-        "git_url": "https://github.com/spencer-tb/execution-specs.git",
-        "branch": "forks/bpo1",
-        "commit": "c0cdc5ed0e8c0d940d9277da4f532c2d8431e28d"
+        "git_url": "https://github.com/ethereum/execution-specs.git",
+        "branch": "forks/bpos",
+        "commit": "7aacb2c54111391af5e98c505d5010b5698a770f"
     },
     "Frontier": {
         "same_as": "EELSMaster"

--- a/src/pytest_plugins/eels_resolutions.json
+++ b/src/pytest_plugins/eels_resolutions.json
@@ -1,8 +1,8 @@
 {
     "EELSMaster": {
-        "git_url": "https://github.com/marioevz/execution-specs.git",
+        "git_url": "https://github.com/spencer-tb/execution-specs.git",
         "branch": "forks/bpo1",
-        "commit": "3387e5f4aedfe99becfdc39b444d6371e25e0924"
+        "commit": "c0cdc5ed0e8c0d940d9277da4f532c2d8431e28d"
     },
     "Frontier": {
         "same_as": "EELSMaster"


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Follow up to #2234.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
