### PR TITLE
feat(besu): add exception mapping

### DIFF
--- a/src/ethereum_clis/clis/besu.py
+++ b/src/ethereum_clis/clis/besu.py
@@ -273,6 +273,26 @@ class BesuExceptionMapper(ExceptionMapper):
         BlockException.RLP_BLOCK_LIMIT_EXCEEDED: (
             r"Block size of \d+ bytes exceeds limit of \d+ bytes"
         ),
+        BlockException.INVALID_BAL_EXTRA_ACCOUNT: (
+            r"Block access list hash mismatch, "
+            r"calculated:\s*(0x[a-f0-9]+)\s+header:\s*(0x[a-f0-9]+)"
+        ),
+        BlockException.INVALID_BAL_HASH: (
+            r"Block access list hash mismatch, "
+            r"calculated:\s*(0x[a-f0-9]+)\s+header:\s*(0x[a-f0-9]+)"
+        ),
+        BlockException.INVALID_BAL_MISSING_ACCOUNT: (
+            r"Block access list hash mismatch, "
+            r"calculated:\s*(0x[a-f0-9]+)\s+header:\s*(0x[a-f0-9]+)"
+        ),
+        BlockException.INVALID_BLOCK_ACCESS_LIST: (
+            r"Block access list hash mismatch, "
+            r"calculated:\s*(0x[a-f0-9]+)\s+header:\s*(0x[a-f0-9]+)"
+        ),
+        BlockException.INCORRECT_BLOCK_FORMAT: (
+            r"Block access list hash mismatch, "
+            r"calculated:\s*(0x[a-f0-9]+)\s+header:\s*(0x[a-f0-9]+)"
+        ),
         TransactionException.INITCODE_SIZE_EXCEEDED: (
             r"transaction invalid Initcode size of \d+ exceeds maximum size of \d+"
         ),


### PR DESCRIPTION
Adds BAL exception mapping for Besu. This is a necessary change to make BAL engine tests running against Besu valid.

I understand this repo is being migrated but it is currently still being used by hive EEST simulators. Merging this PR will make hive tests run from [raxhvl:feat/asmterdam-bal](https://github.com/ethereum/hive/pull/1349) valid without having to merge the following PRs and rebase / merge:
https://github.com/ethereum/hive/pull/1358
https://github.com/ethereum/execution-specs/pull/1640
https://github.com/ethereum/execution-specs/pull/1641

<!-- 
⚠️ NOTICE: This repository is migrating to ethereum/execution-specs on October 24, 2025.
New PRs will not be accepted after October 20, 2025.
Please see: https://github.com/ethereum/execution-spec-tests/issues/2303
-->