### PR TITLE
fix(benchmark): stateful test issue

### DIFF
--- a/src/ethereum_test_specs/benchmark.py
+++ b/src/ethereum_test_specs/benchmark.py
@@ -218,8 +218,8 @@ class BenchmarkTest(BaseTest):
 
         return [execution_block]
 
-    def generate_blockchain_test(self, fork: Fork) -> BlockchainTest:
-        """Create a BlockchainTest from this BenchmarkTest."""
+    def generate_blocks(self, fork: Fork) -> List[Block]:
+        """Generate blocks from the test properties."""
         set_props = [
             name
             for name, val in [
@@ -251,11 +251,11 @@ class BenchmarkTest(BaseTest):
 
             blocks.append(Block(txs=transactions))
 
-        else:
-            raise ValueError(
-                "Cannot create BlockchainTest without a code generator, transactions, or blocks"
-            )
+        return blocks
 
+    def generate_blockchain_test(self, fork: Fork) -> BlockchainTest:
+        """Create a BlockchainTest from this BenchmarkTest."""
+        blocks = self.generate_blocks(fork)
         return BlockchainTest.from_test(
             base_test=self,
             genesis_environment=self.env,
@@ -286,11 +286,12 @@ class BenchmarkTest(BaseTest):
         execute_format: ExecuteFormat,
     ) -> BaseExecute:
         """Execute the benchmark test by sending it to the live network."""
-        del fork
-
         if execute_format == TransactionPost:
+            blocks: List[List[Transaction]] = [
+                list(block.txs) for block in self.generate_blocks(fork)
+            ]
             return TransactionPost(
-                blocks=[[self.tx]],
+                blocks=blocks,
                 post=self.post,
             )
         raise Exception(f"Unsupported execute format: {execute_format}")

--- a/tests/benchmark/test_worst_stateful_opcodes.py
+++ b/tests/benchmark/test_worst_stateful_opcodes.py
@@ -50,7 +50,6 @@ def test_worst_address_state_cold(
     fork: Fork,
     opcode: Op,
     absent_accounts: bool,
-    env: Environment,
     gas_benchmark_value: int,
 ) -> None:
     """
@@ -86,7 +85,7 @@ def test_worst_address_state_cold(
 
         setup_tx = Transaction(
             to=factory_address,
-            gas_limit=env.gas_limit,
+            gas_limit=20 * gas_benchmark_value,
             sender=pre.fund_eoa(),
         )
         blocks.append(Block(txs=[setup_tx]))
@@ -334,7 +333,7 @@ def test_worst_storage_access_cold(
     sender_addr = pre.fund_eoa()
     setup_tx = Transaction(
         to=None,
-        gas_limit=env.gas_limit,
+        gas_limit=20 * gas_benchmark_value,
         data=creation_code,
         sender=sender_addr,
     )
@@ -411,7 +410,7 @@ def test_worst_storage_access_warm(
         sender_addr = pre.fund_eoa()
         setup_tx = Transaction(
             to=None,
-            gas_limit=env.gas_limit,
+            gas_limit=20 * gas_benchmark_value,
             data=creation_code,
             sender=sender_addr,
         )
@@ -432,10 +431,7 @@ def test_worst_storage_access_warm(
 
 def test_worst_blockhash(
     benchmark_test: BenchmarkTestFiller,
-    pre: Alloc,
-    fork: Fork,
     gas_benchmark_value: int,
-    tx_gas_limit_cap: int,
 ) -> None:
     """
     Test running a block with as many blockhash accessing oldest allowed block
@@ -507,7 +503,6 @@ def test_worst_selfdestruct_existing(
     fork: Fork,
     pre: Alloc,
     value_bearing: bool,
-    env: Environment,
     gas_benchmark_value: int,
 ) -> None:
     """
@@ -588,7 +583,7 @@ def test_worst_selfdestruct_existing(
 
     contracts_deployment_tx = Transaction(
         to=factory_caller_address,
-        gas_limit=env.gas_limit,
+        gas_limit=20 * gas_benchmark_value,
         data=Hash(num_contracts),
         sender=pre.fund_eoa(),
     )
@@ -814,7 +809,6 @@ def test_worst_selfdestruct_initcode(
     code_tx = Transaction(
         to=code_addr,
         gas_limit=gas_benchmark_value,
-        gas_price=10,
         sender=pre.fund_eoa(),
     )
 


### PR DESCRIPTION
<!-- 
⚠️ NOTICE: This repository is migrating to ethereum/execution-specs on October 24, 2025.
New PRs will not be accepted after October 20, 2025.
Please see: https://github.com/ethereum/execution-spec-tests/issues/2303
-->

This is a workaround PR for stateful benchmarking. The original benchmark test wrapper does not support `execute` format, and there is some issue in existing stateful benchmark test cases.