### PR TITLE
clients/ethrex: add error mapping for gas overflow error

### DIFF
--- a/src/ethereum_clis/clis/ethrex.py
+++ b/src/ethereum_clis/clis/ethrex.py
@@ -93,4 +93,5 @@ class EthrexExceptionMapper(ExceptionMapper):
         BlockException.INVALID_BLOCK_HASH: (r"Invalid block hash. Expected \w+, got \w+"),
         BlockException.GASLIMIT_PRICE_PRODUCT_OVERFLOW: (r"Invalid transaction: Gas limit price product overflow*"),
         BlockException.RLP_BLOCK_LIMIT_EXCEEDED: (r"Maximum block size exceeded.*"),
+        BlockException.GAS_LIMIT_EXCEEDS_MAXIMUM: (r"Invalid transaction: Transaction gas limit exceeds maximum.*"),
     }


### PR DESCRIPTION
**Description**

Added mapping for gas overflow error, to pass some of the failing blockchain and hive engine tests.