### PR TITLE
chore(consume): fix consume sync logger errors

### DIFF
--- a/src/pytest_plugins/consume/simulators/simulator_logic/test_via_sync.py
+++ b/src/pytest_plugins/consume/simulators/simulator_logic/test_via_sync.py
@@ -419,10 +419,16 @@ def test_blockchain_via_sync(
         assert eth_rpc is not None, "eth_rpc is required"
         assert sync_eth_rpc is not None, "sync_eth_rpc is required"
 
-        for attempt in range(3):
+        for attempt in range(5):
             try:
                 sync_block = sync_eth_rpc.get_block_by_hash(last_valid_block_hash)
                 client_block = eth_rpc.get_block_by_hash(last_valid_block_hash)
+
+                if sync_block is None or client_block is None:
+                    raise LoggedError(
+                        f"Failed to retrieve block {last_valid_block_hash} "
+                        f"on attempt {attempt + 1}"
+                    )
 
                 if sync_block["stateRoot"] != client_block["stateRoot"]:
                     raise LoggedError(
@@ -438,8 +444,9 @@ def test_blockchain_via_sync(
                             f"Expected: {fixture.post_state_hash}, "
                             f"Got: {sync_block['stateRoot']}"
                         )
+                break
             except Exception as e:
-                if attempt < 2:
+                if attempt < 4:
                     time.sleep(1)
                     continue
                 raise e


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Consume sync can fail with `TypeError: 'NoneType' object is not subscriptable` when attempting to verify block state roots immediately after the sync completes. The `get_block_by_hash()` call returns `None` because the block isn't yet queryable, even though the forkchoice update returned `VALID`.

### Solution To Try
Add explicit `None` checks for retrieved blocks in the verification retry loop.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Follow up from: #2252 

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
