### PR TITLE
test(eip6110): cover forged deposit request bodies

### DIFF
--- a/tests/prague/eip6110_deposits/test_deposits.py
+++ b/tests/prague/eip6110_deposits/test_deposits.py
@@ -15,7 +15,9 @@ from ethereum_test_tools import (
     BlockchainTestFiller,
     BlockException,
     Environment,
+    Header,
     Macros,
+    Requests,
 )
 from ethereum_test_tools import Opcodes as Op
 
@@ -935,6 +937,75 @@ def test_deposit(
         blocks=blocks,
     )
 
+
+@pytest.mark.parametrize(
+    "block_body_requests,exception",
+    [
+        pytest.param(
+            [
+                DepositRequest(
+                    pubkey=0x01,
+                    withdrawal_credentials=0x02,
+                    amount=32_000_000_000,
+                    signature=0x03,
+                    index=0x0,
+                ),
+            ],
+            None,
+            id="matching_engine_requests",
+        ),
+        pytest.param(
+            [
+                DepositRequest(
+                    pubkey=0x01,
+                    withdrawal_credentials=0x02,
+                    amount=31_000_000_000,
+                    signature=0x03,
+                    index=0x0,
+                ),
+            ],
+            BlockException.INVALID_REQUESTS,
+            marks=pytest.mark.exception_test,
+            id="forged_engine_deposit_request",
+        ),
+    ],
+)
+@pytest.mark.pre_alloc_group(
+    "deposit_requests",
+    reason="Checks requests_hash validation against deposits derived from execution logs",
+)
+def test_deposit_requests_hash_uses_execution_logs(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    block_body_requests: List[DepositRequest],
+    exception: BlockException | None,
+) -> None:
+    """
+    Pair a valid Engine API requests body with a forged deposit body that keeps
+    the block header requests_hash internally consistent.
+    """
+    actual_request = DepositRequest(
+        pubkey=0x01,
+        withdrawal_credentials=0x02,
+        amount=32_000_000_000,
+        signature=0x03,
+        index=0x0,
+    )
+    deposit = DepositTransaction(requests=[actual_request])
+    deposit.update_pre(pre)
+
+    blockchain_test(
+        pre=pre,
+        post={},
+        blocks=[
+            Block(
+                txs=deposit.transactions(),
+                header_verify=Header(requests_hash=Requests(actual_request)),
+                requests=Requests(*block_body_requests).requests_list,
+                exception=exception,
+            ),
+        ],
+    )
 
 @pytest.mark.parametrize(
     "requests,block_body_override_requests,exception",


### PR DESCRIPTION
## Summary
- add a paired EIP-6110 blockchain test for Engine API deposit requests bodies
- valid case supplies a requests body matching the deposit emitted by execution logs
- forged case supplies a different deposit body and expects INVALID_REQUESTS while the header requests_hash remains internally consistent with that forged body

## Validation
- uv run python -m py_compile tests/prague/eip6110_deposits/test_deposits.py
- git diff --check
- uv run pytest --collect-only tests/prague/eip6110_deposits/test_deposits.py -k test_deposit_requests_hash_uses_execution_logs -q
- attempted: uv run fill --fork Prague -m blockchain_test -k test_deposit_requests_hash_uses_execution_logs tests/prague/eip6110_deposits/test_deposits.py -q
  - blocked before test execution because the default EELS resolver tries to clone missing branch forks/bpos for Prague
- attempted with local resolver: EELS_RESOLUTIONS='{"Prague":{"path":"/home/zksecurity/evm-asm/execution-specs"}}' uv run fill --fork Prague -m blockchain_test -k test_deposit_requests_hash_uses_execution_logs --output /tmp/e3vib-fill tests/prague/eip6110_deposits/test_deposits.py -q
  - reached transition output validation, then failed because local Prague resolver receipt logs omit blockNumber/transactionHash/transactionIndex/blockHash/logIndex/removed fields