### PR TITLE
chore(tooling): Enable all `ruff` `ARG` rules and fix all violations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,10 +164,6 @@ ignore = [
     "D205", # Missing blank line after summary
     "D212", # Multi-line docstring summary should start at the first line
     "D401", # First line should be in imperative mood ("Do", not "Does")
-    # TODO: ethereum/execution-spec-tests#2176
-    "ARG002", # unused-method-argument
-    "ARG003", # unused-class-method-argument
-    "ARG005", # unused-lambda-argument
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/src/ethereum_clis/clis/besu.py
+++ b/src/ethereum_clis/clis/besu.py
@@ -108,6 +108,8 @@ class BesuTransitionTool(TransitionTool):
         slow_request: bool = False,
     ) -> TransitionToolOutput:
         """Execute `evm t8n` with the specified arguments."""
+        del slow_request
+
         if not self.process:
             self.start_server()
 

--- a/src/ethereum_clis/clis/ethereumjs.py
+++ b/src/ethereum_clis/clis/ethereumjs.py
@@ -42,6 +42,7 @@ class EthereumJSTransitionTool(TransitionTool):
 
         Currently, EthereumJS-t8n provides no way to determine supported forks.
         """
+        del fork
         return True
 
 

--- a/src/ethereum_clis/clis/evmone.py
+++ b/src/ethereum_clis/clis/evmone.py
@@ -55,6 +55,7 @@ class EvmOneTransitionTool(TransitionTool):
         Return True if the fork is supported by the tool. Currently, evmone-t8n
         provides no way to determine supported forks.
         """
+        del fork
         return True
 
 
@@ -71,6 +72,7 @@ class EvmoneFixtureConsumerCommon:
         trace: bool = False,
     ):
         """Initialize the EvmoneFixtureConsumerCommon class."""
+        del trace
         self._info_metadata: Optional[Dict[str, Any]] = {}
 
     def _run_command(self, command: List[str]) -> subprocess.CompletedProcess:

--- a/src/ethereum_clis/clis/nethermind.py
+++ b/src/ethereum_clis/clis/nethermind.py
@@ -151,6 +151,7 @@ class NethtestFixtureConsumer(
         function is cached in order to only call the command once and
         `consume_state_test` can simply select the result that was requested.
         """
+        del fixture_path
         result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
 
         if debug_output_path:
@@ -228,6 +229,8 @@ class NethtestFixtureConsumer(
         debug_output_path: Optional[Path] = None,
     ) -> None:
         """Execute the the fixture at `fixture_path` via `nethtest`."""
+        del fixture_path
+        del fixture_name
         result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
 
         if debug_output_path:
@@ -249,6 +252,7 @@ class NethtestFixtureConsumer(
         debug_output_path: Optional[Path] = None,
     ) -> Tuple[Dict[Any, Any], str, str]:
         """Consume an entire EOF fixture file."""
+        del fixture_path
         result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
 
         pattern = re.compile(r"^(test_.+?)\s+(PASS|FAIL)$", re.MULTILINE)

--- a/src/ethereum_clis/transition_tool.py
+++ b/src/ethereum_clis/transition_tool.py
@@ -384,6 +384,7 @@ class TransitionTool(EthereumCLI):
 
     def _generate_post_args(self, t8n_data: TransitionToolData) -> Dict[str, List[str] | str]:
         """Generate the arguments for the POST request to the t8n-server."""
+        del t8n_data
         return {}
 
     def _evaluate_server(

--- a/src/ethereum_test_base_types/tests/test_base_types.py
+++ b/src/ethereum_test_base_types/tests/test_base_types.py
@@ -222,6 +222,7 @@ class TestPydanticModelConversion:
         self, can_be_deserialized: bool, model_instance: Any, json: str | Dict[str, Any]
     ) -> None:
         """Test that to_json returns the expected JSON for the given object."""
+        del can_be_deserialized
         assert to_json(model_instance) == json
 
     def test_json_deserialization(

--- a/src/ethereum_test_benchmark/benchmark_code_generator.py
+++ b/src/ethereum_test_benchmark/benchmark_code_generator.py
@@ -21,7 +21,7 @@ class JumpLoopGenerator(BenchmarkCodeGenerator):
         code = self.generate_repeated_code(self.attack_block, self.setup, fork)
         self._contract_address = pre.deploy_contract(code=code)
 
-    def generate_transaction(self, pre: Alloc, gas_limit: int, fork: Fork) -> Transaction:
+    def generate_transaction(self, pre: Alloc, gas_limit: int) -> Transaction:
         """Generate transaction that executes the looping contract."""
         if not hasattr(self, "_contract_address"):
             raise ValueError("deploy_contracts must be called before generate_transaction")
@@ -68,7 +68,7 @@ class ExtCallGenerator(BenchmarkCodeGenerator):
         caller_code = self.generate_repeated_code(code_sequence, Bytecode(), fork)
         self._contract_address = pre.deploy_contract(code=caller_code)
 
-    def generate_transaction(self, pre: Alloc, gas_limit: int, fork: Fork) -> Transaction:
+    def generate_transaction(self, pre: Alloc, gas_limit: int) -> Transaction:
         """Generate transaction that executes the caller contract."""
         if not hasattr(self, "_contract_address"):
             raise ValueError("deploy_contracts must be called before generate_transaction")

--- a/src/ethereum_test_execution/transaction_post.py
+++ b/src/ethereum_test_execution/transaction_post.py
@@ -37,6 +37,8 @@ class TransactionPost(BaseExecute):
         request: FixtureRequest,
     ) -> None:
         """Execute the format."""
+        del fork
+        del engine_rpc
         assert not any(tx.ty == 3 for block in self.blocks for tx in block), (
             "Transaction type 3 is not supported in execute mode."
         )

--- a/src/ethereum_test_fixtures/base.py
+++ b/src/ethereum_test_fixtures/base.py
@@ -156,6 +156,7 @@ class BaseFixture(CamelModel):
 
         By default, all fixtures support all forks.
         """
+        del fork
         return True
 
     @classmethod
@@ -168,6 +169,7 @@ class BaseFixture(CamelModel):
         Discard a fixture format from filling if the appropriate marker is
         used.
         """
+        del fork, markers
         return False
 
 

--- a/src/ethereum_test_fixtures/blockchain.py
+++ b/src/ethereum_test_fixtures/blockchain.py
@@ -679,5 +679,6 @@ class BlockchainEngineSyncFixture(BlockchainEngineFixture):
         markers: List[pytest.Mark],
     ) -> bool:
         """Discard the fixture format based on the provided markers."""
+        del fork
         marker_names = [m.name for m in markers]
         return "verify_sync" not in marker_names

--- a/src/ethereum_test_fixtures/tests/test_blockchain.py
+++ b/src/ethereum_test_fixtures/tests/test_blockchain.py
@@ -961,6 +961,7 @@ class TestPydanticModelConversion:
         self, can_be_deserialized: bool, model_instance: Any, json_repr: str | Dict[str, Any]
     ) -> None:
         """Test that to_json returns the expected JSON for the given object."""
+        del can_be_deserialized
         assert to_json(model_instance) == json_repr
 
     def test_json_deserialization(
@@ -1308,6 +1309,7 @@ class TestPydanticAdaptersConversion:
         json_repr: str | Dict[str, Any],
     ) -> None:
         """Test that to_json returns the expected JSON for the given object."""
+        del can_be_deserialized
         assert (
             adapter.dump_python(
                 type_instance,

--- a/src/ethereum_test_fixtures/tests/test_eof.py
+++ b/src/ethereum_test_fixtures/tests/test_eof.py
@@ -85,6 +85,7 @@ class TestPydanticModelConversion:
         self, can_be_deserialized: bool, model_instance: Any, json_repr: str | Dict[str, Any]
     ) -> None:
         """Test that to_json returns the expected JSON for the given object."""
+        del can_be_deserialized
         serialized = to_json(model_instance)
         serialized.pop("_info")
         assert serialized == json_repr

--- a/src/ethereum_test_fixtures/tests/test_state.py
+++ b/src/ethereum_test_fixtures/tests/test_state.py
@@ -102,6 +102,7 @@ class TestPydanticModelConversion:
         self, can_be_deserialized: bool, model_instance: Any, json: str | Dict[str, Any]
     ) -> None:
         """Test that to_json returns the expected JSON for the given object."""
+        del can_be_deserialized
         assert to_json(model_instance) == json
 
     def test_json_deserialization(

--- a/src/ethereum_test_forks/base_fork.py
+++ b/src/ethereum_test_forks/base_fork.py
@@ -780,6 +780,7 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
         Return fork at the given block number and timestamp. Useful only for
         transition forks, and it's a no-op for normal forks.
         """
+        del block_number, timestamp
         return cls
 
     @classmethod

--- a/src/ethereum_test_forks/forks/forks.py
+++ b/src/ethereum_test_forks/forks/forks.py
@@ -38,6 +38,7 @@ class Frontier(BaseFork, solc_name="homestead"):
         Return fork name as it's meant to be passed to the transition tool for
         execution.
         """
+        del block_number, timestamp
         if cls._transition_tool_name is not None:
             return cls._transition_tool_name
         return cls.name()
@@ -52,31 +53,37 @@ class Frontier(BaseFork, solc_name="homestead"):
     @classmethod
     def header_base_fee_required(cls, *, block_number: int = 0, timestamp: int = 0) -> bool:
         """At genesis, header must not contain base fee."""
+        del block_number, timestamp
         return False
 
     @classmethod
     def header_prev_randao_required(cls, *, block_number: int = 0, timestamp: int = 0) -> bool:
         """At genesis, header must not contain Prev Randao value."""
+        del block_number, timestamp
         return False
 
     @classmethod
     def header_zero_difficulty_required(cls, *, block_number: int = 0, timestamp: int = 0) -> bool:
         """At genesis, header must not have difficulty zero."""
+        del block_number, timestamp
         return False
 
     @classmethod
     def header_withdrawals_required(cls, *, block_number: int = 0, timestamp: int = 0) -> bool:
         """At genesis, header must not contain withdrawals."""
+        del block_number, timestamp
         return False
 
     @classmethod
     def header_excess_blob_gas_required(cls, *, block_number: int = 0, timestamp: int = 0) -> bool:
         """At genesis, header must not contain excess blob gas."""
+        del block_number, timestamp
         return False
 
     @classmethod
     def header_blob_gas_used_required(cls, *, block_number: int = 0, timestamp: int = 0) -> bool:
         """At genesis, header must not contain blob gas used."""
+        del block_number, timestamp
         return False
 
     @classmethod
@@ -84,6 +91,7 @@ class Frontier(BaseFork, solc_name="homestead"):
         """
         Return dataclass with the defined gas costs constants for genesis.
         """
+        del block_number, timestamp
         return GasCosts(
             G_JUMPDEST=1,
             G_BASE=2,
@@ -195,6 +203,7 @@ class Frontier(BaseFork, solc_name="homestead"):
     @classmethod
     def base_fee_max_change_denominator(cls, *, block_number: int = 0, timestamp: int = 0) -> int:
         """Return the base fee max change denominator at a given fork."""
+        del block_number, timestamp
         raise NotImplementedError(
             f"Base fee max change denominator is not supported in {cls.name()}"
         )
@@ -202,6 +211,7 @@ class Frontier(BaseFork, solc_name="homestead"):
     @classmethod
     def base_fee_elasticity_multiplier(cls, *, block_number: int = 0, timestamp: int = 0) -> int:
         """Return the base fee elasticity multiplier at a given fork."""
+        del block_number, timestamp
         raise NotImplementedError(
             f"Base fee elasticity multiplier is not supported in {cls.name()}"
         )
@@ -211,6 +221,7 @@ class Frontier(BaseFork, solc_name="homestead"):
         cls, *, block_number: int = 0, timestamp: int = 0
     ) -> TransactionDataFloorCostCalculator:
         """At frontier, the transaction data floor cost is a constant zero."""
+        del block_number, timestamp
 
         def fn(*, data: BytesConvertible) -> int:
             del data
@@ -279,11 +290,13 @@ class Frontier(BaseFork, solc_name="homestead"):
     @classmethod
     def min_base_fee_per_blob_gas(cls, *, block_number: int = 0, timestamp: int = 0) -> int:
         """Return the amount of blob gas used per blob at a given fork."""
+        del block_number, timestamp
         raise NotImplementedError(f"Base fee per blob gas is not supported in {cls.name()}")
 
     @classmethod
     def blob_base_fee_update_fraction(cls, *, block_number: int = 0, timestamp: int = 0) -> int:
         """Return the blob base fee update fraction at a given fork."""
+        del block_number, timestamp
         raise NotImplementedError(
             f"Blob base fee update fraction is not supported in {cls.name()}"
         )
@@ -291,21 +304,25 @@ class Frontier(BaseFork, solc_name="homestead"):
     @classmethod
     def blob_gas_per_blob(cls, *, block_number: int = 0, timestamp: int = 0) -> int:
         """Return the amount of blob gas used per blob at a given fork."""
+        del block_number, timestamp
         return 0
 
     @classmethod
     def supports_blobs(cls, *, block_number: int = 0, timestamp: int = 0) -> bool:
         """Blobs are not supported at Frontier."""
+        del block_number, timestamp
         return False
 
     @classmethod
     def target_blobs_per_block(cls, *, block_number: int = 0, timestamp: int = 0) -> int:
         """Return the target number of blobs per block at a given fork."""
+        del block_number, timestamp
         raise NotImplementedError(f"Target blobs per block is not supported in {cls.name()}")
 
     @classmethod
     def max_blobs_per_block(cls, *, block_number: int = 0, timestamp: int = 0) -> int:
         """Return the max number of blobs per block at a given fork."""
+        del block_number, timestamp
         raise NotImplementedError(f"Max blobs per block is not supported in {cls.name()}")
 
     @classmethod
@@ -314,11 +331,13 @@ class Frontier(BaseFork, solc_name="homestead"):
         Return whether the fork uses a reserve price mechanism for blobs or
         not.
         """
+        del block_number, timestamp
         raise NotImplementedError(f"Blob reserve price is not supported in {cls.name()}")
 
     @classmethod
     def blob_base_cost(cls, *, block_number: int = 0, timestamp: int = 0) -> int:
         """Return the base cost of a blob at a given fork."""
+        del block_number, timestamp
         raise NotImplementedError(f"Blob base cost is not supported in {cls.name()}")
 
     @classmethod
@@ -333,21 +352,25 @@ class Frontier(BaseFork, solc_name="homestead"):
     @classmethod
     def max_blobs_per_tx(cls, *, block_number: int = 0, timestamp: int = 0) -> int:
         """Return the max number of blobs per tx at a given fork."""
+        del block_number, timestamp
         raise NotImplementedError(f"Max blobs per tx is not supported in {cls.name()}")
 
     @classmethod
     def blob_schedule(cls, *, block_number: int = 0, timestamp: int = 0) -> BlobSchedule | None:
         """At genesis, no blob schedule is used."""
+        del block_number, timestamp
         return None
 
     @classmethod
     def header_requests_required(cls, *, block_number: int = 0, timestamp: int = 0) -> bool:
         """At genesis, header must not contain beacon chain requests."""
+        del block_number, timestamp
         return False
 
     @classmethod
     def header_bal_hash_required(cls, *, block_number: int = 0, timestamp: int = 0) -> bool:
         """At genesis, header must not contain block access list hash."""
+        del block_number, timestamp
         return False
 
     @classmethod
@@ -355,26 +378,31 @@ class Frontier(BaseFork, solc_name="homestead"):
         cls, *, block_number: int = 0, timestamp: int = 0
     ) -> Optional[int]:
         """At genesis, payloads cannot be sent through the engine API."""
+        del block_number, timestamp
         return None
 
     @classmethod
     def header_beacon_root_required(cls, *, block_number: int = 0, timestamp: int = 0) -> bool:
         """At genesis, header must not contain parent beacon block root."""
+        del block_number, timestamp
         return False
 
     @classmethod
     def engine_new_payload_blob_hashes(cls, *, block_number: int = 0, timestamp: int = 0) -> bool:
         """At genesis, payloads do not have blob hashes."""
+        del block_number, timestamp
         return False
 
     @classmethod
     def engine_new_payload_beacon_root(cls, *, block_number: int = 0, timestamp: int = 0) -> bool:
         """At genesis, payloads do not have a parent beacon block root."""
+        del block_number, timestamp
         return False
 
     @classmethod
     def engine_new_payload_requests(cls, *, block_number: int = 0, timestamp: int = 0) -> bool:
         """At genesis, payloads do not have requests."""
+        del block_number, timestamp
         return False
 
     @classmethod
@@ -382,6 +410,7 @@ class Frontier(BaseFork, solc_name="homestead"):
         cls, *, block_number: int = 0, timestamp: int = 0
     ) -> bool:
         """At genesis, payloads do not have block access list."""
+        del block_number, timestamp
         return False
 
     @classmethod
@@ -392,6 +421,7 @@ class Frontier(BaseFork, solc_name="homestead"):
         timestamp: int = 0,
     ) -> bool:
         """At genesis, payloads do not have target blobs per block."""
+        del block_number, timestamp
         return False
 
     @classmethod
@@ -402,6 +432,7 @@ class Frontier(BaseFork, solc_name="homestead"):
         At genesis, payload attributes do not include the target blobs per
         block.
         """
+        del block_number, timestamp
         return False
 
     @classmethod
@@ -411,6 +442,7 @@ class Frontier(BaseFork, solc_name="homestead"):
         """
         At genesis, payload attributes do not include the max blobs per block.
         """
+        del block_number, timestamp
         return False
 
     @classmethod
@@ -434,6 +466,7 @@ class Frontier(BaseFork, solc_name="homestead"):
         cls, *, block_number: int = 0, timestamp: int = 0
     ) -> Optional[int]:
         """At genesis, blobs cannot be retrieved through the engine API."""
+        del block_number, timestamp
         return None
 
     @classmethod
@@ -442,41 +475,49 @@ class Frontier(BaseFork, solc_name="homestead"):
         At Genesis the expected reward amount in wei is
         5_000_000_000_000_000_000.
         """
+        del block_number, timestamp
         return 5_000_000_000_000_000_000
 
     @classmethod
     def tx_types(cls, *, block_number: int = 0, timestamp: int = 0) -> List[int]:
         """At Genesis, only legacy transactions are allowed."""
+        del block_number, timestamp
         return [0]
 
     @classmethod
     def contract_creating_tx_types(cls, *, block_number: int = 0, timestamp: int = 0) -> List[int]:
         """At Genesis, only legacy transactions are allowed."""
+        del block_number, timestamp
         return [0]
 
     @classmethod
     def transaction_gas_limit_cap(cls, *, block_number: int = 0, timestamp: int = 0) -> int | None:
         """At Genesis, no transaction gas limit cap is imposed."""
+        del block_number, timestamp
         return None
 
     @classmethod
     def block_rlp_size_limit(cls, *, block_number: int = 0, timestamp: int = 0) -> int | None:
         """At Genesis, no RLP block size limit is imposed."""
+        del block_number, timestamp
         return None
 
     @classmethod
     def precompiles(cls, *, block_number: int = 0, timestamp: int = 0) -> List[Address]:
         """At Genesis, no pre-compiles are present."""
+        del block_number, timestamp
         return []
 
     @classmethod
     def system_contracts(cls, *, block_number: int = 0, timestamp: int = 0) -> List[Address]:
         """At Genesis, no system-contracts are present."""
+        del block_number, timestamp
         return []
 
     @classmethod
     def evm_code_types(cls, *, block_number: int = 0, timestamp: int = 0) -> List[EVMCodeType]:
         """At Genesis, only legacy EVM code is supported."""
+        del block_number, timestamp
         return [EVMCodeType.LEGACY]
 
     @classmethod
@@ -487,16 +528,19 @@ class Frontier(BaseFork, solc_name="homestead"):
 
         However, the default is set to the limit of EIP-170 (Spurious Dragon)
         """
+        del block_number, timestamp
         return 0x6000
 
     @classmethod
     def max_stack_height(cls, *, block_number: int = 0, timestamp: int = 0) -> int:
         """At genesis, the maximum stack height is 1024."""
+        del block_number, timestamp
         return 1024
 
     @classmethod
     def max_initcode_size(cls, *, block_number: int = 0, timestamp: int = 0) -> int:
         """At genesis, there is no upper bound for initcode size."""
+        del block_number, timestamp
         """However, the default is set to the limit of EIP-3860 (Shanghai)"""
         return 0xC000
 
@@ -505,6 +549,7 @@ class Frontier(BaseFork, solc_name="homestead"):
         cls, *, block_number: int = 0, timestamp: int = 0
     ) -> List[Tuple[Opcodes, EVMCodeType]]:
         """Return list of call opcodes supported by the fork."""
+        del block_number, timestamp
         return [
             (Opcodes.CALL, EVMCodeType.LEGACY),
             (Opcodes.CALLCODE, EVMCodeType.LEGACY),
@@ -513,6 +558,7 @@ class Frontier(BaseFork, solc_name="homestead"):
     @classmethod
     def valid_opcodes(cls, *, block_number: int = 0, timestamp: int = 0) -> List[Opcodes]:
         """Return list of Opcodes that are valid to work on this fork."""
+        del block_number, timestamp
         return [
             Opcodes.STOP,
             Opcodes.ADD,
@@ -650,6 +696,7 @@ class Frontier(BaseFork, solc_name="homestead"):
         cls, *, block_number: int = 0, timestamp: int = 0
     ) -> List[Tuple[Opcodes, EVMCodeType]]:
         """At Genesis, only `CREATE` opcode is supported."""
+        del block_number, timestamp
         return [
             (Opcodes.CREATE, EVMCodeType.LEGACY),
         ]
@@ -657,11 +704,13 @@ class Frontier(BaseFork, solc_name="homestead"):
     @classmethod
     def max_refund_quotient(cls, *, block_number: int = 0, timestamp: int = 0) -> int:
         """Return the max refund quotient at Genesis."""
+        del block_number, timestamp
         return 2
 
     @classmethod
     def max_request_type(cls, *, block_number: int = 0, timestamp: int = 0) -> int:
         """At genesis, no request type is supported, signaled by -1."""
+        del block_number, timestamp
         return -1
 
     @classmethod
@@ -671,6 +720,7 @@ class Frontier(BaseFork, solc_name="homestead"):
 
         Frontier does not require pre-allocated accounts
         """
+        del block_number, timestamp
         return {}
 
     @classmethod
@@ -680,6 +730,7 @@ class Frontier(BaseFork, solc_name="homestead"):
 
         Frontier does not require pre-allocated accounts
         """
+        del block_number, timestamp
         return {}
 
 
@@ -711,6 +762,7 @@ class Homestead(Frontier):
     @classmethod
     def valid_opcodes(cls, *, block_number: int = 0, timestamp: int = 0) -> List[Opcodes]:
         """Return the list of Opcodes that are valid to work on this fork."""
+        del block_number, timestamp
         return [Opcodes.DELEGATECALL] + super(Homestead, cls).valid_opcodes()
 
     @classmethod
@@ -776,6 +828,7 @@ class Byzantium(Homestead):
         At Byzantium, the block reward is reduced to 3_000_000_000_000_000_000
         wei.
         """
+        del block_number, timestamp
         return 3_000_000_000_000_000_000
 
     @classmethod
@@ -800,6 +853,7 @@ class Byzantium(Homestead):
         At Spurious Dragon, an upper bound was introduced for max contract code
         size.
         """
+        del block_number, timestamp
         return 0x6000
 
     @classmethod
@@ -814,6 +868,7 @@ class Byzantium(Homestead):
     @classmethod
     def valid_opcodes(cls, *, block_number: int = 0, timestamp: int = 0) -> List[Opcodes]:
         """Return list of Opcodes that are valid to work on this fork."""
+        del block_number, timestamp
         return [
             Opcodes.REVERT,
             Opcodes.RETURNDATASIZE,
@@ -831,6 +886,7 @@ class Constantinople(Byzantium):
         At Constantinople, the block reward is reduced to
         2_000_000_000_000_000_000 wei.
         """
+        del block_number, timestamp
         return 2_000_000_000_000_000_000
 
     @classmethod
@@ -845,6 +901,7 @@ class Constantinople(Byzantium):
     @classmethod
     def valid_opcodes(cls, *, block_number: int = 0, timestamp: int = 0) -> List[Opcodes]:
         """Return list of Opcodes that are valid to work on this fork."""
+        del block_number, timestamp
         return [
             Opcodes.SHL,
             Opcodes.SHR,
@@ -873,6 +930,7 @@ class Istanbul(ConstantinopleFix):
     @classmethod
     def valid_opcodes(cls, *, block_number: int = 0, timestamp: int = 0) -> List[Opcodes]:
         """Return list of Opcodes that are valid to work on this fork."""
+        del block_number, timestamp
         return [Opcodes.CHAINID, Opcodes.SELFBALANCE] + super(Istanbul, cls).valid_opcodes()
 
     @classmethod
@@ -953,6 +1011,7 @@ class London(Berlin):
     @classmethod
     def header_base_fee_required(cls, *, block_number: int = 0, timestamp: int = 0) -> bool:
         """Header must contain the Base Fee starting from London."""
+        del block_number, timestamp
         return True
 
     @classmethod
@@ -970,21 +1029,25 @@ class London(Berlin):
     @classmethod
     def valid_opcodes(cls, *, block_number: int = 0, timestamp: int = 0) -> List[Opcodes]:
         """Return list of Opcodes that are valid to work on this fork."""
+        del block_number, timestamp
         return [Opcodes.BASEFEE] + super(London, cls).valid_opcodes()
 
     @classmethod
     def max_refund_quotient(cls, *, block_number: int = 0, timestamp: int = 0) -> int:
         """Return the max refund quotient at London."""
+        del block_number, timestamp
         return 5
 
     @classmethod
     def base_fee_max_change_denominator(cls, *, block_number: int = 0, timestamp: int = 0) -> int:
         """Return the base fee max change denominator at London."""
+        del block_number, timestamp
         return 8
 
     @classmethod
     def base_fee_elasticity_multiplier(cls, *, block_number: int = 0, timestamp: int = 0) -> int:
         """Return the base fee elasticity multiplier at London."""
+        del block_number, timestamp
         return 2
 
     @classmethod
@@ -1140,16 +1203,19 @@ class Paris(
     @classmethod
     def header_prev_randao_required(cls, *, block_number: int = 0, timestamp: int = 0) -> bool:
         """Prev Randao is required starting from Paris."""
+        del block_number, timestamp
         return True
 
     @classmethod
     def header_zero_difficulty_required(cls, *, block_number: int = 0, timestamp: int = 0) -> bool:
         """Zero difficulty is required starting from Paris."""
+        del block_number, timestamp
         return True
 
     @classmethod
     def get_reward(cls, *, block_number: int = 0, timestamp: int = 0) -> int:
         """Paris updates the reward to 0."""
+        del block_number, timestamp
         return 0
 
     @classmethod
@@ -1157,6 +1223,7 @@ class Paris(
         cls, *, block_number: int = 0, timestamp: int = 0
     ) -> Optional[int]:
         """From Paris, payloads can be sent through the engine API."""
+        del block_number, timestamp
         return 1
 
 
@@ -1166,6 +1233,7 @@ class Shanghai(Paris):
     @classmethod
     def header_withdrawals_required(cls, *, block_number: int = 0, timestamp: int = 0) -> bool:
         """Withdrawals are required starting from Shanghai."""
+        del block_number, timestamp
         return True
 
     @classmethod
@@ -1173,16 +1241,19 @@ class Shanghai(Paris):
         cls, *, block_number: int = 0, timestamp: int = 0
     ) -> Optional[int]:
         """From Shanghai, new payload calls must use version 2."""
+        del block_number, timestamp
         return 2
 
     @classmethod
     def max_initcode_size(cls, *, block_number: int = 0, timestamp: int = 0) -> int:
         """From Shanghai, the initcode size is now limited. See EIP-3860."""
+        del block_number, timestamp
         return 0xC000
 
     @classmethod
     def valid_opcodes(cls, *, block_number: int = 0, timestamp: int = 0) -> List[Opcodes]:
         """Return list of Opcodes that are valid to work on this fork."""
+        del block_number, timestamp
         return [Opcodes.PUSH0] + super(Shanghai, cls).valid_opcodes()
 
 
@@ -1217,16 +1288,19 @@ class Cancun(Shanghai):
     @classmethod
     def header_excess_blob_gas_required(cls, *, block_number: int = 0, timestamp: int = 0) -> bool:
         """Excess blob gas is required starting from Cancun."""
+        del block_number, timestamp
         return True
 
     @classmethod
     def header_blob_gas_used_required(cls, *, block_number: int = 0, timestamp: int = 0) -> bool:
         """Blob gas used is required starting from Cancun."""
+        del block_number, timestamp
         return True
 
     @classmethod
     def header_beacon_root_required(cls, *, block_number: int = 0, timestamp: int = 0) -> bool:
         """Parent beacon block root is required starting from Cancun."""
+        del block_number, timestamp
         return True
 
     @classmethod
@@ -1291,21 +1365,25 @@ class Cancun(Shanghai):
     @classmethod
     def min_base_fee_per_blob_gas(cls, *, block_number: int = 0, timestamp: int = 0) -> int:
         """Return the minimum base fee per blob gas for Cancun."""
+        del block_number, timestamp
         return 1
 
     @classmethod
     def blob_base_fee_update_fraction(cls, *, block_number: int = 0, timestamp: int = 0) -> int:
         """Return the blob base fee update fraction for Cancun."""
+        del block_number, timestamp
         return 3338477
 
     @classmethod
     def blob_gas_per_blob(cls, *, block_number: int = 0, timestamp: int = 0) -> int:
         """Blobs are enabled starting from Cancun."""
+        del block_number, timestamp
         return 2**17
 
     @classmethod
     def supports_blobs(cls, *, block_number: int = 0, timestamp: int = 0) -> bool:
         """At Cancun, blobs support is enabled."""
+        del block_number, timestamp
         return True
 
     @classmethod
@@ -1314,6 +1392,7 @@ class Cancun(Shanghai):
         Blobs are enabled starting from Cancun, with a static target of 3 blobs
         per block.
         """
+        del block_number, timestamp
         return 3
 
     @classmethod
@@ -1322,11 +1401,13 @@ class Cancun(Shanghai):
         Blobs are enabled starting from Cancun, with a static max of 6 blobs
         per block.
         """
+        del block_number, timestamp
         return 6
 
     @classmethod
     def blob_reserve_price_active(cls, *, block_number: int = 0, timestamp: int = 0) -> bool:
         """Blob reserve price is not supported in Cancun."""
+        del block_number, timestamp
         return False
 
     @classmethod
@@ -1337,6 +1418,7 @@ class Cancun(Shanghai):
         Pre-Osaka forks don't use tx wrapper versions for full blob
         transactions.
         """
+        del block_number, timestamp
         return None
 
     @classmethod
@@ -1388,6 +1470,7 @@ class Cancun(Shanghai):
     @classmethod
     def system_contracts(cls, *, block_number: int = 0, timestamp: int = 0) -> List[Address]:
         """Cancun introduces the system contract for EIP-4788."""
+        del block_number, timestamp
         return [Address(0x000F3DF6D732807EF1319FB7B8BB8522D0BEAC02, label="BEACON_ROOTS_ADDRESS")]
 
     @classmethod
@@ -1396,6 +1479,7 @@ class Cancun(Shanghai):
         Cancun requires pre-allocation of the beacon root contract for EIP-4788
         on blockchain type tests.
         """
+        del block_number, timestamp
         new_allocation = {
             0x000F3DF6D732807EF1319FB7B8BB8522D0BEAC02: {
                 "nonce": 1,
@@ -1411,6 +1495,7 @@ class Cancun(Shanghai):
         cls, *, block_number: int = 0, timestamp: int = 0
     ) -> Optional[int]:
         """From Cancun, new payload calls must use version 3."""
+        del block_number, timestamp
         return 3
 
     @classmethod
@@ -1418,21 +1503,25 @@ class Cancun(Shanghai):
         cls, *, block_number: int = 0, timestamp: int = 0
     ) -> Optional[int]:
         """At Cancun, the engine get blobs version is 1."""
+        del block_number, timestamp
         return 1
 
     @classmethod
     def engine_new_payload_blob_hashes(cls, *, block_number: int = 0, timestamp: int = 0) -> bool:
         """From Cancun, payloads must have blob hashes."""
+        del block_number, timestamp
         return True
 
     @classmethod
     def engine_new_payload_beacon_root(cls, *, block_number: int = 0, timestamp: int = 0) -> bool:
         """From Cancun, payloads must have a parent beacon block root."""
+        del block_number, timestamp
         return True
 
     @classmethod
     def valid_opcodes(cls, *, block_number: int = 0, timestamp: int = 0) -> List[Opcodes]:
         """Return list of Opcodes that are valid to work on this fork."""
+        del block_number, timestamp
         return [
             Opcodes.BLOBHASH,
             Opcodes.BLOBBASEFEE,
@@ -1528,6 +1617,7 @@ class Prague(Cancun):
         At Prague, three request types are introduced, hence the max request
         type is 2.
         """
+        del block_number, timestamp
         return 2
 
     @classmethod
@@ -1617,16 +1707,19 @@ class Prague(Cancun):
     @classmethod
     def blob_base_fee_update_fraction(cls, *, block_number: int = 0, timestamp: int = 0) -> int:
         """Return the blob base fee update fraction for Prague."""
+        del block_number, timestamp
         return 5007716
 
     @classmethod
     def target_blobs_per_block(cls, *, block_number: int = 0, timestamp: int = 0) -> int:
         """Blobs in Prague, have a static target of 6 blobs per block."""
+        del block_number, timestamp
         return 6
 
     @classmethod
     def max_blobs_per_block(cls, *, block_number: int = 0, timestamp: int = 0) -> int:
         """Blobs in Prague, have a static max of 9 blobs per block."""
+        del block_number, timestamp
         return 9
 
     @classmethod
@@ -1636,6 +1729,7 @@ class Prague(Cancun):
         EIP-6110, the exits contract for EIP-7002, and the history storage
         contract for EIP-2935.
         """
+        del block_number, timestamp
         new_allocation = {}
 
         # Add the beacon chain deposit contract
@@ -1698,6 +1792,7 @@ class Prague(Cancun):
         Prague requires that the execution layer header contains the beacon
         chain requests hash.
         """
+        del block_number, timestamp
         return True
 
     @classmethod
@@ -1705,6 +1800,7 @@ class Prague(Cancun):
         """
         From Prague, new payloads include the requests hash as a parameter.
         """
+        del block_number, timestamp
         return True
 
     @classmethod
@@ -1712,6 +1808,7 @@ class Prague(Cancun):
         cls, *, block_number: int = 0, timestamp: int = 0
     ) -> Optional[int]:
         """From Prague, new payload calls must use version 4."""
+        del block_number, timestamp
         return 4
 
     @classmethod
@@ -1721,6 +1818,7 @@ class Prague(Cancun):
         """
         At Prague, version number of NewPayload and ForkchoiceUpdated diverge.
         """
+        del block_number, timestamp
         return 3
 
 
@@ -1738,6 +1836,7 @@ class Osaka(Prague, solc_name="cancun"):
         cls, *, block_number: int = 0, timestamp: int = 0
     ) -> Optional[int]:
         """From Osaka, get payload calls must use version 5."""
+        del block_number, timestamp
         return 5
 
     @classmethod
@@ -1745,6 +1844,7 @@ class Osaka(Prague, solc_name="cancun"):
         cls, *, block_number: int = 0, timestamp: int = 0
     ) -> Optional[int]:
         """At Osaka, the engine get blobs version is 2."""
+        del block_number, timestamp
         return 2
 
     @classmethod
@@ -1752,16 +1852,20 @@ class Osaka(Prague, solc_name="cancun"):
         cls, *, block_number: int = 0, timestamp: int = 0
     ) -> int | None:
         """At Osaka, the full blob transaction wrapper version is defined."""
+        del block_number, timestamp
         return 1
 
     @classmethod
     def transaction_gas_limit_cap(cls, *, block_number: int = 0, timestamp: int = 0) -> int | None:
         """At Osaka, transaction gas limit is capped at 16 million (2**24)."""
+        del block_number, timestamp
         return 16_777_216
 
     @classmethod
     def block_rlp_size_limit(cls, *, block_number: int = 0, timestamp: int = 0) -> int | None:
         """From Osaka, block RLP size is limited as specified in EIP-7934."""
+        del block_number, timestamp
+
         max_block_size = 10_485_760
         safety_margin = 2_097_152
         return max_block_size - safety_margin
@@ -1777,6 +1881,7 @@ class Osaka(Prague, solc_name="cancun"):
     @classmethod
     def valid_opcodes(cls, *, block_number: int = 0, timestamp: int = 0) -> List[Opcodes]:
         """Return list of Opcodes that are valid to work on this fork."""
+        del block_number, timestamp
         return [
             Opcodes.CLZ,
         ] + super(Prague, cls).valid_opcodes()
@@ -1854,16 +1959,19 @@ class Osaka(Prague, solc_name="cancun"):
         Blobs in Osaka, have a static max of 6 blobs per tx. Differs from the
         max per block.
         """
+        del block_number, timestamp
         return 6
 
     @classmethod
     def blob_reserve_price_active(cls, *, block_number: int = 0, timestamp: int = 0) -> bool:
         """Blob reserve price is supported in Osaka."""
+        del block_number, timestamp
         return True
 
     @classmethod
     def blob_base_cost(cls, *, block_number: int = 0, timestamp: int = 0) -> int:
         """Return the base cost of a blob at a given fork."""
+        del block_number, timestamp
         return 2**13  # EIP-7918 new parameter
 
 
@@ -1873,16 +1981,19 @@ class BPO1(Osaka, bpo_fork=True):
     @classmethod
     def blob_base_fee_update_fraction(cls, *, block_number: int = 0, timestamp: int = 0) -> int:
         """Return the blob base fee update fraction for BPO1."""
+        del block_number, timestamp
         return 8346193
 
     @classmethod
     def target_blobs_per_block(cls, *, block_number: int = 0, timestamp: int = 0) -> int:
         """Blobs in BPO1 have a target of 10 blobs per block."""
+        del block_number, timestamp
         return 10
 
     @classmethod
     def max_blobs_per_block(cls, *, block_number: int = 0, timestamp: int = 0) -> int:
         """Blobs in BPO1 have a max of 15 blobs per block."""
+        del block_number, timestamp
         return 15
 
 
@@ -1892,16 +2003,19 @@ class BPO2(BPO1, bpo_fork=True):
     @classmethod
     def blob_base_fee_update_fraction(cls, *, block_number: int = 0, timestamp: int = 0) -> int:
         """Return the blob base fee update fraction for BPO2."""
+        del block_number, timestamp
         return 11684671
 
     @classmethod
     def target_blobs_per_block(cls, *, block_number: int = 0, timestamp: int = 0) -> int:
         """Blobs in BPO2 have a target of 14 blobs per block."""
+        del block_number, timestamp
         return 14
 
     @classmethod
     def max_blobs_per_block(cls, *, block_number: int = 0, timestamp: int = 0) -> int:
         """Blobs in BPO2 have a max of 21 blobs per block."""
+        del block_number, timestamp
         return 21
 
 
@@ -1914,16 +2028,19 @@ class BPO3(BPO2, bpo_fork=True):
     @classmethod
     def blob_base_fee_update_fraction(cls, *, block_number: int = 0, timestamp: int = 0) -> int:
         """Return the blob base fee update fraction for BPO3."""
+        del block_number, timestamp
         return 20609697
 
     @classmethod
     def target_blobs_per_block(cls, *, block_number: int = 0, timestamp: int = 0) -> int:
         """Blobs in BPO3 have a target of 21 blobs per block."""
+        del block_number, timestamp
         return 21
 
     @classmethod
     def max_blobs_per_block(cls, *, block_number: int = 0, timestamp: int = 0) -> int:
         """Blobs in BPO3 have a max of 32 blobs per block."""
+        del block_number, timestamp
         return 32
 
 
@@ -1936,16 +2053,19 @@ class BPO4(BPO3, bpo_fork=True):
     @classmethod
     def blob_base_fee_update_fraction(cls, *, block_number: int = 0, timestamp: int = 0) -> int:
         """Return the blob base fee update fraction for BPO4."""
+        del block_number, timestamp
         return 13739630
 
     @classmethod
     def target_blobs_per_block(cls, *, block_number: int = 0, timestamp: int = 0) -> int:
         """Blobs in BPO4 have a target of 14 blobs per block."""
+        del block_number, timestamp
         return 14
 
     @classmethod
     def max_blobs_per_block(cls, *, block_number: int = 0, timestamp: int = 0) -> int:
         """Blobs in BPO4 have a max of 21 blobs per block."""
+        del block_number, timestamp
         return 21
 
 
@@ -1966,6 +2086,7 @@ class Amsterdam(Osaka):
         """
         From Amsterdam, header must contain block access list hash (EIP-7928).
         """
+        del block_number, timestamp
         return True
 
     @classmethod
@@ -1978,6 +2099,7 @@ class Amsterdam(Osaka):
         cls, *, block_number: int = 0, timestamp: int = 0
     ) -> Optional[int]:
         """From Amsterdam, new payload calls must use version 5."""
+        del block_number, timestamp
         return 5
 
     @classmethod
@@ -1988,6 +2110,7 @@ class Amsterdam(Osaka):
         From Amsterdam, engine execution payload includes `block_access_list`
         as a parameter.
         """
+        del block_number, timestamp
         return True
 
 

--- a/src/ethereum_test_forks/tests/test_forks.py
+++ b/src/ethereum_test_forks/tests/test_forks.py
@@ -298,6 +298,7 @@ class PrePreAllocFork(Shanghai):
     @classmethod
     def pre_allocation(cls, *, block_number: int = 0, timestamp: int = 0) -> Dict:
         """Return some starting point for allocation."""
+        del block_number, timestamp
         return {"test": "test"}
 
 
@@ -307,6 +308,7 @@ class PreAllocFork(PrePreAllocFork):
     @classmethod
     def pre_allocation(cls, *, block_number: int = 0, timestamp: int = 0) -> Dict:
         """Add allocation to the pre-existing one from previous fork."""
+        del block_number, timestamp
         return {"test2": "test2"} | super(PreAllocFork, cls).pre_allocation()
 
 

--- a/src/ethereum_test_rpc/rpc_types.py
+++ b/src/ethereum_test_rpc/rpc_types.py
@@ -35,7 +35,7 @@ class JSONRPCError(Exception):
     code: int
     message: str
 
-    def __init__(self, code: int | str, message: str, **kwargs: Any) -> None:
+    def __init__(self, code: int | str, message: str) -> None:
         """Initialize the JSONRPCError."""
         self.code = int(code)
         self.message = message

--- a/src/ethereum_test_specs/base.py
+++ b/src/ethereum_test_specs/base.py
@@ -105,6 +105,7 @@ class BaseTest(BaseModel):
         Discard a fixture format from filling if the appropriate marker is
         used.
         """
+        del fork, fixture_format, markers
         return False
 
     @classmethod
@@ -148,6 +149,7 @@ class BaseTest(BaseModel):
         Discard an execute format from executing if the appropriate marker is
         used.
         """
+        del execute_format, fork, markers
         return False
 
     @abstractmethod
@@ -168,6 +170,7 @@ class BaseTest(BaseModel):
         execute_format: ExecuteFormat,
     ) -> BaseExecute:
         """Generate the list of test fixtures."""
+        del fork
         raise Exception(f"Unsupported execute format: {execute_format}")
 
     @classmethod

--- a/src/ethereum_test_specs/benchmark.py
+++ b/src/ethereum_test_specs/benchmark.py
@@ -47,7 +47,7 @@ class BenchmarkCodeGenerator(ABC):
         ...
 
     @abstractmethod
-    def generate_transaction(self, pre: Alloc, gas_limit: int, fork: Fork) -> Transaction:
+    def generate_transaction(self, pre: Alloc, gas_limit: int) -> Transaction:
         """Generate a transaction with the specified gas limit."""
         ...
 
@@ -134,6 +134,8 @@ class BenchmarkTest(BaseTest):
         Discard a fixture format from filling if the
         appropriate marker is used.
         """
+        del fork
+
         if "blockchain_test_only" in [m.name for m in markers]:
             return fixture_format != BlockchainFixture
         if "blockchain_test_engine_only" in [m.name for m in markers]:
@@ -142,6 +144,7 @@ class BenchmarkTest(BaseTest):
 
     def get_genesis_environment(self, fork: Fork) -> Environment:
         """Get the genesis environment for this benchmark test."""
+        del fork
         return self.env
 
     def split_transaction(self, tx: Transaction, gas_limit_cap: int | None) -> List[Transaction]:
@@ -177,7 +180,7 @@ class BenchmarkTest(BaseTest):
 
         self.code_generator.deploy_contracts(self.pre, fork)
         gas_limit = fork.transaction_gas_limit_cap() or self.gas_benchmark_value
-        benchmark_tx = self.code_generator.generate_transaction(self.pre, gas_limit, fork)
+        benchmark_tx = self.code_generator.generate_transaction(self.pre, gas_limit)
 
         execution_txs = self.split_transaction(benchmark_tx, gas_limit)
         execution_block = Block(txs=execution_txs)
@@ -257,6 +260,8 @@ class BenchmarkTest(BaseTest):
         execute_format: ExecuteFormat,
     ) -> BaseExecute:
         """Execute the benchmark test by sending it to the live network."""
+        del fork
+
         if execute_format == TransactionPost:
             return TransactionPost(
                 blocks=[[self.tx]],

--- a/src/ethereum_test_specs/blobs.py
+++ b/src/ethereum_test_specs/blobs.py
@@ -39,6 +39,7 @@ class BlobsTest(BaseTest):
         fixture_format: FixtureFormat,
     ) -> BaseFixture:
         """Generate the list of test fixtures."""
+        del t8n, fork
         raise Exception(f"Unknown fixture format: {fixture_format}")
 
     def execute(
@@ -48,6 +49,8 @@ class BlobsTest(BaseTest):
         execute_format: ExecuteFormat,
     ) -> BaseExecute:
         """Generate the list of test fixtures."""
+        del fork
+
         if execute_format == BlobTransaction:
             return BlobTransaction(
                 txs=self.txs, nonexisting_blob_hashes=self.nonexisting_blob_hashes

--- a/src/ethereum_test_specs/blockchain.py
+++ b/src/ethereum_test_specs/blockchain.py
@@ -442,6 +442,8 @@ class BlockchainTest(BaseTest):
         Discard a fixture format from filling if the appropriate marker is
         used.
         """
+        del fork
+
         marker_names = [m.name for m in markers]
         if fixture_format != BlockchainFixture and "blockchain_test_only" in marker_names:
             return True
@@ -914,6 +916,8 @@ class BlockchainTest(BaseTest):
         execute_format: ExecuteFormat,
     ) -> BaseExecute:
         """Generate the list of test fixtures."""
+        del fork
+
         if execute_format == TransactionPost:
             blocks: List[List[Transaction]] = []
             for block in self.blocks:

--- a/src/ethereum_test_specs/eof.py
+++ b/src/ethereum_test_specs/eof.py
@@ -308,6 +308,8 @@ class EOFTest(BaseTest):
         Discard a fixture format from filling if the appropriate marker is
         used.
         """
+        del fork
+
         if "eof_test_only" in [m.name for m in markers]:
             return fixture_format != EOFFixture
         return False
@@ -493,6 +495,7 @@ class EOFTest(BaseTest):
 
     def generate_state_test(self, fork: Fork) -> StateTest:
         """Generate the StateTest filler."""
+        del fork
         return StateTest.from_test(
             base_test=self,
             pre=self.pre,
@@ -639,6 +642,8 @@ class EOFStateTest(EOFTest, Transaction):
 
     def generate_state_test(self, fork: Fork) -> StateTest:
         """Generate the StateTest filler."""
+        del fork
+
         assert self.pre is not None, "pre must be set to generate a StateTest."
         assert self.post is not None, "post must be set to generate a StateTest."
 

--- a/src/ethereum_test_specs/state.py
+++ b/src/ethereum_test_specs/state.py
@@ -180,6 +180,8 @@ class StateTest(BaseTest):
         Discard a fixture format from filling if the appropriate marker is
         used.
         """
+        del fork
+
         if "state_test_only" in [m.name for m in markers]:
             return fixture_format != StateFixture
         return False
@@ -443,6 +445,8 @@ class StateTest(BaseTest):
         execute_format: ExecuteFormat,
     ) -> BaseExecute:
         """Generate the list of test fixtures."""
+        del fork
+
         if execute_format == TransactionPost:
             # Pass gas validation params for benchmark tests
             # If not benchmark mode, skip gas used validation

--- a/src/ethereum_test_specs/tests/test_fixtures.py
+++ b/src/ethereum_test_specs/tests/test_fixtures.py
@@ -481,7 +481,6 @@ class TestFillBlockchainValidTxs:
     @pytest.fixture
     def blockchain_test_fixture(  # noqa: D102
         self,
-        check_hive: bool,
         fork: Fork,
         pre: Mapping[Any, Any],
         post: Mapping[Any, Any],
@@ -502,7 +501,6 @@ class TestFillBlockchainValidTxs:
     def test_fill_blockchain_valid_txs(  # noqa: D102
         self,
         fork: Fork,
-        check_hive: bool,
         fixture_format: FixtureFormat,
         expected_json_file: str,
         blockchain_test_fixture: BlockchainFixture,

--- a/src/ethereum_test_specs/transaction.py
+++ b/src/ethereum_test_specs/transaction.py
@@ -82,6 +82,8 @@ class TransactionTest(BaseTest):
         fixture_format: FixtureFormat,
     ) -> BaseFixture:
         """Generate the TransactionTest fixture."""
+        del t8n
+
         self.check_exception_test(exception=self.tx.error is not None)
         if fixture_format == TransactionFixture:
             return self.make_transaction_test_fixture(fork)
@@ -95,6 +97,8 @@ class TransactionTest(BaseTest):
         execute_format: ExecuteFormat,
     ) -> BaseExecute:
         """Execute the transaction test by sending it to the live network."""
+        del fork
+
         if execute_format == TransactionPost:
             return TransactionPost(
                 blocks=[[self.tx]],

--- a/src/ethereum_test_types/tests/test_types.py
+++ b/src/ethereum_test_types/tests/test_types.py
@@ -646,6 +646,7 @@ class TestPydanticModelConversion:
         self, can_be_deserialized: bool, model_instance: Any, json: str | Dict[str, Any]
     ) -> None:
         """Test that to_json returns the expected JSON for the given object."""
+        del can_be_deserialized
         assert to_json(model_instance) == json
 
     def test_json_deserialization(

--- a/src/ethereum_test_vm/opcodes.py
+++ b/src/ethereum_test_vm/opcodes.py
@@ -339,6 +339,7 @@ class Macro(Bytecode):
 
     def __call__(self, *args_t: OpcodeCallArg, **kwargs: Any) -> Bytecode:
         """Perform macro operation if any. Otherwise is a no-op."""
+        del kwargs
         if self.lambda_operation is not None:
             return self.lambda_operation(*args_t)
 

--- a/src/pytest_plugins/custom_logging/plugin_logging.py
+++ b/src/pytest_plugins/custom_logging/plugin_logging.py
@@ -103,6 +103,8 @@ class UTCFormatter(logging.Formatter):
 
     def formatTime(self, record: LogRecord, datefmt: str | None = None) -> str:  # noqa: D102,N802
         # camelcase required
+        del datefmt
+
         dt = datetime.fromtimestamp(record.created, tz=timezone.utc)
         return dt.strftime("%Y-%m-%d %H:%M:%S.%f")[:-3] + "+00:00"
 

--- a/src/pytest_plugins/custom_logging/tests/test_logging.py
+++ b/src/pytest_plugins/custom_logging/tests/test_logging.py
@@ -195,7 +195,7 @@ class TestStandaloneConfiguration:
 class TestPytestIntegration:
     """Test the pytest integration of the logging module."""
 
-    def test_pytest_configure(self, monkeypatch: pytest.MonkeyPatch, tmpdir: Any) -> None:
+    def test_pytest_configure(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test that pytest_configure sets up logging correctly."""
         from pytest_plugins.custom_logging.plugin_logging import pytest_configure
 

--- a/src/pytest_plugins/filler/gen_test_doc/gen_test_doc.py
+++ b/src/pytest_plugins/filler/gen_test_doc/gen_test_doc.py
@@ -299,6 +299,7 @@ class TestDocsGenerator:
         config: pytest.Config,
     ) -> None:
         """Add a summary line for the docs."""
+        del exitstatus, config
         terminalreporter.write_sep("=", f"{len(self.page_props)} doc pages generated", bold=True)
 
     def _setup_logger(self) -> None:

--- a/src/pytest_plugins/filler/gen_test_doc/page_props.py
+++ b/src/pytest_plugins/filler/gen_test_doc/page_props.py
@@ -160,6 +160,7 @@ class EipChecklistPageProps(PagePropsBase):
 
     def write_page(self, file_opener: FileOpener, jinja2_env: Environment) -> None:
         """Write the page to the target directory."""
+        del jinja2_env
         with file_opener.open(self.target_output_file, "w") as destination:
             destination.write("\n".join(self.lines))
 

--- a/src/pytest_plugins/filler/ported_tests.py
+++ b/src/pytest_plugins/filler/ported_tests.py
@@ -135,6 +135,7 @@ class PortedFromDisplay:
         items: List[pytest.Item],
     ) -> object:
         """Extract ported_from information from collected test items."""
+        del session
         yield
 
         # Only run on master node when using pytest-xdist
@@ -193,6 +194,7 @@ class PortedFromDisplay:
     @pytest.hookimpl(tryfirst=True)
     def pytest_runtestloop(self, session: pytest.Session) -> bool:
         """Skip test execution, only show ported_from information."""
+        del session
         return True
 
     def pytest_terminal_summary(
@@ -202,6 +204,7 @@ class PortedFromDisplay:
         config: pytest.Config,
     ) -> None:
         """Add a summary line."""
+        del exitstatus
         if config.getoption("verbose") < 0:
             return
         mode_desc = "PR URLs" if self.show_mode == "prs" else "static filler paths"

--- a/src/pytest_plugins/filler/pre_alloc.py
+++ b/src/pytest_plugins/filler/pre_alloc.py
@@ -158,6 +158,8 @@ class Alloc(BaseAlloc):
         hard-code the contract address. Do NOT use in new tests as it will be
         removed in the future!
         """
+        del stub
+
         if storage is None:
             storage = {}
         if address is not None:
@@ -216,6 +218,8 @@ class Alloc(BaseAlloc):
         If amount is 0, nothing will be added to the pre-alloc but a new and
         unique EOA will be returned.
         """
+        del label
+
         eoa = next(self._eoa_iterator)
         if amount is None:
             amount = self._eoa_fund_amount_default

--- a/src/pytest_plugins/filler/tests/test_filling_session.py
+++ b/src/pytest_plugins/filler/tests/test_filling_session.py
@@ -42,6 +42,7 @@ class MockFixtureOutput:
     @classmethod
     def from_config(cls, config: Any) -> "MockFixtureOutput":
         """Mock factory method."""
+        del config
         return cls()
 
 

--- a/src/pytest_plugins/spec_version_checker/spec_version_checker.py
+++ b/src/pytest_plugins/spec_version_checker/spec_version_checker.py
@@ -160,7 +160,7 @@ class EIPSpecTestItem(Item):
           **kwargs: Additional keyword arguments
 
         """
-        super().__init__(name, parent)
+        super().__init__(name, parent, **kwargs)
         self.module = None  # type: ignore
         self.github_token = None
 

--- a/tests/frontier/scenarios/programs/all_frontier_opcodes.py
+++ b/tests/frontier/scenarios/programs/all_frontier_opcodes.py
@@ -479,6 +479,7 @@ class ProgramAllFrontierOpcodes(ScenarioTestProgram):
 
     def make_test_code(self, pre: Alloc, fork: Fork) -> Bytecode:
         """Test code."""
+        del pre, fork
         return make_all_opcode_program()
 
     @cached_property

--- a/tests/frontier/scenarios/programs/context_calls.py
+++ b/tests/frontier/scenarios/programs/context_calls.py
@@ -22,6 +22,7 @@ class ProgramAddress(ScenarioTestProgram):
 
     def make_test_code(self, pre: Alloc, fork: Fork) -> Bytecode:
         """Test code."""
+        del pre, fork
         return Op.MSTORE(0, Op.ADDRESS) + Op.RETURN(0, 32)
 
     @cached_property
@@ -41,6 +42,7 @@ class ProgramBalance(ScenarioTestProgram):
 
     def make_test_code(self, pre: Alloc, fork: Fork) -> Bytecode:
         """Test code."""
+        del fork
         external_address = pre.deploy_contract(code=Op.ADD(1, 1), balance=self.external_balance)
         return Op.MSTORE(0, Op.BALANCE(external_address)) + Op.RETURN(0, 32)
 
@@ -59,6 +61,7 @@ class ProgramOrigin(ScenarioTestProgram):
 
     def make_test_code(self, pre: Alloc, fork: Fork) -> Bytecode:
         """Test code."""
+        del pre, fork
         return Op.MSTORE(0, Op.ORIGIN) + Op.RETURN(0, 32)
 
     @cached_property
@@ -76,6 +79,7 @@ class ProgramCaller(ScenarioTestProgram):
 
     def make_test_code(self, pre: Alloc, fork: Fork) -> Bytecode:
         """Test code."""
+        del pre, fork
         return Op.MSTORE(0, Op.CALLER) + Op.RETURN(0, 32)
 
     @cached_property
@@ -93,6 +97,7 @@ class ProgramCallValue(ScenarioTestProgram):
 
     def make_test_code(self, pre: Alloc, fork: Fork) -> Bytecode:
         """Test code."""
+        del pre, fork
         return Op.MSTORE(0, Op.CALLVALUE) + Op.RETURN(0, 32)
 
     @cached_property
@@ -110,6 +115,7 @@ class ProgramCallDataLoad(ScenarioTestProgram):
 
     def make_test_code(self, pre: Alloc, fork: Fork) -> Bytecode:
         """Test code."""
+        del pre, fork
         return Op.MSTORE(0, Op.CALLDATALOAD(0)) + Op.RETURN(0, 32)
 
     @cached_property
@@ -127,6 +133,7 @@ class ProgramCallDataSize(ScenarioTestProgram):
 
     def make_test_code(self, pre: Alloc, fork: Fork) -> Bytecode:
         """Test code."""
+        del pre, fork
         return Op.MSTORE(0, Op.CALLDATASIZE) + Op.RETURN(0, 32)
 
     @cached_property
@@ -144,6 +151,7 @@ class ProgramCallDataCopy(ScenarioTestProgram):
 
     def make_test_code(self, pre: Alloc, fork: Fork) -> Bytecode:
         """Test code."""
+        del pre, fork
         return Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE) + Op.RETURN(0, 32)
 
     @cached_property
@@ -161,6 +169,7 @@ class ProgramCodeCopyCodeSize(ScenarioTestProgram):
 
     def make_test_code(self, pre: Alloc, fork: Fork) -> Bytecode:
         """Test code."""
+        del pre, fork
         return Op.MSTORE(0, Op.CODESIZE) + Op.CODECOPY(0, 0, 30) + Op.RETURN(0, 32)
 
     @cached_property
@@ -180,6 +189,7 @@ class ProgramGasPrice(ScenarioTestProgram):
 
     def make_test_code(self, pre: Alloc, fork: Fork) -> Bytecode:
         """Test code."""
+        del fork
         gas_hash = make_gas_hash_contract(pre)
 
         return (
@@ -206,6 +216,8 @@ class ProgramExtCodeCopyExtCodeSize(ScenarioTestProgram):
 
     def make_test_code(self, pre: Alloc, fork: Fork) -> Bytecode:
         """Test code."""
+        del fork
+
         external_address = pre.deploy_contract(code=Op.ADD(1, 1), balance=self.external_balance)
         return (
             Op.MSTORE(0, Op.EXTCODESIZE(external_address))
@@ -230,6 +242,7 @@ class ProgramReturnDataSize(ScenarioTestProgram):
 
     def make_test_code(self, pre: Alloc, fork: Fork) -> Bytecode:
         """Test code."""
+        del pre, fork
         return (
             Op.MSTORE(0, Op.RETURNDATASIZE)
             + Op.CALL(100000, 2, 0, 0, 10, 32, 20)
@@ -252,6 +265,7 @@ class ProgramReturnDataCopy(ScenarioTestProgram):
 
     def make_test_code(self, pre: Alloc, fork: Fork) -> Bytecode:
         """Test code."""
+        del pre, fork
         return (
             Op.CALL(100000, 2, 0, 0, 10, 32, 20) + Op.RETURNDATACOPY(0, 0, 32) + Op.RETURN(0, 32)
         )
@@ -274,6 +288,8 @@ class ProgramExtCodehash(ScenarioTestProgram):
 
     def make_test_code(self, pre: Alloc, fork: Fork) -> Bytecode:
         """Test code."""
+        del fork
+
         external_address = pre.deploy_contract(code=Op.ADD(1, 1), balance=123)
         return Op.MSTORE(0, Op.EXTCODEHASH(external_address)) + Op.RETURN(0, 32)
 
@@ -297,6 +313,8 @@ class ProgramBlockhash(ScenarioTestProgram):
 
     def make_test_code(self, pre: Alloc, fork: Fork) -> Bytecode:
         """Test code."""
+        del fork
+
         # Calculate gas hash of Op.BLOCKHASH(0) value
         gas_hash = make_gas_hash_contract(pre)
 
@@ -322,6 +340,7 @@ class ProgramCoinbase(ScenarioTestProgram):
 
     def make_test_code(self, pre: Alloc, fork: Fork) -> Bytecode:
         """Test code."""
+        del pre, fork
         return Op.MSTORE(0, Op.COINBASE) + Op.RETURN(0, 32)
 
     @cached_property
@@ -339,6 +358,8 @@ class ProgramTimestamp(ScenarioTestProgram):
 
     def make_test_code(self, pre: Alloc, fork: Fork) -> Bytecode:
         """Test code."""
+        del fork
+
         gas_hash = make_gas_hash_contract(pre)
         return (
             Op.MSTORE(64, Op.TIMESTAMP)
@@ -362,6 +383,7 @@ class ProgramNumber(ScenarioTestProgram):
 
     def make_test_code(self, pre: Alloc, fork: Fork) -> Bytecode:
         """Test code."""
+        del pre, fork
         return Op.MSTORE(0, Op.NUMBER) + Op.RETURN(0, 32)
 
     @cached_property
@@ -379,6 +401,8 @@ class ProgramDifficultyRandao(ScenarioTestProgram):
 
     def make_test_code(self, pre: Alloc, fork: Fork) -> Bytecode:
         """Test code."""
+        del fork
+
         # Calculate gas hash of DIFFICULTY value
         gas_hash = make_gas_hash_contract(pre)
         return (
@@ -404,6 +428,7 @@ class ProgramGasLimit(ScenarioTestProgram):
 
     def make_test_code(self, pre: Alloc, fork: Fork) -> Bytecode:
         """Test code."""
+        del pre, fork
         return Op.MSTORE(0, Op.GASLIMIT) + Op.RETURN(0, 32)
 
     @cached_property
@@ -421,6 +446,7 @@ class ProgramChainid(ScenarioTestProgram):
 
     def make_test_code(self, pre: Alloc, fork: Fork) -> Bytecode:
         """Test code."""
+        del pre, fork
         return Op.MSTORE(0, Op.CHAINID) + Op.RETURN(0, 32)
 
     @cached_property
@@ -441,6 +467,7 @@ class ProgramSelfbalance(ScenarioTestProgram):
 
     def make_test_code(self, pre: Alloc, fork: Fork) -> Bytecode:
         """Test code."""
+        del pre, fork
         return Op.MSTORE(0, Op.SELFBALANCE) + Op.RETURN(0, 32)
 
     @cached_property
@@ -458,6 +485,8 @@ class ProgramBasefee(ScenarioTestProgram):
 
     def make_test_code(self, pre: Alloc, fork: Fork) -> Bytecode:
         """Test code."""
+        del fork
+
         gas_hash = make_gas_hash_contract(pre)
         return (
             Op.MSTORE(64, Op.BASEFEE)
@@ -481,6 +510,7 @@ class ProgramBlobhash(ScenarioTestProgram):
 
     def make_test_code(self, pre: Alloc, fork: Fork) -> Bytecode:
         """Test code."""
+        del pre, fork
         return Op.MSTORE(0, Op.BLOBHASH(0)) + Op.RETURN(0, 32)
 
     @cached_property
@@ -498,6 +528,8 @@ class ProgramBlobBaseFee(ScenarioTestProgram):
 
     def make_test_code(self, pre: Alloc, fork: Fork) -> Bytecode:
         """Test code."""
+        del fork
+
         gas_hash = make_gas_hash_contract(pre)
         return (
             Op.MSTORE(64, Op.BLOBBASEFEE)
@@ -521,6 +553,7 @@ class ProgramTload(ScenarioTestProgram):
 
     def make_test_code(self, pre: Alloc, fork: Fork) -> Bytecode:
         """Test code."""
+        del pre, fork
         return Op.MSTORE(0, Op.TLOAD(0)) + Op.RETURN(0, 32)
 
     @cached_property
@@ -538,6 +571,7 @@ class ProgramMcopy(ScenarioTestProgram):
 
     def make_test_code(self, pre: Alloc, fork: Fork) -> Bytecode:
         """Test code."""
+        del pre, fork
         return (
             Op.MSTORE(0, 0)
             + Op.MSTORE(32, 0x000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F)
@@ -563,6 +597,7 @@ class ProgramPush0(ScenarioTestProgram):
 
     def make_test_code(self, pre: Alloc, fork: Fork) -> Bytecode:
         """Test code."""
+        del pre, fork
         return Op.PUSH1(10) + Op.PUSH0 + Op.MSTORE + Op.RETURN(0, 32)
 
     @cached_property

--- a/tests/frontier/scenarios/programs/static_violation.py
+++ b/tests/frontier/scenarios/programs/static_violation.py
@@ -14,6 +14,7 @@ class ProgramSstoreSload(ScenarioTestProgram):
 
     def make_test_code(self, pre: Alloc, fork: Fork) -> Bytecode:
         """Test code."""
+        del pre, fork
         return (
             Op.SSTORE(0, 11)
             + Op.MSTORE(0, Op.ADD(Op.MLOAD(0), Op.SLOAD(0)))
@@ -37,6 +38,7 @@ class ProgramTstoreTload(ScenarioTestProgram):
 
     def make_test_code(self, pre: Alloc, fork: Fork) -> Bytecode:
         """Test code."""
+        del pre, fork
         return Op.TSTORE(0, 11) + Op.MSTORE(0, Op.TLOAD(0)) + Op.RETURN(0, 32)
 
     @cached_property
@@ -54,6 +56,7 @@ class ProgramLogs(ScenarioTestProgram):
 
     def make_test_code(self, pre: Alloc, fork: Fork) -> Bytecode:
         """Test code."""
+        del pre, fork
         return (
             Op.MSTORE(0, 0x1122334455667788991011121314151617181920212223242526272829303132)
             + Op.LOG0(0, 1)
@@ -80,6 +83,7 @@ class ProgramSuicide(ScenarioTestProgram):
 
     def make_test_code(self, pre: Alloc, fork: Fork) -> Bytecode:
         """Test code."""
+        del pre, fork
         return Op.MSTORE(0, 1) + Op.SELFDESTRUCT(0) + Op.RETURN(0, 32)
 
     @cached_property

--- a/tests/prague/eip6110_deposits/helpers.py
+++ b/tests/prague/eip6110_deposits/helpers.py
@@ -186,6 +186,7 @@ class DepositRequest(DepositRequestBase):
 
     def with_source_address(self, source_address: Address) -> "DepositRequest":
         """Return a copy."""
+        del source_address
         return self.copy()
 
 


### PR DESCRIPTION
## 🗒️ Description

Enable all ARG ruff checks - Closes #2176

Deferred to `del` approach discussed [here](https://github.com/ethereum/execution-spec-tests/pull/2166#discussion_r2355440278)

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] ~~All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).