### PR TITLE
fix(rpc): Always set data on JSONRPCError, account for None

### DIFF
--- a/src/ethereum_test_rpc/rpc_types.py
+++ b/src/ethereum_test_rpc/rpc_types.py
@@ -40,12 +40,11 @@ class JSONRPCError(Exception):
         """Initialize the JSONRPCError."""
         self.code = int(code)
         self.message = message
-        if data:
-            self.data = data
+        self.data = data
 
     def __str__(self) -> str:
         """Return string representation of the JSONRPCError."""
-        if self.data:
+        if self.data is not None:
             return f"JSONRPCError(code={self.code}, message={self.message}, data={self.data})"
 
         return f"JSONRPCError(code={self.code}, message={self.message})"


### PR DESCRIPTION
## 🗒️ Description
The `self.data` notation was erroring because `self.data` didn't get set if `data` came in as `None`. Removed `if self.data:` line so it always gets set now and is accounted for in `__str__`. 

## 🔗 Related Issues or PRs
N/A

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] ~~Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.~~
- [ ] ~~Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.~~
- [ ] ~~Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.~~
